### PR TITLE
Add broadcast filters for expired and zero traffic subscriptions

### DIFF
--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -554,7 +554,12 @@ def get_broadcast_target_keyboard(language: str = "ru") -> InlineKeyboardMarkup:
             InlineKeyboardButton(text="❌ Без подписки", callback_data="broadcast_no_sub")
         ],
         [
-            InlineKeyboardButton(text="⏰ Истекающие", callback_data="broadcast_expiring")
+            InlineKeyboardButton(text="⏰ Истекающие", callback_data="broadcast_expiring"),
+            InlineKeyboardButton(text="⛔️ Истекшие", callback_data="broadcast_expired")
+        ],
+        [
+            InlineKeyboardButton(text="🛑 Активные (0 ГБ)", callback_data="broadcast_active_zero_traffic"),
+            InlineKeyboardButton(text="🛑 Триал (0 ГБ)", callback_data="broadcast_trial_zero_traffic")
         ],
         [
             InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_messages")


### PR DESCRIPTION
## Summary
- add new broadcast filter buttons for expired and zero-traffic subscriptions in the admin panel
- extend broadcast target handling to support expired, zero-traffic, and refined no-subscription user selections
- map display names for the new broadcast targets in previews and history
