### PR TITLE
Ensure saved-cart reminder can access FSM storage

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -76,6 +76,8 @@ async def setup_bot() -> tuple[Bot, Dispatcher]:
     
     
     dp = Dispatcher(storage=storage)
+    # expose dispatcher on the bot instance so background services can access FSM storage
+    setattr(bot, "dispatcher", dp)
 
     dp.message.middleware(GlobalErrorMiddleware())
     dp.callback_query.middleware(GlobalErrorMiddleware())

--- a/app/handlers/balance.py
+++ b/app/handlers/balance.py
@@ -384,60 +384,15 @@ async def handle_successful_topup_with_cart(
     bot,
     db: AsyncSession
 ):
-    from app.database.crud.user import get_user_by_id
-    from aiogram.fsm.context import FSMContext
-    from aiogram.fsm.storage.base import StorageKey
-    from app.bot import dp
-    
-    user = await get_user_by_id(db, user_id)
-    if not user:
-        return
-    
-    storage = dp.storage
-    key = StorageKey(bot_id=bot.id, chat_id=user.telegram_id, user_id=user.telegram_id)
-    
-    try:
-        state_data = await storage.get_data(key)
-        current_state = await storage.get_state(key)
-        
-        if (current_state == "SubscriptionStates:cart_saved_for_topup" and 
-            state_data.get('saved_cart')):
-            
-            texts = get_texts(user.language)
-            total_price = state_data.get('total_price', 0)
-            
-            keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                [types.InlineKeyboardButton(
-                    text="🛒 Вернуться к оформлению подписки", 
-                    callback_data="return_to_saved_cart"
-                )],
-                [types.InlineKeyboardButton(
-                    text="💰 Мой баланс", 
-                    callback_data="menu_balance"
-                )],
-                [types.InlineKeyboardButton(
-                    text="🏠 Главное меню", 
-                    callback_data="back_to_menu"
-                )]
-            ])
-            
-            success_text = (
-                f"✅ Баланс пополнен на {texts.format_price(amount_kopeks)}!\n\n"
-                f"💰 Текущий баланс: {texts.format_price(user.balance_kopeks)}\n\n"
-                f"🛒 У вас есть сохраненная корзина подписки\n"
-                f"Стоимость: {texts.format_price(total_price)}\n\n"
-                f"Хотите продолжить оформление?"
-            )
-            
-            await bot.send_message(
-                chat_id=user.telegram_id,
-                text=success_text,
-                reply_markup=keyboard,
-                parse_mode="HTML"
-            )
-            
-    except Exception as e:
-        logger.error(f"Ошибка обработки успешного пополнения с корзиной: {e}")
+    dispatcher = getattr(bot, "dispatcher", None)
+    storage = getattr(dispatcher, "storage", None) if dispatcher else None
+    await notify_saved_cart_after_topup(
+        db=db,
+        bot=bot,
+        user_id=user_id,
+        amount_kopeks=amount_kopeks,
+        storage=storage,
+    )
 
 @error_handler
 async def request_support_topup(

--- a/app/services/cart_topup_service.py
+++ b/app/services/cart_topup_service.py
@@ -1,0 +1,193 @@
+import logging
+from typing import Optional
+
+from aiogram import Dispatcher, types
+from aiogram.fsm.storage.base import BaseStorage, StorageKey
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.crud.user import get_user_by_id
+from app.localization.texts import get_texts
+from app.states import SubscriptionStates
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_saved_cart_after_topup(
+    db: AsyncSession,
+    bot,
+    user_id: int,
+    amount_kopeks: int,
+    storage: Optional[BaseStorage] = None,
+) -> bool:
+    """Send prompt to return to saved cart after successful top-up if needed."""
+    if not bot:
+        return False
+
+    user = await get_user_by_id(db, user_id)
+    if not user:
+        return False
+
+    fsm_storage = storage or _resolve_storage(bot)
+    if not fsm_storage:
+        logger.debug("FSM storage is not available for bot %s", _describe_bot(bot))
+        return False
+
+    try:
+        bot_id = await _resolve_bot_id(bot)
+        if bot_id is None:
+            logger.error("Не удалось определить bot_id для уведомления о корзине")
+            return False
+
+        key = StorageKey(bot_id=bot_id, chat_id=user.telegram_id, user_id=user.telegram_id)
+        state_data = await fsm_storage.get_data(key)
+        current_state = await fsm_storage.get_state(key)
+    except Exception as exc:
+        logger.error("Не удалось получить состояние корзины из FSM: %s", exc, exc_info=True)
+        return False
+
+    if not state_data.get("saved_cart"):
+        logger.debug("У пользователя %s нет сохраненной корзины", user.telegram_id)
+        return False
+
+    if state_data.get("return_to_cart") is False:
+        logger.debug("Повторное уведомление о корзине для пользователя %s не требуется", user.telegram_id)
+        return False
+
+    if current_state not in (None, SubscriptionStates.cart_saved_for_topup.state):
+        logger.debug(
+            "Текущее состояние %s пользователя %s не соответствует сохраненной корзине",
+            current_state,
+            user.telegram_id,
+        )
+        return False
+
+    texts = get_texts(user.language)
+    total_price = state_data.get("total_price", 0)
+    has_enough_balance = user.balance_kopeks >= total_price > 0
+
+    balance_text = texts.format_price(user.balance_kopeks)
+    total_text = texts.format_price(total_price) if total_price else None
+
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                types.InlineKeyboardButton(
+                    text="🛒 Вернуться к оформлению подписки",
+                    callback_data="return_to_saved_cart",
+                )
+            ],
+            [
+                types.InlineKeyboardButton(
+                    text="💰 Мой баланс",
+                    callback_data="menu_balance",
+                )
+            ],
+            [
+                types.InlineKeyboardButton(
+                    text="🏠 Главное меню",
+                    callback_data="back_to_menu",
+                )
+            ],
+        ]
+    )
+
+    success_parts = [
+        f"✅ Баланс пополнен на {texts.format_price(amount_kopeks)}!",
+        "",
+        f"💰 Текущий баланс: {balance_text}",
+    ]
+
+    if total_price:
+        success_parts.extend(
+            [
+                "",
+                "🛒 У вас есть сохраненная корзина подписки",
+                f"Стоимость: {total_text}",
+            ]
+        )
+
+    if has_enough_balance:
+        success_parts.extend([
+            "",
+            "🎯 Теперь средств достаточно, можно продолжить оформление.",
+        ])
+    elif total_price:
+        missing_amount = total_price - user.balance_kopeks
+        if missing_amount > 0:
+            success_parts.extend(
+                [
+                    "",
+                    "⚠️ Пока средств недостаточно для оформления.",
+                    f"Не хватает: {texts.format_price(missing_amount)}",
+                    "Пополните баланс еще или вернитесь к корзине, чтобы изменить параметры.",
+                ]
+            )
+
+    success_parts.extend([
+        "",
+        "Хотите продолжить оформление?",
+    ])
+
+    success_text = "\n".join(success_parts)
+
+    await bot.send_message(
+        chat_id=user.telegram_id,
+        text=success_text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+    )
+
+    try:
+        await fsm_storage.update_data(key, return_to_cart=False)
+    except Exception as exc:
+        logger.warning(
+            "Не удалось обновить флаг возврата к корзине для пользователя %s: %s",
+            user.telegram_id,
+            exc,
+        )
+
+    return True
+
+
+async def _resolve_bot_id(bot) -> Optional[int]:
+    bot_id = getattr(bot, "id", None)
+    if bot_id:
+        return bot_id
+
+    try:
+        me = await bot.get_me()
+    except Exception as exc:
+        logger.error("Не удалось получить информацию о боте: %s", exc, exc_info=True)
+        return None
+
+    return getattr(me, "id", None)
+
+
+def _resolve_storage(bot) -> Optional[BaseStorage]:
+    try:
+        dispatcher = Dispatcher.get_current()
+    except LookupError:
+        dispatcher = None
+
+    if not dispatcher and bot:
+        dispatcher = getattr(bot, "dispatcher", None)
+
+    if dispatcher and getattr(dispatcher, "storage", None):
+        return dispatcher.storage
+
+    return None
+
+
+def _describe_bot(bot) -> str:
+    if not bot:
+        return "<unknown>"
+
+    bot_id = getattr(bot, "id", None)
+    if bot_id:
+        return str(bot_id)
+
+    token = getattr(bot, "token", None)
+    if token and isinstance(token, str) and token:
+        return token.split(":", maxsplit=1)[0]
+
+    return bot.__class__.__name__

