### PR TITLE
Add automated inactivity and post-expiration notifications

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -418,7 +418,9 @@ class Subscription(Base):
     
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
-    
+
+    first_usage_at = Column(DateTime, nullable=True)
+
     remnawave_short_uuid = Column(String(255), nullable=True)
     
     user = relationship("User", back_populates="subscription")

--- a/app/database/universal_migration.py
+++ b/app/database/universal_migration.py
@@ -1189,6 +1189,34 @@ async def add_ticket_sla_columns():
         logger.error(f"Ошибка добавления SLA колонки в tickets: {e}")
         return False
 
+
+async def add_subscription_first_usage_column() -> bool:
+    try:
+        column_exists = await check_column_exists('subscriptions', 'first_usage_at')
+        if column_exists:
+            return True
+
+        async with engine.begin() as conn:
+            db_type = await get_database_type()
+            if db_type == 'sqlite':
+                alter_sql = "ALTER TABLE subscriptions ADD COLUMN first_usage_at DATETIME"
+            elif db_type == 'postgresql':
+                alter_sql = "ALTER TABLE subscriptions ADD COLUMN first_usage_at TIMESTAMP NULL"
+            elif db_type == 'mysql':
+                alter_sql = "ALTER TABLE subscriptions ADD COLUMN first_usage_at DATETIME NULL"
+            else:
+                logger.error(f"Неподдерживаемый тип БД для добавления first_usage_at: {db_type}")
+                return False
+
+            await conn.execute(text(alter_sql))
+            logger.info("✅ Добавлена колонка subscriptions.first_usage_at")
+            return True
+
+    except Exception as e:
+        logger.error(f"Ошибка добавления first_usage_at в subscriptions: {e}")
+        return False
+
+
 async def fix_foreign_keys_for_user_deletion():
     try:
         async with engine.begin() as conn:
@@ -1502,6 +1530,13 @@ async def run_universal_migration():
         else:
             logger.warning("⚠️ Проблемы с добавлением полей SLA в tickets")
 
+        logger.info("=== ДОБАВЛЕНИЕ ПОЛЯ FIRST_USAGE_AT В SUBSCRIPTIONS ===")
+        first_usage_added = await add_subscription_first_usage_column()
+        if first_usage_added:
+            logger.info("✅ Поле first_usage_at в subscriptions готово")
+        else:
+            logger.warning("⚠️ Проблемы с добавлением поля first_usage_at в subscriptions")
+
         logger.info("=== СОЗДАНИЕ ТАБЛИЦЫ АУДИТА ПОДДЕРЖКИ ===")
         try:
             async with engine.begin() as conn:
@@ -1651,6 +1686,7 @@ async def check_migration_status():
             "promo_groups_period_discounts_column": False,
             "promo_groups_auto_assign_column": False,
             "users_auto_promo_group_assigned_column": False,
+            "subscriptions_first_usage_column": False,
         }
         
         status["has_made_first_topup_column"] = await check_column_exists('users', 'has_made_first_topup')
@@ -1666,6 +1702,7 @@ async def check_migration_status():
         status["promo_groups_period_discounts_column"] = await check_column_exists('promo_groups', 'period_discounts')
         status["promo_groups_auto_assign_column"] = await check_column_exists('promo_groups', 'auto_assign_total_spent_kopeks')
         status["users_auto_promo_group_assigned_column"] = await check_column_exists('users', 'auto_promo_group_assigned')
+        status["subscriptions_first_usage_column"] = await check_column_exists('subscriptions', 'first_usage_at')
         
         media_fields_exist = (
             await check_column_exists('broadcast_history', 'has_media') and
@@ -1701,6 +1738,7 @@ async def check_migration_status():
             "promo_groups_period_discounts_column": "Колонка period_discounts у промо-групп",
             "promo_groups_auto_assign_column": "Колонка auto_assign_total_spent_kopeks у промо-групп",
             "users_auto_promo_group_assigned_column": "Флаг автоназначения промогруппы у пользователей",
+            "subscriptions_first_usage_column": "Колонка first_usage_at в subscriptions",
         }
         
         for check_key, check_status in status.items():

