### PR TITLE
Limit unknown message handler to default state

### DIFF
--- a/app/handlers/common.py
+++ b/app/handlers/common.py
@@ -1,5 +1,6 @@
 import logging
 from aiogram import Dispatcher, types, F
+from aiogram.filters import StateFilter
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -124,6 +125,7 @@ def register_handlers(dp: Dispatcher):
     # чтобы их обработка не прерывалась общим хендлером неизвестных сообщений
     dp.message.register(
         handle_unknown_message,
+        StateFilter(None),
         F.successful_payment.is_(None)
     )
     


### PR DESCRIPTION
## Summary
- ensure the fallback unknown-message handler only triggers when no FSM state is active by adding a StateFilter
