### PR TITLE
Notify users about saved cart after top-up

### DIFF
--- a/app/handlers/balance.py
+++ b/app/handlers/balance.py
@@ -384,60 +384,12 @@ async def handle_successful_topup_with_cart(
     bot,
     db: AsyncSession
 ):
-    from app.database.crud.user import get_user_by_id
-    from aiogram.fsm.context import FSMContext
-    from aiogram.fsm.storage.base import StorageKey
-    from app.bot import dp
-    
-    user = await get_user_by_id(db, user_id)
-    if not user:
-        return
-    
-    storage = dp.storage
-    key = StorageKey(bot_id=bot.id, chat_id=user.telegram_id, user_id=user.telegram_id)
-    
-    try:
-        state_data = await storage.get_data(key)
-        current_state = await storage.get_state(key)
-        
-        if (current_state == "SubscriptionStates:cart_saved_for_topup" and 
-            state_data.get('saved_cart')):
-            
-            texts = get_texts(user.language)
-            total_price = state_data.get('total_price', 0)
-            
-            keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                [types.InlineKeyboardButton(
-                    text="🛒 Вернуться к оформлению подписки", 
-                    callback_data="return_to_saved_cart"
-                )],
-                [types.InlineKeyboardButton(
-                    text="💰 Мой баланс", 
-                    callback_data="menu_balance"
-                )],
-                [types.InlineKeyboardButton(
-                    text="🏠 Главное меню", 
-                    callback_data="back_to_menu"
-                )]
-            ])
-            
-            success_text = (
-                f"✅ Баланс пополнен на {texts.format_price(amount_kopeks)}!\n\n"
-                f"💰 Текущий баланс: {texts.format_price(user.balance_kopeks)}\n\n"
-                f"🛒 У вас есть сохраненная корзина подписки\n"
-                f"Стоимость: {texts.format_price(total_price)}\n\n"
-                f"Хотите продолжить оформление?"
-            )
-            
-            await bot.send_message(
-                chat_id=user.telegram_id,
-                text=success_text,
-                reply_markup=keyboard,
-                parse_mode="HTML"
-            )
-            
-    except Exception as e:
-        logger.error(f"Ошибка обработки успешного пополнения с корзиной: {e}")
+    await notify_saved_cart_after_topup(
+        db=db,
+        bot=bot,
+        user_id=user_id,
+        amount_kopeks=amount_kopeks,
+    )
 
 @error_handler
 async def request_support_topup(

--- a/app/services/cart_topup_service.py
+++ b/app/services/cart_topup_service.py
@@ -1,0 +1,89 @@
+import logging
+from aiogram import types
+from aiogram.fsm.storage.base import StorageKey
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.crud.user import get_user_by_id
+from app.localization.texts import get_texts
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_saved_cart_after_topup(
+    db: AsyncSession,
+    bot,
+    user_id: int,
+    amount_kopeks: int,
+) -> bool:
+    """Send prompt to return to saved cart after successful top-up if needed."""
+    if not bot:
+        return False
+
+    user = await get_user_by_id(db, user_id)
+    if not user:
+        return False
+
+    try:
+        from app.bot import dp
+
+        storage = dp.storage
+        key = StorageKey(bot_id=bot.id, chat_id=user.telegram_id, user_id=user.telegram_id)
+
+        state_data = await storage.get_data(key)
+        current_state = await storage.get_state(key)
+
+        if current_state != "SubscriptionStates:cart_saved_for_topup":
+            return False
+
+        if not state_data.get("saved_cart"):
+            return False
+
+        texts = get_texts(user.language)
+        total_price = state_data.get("total_price", 0)
+
+        keyboard = types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text="🛒 Вернуться к оформлению подписки",
+                        callback_data="return_to_saved_cart",
+                    )
+                ],
+                [
+                    types.InlineKeyboardButton(
+                        text="💰 Мой баланс",
+                        callback_data="menu_balance",
+                    )
+                ],
+                [
+                    types.InlineKeyboardButton(
+                        text="🏠 Главное меню",
+                        callback_data="back_to_menu",
+                    )
+                ],
+            ]
+        )
+
+        success_text = (
+            f"✅ Баланс пополнен на {texts.format_price(amount_kopeks)}!\n\n"
+            f"💰 Текущий баланс: {texts.format_price(user.balance_kopeks)}\n\n"
+            f"🛒 У вас есть сохраненная корзина подписки\n"
+            f"Стоимость: {texts.format_price(total_price)}\n\n"
+            f"Хотите продолжить оформление?"
+        )
+
+        await bot.send_message(
+            chat_id=user.telegram_id,
+            text=success_text,
+            reply_markup=keyboard,
+            parse_mode="HTML",
+        )
+
+        return True
+
+    except Exception as exc:
+        logger.error(
+            "Ошибка обработки успешного пополнения с корзиной: %s",
+            exc,
+        )
+        return False

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -22,6 +22,7 @@ from app.external.cryptobot import CryptoBotService
 from app.utils.currency_converter import currency_converter
 from app.database.database import get_db
 from app.localization.texts import get_texts
