### PR TITLE
Respect base promo period discount flag

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -181,10 +181,11 @@ class PromoGroup(Base):
             try:
                 from app.config import settings
 
-                discounts = settings.get_base_promo_group_period_discounts()
-                if period_days in discounts:
-                    period_discount = discounts[period_days]
-                    percent = period_discount
+                if settings.is_base_promo_group_period_discount_enabled():
+                    discounts = settings.get_base_promo_group_period_discounts()
+                    if period_days in discounts:
+                        period_discount = discounts[period_days]
+                        percent = period_discount
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- guard base promo group period discounts behind the feature flag when computing promo group discounts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1376d4ce88320a9a881e18777c2ce