--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -920,7 +920,8 @@ def get_monitoring_status_keyboard(
     keyboard.append(info_row)
     
     test_row = [
-        InlineKeyboardButton(text="🧪 Тест уведомлений", callback_data="admin_mon_test_notifications")
+        InlineKeyboardButton(text="🧪 Тест уведомлений", callback_data="admin_mon_test_notifications"),
+        InlineKeyboardButton(text="🔔 Настройки уведомлений", callback_data="admin_mon_toggle_notifications"),
     ]
     keyboard.append(test_row)
     
@@ -943,6 +944,65 @@ def get_monitoring_settings_keyboard() -> InlineKeyboardMarkup:
         [
             InlineKeyboardButton(text="⬅️ К мониторингу", callback_data="admin_monitoring")
         ]
+    ])
+
+
+def get_monitoring_notification_settings_keyboard(settings_data: dict) -> InlineKeyboardMarkup:
+    def _status(enabled: bool) -> str:
+        return "🟢" if enabled else "🔴"
+
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(
+                text=f"{_status(settings_data.get('trial_inactive_1h_enabled'))} Триал · 1 час",
+                callback_data="admin_mon_toggle_notif_trial1h",
+            ),
+            InlineKeyboardButton(
+                text=f"{_status(settings_data.get('trial_inactive_24h_enabled'))} Триал · 24 часа",
+                callback_data="admin_mon_toggle_notif_trial24h",
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"{_status(settings_data.get('expired_day1_enabled'))} Истекла · 1 день",
+                callback_data="admin_mon_toggle_notif_expired_day1",
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"{_status(settings_data.get('expired_day23_enabled'))} Истекла · 2-3 дня",
+                callback_data="admin_mon_toggle_notif_expired_day23",
+            ),
+            InlineKeyboardButton(
+                text=f"✏️ Скидка {settings_data.get('expired_day23_discount_percent', 0)}%",
+                callback_data="admin_mon_edit_notif_day23_discount",
+            ),
+            InlineKeyboardButton(
+                text=f"⏳ {settings_data.get('expired_day23_valid_hours', 0)} ч",
+                callback_data="admin_mon_edit_notif_day23_valid",
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"{_status(settings_data.get('expired_dayn_enabled'))} Истекла · N дней",
+                callback_data="admin_mon_toggle_notif_expired_dayn",
+            ),
+            InlineKeyboardButton(
+                text=f"✏️ Скидка {settings_data.get('expired_dayn_discount_percent', 0)}%",
+                callback_data="admin_mon_edit_notif_dayn_discount",
+            ),
+            InlineKeyboardButton(
+                text=f"⏳ {settings_data.get('expired_dayn_valid_hours', 0)} ч",
+                callback_data="admin_mon_edit_notif_dayn_valid",
+            ),
+            InlineKeyboardButton(
+                text=f"📅 от {settings_data.get('expired_dayn_threshold_days', 0)} дн.",
+                callback_data="admin_mon_edit_notif_dayn_threshold",
+            ),
+        ],
+        [
+            InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_monitoring"),
+        ],
     ])
 
 

