### PR TITLE
Fix edit_text patch signature

### DIFF
--- a/app/utils/message_patch.py
+++ b/app/utils/message_patch.py
@@ -20,7 +20,16 @@ async def _answer_with_photo(self: Message, text: str = None, **kwargs):
     return await _original_answer(self, text, **kwargs)
 
 
-async def _edit_with_photo(self: Message, text: str, **kwargs):
+async def _edit_with_photo(
+    self: Message,
+    text: str,
+    parse_mode: str | None = None,
+    entities=None,
+    disable_web_page_preview: bool | None = None,
+    reply_markup=None,
+    message_effect_id=None,
+    **kwargs,
+):
     if self.photo:
         # Всегда используем логотип если включен режим логотипа,
         # кроме специальных случаев (QR сообщения)
@@ -31,10 +40,28 @@ async def _edit_with_photo(self: Message, text: str, **kwargs):
         else:
             media = self.photo[-1].file_id
         media_kwargs = {"media": media, "caption": text}
-        if "parse_mode" in kwargs:
-            media_kwargs["parse_mode"] = kwargs.pop("parse_mode")
-        return await self.edit_media(InputMediaPhoto(**media_kwargs), **kwargs)
-    return await _original_edit_text(self, text, **kwargs)
+        if parse_mode:
+            media_kwargs["parse_mode"] = parse_mode
+        if entities:
+            media_kwargs["caption_entities"] = entities
+
+        edit_kwargs = {**kwargs}
+        if reply_markup is not None:
+            edit_kwargs["reply_markup"] = reply_markup
+        if message_effect_id is not None:
+            edit_kwargs["message_effect_id"] = message_effect_id
+
+        return await self.edit_media(InputMediaPhoto(**media_kwargs), **edit_kwargs)
+    return await _original_edit_text(
+        self,
+        text,
+        parse_mode=parse_mode,
+        entities=entities,
+        disable_web_page_preview=disable_web_page_preview,
+        reply_markup=reply_markup,
+        message_effect_id=message_effect_id,
+        **kwargs,
+    )
 
 
 def patch_message_methods():


### PR DESCRIPTION
## Summary
- update the patched Message.edit_text helper to mirror aiogram's signature
- forward optional parameters when editing messages with or without photos
