### PR TITLE
Allow admins to bypass channel subscription check

### DIFF
--- a/app/middlewares/channel_checker.py
+++ b/app/middlewares/channel_checker.py
@@ -49,6 +49,16 @@ class ChannelCheckerMiddleware(BaseMiddleware):
             return await handler(event, data)
 
 
+        # Админам разрешаем пропускать проверку подписки, чтобы не блокировать
+        # работу панели управления даже при отсутствии подписки. Важно делать
+        # это до обращения к состоянию, чтобы не выполнять лишние операции.
+        if settings.is_admin(telegram_id):
+            logger.debug(
+                "✅ Пользователь %s является администратором — пропускаем проверку подписки",
+                telegram_id,
+            )
+            return await handler(event, data)
+
         state: FSMContext = data.get('state')
         current_state = None
 


### PR DESCRIPTION
## Summary
- skip the channel subscription middleware for administrator accounts so they can manage monitoring settings without being forced to subscribe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d389f86fa0832082d4b7f5c1cd7077