### PR TITLE
Fix async rules loading for new users

### DIFF
--- a/app/handlers/common.py
+++ b/app/handlers/common.py
@@ -4,7 +4,7 @@ from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.models import User
-from app.localization.texts import get_texts
+from app.localization.texts import get_texts, get_rules
 from app.keyboards.inline import get_back_keyboard
 
 logger = logging.getLogger(__name__)
@@ -67,8 +67,8 @@ async def show_rules(
 ):
     
     texts = get_texts(db_user.language)
-    
-    rules_text = texts.RULES_TEXT
+
+    rules_text = await get_rules(db_user.language)
     
     await callback.message.edit_text(
         rules_text,

--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from app.config import settings
 from app.database.crud.user import get_user_by_telegram_id, update_user
 from app.keyboards.inline import get_main_menu_keyboard
-from app.localization.texts import get_texts, get_rules_sync
+from app.localization.texts import get_texts, get_rules
 from app.database.models import User
 from app.utils.user_utils import mark_user_as_had_paid_subscription
 from app.database.crud.user_message import get_random_active_message
@@ -80,7 +80,7 @@ async def show_service_rules(
     rules_text = await get_current_rules_content(db, db_user.language)
 
     if not rules_text:
-        rules_text = get_rules_sync(db_user.language)
+        rules_text = await get_rules(db_user.language)
 
     await callback.message.edit_text(
         f"{texts.t('RULES_HEADER', '📋 <b>Правила сервиса</b>')}\n\n{rules_text}",

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -22,7 +22,7 @@ from app.keyboards.inline import (
     get_rules_keyboard, get_main_menu_keyboard, get_post_registration_keyboard
 )
 from app.localization.loader import DEFAULT_LANGUAGE
-from app.localization.texts import get_texts
+from app.localization.texts import get_texts, get_rules
 from app.services.referral_service import process_referral_registration
 from app.services.campaign_service import AdvertisingCampaignService
 from app.utils.user_utils import generate_unique_referral_code
@@ -122,8 +122,9 @@ async def handle_potential_referral_code(
         language = data.get('language', DEFAULT_LANGUAGE)
         texts = get_texts(language)
         
+        rules_text = await get_rules(language)
         await message.answer(
-            texts.RULES_TEXT,
+            rules_text,
             reply_markup=get_rules_keyboard(language)
         )
         await state.set_state(RegistrationStates.waiting_for_rules_accept)
@@ -341,8 +342,9 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
                 await complete_registration(message, state, db)
         return
 
+    rules_text = await get_rules(language)
     await message.answer(
-        texts.RULES_TEXT,
+        rules_text,
         reply_markup=get_rules_keyboard(language)
     )
     logger.info(f"📋 Правила отправлены")
@@ -1187,17 +1189,19 @@ async def required_sub_channel_check(
                 from app.utils.message_patch import LOGO_PATH
                 from aiogram.types import FSInputFile
 
+                rules_text = await get_rules(language)
+
                 if settings.ENABLE_LOGO_MODE:
                     await bot.send_photo(
                         chat_id=query.from_user.id,
                         photo=FSInputFile(LOGO_PATH),
-                        caption=texts.RULES_TEXT,
+                        caption=rules_text,
                         reply_markup=get_rules_keyboard(language),
                     )
                 else:
                     await bot.send_message(
                         chat_id=query.from_user.id,
-                        text=texts.RULES_TEXT,
+                        text=rules_text,
                         reply_markup=get_rules_keyboard(language),
                     )
                 await state.set_state(RegistrationStates.waiting_for_rules_accept)

--- a/app/localization/texts.py
+++ b/app/localization/texts.py
@@ -16,6 +16,15 @@ _logger = logging.getLogger(__name__)
 _cached_rules: Dict[str, str] = {}
 
 
+def _get_cached_rules_value(language: str) -> str:
+    if language in _cached_rules:
+        return _cached_rules[language]
+
+    default = _get_default_rules(language)
+    _cached_rules[language] = default
+    return default
+
+
 def _build_dynamic_values(language: str) -> Dict[str, Any]:
     language_code = (language or DEFAULT_LANGUAGE).split("-")[0].lower()
 
@@ -122,7 +131,7 @@ class Texts:
 
     def _get_value(self, item: str) -> Any:
         if item == "RULES_TEXT":
-            return get_rules_sync(self.language)
+            return _get_cached_rules_value(self.language)
 
         if item in self._values:
             return self._values[item]
@@ -188,13 +197,19 @@ def get_rules_sync(language: str = DEFAULT_LANGUAGE) -> str:
         return _cached_rules[language]
 
     try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        rules = loop.run_until_complete(get_rules_from_db(language))
-        return rules
-    finally:
-        asyncio.set_event_loop(None)
-        loop.close()
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(get_rules(language))
+
+    loop.create_task(get_rules(language))
+    return _get_cached_rules_value(language)
+
+
+async def get_rules(language: str = DEFAULT_LANGUAGE) -> str:
+    if language in _cached_rules:
+        return _cached_rules[language]
+
+    return await get_rules_from_db(language)
 
 
 async def refresh_rules_cache(language: str = DEFAULT_LANGUAGE) -> None:


### PR DESCRIPTION
## Summary
- add asynchronous rules fetching helper that caches and avoids nested event loop errors
- update handlers to await the asynchronous rules text before sending registration and menu responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddc55a2e48320aec20dea76d91c83