+from app.services.cart_topup_service import notify_saved_cart_after_topup
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,12 @@ class PaymentService:
                             f"Баланс пополнен автоматически!",
                             parse_mode="HTML",
                             reply_markup=keyboard,
+                        )
+                        await notify_saved_cart_after_topup(
+                            db=db,
+                            bot=self.bot,
+                            user_id=user.id,
+                            amount_kopeks=amount_kopeks,
                         )
                         logger.info(
                             f"✅ Отправлено уведомление пользователю {user.telegram_id} о пополнении на {int(rubles_amount)}₽"
@@ -470,6 +477,12 @@ class PaymentService:
                                 parse_mode="HTML",
                                 reply_markup=keyboard,
                             )
+                            await notify_saved_cart_after_topup(
+                                db=db,
+                                bot=self.bot,
+                                user_id=user.id,
+                                amount_kopeks=updated_payment.amount_kopeks,
+                            )
                             logger.info(
                                 f"✅ Отправлено уведомление пользователю {user.telegram_id} о пополнении на {updated_payment.amount_kopeks//100}₽"
                             )
@@ -586,6 +599,13 @@ class PaymentService:
                 parse_mode="HTML",
                 reply_markup=keyboard,
             )
+            if user:
+                await notify_saved_cart_after_topup(
+                    db=db,
+                    bot=self.bot,
+                    user_id=user.id,
+                    amount_kopeks=amount_kopeks,
+                )
         except Exception as e:
             logger.error(f"Ошибка отправки уведомления пользователю {telegram_id}: {e}")
     
@@ -865,6 +885,12 @@ class PaymentService:
                                 f"Баланс пополнен автоматически!",
                                 parse_mode="HTML",
                                 reply_markup=keyboard,
+                            )
+                            await notify_saved_cart_after_topup(
+                                db=db,
+                                bot=self.bot,
+                                user_id=user.id,
+                                amount_kopeks=amount_kopeks,
                             )
                             logger.info(f"✅ Отправлено уведомление пользователю {user.telegram_id} о пополнении на {amount_rubles:.2f}₽ ({updated_payment.asset})")
                         except Exception as e:

--- a/app/services/tribute_service.py
+++ b/app/services/tribute_service.py
@@ -16,6 +16,7 @@ from app.database.crud.transaction import (
 from app.database.crud.user import get_user_by_telegram_id, add_user_balance
 from app.external.tribute import TributeService as TributeAPI
 from app.localization.texts import get_texts
+from app.services.cart_topup_service import notify_saved_cart_after_topup
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,12 @@ class TributeService:
                     logger.error(f"Ошибка отправки уведомления о Tribute пополнении: {e}")
                 
                 await self._send_success_notification(user_telegram_id, amount_kopeks)
+                await notify_saved_cart_after_topup(
+                    db=session,
+                    bot=self.bot,
+                    user_id=user.id,
+                    amount_kopeks=amount_kopeks,
+                )
                 
                 logger.info(f"🎉 Успешно обработан Tribute платеж: {amount_kopeks/100}₽ для пользователя {user_telegram_id}")
                 break
@@ -366,6 +373,12 @@ class TributeService:
                 logger.info(f"💰 ПРИНУДИТЕЛЬНО обновлен баланс: {old_balance} -> {user.balance_kopeks} коп")
                 
                 await self._send_success_notification(user_id, amount_kopeks)
+                await notify_saved_cart_after_topup(
+                    db=session,
+                    bot=self.bot,
+                    user_id=user.id,
+                    amount_kopeks=amount_kopeks,
+                )
                 
                 logger.info(f"✅ Принудительно обработан платеж {payment_id}")
                 return True


### PR DESCRIPTION
## Summary
- extract saved cart top-up notification into dedicated service
- reuse the helper after Telegram Stars, YooKassa, CryptoBot, and Tribute top-ups to prompt returning to the cart
- update balance handler to delegate to the new helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf9aa7c548320b4f6e37efdbba916