### PR TITLE
Unify admin subscription and settings menu

### DIFF
--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -393,10 +393,9 @@ def get_user_management_keyboard(user_id: int, user_status: str, language: str =
     keyboard = [
         [
             InlineKeyboardButton(text="💰 Баланс", callback_data=f"admin_user_balance_{user_id}"),
-            InlineKeyboardButton(text="📱 Подписка", callback_data=f"admin_user_subscription_{user_id}")
+            InlineKeyboardButton(text="📱 Подписка и настройки", callback_data=f"admin_user_subscription_{user_id}")
         ],
         [
-            InlineKeyboardButton(text="⚙️ Настройка", callback_data=f"admin_user_servers_{user_id}"), 
             InlineKeyboardButton(text="📊 Статистика", callback_data=f"admin_user_statistics_{user_id}")
         ],
         [


### PR DESCRIPTION
## Summary
- merge the admin "Подписка" and "Настройка" menus into a single subscription overview
- display subscription status together with connected servers and management actions in one screen
- update navigation buttons to return to the combined "Подписка и настройки" view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd4c159c608320ac6e58cf84008021