### PR TITLE
Add return button after creating promo group

### DIFF
--- a/app/handlers/admin/promo_groups.py
+++ b/app/handlers/admin/promo_groups.py
@@ -315,7 +315,22 @@ async def process_create_group_devices(
 
     await state.clear()
     await message.answer(
-        texts.t("ADMIN_PROMO_GROUP_CREATED", "Промогруппа «{name}» создана.").format(name=group.name)
+        texts.t("ADMIN_PROMO_GROUP_CREATED", "Промогруппа «{name}» создана.").format(
+            name=group.name
+        ),
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text=texts.t(
+                            "ADMIN_PROMO_GROUP_CREATED_BACK_BUTTON",
+                            "↩️ К промогруппам",
+                        ),
+                        callback_data="admin_promo_groups",
+                    )
+                ]
+            ]
+        ),
     )
 
 

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -154,6 +154,7 @@
   "ADMIN_PROMO_GROUP_CREATE_DEVICES_PROMPT": "Enter device discount (0-100):",
   "ADMIN_PROMO_GROUP_INVALID_PERCENT": "Enter a number from 0 to 100.",
   "ADMIN_PROMO_GROUP_CREATED": "Promo group “{name}” created.",
+  "ADMIN_PROMO_GROUP_CREATED_BACK_BUTTON": "↩️ Back to promo groups",
   "ADMIN_PROMO_GROUP_EDIT_NAME_PROMPT": "Enter a new name (current: {name}):",
   "ADMIN_PROMO_GROUP_EDIT_TRAFFIC_PROMPT": "Enter new traffic discount (0-100):",
   "ADMIN_PROMO_GROUP_EDIT_SERVERS_PROMPT": "Enter new server discount (0-100):",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -42,6 +42,7 @@
   "ADMIN_PROMO_GROUP_CREATE_DEVICES_PROMPT": "Введите скидку на устройства (0-100):",
   "ADMIN_PROMO_GROUP_INVALID_PERCENT": "Введите число от 0 до 100.",
   "ADMIN_PROMO_GROUP_CREATED": "Промогруппа «{name}» создана.",
+  "ADMIN_PROMO_GROUP_CREATED_BACK_BUTTON": "↩️ К промогруппам",
   "ADMIN_PROMO_GROUP_EDIT_NAME_PROMPT": "Введите новое название промогруппы (текущее: {name}):",
   "ADMIN_PROMO_GROUP_EDIT_TRAFFIC_PROMPT": "Введите новую скидку на трафик (0-100):",
   "ADMIN_PROMO_GROUP_EDIT_SERVERS_PROMPT": "Введите новую скидку на серверы (0-100):",


### PR DESCRIPTION
## Summary
- add a return-to-promo-groups button after successful creation
- localize the button label in Russian and English
