### PR TITLE
Fix subscription checkout resume callbacks registration

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -4152,6 +4152,21 @@ def register_handlers(dp: Dispatcher):
         F.data == "subscription_confirm",
         SubscriptionStates.confirming_purchase
     )
+
+    dp.callback_query.register(
+        resume_subscription_checkout,
+        F.data == "subscription_resume_checkout",
+    )
+
+    dp.callback_query.register(
+        return_to_saved_cart,
+        F.data == "return_to_saved_cart",
+    )
+
+    dp.callback_query.register(
+        clear_saved_cart,
+        F.data == "clear_saved_cart",
+    )
     
     dp.callback_query.register(
         handle_autopay_menu,


### PR DESCRIPTION
## Summary
- register the callback handlers for resuming a saved subscription checkout and clearing the saved cart
- ensure the "return to saved cart" button works after balance top-up

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cde321edf48320821072c988926135