### PR TITLE
Add advanced configuration for trial promo codes

### DIFF
--- a/app/database/crud/promocode.py
+++ b/app/database/crud/promocode.py
@@ -25,16 +25,24 @@ async def create_promocode(
     type: PromoCodeType,
     balance_bonus_kopeks: int = 0,
     subscription_days: int = 0,
+    subscription_traffic_gb: Optional[int] = None,
+    subscription_device_limit: Optional[int] = None,
+    subscription_squads: Optional[List[str]] = None,
+    traffic_reset_strategy: Optional[str] = None,
     max_uses: int = 1,
     valid_until: Optional[datetime] = None,
     created_by: Optional[int] = None
 ) -> PromoCode:
-    
+
     promocode = PromoCode(
         code=code.upper(),
         type=type.value,
         balance_bonus_kopeks=balance_bonus_kopeks,
         subscription_days=subscription_days,
+        subscription_traffic_gb=subscription_traffic_gb,
+        subscription_device_limit=subscription_device_limit,
+        subscription_squads=subscription_squads or [],
+        traffic_reset_strategy=traffic_reset_strategy,
         max_uses=max_uses,
         valid_until=valid_until,
         created_by=created_by

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -41,16 +41,25 @@ async def create_trial_subscription(
     duration_days: int = None,
     traffic_limit_gb: int = None,
     device_limit: int = None,
-    squad_uuid: str = None
+    squad_uuid: str = None,
+    squad_uuids: Optional[List[str]] = None,
+    traffic_reset_strategy: Optional[str] = None,
 ) -> Subscription:
-    
+
     duration_days = duration_days or settings.TRIAL_DURATION_DAYS
     traffic_limit_gb = traffic_limit_gb or settings.TRIAL_TRAFFIC_LIMIT_GB
     device_limit = device_limit or settings.TRIAL_DEVICE_LIMIT
-    squad_uuid = squad_uuid or settings.TRIAL_SQUAD_UUID
-    
+    if squad_uuids is None:
+        if squad_uuid:
+            squad_uuids = [squad_uuid]
+        elif settings.TRIAL_SQUAD_UUID:
+            squad_uuids = [settings.TRIAL_SQUAD_UUID]
+        else:
+            squad_uuids = []
+    traffic_reset_strategy = traffic_reset_strategy or settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+
     end_date = datetime.utcnow() + timedelta(days=duration_days)
-    
+
     subscription = Subscription(
         user_id=user_id,
         status=SubscriptionStatus.ACTIVE.value,
@@ -59,7 +68,8 @@ async def create_trial_subscription(
         end_date=end_date,
         traffic_limit_gb=traffic_limit_gb,
         device_limit=device_limit,
-        connected_squads=[squad_uuid] if squad_uuid else []
+        connected_squads=squad_uuids,
+        traffic_reset_strategy=traffic_reset_strategy,
     )
     
     db.add(subscription)
@@ -76,11 +86,13 @@ async def create_paid_subscription(
     duration_days: int,
     traffic_limit_gb: int = 0, 
     device_limit: int = 1,
-    connected_squads: List[str] = None
+    connected_squads: List[str] = None,
+    traffic_reset_strategy: Optional[str] = None,
 ) -> Subscription:
-    
+
     end_date = datetime.utcnow() + timedelta(days=duration_days)
-    
+    traffic_reset_strategy = traffic_reset_strategy or settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+
     subscription = Subscription(
         user_id=user_id,
         status=SubscriptionStatus.ACTIVE.value,
@@ -89,7 +101,8 @@ async def create_paid_subscription(
         end_date=end_date,
         traffic_limit_gb=traffic_limit_gb,
         device_limit=device_limit,
-        connected_squads=connected_squads or []
+        connected_squads=connected_squads or [],
+        traffic_reset_strategy=traffic_reset_strategy,
     )
     
     db.add(subscription)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -267,8 +267,10 @@ class Subscription(Base):
     subscription_url = Column(String, nullable=True)
     
     device_limit = Column(Integer, default=1)
-    
+
     connected_squads = Column(JSON, default=list)
+
+    traffic_reset_strategy = Column(String(20), default="MONTH")
     
     autopay_enabled = Column(Boolean, default=False)
     autopay_days_before = Column(Integer, default=3)
@@ -473,10 +475,15 @@ class PromoCode(Base):
     code = Column(String(50), unique=True, nullable=False, index=True)
     type = Column(String(50), nullable=False)
     
-    balance_bonus_kopeks = Column(Integer, default=0)  
-    subscription_days = Column(Integer, default=0) 
-    
-    max_uses = Column(Integer, default=1)  
+    balance_bonus_kopeks = Column(Integer, default=0)
+    subscription_days = Column(Integer, default=0)
+    subscription_traffic_gb = Column(Integer, nullable=True)
+    subscription_device_limit = Column(Integer, nullable=True)
+    subscription_squads = Column(JSON, default=list)
+
+    traffic_reset_strategy = Column(String(20), nullable=True)
+
+    max_uses = Column(Integer, default=1)
     current_uses = Column(Integer, default=0)
     
     valid_from = Column(DateTime, default=func.now())

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -38,9 +38,10 @@ def _resolve_discount_percent(
 
     return 0
 
-def get_traffic_reset_strategy():
+def get_traffic_reset_strategy(strategy_name: Optional[str] = None):
     from app.config import settings
-    strategy = settings.DEFAULT_TRAFFIC_RESET_STRATEGY.upper()
+    base_strategy = strategy_name or settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+    strategy = base_strategy.upper()
     
     strategy_mapping = {
         'NO_RESET': 'NO_RESET',
@@ -50,7 +51,9 @@ def get_traffic_reset_strategy():
     }
     
     mapped_strategy = strategy_mapping.get(strategy, 'NO_RESET')
-    logger.info(f"🔄 Стратегия сброса трафика из конфига: {strategy} -> {mapped_strategy}")
+    logger.info(
+        f"🔄 Стратегия сброса трафика: {strategy} -> {mapped_strategy}"
+    )
     return getattr(TrafficLimitStrategy, mapped_strategy)
 
 
@@ -100,7 +103,9 @@ class SubscriptionService:
                         status=UserStatus.ACTIVE,
                         expire_at=subscription.end_date,
                         traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                        traffic_limit_strategy=get_traffic_reset_strategy(),
+                        traffic_limit_strategy=get_traffic_reset_strategy(
+                            subscription.traffic_reset_strategy
+                        ),
                         hwid_device_limit=subscription.device_limit,
                         description=settings.format_remnawave_user_description(
                             full_name=user.full_name,
@@ -118,7 +123,9 @@ class SubscriptionService:
                         expire_at=subscription.end_date,
                         status=UserStatus.ACTIVE,
                         traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                        traffic_limit_strategy=get_traffic_reset_strategy(),
+                        traffic_limit_strategy=get_traffic_reset_strategy(
+                            subscription.traffic_reset_strategy
+                        ),
                         telegram_id=user.telegram_id,
                         hwid_device_limit=subscription.device_limit,
                         description=settings.format_remnawave_user_description(
@@ -137,7 +144,10 @@ class SubscriptionService:
                 
                 logger.info(f"✅ Создан/обновлен RemnaWave пользователь для подписки {subscription.id}")
                 logger.info(f"🔗 Ссылка на подписку: {updated_user.subscription_url}")
-                strategy_name = settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                strategy_name = (
+                    subscription.traffic_reset_strategy
+                    or settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                )
                 logger.info(f"📊 Стратегия сброса трафика: {strategy_name}")
                 return updated_user
                 
@@ -179,7 +189,9 @@ class SubscriptionService:
                     status=UserStatus.ACTIVE if is_actually_active else UserStatus.EXPIRED,
                     expire_at=subscription.end_date,
                     traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                    traffic_limit_strategy=get_traffic_reset_strategy(),
+                    traffic_limit_strategy=get_traffic_reset_strategy(
+                        subscription.traffic_reset_strategy
+                    ),
                     hwid_device_limit=subscription.device_limit,
                     description=settings.format_remnawave_user_description(
                         full_name=user.full_name,
@@ -194,7 +206,10 @@ class SubscriptionService:
                 
                 status_text = "активным" if is_actually_active else "истёкшим"
                 logger.info(f"✅ Обновлен RemnaWave пользователь {user.remnawave_uuid} со статусом {status_text}")
-                strategy_name = settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                strategy_name = (
+                    subscription.traffic_reset_strategy
+                    or settings.DEFAULT_TRAFFIC_RESET_STRATEGY
+                )
                 logger.info(f"📊 Стратегия сброса трафика: {strategy_name}")
                 return updated_user
                 

--- a/app/states.py
+++ b/app/states.py
@@ -42,6 +42,10 @@ class AdminStates(StatesGroup):
     setting_promocode_value = State()
     setting_promocode_uses = State()
     setting_promocode_expiry = State()
+    setting_promocode_trial_devices = State()
+    setting_promocode_trial_traffic = State()
+    setting_promocode_trial_reset = State()
+    selecting_promocode_trial_squads = State()
 
     creating_campaign_name = State()
     creating_campaign_start = State()

--- a/migrations/alembic/versions/d21e72b9c3ab_add_trial_promocode_fields.py
+++ b/migrations/alembic/versions/d21e72b9c3ab_add_trial_promocode_fields.py
@@ -1,0 +1,86 @@
+"""Add trial promocode parameters"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd21e72b9c3ab'
+down_revision: Union[str, None] = '8fd1e338eb45'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PROMOCODES_TABLE = 'promocodes'
+SUBSCRIPTIONS_TABLE = 'subscriptions'
+
+
+def _column_exists(inspector: sa.Inspector, table_name: str, column_name: str) -> bool:
+    return any(column['name'] == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _column_exists(inspector, PROMOCODES_TABLE, 'subscription_traffic_gb'):
+        op.add_column(
+            PROMOCODES_TABLE,
+            sa.Column('subscription_traffic_gb', sa.Integer(), nullable=True)
+        )
+
+    inspector = sa.inspect(bind)
+    if not _column_exists(inspector, PROMOCODES_TABLE, 'subscription_device_limit'):
+        op.add_column(
+            PROMOCODES_TABLE,
+            sa.Column('subscription_device_limit', sa.Integer(), nullable=True)
+        )
+
+    inspector = sa.inspect(bind)
+    if not _column_exists(inspector, PROMOCODES_TABLE, 'subscription_squads'):
+        op.add_column(
+            PROMOCODES_TABLE,
+            sa.Column('subscription_squads', sa.JSON(), nullable=True)
+        )
+
+    inspector = sa.inspect(bind)
+    if not _column_exists(inspector, PROMOCODES_TABLE, 'traffic_reset_strategy'):
+        op.add_column(
+            PROMOCODES_TABLE,
+            sa.Column('traffic_reset_strategy', sa.String(length=20), nullable=True)
+        )
+
+    inspector = sa.inspect(bind)
+    if not _column_exists(inspector, SUBSCRIPTIONS_TABLE, 'traffic_reset_strategy'):
+        op.add_column(
+            SUBSCRIPTIONS_TABLE,
+            sa.Column('traffic_reset_strategy', sa.String(length=20), nullable=True)
+        )
+        op.execute(
+            sa.text(
+                "UPDATE subscriptions SET traffic_reset_strategy = 'MONTH' "
+                "WHERE traffic_reset_strategy IS NULL"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _column_exists(inspector, SUBSCRIPTIONS_TABLE, 'traffic_reset_strategy'):
+        op.drop_column(SUBSCRIPTIONS_TABLE, 'traffic_reset_strategy')
+
+    inspector = sa.inspect(bind)
+    if _column_exists(inspector, PROMOCODES_TABLE, 'traffic_reset_strategy'):
+        op.drop_column(PROMOCODES_TABLE, 'traffic_reset_strategy')
+
+    inspector = sa.inspect(bind)
+    if _column_exists(inspector, PROMOCODES_TABLE, 'subscription_squads'):
+        op.drop_column(PROMOCODES_TABLE, 'subscription_squads')
+
+    inspector = sa.inspect(bind)
+    if _column_exists(inspector, PROMOCODES_TABLE, 'subscription_device_limit'):
+        op.drop_column(PROMOCODES_TABLE, 'subscription_device_limit')
+
+    inspector = sa.inspect(bind)
+    if _column_exists(inspector, PROMOCODES_TABLE, 'subscription_traffic_gb'):
+        op.drop_column(PROMOCODES_TABLE, 'subscription_traffic_gb')


### PR DESCRIPTION
## Summary
- add multi-step trial promo code creation flow to capture devices, traffic, reset strategy, and squad selection
- extend promo code and subscription models plus migration to persist the new trial parameters
- update services to apply the configured trial settings when provisioning subscriptions