--- a/app/services/notification_settings_service.py
+++ b/app/services/notification_settings_service.py
@@ -1,0 +1,216 @@
+"""Runtime storage for user notification preferences."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationSettingsService:
+    """Manage runtime-configurable notification settings.
+
+    Values are stored in ``data/notification_settings.json`` and can be
+    modified from the admin panel without restarting the bot.
+    """
+
+    _storage_path: Path = Path("data/notification_settings.json")
+    _data: Dict[str, Any] = {}
+    _loaded: bool = False
+
+    _defaults: Dict[str, Any] = {
+        "trial_inactive_1h_enabled": True,
+        "trial_inactive_24h_enabled": True,
+        "expired_day1_enabled": True,
+        "expired_day23_enabled": True,
+        "expired_day23_discount_percent": 20,
+        "expired_day23_valid_hours": 24,
+        "expired_dayn_enabled": True,
+        "expired_dayn_discount_percent": 30,
+        "expired_dayn_valid_hours": 24,
+        "expired_dayn_threshold_days": 5,
+    }
+
+    @classmethod
+    def _ensure_storage_dir(cls) -> None:
+        try:
+            cls._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to create notification settings directory: %s", exc)
+
+    @classmethod
+    def _load(cls) -> None:
+        if cls._loaded:
+            return
+
+        cls._ensure_storage_dir()
+        if cls._storage_path.exists():
+            try:
+                cls._data = json.loads(cls._storage_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.error("Failed to load notification settings: %s", exc)
+                cls._data = {}
+        else:
+            cls._data = {}
+
+        cls._loaded = True
+
+    @classmethod
+    def _save(cls) -> bool:
+        cls._ensure_storage_dir()
+        try:
+            cls._storage_path.write_text(
+                json.dumps(cls._data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to save notification settings: %s", exc)
+            return False
+
+    # Helper accessors -----------------------------------------------------
+    @classmethod
+    def _get_bool(cls, key: str) -> bool:
+        cls._load()
+        if key in cls._data:
+            return bool(cls._data[key])
+        return bool(cls._defaults.get(key, False))
+
+    @classmethod
+    def _set_bool(cls, key: str, value: bool) -> bool:
+        cls._load()
+        cls._data[key] = bool(value)
+        return cls._save()
+
+    @classmethod
+    def _get_int(cls, key: str) -> int:
+        cls._load()
+        if key in cls._data:
+            try:
+                return int(cls._data[key])
+            except (TypeError, ValueError):
+                pass
+        return int(cls._defaults.get(key, 0))
+
+    @classmethod
+    def _set_int(cls, key: str, value: int) -> bool:
+        cls._load()
+        cls._data[key] = int(value)
+        return cls._save()
+
+    @classmethod
+    def get_all(cls) -> Dict[str, Any]:
+        cls._load()
+        data = {**cls._defaults, **cls._data}
+        # cast ints to ensure consistent types
+        int_keys = [
+            "expired_day23_discount_percent",
+            "expired_day23_valid_hours",
+            "expired_dayn_discount_percent",
+            "expired_dayn_valid_hours",
+            "expired_dayn_threshold_days",
+        ]
+        for key in int_keys:
+            try:
+                data[key] = int(data[key])
+            except (TypeError, ValueError):
+                data[key] = int(cls._defaults[key])
+        bool_keys = [
+            "trial_inactive_1h_enabled",
+            "trial_inactive_24h_enabled",
+            "expired_day1_enabled",
+            "expired_day23_enabled",
+            "expired_dayn_enabled",
+        ]
+        for key in bool_keys:
+            data[key] = bool(data.get(key, cls._defaults[key]))
+        return data
+
+    # Trial inactivity -----------------------------------------------------
+    @classmethod
+    def is_trial_inactive_1h_enabled(cls) -> bool:
+        return cls._get_bool("trial_inactive_1h_enabled")
+
+    @classmethod
+    def set_trial_inactive_1h_enabled(cls, enabled: bool) -> bool:
+        return cls._set_bool("trial_inactive_1h_enabled", enabled)
+
+    @classmethod
+    def is_trial_inactive_24h_enabled(cls) -> bool:
+        return cls._get_bool("trial_inactive_24h_enabled")
+
+    @classmethod
+    def set_trial_inactive_24h_enabled(cls, enabled: bool) -> bool:
+        return cls._set_bool("trial_inactive_24h_enabled", enabled)
+
+    # Expired subscription follow-ups -------------------------------------
+    @classmethod
+    def is_expired_day1_enabled(cls) -> bool:
+        return cls._get_bool("expired_day1_enabled")
+
+    @classmethod
+    def set_expired_day1_enabled(cls, enabled: bool) -> bool:
+        return cls._set_bool("expired_day1_enabled", enabled)
+
+    @classmethod
+    def is_expired_day23_enabled(cls) -> bool:
+        return cls._get_bool("expired_day23_enabled")
+
+    @classmethod
+    def set_expired_day23_enabled(cls, enabled: bool) -> bool:
+        return cls._set_bool("expired_day23_enabled", enabled)
+
+    @classmethod
+    def get_expired_day23_discount_percent(cls) -> int:
+        return max(0, min(100, cls._get_int("expired_day23_discount_percent")))
+
+    @classmethod
+    def set_expired_day23_discount_percent(cls, percent: int) -> bool:
+        percent = max(0, min(100, int(percent)))
+        return cls._set_int("expired_day23_discount_percent", percent)
+
+    @classmethod
+    def get_expired_day23_valid_hours(cls) -> int:
+        return max(1, cls._get_int("expired_day23_valid_hours"))
+
+    @classmethod
+    def set_expired_day23_valid_hours(cls, hours: int) -> bool:
+        hours = max(1, int(hours))
+        return cls._set_int("expired_day23_valid_hours", hours)
+
+    @classmethod
+    def is_expired_dayn_enabled(cls) -> bool:
+        return cls._get_bool("expired_dayn_enabled")
+
+    @classmethod
+    def set_expired_dayn_enabled(cls, enabled: bool) -> bool:
+        return cls._set_bool("expired_dayn_enabled", enabled)
+
+    @classmethod
+    def get_expired_dayn_discount_percent(cls) -> int:
+        return max(0, min(100, cls._get_int("expired_dayn_discount_percent")))
+
+    @classmethod
+    def set_expired_dayn_discount_percent(cls, percent: int) -> bool:
+        percent = max(0, min(100, int(percent)))
+        return cls._set_int("expired_dayn_discount_percent", percent)
+
+    @classmethod
+    def get_expired_dayn_valid_hours(cls) -> int:
+        return max(1, cls._get_int("expired_dayn_valid_hours"))
+
+    @classmethod
+    def set_expired_dayn_valid_hours(cls, hours: int) -> bool:
+        hours = max(1, int(hours))
+        return cls._set_int("expired_dayn_valid_hours", hours)
+
+    @classmethod
+    def get_expired_dayn_threshold_days(cls) -> int:
+        return max(4, cls._get_int("expired_dayn_threshold_days"))
+
+    @classmethod
+    def set_expired_dayn_threshold_days(cls, days: int) -> bool:
+        days = max(4, int(days))
+        return cls._set_int("expired_dayn_threshold_days", days)

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -268,12 +268,15 @@ class SubscriptionService:
                 remnawave_user = await api.get_user_by_uuid(user.remnawave_uuid)
                 if not remnawave_user:
                     return False
-                
+
                 used_gb = self._bytes_to_gb(remnawave_user.used_traffic_bytes)
                 subscription.traffic_used_gb = used_gb
-                
+
+                if used_gb > 0 and not subscription.first_usage_at:
+                    subscription.first_usage_at = datetime.utcnow()
+
                 await db.commit()
-                
+
                 logger.debug(f"Синхронизирован трафик для подписки {subscription.id}: {used_gb} ГБ")
                 return True
                 

--- a/app/states.py
+++ b/app/states.py
@@ -121,6 +121,10 @@ class AdminTicketStates(StatesGroup):
 class SupportSettingsStates(StatesGroup):
     waiting_for_desc = State()
 
+
+class NotificationSettingsStates(StatesGroup):
+    waiting_for_value = State()
+
 class AutoPayStates(StatesGroup):
     setting_autopay_days = State()
     confirming_autopay_toggle = State()


### PR DESCRIPTION
## Summary
- add runtime-configurable notification settings service with admin UI controls
- introduce first_usage_at tracking for subscriptions and trigger trial inactivity reminders
- send staged renewal offers after expiry including discount messaging and logging