### PR TITLE
Fix Telegram Stars payments handler priority

### DIFF
--- a/app/handlers/common.py
+++ b/app/handlers/common.py
@@ -120,5 +120,10 @@ def register_handlers(dp: Dispatcher):
     )
 
     # Самый последний: ловим любые неизвестные текстовые сообщения
-    dp.message.register(handle_unknown_message)
+    # Исключаем специальные сервисные события (например, успешные платежи),
+    # чтобы их обработка не прерывалась общим хендлером неизвестных сообщений
+    dp.message.register(
+        handle_unknown_message,
+        F.successful_payment.is_(None)
+    )
     


### PR DESCRIPTION
## Summary
- prevent the generic unknown-message handler from intercepting Telegram Stars payment confirmations
- ensure successful payment events reach the dedicated Stars processor while keeping the fallback for regular unknown messages