--- a/app/services/tribute_service.py
+++ b/app/services/tribute_service.py
@@ -16,14 +16,17 @@ from app.database.crud.transaction import (
 from app.database.crud.user import get_user_by_telegram_id, add_user_balance
 from app.external.tribute import TributeService as TributeAPI
 from app.localization.texts import get_texts
+from app.services.cart_topup_service import notify_saved_cart_after_topup
 
 logger = logging.getLogger(__name__)
 
 
 class TributeService:
-    
+
     def __init__(self, bot: Bot):
         self.bot = bot
+        dispatcher = getattr(bot, "dispatcher", None)
+        self.fsm_storage = getattr(dispatcher, "storage", None) if dispatcher else None
         self.tribute_api = TributeAPI()
     
     async def create_payment_link(
@@ -153,6 +156,13 @@ class TributeService:
                     logger.error(f"Ошибка отправки уведомления о Tribute пополнении: {e}")
                 
                 await self._send_success_notification(user_telegram_id, amount_kopeks)
+                await notify_saved_cart_after_topup(
+                    db=session,
+                    bot=self.bot,
+                    user_id=user.id,
+                    amount_kopeks=amount_kopeks,
+                    storage=self.fsm_storage,
+                )
                 
                 logger.info(f"🎉 Успешно обработан Tribute платеж: {amount_kopeks/100}₽ для пользователя {user_telegram_id}")
                 break
@@ -366,6 +376,13 @@ class TributeService:
                 logger.info(f"💰 ПРИНУДИТЕЛЬНО обновлен баланс: {old_balance} -> {user.balance_kopeks} коп")
                 
                 await self._send_success_notification(user_id, amount_kopeks)
+                await notify_saved_cart_after_topup(
+                    db=session,
+                    bot=self.bot,
+                    user_id=user.id,
+                    amount_kopeks=amount_kopeks,
+                    storage=self.fsm_storage,
+                )
                 
                 logger.info(f"✅ Принудительно обработан платеж {payment_id}")
                 return True


### PR DESCRIPTION
## Summary
- resolve the bot id lazily when checking FSM data for saved carts and improve logging when storage is missing
- cache dispatcher storage on payment-related services and pass it to the saved-cart notifier for every top-up scenario
- ensure balance handlers also forward dispatcher storage so cart reminders can be sent reliably after deposits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf9aa7c548320b4f6e37efdbba916