### PR TITLE
feat: extend trial promocodes with custom resources

### DIFF
--- a/app/database/crud/promocode.py
+++ b/app/database/crud/promocode.py
@@ -25,16 +25,24 @@ async def create_promocode(
     type: PromoCodeType,
     balance_bonus_kopeks: int = 0,
     subscription_days: int = 0,
+    trial_device_limit: Optional[int] = None,
+    trial_traffic_limit_gb: Optional[int] = None,
+    trial_traffic_reset_strategy: Optional[str] = None,
+    trial_squad_uuids: Optional[List[str]] = None,
     max_uses: int = 1,
     valid_until: Optional[datetime] = None,
     created_by: Optional[int] = None
 ) -> PromoCode:
-    
+
     promocode = PromoCode(
         code=code.upper(),
         type=type.value,
         balance_bonus_kopeks=balance_bonus_kopeks,
         subscription_days=subscription_days,
+        trial_device_limit=trial_device_limit,
+        trial_traffic_limit_gb=trial_traffic_limit_gb,
+        trial_traffic_reset_strategy=trial_traffic_reset_strategy,
+        trial_squad_uuids=trial_squad_uuids or [],
         max_uses=max_uses,
         valid_until=valid_until,
         created_by=created_by

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -41,16 +41,28 @@ async def create_trial_subscription(
     duration_days: int = None,
     traffic_limit_gb: int = None,
     device_limit: int = None,
-    squad_uuid: str = None
+    squad_uuid: str = None,
+    connected_squads: Optional[List[str]] = None,
+    traffic_reset_strategy: Optional[str] = None
 ) -> Subscription:
-    
-    duration_days = duration_days or settings.TRIAL_DURATION_DAYS
-    traffic_limit_gb = traffic_limit_gb or settings.TRIAL_TRAFFIC_LIMIT_GB
-    device_limit = device_limit or settings.TRIAL_DEVICE_LIMIT
-    squad_uuid = squad_uuid or settings.TRIAL_SQUAD_UUID
-    
+
+    duration_days = settings.TRIAL_DURATION_DAYS if duration_days is None else duration_days
+    traffic_limit_gb = settings.TRIAL_TRAFFIC_LIMIT_GB if traffic_limit_gb is None else traffic_limit_gb
+    device_limit = settings.TRIAL_DEVICE_LIMIT if device_limit is None else device_limit
+    default_squad = squad_uuid or settings.TRIAL_SQUAD_UUID
+
+    squads: List[str] = []
+    if connected_squads is not None:
+        squads = [uuid for uuid in connected_squads if uuid]
+    elif default_squad:
+        squads = [default_squad]
+
+    reset_strategy = (traffic_reset_strategy or settings.DEFAULT_TRAFFIC_RESET_STRATEGY or "NO_RESET").upper()
+    if reset_strategy not in {"NO_RESET", "DAY", "WEEK", "MONTH"}:
+        reset_strategy = "NO_RESET"
+
     end_date = datetime.utcnow() + timedelta(days=duration_days)
-    
+
     subscription = Subscription(
         user_id=user_id,
         status=SubscriptionStatus.ACTIVE.value,
@@ -59,7 +71,8 @@ async def create_trial_subscription(
         end_date=end_date,
         traffic_limit_gb=traffic_limit_gb,
         device_limit=device_limit,
-        connected_squads=[squad_uuid] if squad_uuid else []
+        connected_squads=squads,
+        traffic_reset_strategy=reset_strategy
     )
     
     db.add(subscription)
@@ -89,7 +102,8 @@ async def create_paid_subscription(
         end_date=end_date,
         traffic_limit_gb=traffic_limit_gb,
         device_limit=device_limit,
-        connected_squads=connected_squads or []
+        connected_squads=connected_squads or [],
+        traffic_reset_strategy=settings.DEFAULT_TRAFFIC_RESET_STRATEGY.upper()
     )
     
     db.add(subscription)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -269,6 +269,7 @@ class Subscription(Base):
     device_limit = Column(Integer, default=1)
     
     connected_squads = Column(JSON, default=list)
+    traffic_reset_strategy = Column(String(50), nullable=True)
     
     autopay_enabled = Column(Boolean, default=False)
     autopay_days_before = Column(Integer, default=3)
@@ -473,8 +474,13 @@ class PromoCode(Base):
     code = Column(String(50), unique=True, nullable=False, index=True)
     type = Column(String(50), nullable=False)
     
-    balance_bonus_kopeks = Column(Integer, default=0)  
-    subscription_days = Column(Integer, default=0) 
+    balance_bonus_kopeks = Column(Integer, default=0)
+    subscription_days = Column(Integer, default=0)
+
+    trial_device_limit = Column(Integer, nullable=True)
+    trial_traffic_limit_gb = Column(Integer, nullable=True)
+    trial_traffic_reset_strategy = Column(String(50), nullable=True)
+    trial_squad_uuids = Column(JSON, default=list)
     
     max_uses = Column(Integer, default=1)  
     current_uses = Column(Integer, default=0)

--- a/app/services/promocode_service.py
+++ b/app/services/promocode_service.py
@@ -127,17 +127,29 @@ class PromoCodeService:
             
             if not subscription:
                 trial_days = promocode.subscription_days if promocode.subscription_days > 0 else settings.TRIAL_DURATION_DAYS
-                
+
                 trial_subscription = await create_trial_subscription(
-                    db, 
-                    user.id, 
-                    duration_days=trial_days 
+                    db,
+                    user.id,
+                    duration_days=trial_days,
+                    traffic_limit_gb=promocode.trial_traffic_limit_gb,
+                    device_limit=promocode.trial_device_limit,
+                    connected_squads=promocode.trial_squad_uuids,
+                    traffic_reset_strategy=promocode.trial_traffic_reset_strategy
                 )
-                
+
                 await self.subscription_service.create_remnawave_user(db, trial_subscription)
-                
+
                 effects.append(f"🎁 Активирована тестовая подписка на {trial_days} дней")
-                logger.info(f"✅ Создана триал подписка для пользователя {user.telegram_id} на {trial_days} дней")
+                logger.info(
+                    "✅ Создана триал подписка для пользователя %s на %s дней (трафик=%s ГБ, устройства=%s, сброс=%s, сквады=%s)",
+                    user.telegram_id,
+                    trial_days,
+                    trial_subscription.traffic_limit_gb,
+                    trial_subscription.device_limit,
+                    trial_subscription.traffic_reset_strategy,
+                    trial_subscription.connected_squads,
+                )
             else:
                 effects.append("ℹ️ У вас уже есть активная подписка")
         

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -55,7 +55,7 @@ def get_traffic_reset_strategy():
 
 
 class SubscriptionService:
-    
+
     def __init__(self):
         auth_params = settings.get_remnawave_auth_params()
         self.api = RemnaWaveAPI(
@@ -65,10 +65,24 @@ class SubscriptionService:
             username=auth_params["username"],
             password=auth_params["password"]
         )
-    
+
+    @staticmethod
+    def _resolve_subscription_traffic_strategy(subscription: Subscription) -> TrafficLimitStrategy:
+        strategy_value = getattr(subscription, "traffic_reset_strategy", None)
+        if strategy_value:
+            normalized_value = str(strategy_value).upper()
+            try:
+                return TrafficLimitStrategy(normalized_value)
+            except ValueError:
+                try:
+                    return TrafficLimitStrategy[normalized_value]
+                except KeyError:
+                    logger.warning(f"⚠️ Неизвестная стратегия сброса трафика: {strategy_value}, используется значение по умолчанию")
+        return get_traffic_reset_strategy()
+
     async def create_remnawave_user(
-        self, 
-        db: AsyncSession, 
+        self,
+        db: AsyncSession,
         subscription: Subscription
     ) -> Optional[RemnaWaveUser]:
         
@@ -82,7 +96,9 @@ class SubscriptionService:
             if not validation_success:
                 logger.error(f"Ошибка валидации подписки для пользователя {user.telegram_id}")
                 return None
-            
+
+            traffic_strategy = self._resolve_subscription_traffic_strategy(subscription)
+
             async with self.api as api:
                 existing_users = await api.get_user_by_telegram_id(user.telegram_id)
                 if existing_users:
@@ -94,13 +110,13 @@ class SubscriptionService:
                         logger.info(f"🔧 Сброшены HWID устройства для пользователя {user.telegram_id}")
                     except Exception as hwid_error:
                         logger.warning(f"⚠️ Не удалось сбросить HWID: {hwid_error}")
-                    
+
                     updated_user = await api.update_user(
                         uuid=remnawave_user.uuid,
                         status=UserStatus.ACTIVE,
                         expire_at=subscription.end_date,
                         traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                        traffic_limit_strategy=get_traffic_reset_strategy(),
+                        traffic_limit_strategy=traffic_strategy,
                         hwid_device_limit=subscription.device_limit,
                         description=settings.format_remnawave_user_description(
                             full_name=user.full_name,
@@ -118,7 +134,7 @@ class SubscriptionService:
                         expire_at=subscription.end_date,
                         status=UserStatus.ACTIVE,
                         traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                        traffic_limit_strategy=get_traffic_reset_strategy(),
+                        traffic_limit_strategy=traffic_strategy,
                         telegram_id=user.telegram_id,
                         hwid_device_limit=subscription.device_limit,
                         description=settings.format_remnawave_user_description(
@@ -130,14 +146,14 @@ class SubscriptionService:
                     )
                 
                 subscription.remnawave_short_uuid = updated_user.short_uuid
-                subscription.subscription_url = updated_user.subscription_url 
+                subscription.subscription_url = updated_user.subscription_url
                 user.remnawave_uuid = updated_user.uuid
-                
+
                 await db.commit()
-                
+
                 logger.info(f"✅ Создан/обновлен RemnaWave пользователь для подписки {subscription.id}")
                 logger.info(f"🔗 Ссылка на подписку: {updated_user.subscription_url}")
-                strategy_name = settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                strategy_name = traffic_strategy.value
                 logger.info(f"📊 Стратегия сброса трафика: {strategy_name}")
                 return updated_user
                 
@@ -174,12 +190,13 @@ class SubscriptionService:
                 logger.info(f"🔔 Статус подписки {subscription.id} автоматически изменен на 'expired'")
             
             async with self.api as api:
+                traffic_strategy = self._resolve_subscription_traffic_strategy(subscription)
                 updated_user = await api.update_user(
                     uuid=user.remnawave_uuid,
                     status=UserStatus.ACTIVE if is_actually_active else UserStatus.EXPIRED,
                     expire_at=subscription.end_date,
                     traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                    traffic_limit_strategy=get_traffic_reset_strategy(),
+                    traffic_limit_strategy=traffic_strategy,
                     hwid_device_limit=subscription.device_limit,
                     description=settings.format_remnawave_user_description(
                         full_name=user.full_name,
@@ -191,10 +208,10 @@ class SubscriptionService:
                 
                 subscription.subscription_url = updated_user.subscription_url
                 await db.commit()
-                
+
                 status_text = "активным" if is_actually_active else "истёкшим"
                 logger.info(f"✅ Обновлен RemnaWave пользователь {user.remnawave_uuid} со статусом {status_text}")
-                strategy_name = settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                strategy_name = traffic_strategy.value
                 logger.info(f"📊 Стратегия сброса трафика: {strategy_name}")
                 return updated_user
                 

--- a/app/states.py
+++ b/app/states.py
@@ -42,6 +42,10 @@ class AdminStates(StatesGroup):
     setting_promocode_value = State()
     setting_promocode_uses = State()
     setting_promocode_expiry = State()
+    setting_promocode_trial_traffic = State()
+    setting_promocode_trial_devices = State()
+    setting_promocode_trial_reset = State()
+    selecting_promocode_trial_squads = State()
 
     creating_campaign_name = State()
     creating_campaign_start = State()


### PR DESCRIPTION
## Summary
- let admins configure trial promocodes with custom traffic, device limits, reset mode, and squad selection
- persist trial promo parameters on promocodes/subscriptions with universal migration hooks
- honor promocode-provided trial limits when creating RemnaWave subscriptions and during panel sync
