### PR TITLE
Add promo groups migration

### DIFF
--- a/migrations/alembic/versions/1f5f3a3f5a4d_add_promo_groups_and_user_fk.py
+++ b/migrations/alembic/versions/1f5f3a3f5a4d_add_promo_groups_and_user_fk.py
@@ -1,0 +1,127 @@
+"""add promo groups table and link users"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "1f5f3a3f5a4d"
+down_revision: Union[str, None] = "cbd1be472f3d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "promo_groups",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "server_discount_percent",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "traffic_discount_percent",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "device_discount_percent",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("name", name="uq_promo_groups_name"),
+    )
+
+    op.add_column(
+        "users",
+        sa.Column("promo_group_id", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        "ix_users_promo_group_id", "users", ["promo_group_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_users_promo_group_id_promo_groups",
+        "users",
+        "promo_groups",
+        ["promo_group_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    promo_groups_table = sa.table(
+        "promo_groups",
+        sa.column("id", sa.Integer()),
+        sa.column("name", sa.String()),
+        sa.column("server_discount_percent", sa.Integer()),
+        sa.column("traffic_discount_percent", sa.Integer()),
+        sa.column("device_discount_percent", sa.Integer()),
+        sa.column("is_default", sa.Boolean()),
+    )
+
+    connection = op.get_bind()
+    default_group_id = connection.execute(
+        sa.insert(promo_groups_table)
+        .values(
+            name="Базовый юзер",
+            server_discount_percent=0,
+            traffic_discount_percent=0,
+            device_discount_percent=0,
+            is_default=True,
+        )
+        .returning(promo_groups_table.c.id)
+    ).scalar_one()
+
+    users_table = sa.table(
+        "users",
+        sa.column("promo_group_id", sa.Integer()),
+    )
+    connection.execute(
+        sa.update(users_table)
+        .where(users_table.c.promo_group_id.is_(None))
+        .values(promo_group_id=default_group_id)
+    )
+
+    op.alter_column(
+        "users",
+        "promo_group_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "users",
+        "promo_group_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+    op.drop_constraint(
+        "fk_users_promo_group_id_promo_groups", "users", type_="foreignkey"
+    )
+    op.drop_index("ix_users_promo_group_id", table_name="users")
+    op.drop_column("users", "promo_group_id")
+    op.drop_table("promo_groups")

--- a/migrations/alembic/versions/8fd1e338eb45_add_sent_notifications_table.py
+++ b/migrations/alembic/versions/8fd1e338eb45_add_sent_notifications_table.py
@@ -1,8 +1,11 @@
 """add sent notifications table"""
 
 from typing import Sequence, Union
+
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
 
 revision: str = '8fd1e338eb45'
 down_revision: Union[str, None] = '3d9b35c6bd8f'
@@ -10,18 +13,46 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+TABLE_NAME = 'sent_notifications'
+UNIQUE_CONSTRAINT_NAME = 'uq_sent_notifications'
+UNIQUE_CONSTRAINT_COLUMNS = ['user_id', 'subscription_id', 'notification_type', 'days_before']
+
+
+def _table_exists(inspector: Inspector) -> bool:
+    return TABLE_NAME in inspector.get_table_names()
+
+
+def _unique_constraint_exists(inspector: Inspector) -> bool:
+    existing_constraints = {
+        constraint['name'] for constraint in inspector.get_unique_constraints(TABLE_NAME)
+    }
+    return UNIQUE_CONSTRAINT_NAME in existing_constraints
+
+
 def upgrade() -> None:
-    op.create_table(
-        'sent_notifications',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
-        sa.Column('subscription_id', sa.Integer(), sa.ForeignKey('subscriptions.id'), nullable=False),
-        sa.Column('notification_type', sa.String(length=50), nullable=False),
-        sa.Column('days_before', sa.Integer(), nullable=True),
-        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now()),
-        sa.UniqueConstraint('user_id', 'subscription_id', 'notification_type', 'days_before', name='uq_sent_notifications'),
-    )
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _table_exists(inspector):
+        op.create_table(
+            TABLE_NAME,
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+            sa.Column('subscription_id', sa.Integer(), sa.ForeignKey('subscriptions.id'), nullable=False),
+            sa.Column('notification_type', sa.String(length=50), nullable=False),
+            sa.Column('days_before', sa.Integer(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), server_default=sa.func.now()),
+            sa.UniqueConstraint(*UNIQUE_CONSTRAINT_COLUMNS, name=UNIQUE_CONSTRAINT_NAME),
+        )
+    elif not _unique_constraint_exists(inspector):
+        op.create_unique_constraint(
+            UNIQUE_CONSTRAINT_NAME, TABLE_NAME, UNIQUE_CONSTRAINT_COLUMNS
+        )
 
 
 def downgrade() -> None:
-    op.drop_table('sent_notifications')
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _table_exists(inspector):
+        op.drop_table(TABLE_NAME)


### PR DESCRIPTION
## Summary
- add an Alembic migration that introduces the `promo_groups` table
- link existing users to a default promo group and enforce the new foreign key
- make the `sent_notifications` migration resilient if the table or constraint already exists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce333bde0083209c74d4f0dbb65ff5