### PR TITLE
Restrict admin server selection by promo group

### DIFF
--- a/app/database/crud/promo_group.py
+++ b/app/database/crud/promo_group.py
@@ -40,6 +40,15 @@ async def get_promo_groups_with_counts(
     return result.all()
 
 
+async def get_all_promo_groups(db: AsyncSession) -> List[PromoGroup]:
+    result = await db.execute(
+        select(PromoGroup).order_by(
+            PromoGroup.is_default.desc(), PromoGroup.name
+        )
+    )
+    return result.scalars().all()
+
+
 async def get_promo_group_by_id(db: AsyncSession, group_id: int) -> Optional[PromoGroup]:
     return await db.get(PromoGroup, group_id)
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     BigInteger,
     UniqueConstraint,
     Index,
+    Table,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, Mapped, mapped_column
@@ -263,6 +264,25 @@ class Pal24Payment(Base):
         )
 
 
+server_squad_promo_groups = Table(
+    "server_squad_promo_groups",
+    Base.metadata,
+    Column(
+        "server_squad_id",
+        Integer,
+        ForeignKey("server_squads.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "promo_group_id",
+        Integer,
+        ForeignKey("promo_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("created_at", DateTime, server_default=func.now()),
+)
+
+
 class PromoGroup(Base):
     __tablename__ = "promo_groups"
 
@@ -278,6 +298,11 @@ class PromoGroup(Base):
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 
     users = relationship("User", back_populates="promo_group")
+    server_squads = relationship(
+        "ServerSquad",
+        secondary="server_squad_promo_groups",
+        back_populates="promo_groups",
+    )
 
     def _get_period_discounts_map(self) -> Dict[int, int]:
         raw_discounts = self.period_discounts or {}
@@ -812,7 +837,7 @@ class BroadcastHistory(Base):
 
 class ServerSquad(Base):
     __tablename__ = "server_squads"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     
     squad_uuid = Column(String(255), unique=True, nullable=False, index=True)
@@ -832,10 +857,16 @@ class ServerSquad(Base):
     sort_order = Column(Integer, default=0)
     
     max_users = Column(Integer, nullable=True) 
-    current_users = Column(Integer, default=0) 
-    
+    current_users = Column(Integer, default=0)
+
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    promo_groups = relationship(
+        "PromoGroup",
+        secondary="server_squad_promo_groups",
+        back_populates="server_squads",
+    )
     
     @property
     def price_rubles(self) -> float:

--- a/app/handlers/admin/servers.py
+++ b/app/handlers/admin/servers.py
@@ -4,17 +4,192 @@ from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.states import AdminStates
-from app.database.models import User
+from app.database.models import User, ServerSquad
 from app.database.crud.server_squad import (
-    get_all_server_squads, get_server_squad_by_id, update_server_squad,
-    delete_server_squad, sync_with_remnawave, get_server_statistics,
-    create_server_squad, get_available_server_squads
+    get_all_server_squads,
+    get_server_squad_by_id,
+    update_server_squad,
+    delete_server_squad,
+    sync_with_remnawave,
+    get_server_statistics,
+    create_server_squad,
+    get_available_server_squads,
+    set_server_squad_promo_groups,
 )
+from app.database.crud.promo_group import get_all_promo_groups
 from app.services.remnawave_service import RemnaWaveService
 from app.utils.decorators import admin_required, error_handler
-from app.utils.cache import cache
+from app.utils.cache import cache, invalidate_available_countries_cache
 
 logger = logging.getLogger(__name__)
+
+
+def _format_server_promo_groups(server: ServerSquad) -> str:
+    if not server.promo_groups:
+        return "—"
+
+    sorted_groups = sorted(
+        server.promo_groups,
+        key=lambda group: (
+            not getattr(group, "is_default", False),
+            group.name.lower(),
+        ),
+    )
+
+    formatted = []
+    for group in sorted_groups:
+        label = group.name
+        if getattr(group, "is_default", False):
+            label = f"{label} ⭐"
+        formatted.append(label)
+
+    return ", ".join(formatted)
+
+
+def _build_server_edit_view(server: ServerSquad):
+    status_emoji = "✅ Доступен" if server.is_available else "❌ Недоступен"
+    price_text = (
+        f"{int(server.price_rubles)} ₽" if server.price_kopeks > 0 else "Бесплатно"
+    )
+    promo_groups_text = _format_server_promo_groups(server)
+
+    text = f"""
+🌐 <b>Редактирование сервера</b>
+
+<b>Информация:</b>
+• ID: {server.id}
+• UUID: <code>{server.squad_uuid}</code>
+• Название: {server.display_name}
+• Оригинальное: {server.original_name or 'Не указано'}
+• Статус: {status_emoji}
+
+<b>Настройки:</b>
+• Цена: {price_text}
+• Код страны: {server.country_code or 'Не указан'}
+• Лимит пользователей: {server.max_users or 'Без лимита'}
+• Текущих пользователей: {server.current_users}
+• Промогруппы: {promo_groups_text}
+
+<b>Описание:</b>
+{server.description or 'Не указано'}
+
+Выберите что изменить:
+"""
+
+    keyboard = [
+        [
+            types.InlineKeyboardButton(
+                text="✏️ Название",
+                callback_data=f"admin_server_edit_name_{server.id}",
+            ),
+            types.InlineKeyboardButton(
+                text="💰 Цена",
+                callback_data=f"admin_server_edit_price_{server.id}",
+            ),
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="🌍 Страна",
+                callback_data=f"admin_server_edit_country_{server.id}",
+            ),
+            types.InlineKeyboardButton(
+                text="👥 Лимит",
+                callback_data=f"admin_server_edit_limit_{server.id}",
+            ),
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="🎯 Промогруппы",
+                callback_data=f"admin_server_edit_promos_{server.id}",
+            )
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="📝 Описание",
+                callback_data=f"admin_server_edit_desc_{server.id}",
+            )
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="❌ Отключить" if server.is_available else "✅ Включить",
+                callback_data=f"admin_server_toggle_{server.id}",
+            )
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="🗑️ Удалить", callback_data=f"admin_server_delete_{server.id}"
+            ),
+            types.InlineKeyboardButton(
+                text="⬅️ Назад", callback_data="admin_servers_list"
+            ),
+        ],
+    ]
+
+    return text, types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def _build_server_promo_groups_keyboard(
+    server_id: int,
+    promo_groups,
+    selected_ids: set,
+):
+    buttons = []
+
+    for group in promo_groups:
+        is_selected = group.id in selected_ids
+        emoji = "✅" if is_selected else "⚪"
+        label = group.name
+        if getattr(group, "is_default", False):
+            label = f"{label} ⭐"
+
+        buttons.append(
+            [
+                types.InlineKeyboardButton(
+                    text=f"{emoji} {label}",
+                    callback_data=f"admin_server_promos_toggle_{server_id}_{group.id}",
+                )
+            ]
+        )
+
+    buttons.append(
+        [
+            types.InlineKeyboardButton(
+                text="💾 Сохранить",
+                callback_data=f"admin_server_promos_save_{server_id}",
+            )
+        ]
+    )
+    buttons.append(
+        [
+            types.InlineKeyboardButton(
+                text="⬅️ Назад", callback_data=f"admin_server_edit_{server_id}"
+            )
+        ]
+    )
+
+    return types.InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def _build_server_promo_groups_text(
+    server: ServerSquad,
+    promo_groups,
+    selected_ids: set,
+) -> str:
+    selected_names = [
+        group.name
+        for group in promo_groups
+        if group.id in selected_ids
+    ]
+
+    selected_display = ", ".join(selected_names) if selected_names else "не выбраны"
+
+    return (
+        "🎯 <b>Промогруппы сервера</b>\n\n"
+        f"Сервер: <b>{server.display_name}</b>\n"
+        "Выберите промогруппы, которым будет доступен этот сервер.\n\n"
+        f"<b>Сейчас выбрано:</b> {selected_display}\n\n"
+        "⚠️ Должна быть активна минимум одна промогруппа."
+    )
 
 
 @admin_required
@@ -165,8 +340,8 @@ async def sync_servers_with_remnawave(
             return
         
         created, updated, disabled = await sync_with_remnawave(db, squads)
-        
-        await cache.delete("available_countries")
+
+        await invalidate_available_countries_cache()
         
         text = f"""
 ✅ <b>Синхронизация завершена</b>
@@ -210,70 +385,26 @@ async def sync_servers_with_remnawave(
 @error_handler
 async def show_server_edit_menu(
     callback: types.CallbackQuery,
+    state: FSMContext,
     db_user: User,
-    db: AsyncSession
+    db: AsyncSession,
 ):
-    
+
     server_id = int(callback.data.split('_')[-1])
     server = await get_server_squad_by_id(db, server_id)
-    
+
     if not server:
         await callback.answer("❌ Сервер не найден!", show_alert=True)
         return
-    
-    status_emoji = "✅ Доступен" if server.is_available else "❌ Недоступен"
-    price_text = f"{int(server.price_rubles)} ₽" if server.price_kopeks > 0 else "Бесплатно"
-    
-    text = f"""
-🌐 <b>Редактирование сервера</b>
 
-<b>Информация:</b>
-• ID: {server.id}
-• UUID: <code>{server.squad_uuid}</code>
-• Название: {server.display_name}
-• Оригинальное: {server.original_name or 'Не указано'}
-• Статус: {status_emoji}
+    await state.clear()
 
-<b>Настройки:</b>
-• Цена: {price_text}
-• Код страны: {server.country_code or 'Не указан'}
-• Лимит пользователей: {server.max_users or 'Без лимита'}
-• Текущих пользователей: {server.current_users}
+    text, markup = _build_server_edit_view(server)
 
-<b>Описание:</b>
-{server.description or 'Не указано'}
-
-Выберите что изменить:
-"""
-    
-    keyboard = [
-        [
-            types.InlineKeyboardButton(text="✏️ Название", callback_data=f"admin_server_edit_name_{server.id}"),
-            types.InlineKeyboardButton(text="💰 Цена", callback_data=f"admin_server_edit_price_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(text="🌍 Страна", callback_data=f"admin_server_edit_country_{server.id}"),
-            types.InlineKeyboardButton(text="👥 Лимит", callback_data=f"admin_server_edit_limit_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(text="📝 Описание", callback_data=f"admin_server_edit_desc_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(
-                text="❌ Отключить" if server.is_available else "✅ Включить",
-                callback_data=f"admin_server_toggle_{server.id}"
-            )
-        ],
-        [
-            types.InlineKeyboardButton(text="🗑️ Удалить", callback_data=f"admin_server_delete_{server.id}"),
-            types.InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_servers_list")
-        ]
-    ]
-    
     await callback.message.edit_text(
         text,
-        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
-        parse_mode="HTML"
+        reply_markup=markup,
+        parse_mode="HTML",
     )
     await callback.answer()
 
@@ -295,68 +426,170 @@ async def toggle_server_availability(
     
     new_status = not server.is_available
     await update_server_squad(db, server_id, is_available=new_status)
-    
-    await cache.delete("available_countries")
+
+    await invalidate_available_countries_cache()
     
     status_text = "включен" if new_status else "отключен"
     await callback.answer(f"✅ Сервер {status_text}!")
-    
+
     server = await get_server_squad_by_id(db, server_id)
-    
-    status_emoji = "✅ Доступен" if server.is_available else "❌ Недоступен"
-    price_text = f"{int(server.price_rubles)} ₽" if server.price_kopeks > 0 else "Бесплатно"
-    
-    text = f"""
-🌐 <b>Редактирование сервера</b>
 
-<b>Информация:</b>
-• ID: {server.id}
-• UUID: <code>{server.squad_uuid}</code>
-• Название: {server.display_name}
-• Оригинальное: {server.original_name or 'Не указано'}
-• Статус: {status_emoji}
+    text, markup = _build_server_edit_view(server)
 
-<b>Настройки:</b>
-• Цена: {price_text}
-• Код страны: {server.country_code or 'Не указан'}
-• Лимит пользователей: {server.max_users or 'Без лимита'}
-• Текущих пользователей: {server.current_users}
-
-<b>Описание:</b>
-{server.description or 'Не указано'}
-
-Выберите что изменить:
-"""
-    
-    keyboard = [
-        [
-            types.InlineKeyboardButton(text="✏️ Название", callback_data=f"admin_server_edit_name_{server.id}"),
-            types.InlineKeyboardButton(text="💰 Цена", callback_data=f"admin_server_edit_price_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(text="🌍 Страна", callback_data=f"admin_server_edit_country_{server.id}"),
-            types.InlineKeyboardButton(text="👥 Лимит", callback_data=f"admin_server_edit_limit_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(text="📝 Описание", callback_data=f"admin_server_edit_desc_{server.id}")
-        ],
-        [
-            types.InlineKeyboardButton(
-                text="❌ Отключить" if server.is_available else "✅ Включить",
-                callback_data=f"admin_server_toggle_{server.id}"
-            )
-        ],
-        [
-            types.InlineKeyboardButton(text="🗑️ Удалить", callback_data=f"admin_server_delete_{server.id}"),
-            types.InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_servers_list")
-        ]
-    ]
-    
     await callback.message.edit_text(
         text,
-        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
-        parse_mode="HTML"
+        reply_markup=markup,
+        parse_mode="HTML",
     )
+
+
+@admin_required
+@error_handler
+async def start_edit_server_promo_groups(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    db_user: User,
+    db: AsyncSession,
+):
+
+    server_id = int(callback.data.split('_')[-1])
+    server = await get_server_squad_by_id(db, server_id)
+
+    if not server:
+        await callback.answer("❌ Сервер не найден!", show_alert=True)
+        return
+
+    promo_groups = await get_all_promo_groups(db)
+
+    if not promo_groups:
+        await callback.answer("⚠️ Нет доступных промогрупп", show_alert=True)
+        return
+
+    selected_ids = {
+        group.id for group in server.promo_groups if group.id is not None
+    }
+
+    if not selected_ids:
+        selected_ids.add(promo_groups[0].id)
+
+    await state.set_state(AdminStates.editing_server_promo_groups)
+    await state.set_data(
+        {
+            "server_id": server_id,
+            "promo_groups": list(selected_ids),
+        }
+    )
+
+    text = _build_server_promo_groups_text(server, promo_groups, selected_ids)
+    keyboard = _build_server_promo_groups_keyboard(server_id, promo_groups, selected_ids)
+
+    await callback.message.edit_text(
+        text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def toggle_server_promo_group(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    db_user: User,
+    db: AsyncSession,
+):
+
+    parts = callback.data.split('_')
+
+    try:
+        server_id = int(parts[-2])
+        group_id = int(parts[-1])
+    except (ValueError, IndexError):
+        await callback.answer("❌ Некорректные данные", show_alert=True)
+        return
+
+    data = await state.get_data()
+
+    if data.get("server_id") != server_id:
+        data["server_id"] = server_id
+
+    selected_ids = set(int(i) for i in data.get("promo_groups", []))
+
+    if group_id in selected_ids:
+        if len(selected_ids) == 1:
+            await callback.answer(
+                "⚠️ Должна быть выбрана минимум одна промогруппа",
+                show_alert=True,
+            )
+            return
+        selected_ids.remove(group_id)
+    else:
+        selected_ids.add(group_id)
+
+    await state.update_data(
+        {
+            "server_id": server_id,
+            "promo_groups": list(selected_ids),
+        }
+    )
+
+    server = await get_server_squad_by_id(db, server_id)
+    promo_groups = await get_all_promo_groups(db)
+
+    if not server or not promo_groups:
+        await callback.answer("❌ Не удалось обновить данные", show_alert=True)
+        return
+
+    text = _build_server_promo_groups_text(server, promo_groups, selected_ids)
+    keyboard = _build_server_promo_groups_keyboard(server_id, promo_groups, selected_ids)
+
+    await callback.message.edit_text(
+        text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def save_server_promo_groups(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    db_user: User,
+    db: AsyncSession,
+):
+
+    data = await state.get_data()
+    server_id = int(data.get("server_id", 0))
+    promo_group_ids = [int(i) for i in data.get("promo_groups", []) if i]
+
+    if not server_id:
+        await callback.answer("❌ Сервер не найден", show_alert=True)
+        return
+
+    if not promo_group_ids:
+        await callback.answer("⚠️ Выберите хотя бы одну промогруппу", show_alert=True)
+        return
+
+    server = await set_server_squad_promo_groups(db, server_id, promo_group_ids)
+
+    if not server:
+        await callback.answer("❌ Не удалось обновить промогруппы", show_alert=True)
+        return
+
+    await state.clear()
+    await invalidate_available_countries_cache()
+
+    text, markup = _build_server_edit_view(server)
+
+    await callback.message.edit_text(
+        text,
+        reply_markup=markup,
+        parse_mode="HTML",
+    )
+    await callback.answer("✅ Промогруппы обновлены")
 
 
 @admin_required
@@ -418,11 +651,11 @@ async def process_server_price_edit(
         price_kopeks = int(price_rubles * 100)
         
         server = await update_server_squad(db, server_id, price_kopeks=price_kopeks)
-        
+
         if server:
             await state.clear()
-            
-            await cache.delete("available_countries")
+
+            await invalidate_available_countries_cache()
             
             price_text = f"{int(price_rubles)} ₽" if price_kopeks > 0 else "Бесплатно"
             await message.answer(
@@ -493,11 +726,11 @@ async def process_server_name_edit(
         return
     
     server = await update_server_squad(db, server_id, display_name=new_name)
-    
+
     if server:
         await state.clear()
-        
-        await cache.delete("available_countries")
+
+        await invalidate_available_countries_cache()
         
         await message.answer(
             f"✅ Название сервера изменено на: <b>{new_name}</b>",
@@ -568,9 +801,9 @@ async def delete_server_execute(
         return
     
     success = await delete_server_squad(db, server_id)
-    
+
     if success:
-        await cache.delete("available_countries")
+        await invalidate_available_countries_cache()
         
         await callback.message.edit_text(
             f"✅ Сервер <b>{server.display_name}</b> успешно удален!",
@@ -697,11 +930,11 @@ async def process_server_country_edit(
         return
     
     server = await update_server_squad(db, server_id, country_code=new_country)
-    
+
     if server:
         await state.clear()
-        
-        await cache.delete("available_countries")
+
+        await invalidate_available_countries_cache()
         
         country_text = new_country or "Удален"
         await message.answer(
@@ -934,8 +1167,28 @@ def register_handlers(dp: Dispatcher):
     dp.callback_query.register(sync_server_user_counts_handler, F.data == "admin_servers_sync_counts")
     dp.callback_query.register(show_server_detailed_stats, F.data == "admin_servers_stats")
     
-    dp.callback_query.register(show_server_edit_menu, F.data.startswith("admin_server_edit_") & ~F.data.contains("name") & ~F.data.contains("price") & ~F.data.contains("country") & ~F.data.contains("limit") & ~F.data.contains("desc"))
+    dp.callback_query.register(
+        show_server_edit_menu,
+        F.data.startswith("admin_server_edit_")
+        & ~F.data.contains("name")
+        & ~F.data.contains("price")
+        & ~F.data.contains("country")
+        & ~F.data.contains("limit")
+        & ~F.data.contains("desc")
+        & ~F.data.contains("promos"),
+    )
     dp.callback_query.register(toggle_server_availability, F.data.startswith("admin_server_toggle_"))
+    dp.callback_query.register(start_edit_server_promo_groups, F.data.startswith("admin_server_edit_promos_"))
+    dp.callback_query.register(
+        toggle_server_promo_group,
+        F.data.startswith("admin_server_promos_toggle_"),
+        state=AdminStates.editing_server_promo_groups,
+    )
+    dp.callback_query.register(
+        save_server_promo_groups,
+        F.data.startswith("admin_server_promos_save_"),
+        state=AdminStates.editing_server_promo_groups,
+    )
     
     dp.callback_query.register(start_server_edit_name, F.data.startswith("admin_server_edit_name_"))
     dp.callback_query.register(start_server_edit_price, F.data.startswith("admin_server_edit_price_"))

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime, timedelta
+from typing import List, Optional, Sequence, Set, Tuple
+
 from aiogram import Dispatcher, types, F
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
@@ -7,7 +9,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.states import AdminStates
-from app.database.models import User, UserStatus, Subscription, SubscriptionStatus, TransactionType 
+from app.database.models import (
+    User,
+    UserStatus,
+    Subscription,
+    SubscriptionStatus,
+    TransactionType,
+    ServerSquad,
+)
 from app.database.crud.user import get_user_by_id
 from app.database.crud.campaign import (
     get_campaign_registration_by_user,
@@ -25,7 +34,11 @@ from app.utils.decorators import admin_required, error_handler
 from app.utils.formatters import format_datetime, format_time_ago
 from app.services.remnawave_service import RemnaWaveService
 from app.external.remnawave_api import TrafficLimitStrategy
-from app.database.crud.server_squad import get_all_server_squads, get_server_squad_by_uuid, get_server_squad_by_id
+from app.database.crud.server_squad import (
+    get_all_server_squads,
+    get_server_squad_by_uuid,
+    get_server_squad_by_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1871,6 +1884,122 @@ async def show_server_selection(
     await _show_servers_for_user(callback, user_id, db)
     await callback.answer()
 
+def _is_server_allowed_for_user(server: ServerSquad, user: Optional[User]) -> bool:
+    promo_groups = list(getattr(server, "promo_groups", []) or [])
+
+    if not promo_groups:
+        return True
+
+    user_group_id = getattr(user, "promo_group_id", None)
+
+    if user_group_id is None:
+        return any(getattr(group, "is_default", False) for group in promo_groups)
+
+    return any(group.id == user_group_id for group in promo_groups)
+
+
+def _prepare_server_choices_for_user(
+    user: Optional[User],
+    servers: Sequence[ServerSquad],
+    current_squads: Set[str],
+) -> List[Tuple[ServerSquad, bool, bool]]:
+    selected_restricted: List[Tuple[ServerSquad, bool, bool]] = []
+    selected_allowed: List[Tuple[ServerSquad, bool, bool]] = []
+    available_allowed: List[Tuple[ServerSquad, bool, bool]] = []
+    inactive_allowed: List[Tuple[ServerSquad, bool, bool]] = []
+
+    for server in servers:
+        is_selected = server.squad_uuid in current_squads
+        is_allowed = _is_server_allowed_for_user(server, user)
+
+        if is_selected and not is_allowed:
+            selected_restricted.append((server, True, False))
+        elif is_selected:
+            selected_allowed.append((server, True, True))
+        elif not is_allowed:
+            continue
+        elif server.is_available:
+            available_allowed.append((server, False, True))
+        else:
+            inactive_allowed.append((server, False, True))
+
+    return selected_restricted + selected_allowed + available_allowed + inactive_allowed
+
+
+def _build_server_selection_view(
+    user: Optional[User],
+    servers: Sequence[ServerSquad],
+    current_squads: Set[str],
+    user_id: int,
+    limit: int,
+) -> Tuple[Optional[str], Optional[types.InlineKeyboardMarkup], bool]:
+    prepared = _prepare_server_choices_for_user(user, servers, current_squads)
+
+    if not prepared:
+        return None, None, False
+
+    has_restricted = any(not is_allowed for _, _, is_allowed in prepared)
+
+    text_lines = [
+        "🌍 <b>Управление серверами</b>",
+        "",
+        "Нажмите на сервер чтобы добавить/убрать:",
+        "✅ - выбранный сервер",
+        "⚪ - доступный сервер",
+    ]
+
+    if has_restricted:
+        text_lines.append(
+            "🚫 - недоступен для промогруппы пользователя (можно только отключить)"
+        )
+
+    text_lines.append("🔒 - неактивный (только для уже назначенных)")
+    text_lines.append("")
+
+    rows: List[List[types.InlineKeyboardButton]] = []
+
+    for server, is_selected, is_allowed in prepared[:limit]:
+        if is_selected and not is_allowed:
+            emoji = "🚫"
+            label = f"{server.display_name} (недоступен)"
+        elif is_selected:
+            emoji = "✅"
+            label = server.display_name
+        elif server.is_available:
+            emoji = "⚪"
+            label = server.display_name
+        else:
+            emoji = "🔒"
+            label = f"{server.display_name} (неактивен)"
+
+        rows.append([
+            types.InlineKeyboardButton(
+                text=f"{emoji} {label}",
+                callback_data=f"admin_user_toggle_server_{user_id}_{server.id}",
+            )
+        ])
+
+    if len(prepared) > limit:
+        text_lines.append(
+            f"📝 Показано первых {limit} из {len(prepared)} серверов"
+        )
+        text_lines.append("")
+
+    rows.append([
+        types.InlineKeyboardButton(
+            text="✅ Готово", callback_data=f"admin_user_subscription_{user_id}"
+        ),
+        types.InlineKeyboardButton(
+            text="⬅️ Назад", callback_data=f"admin_user_subscription_{user_id}"
+        ),
+    ])
+
+    markup = types.InlineKeyboardMarkup(inline_keyboard=rows)
+    text = "\n".join(text_lines)
+
+    return text, markup, True
+
+
 async def _show_servers_for_user(
     callback: types.CallbackQuery,
     user_id: int,
@@ -1878,71 +2007,38 @@ async def _show_servers_for_user(
 ):
     try:
         user = await get_user_by_id(db, user_id)
-        current_squads = []
+        current_squads_list: List[str] = []
         if user and user.subscription:
-            current_squads = user.subscription.connected_squads or []
-        
+            current_squads_list = list(user.subscription.connected_squads or [])
+
+        current_squads = set(current_squads_list)
         all_servers, _ = await get_all_server_squads(db, available_only=False)
-        
-        servers_to_show = []
-        for server in all_servers:
-            if server.is_available or server.squad_uuid in current_squads:
-                servers_to_show.append(server)
-        
-        if not servers_to_show:
+
+        text, markup, has_servers = _build_server_selection_view(
+            user,
+            all_servers,
+            current_squads,
+            user_id,
+            limit=20,
+        )
+
+        if not has_servers:
             await callback.message.edit_text(
-                "❌ Доступные серверы не найдены",
+                "❌ Не найдено серверов для текущей промогруппы",
                 reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[
-                    [types.InlineKeyboardButton(text="⬅️ Назад", callback_data=f"admin_user_subscription_{user_id}")]
-                ])
+                    [
+                        types.InlineKeyboardButton(
+                            text="⬅️ Назад",
+                            callback_data=f"admin_user_subscription_{user_id}",
+                        )
+                    ]
+                ]),
             )
             return
-        
-        text = f"🌍 <b>Управление серверами</b>\n\n"
-        text += f"Нажмите на сервер чтобы добавить/убрать:\n"
-        text += f"✅ - выбранный сервер\n"
-        text += f"⚪ - доступный сервер\n"
-        text += f"🔒 - неактивный (только для уже назначенных)\n\n"
-        
-        keyboard = []
-        selected_servers = [s for s in servers_to_show if s.squad_uuid in current_squads]
-        available_servers = [s for s in servers_to_show if s.squad_uuid not in current_squads and s.is_available]
-        inactive_servers = [s for s in servers_to_show if s.squad_uuid not in current_squads and not s.is_available]
-        
-        sorted_servers = selected_servers + available_servers + inactive_servers
-        
-        for server in sorted_servers[:20]: 
-            is_selected = server.squad_uuid in current_squads
-            
-            if is_selected:
-                emoji = "✅"
-            elif server.is_available:
-                emoji = "⚪"
-            else:
-                emoji = "🔒"
-            
-            display_name = server.display_name
-            if not server.is_available and not is_selected:
-                display_name += " (неактивный)"
-            
-            keyboard.append([
-                types.InlineKeyboardButton(
-                    text=f"{emoji} {display_name}",
-                    callback_data=f"admin_user_toggle_server_{user_id}_{server.id}"
-                )
-            ])
-        
-        if len(servers_to_show) > 20:
-            text += f"\n📝 Показано первых 20 из {len(servers_to_show)} серверов"
-        
-        keyboard.append([
-            types.InlineKeyboardButton(text="✅ Готово", callback_data=f"admin_user_subscription_{user_id}"),
-            types.InlineKeyboardButton(text="⬅️ Назад", callback_data=f"admin_user_subscription_{user_id}")
-        ])
-        
+
         await callback.message.edit_text(
             text,
-            reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+            reply_markup=markup,
         )
         
     except Exception as e:
@@ -1972,11 +2068,21 @@ async def toggle_user_server(
         
         subscription = user.subscription
         current_squads = list(subscription.connected_squads or [])
-        
-        if server.squad_uuid in current_squads:
+        current_squad_set = set(current_squads)
+
+        is_allowed = _is_server_allowed_for_user(server, user)
+
+        if server.squad_uuid in current_squad_set:
             current_squads.remove(server.squad_uuid)
             action_text = "удален"
         else:
+            if not is_allowed:
+                await callback.answer(
+                    "❌ Этот сервер недоступен для промогруппы пользователя",
+                    show_alert=True,
+                )
+                return
+
             current_squads.append(server.squad_uuid)
             action_text = "добавлен"
         
@@ -2018,47 +2124,38 @@ async def refresh_server_selection_screen(
 ):
     try:
         user = await get_user_by_id(db, user_id)
-        current_squads = []
+        current_squads_list: List[str] = []
         if user and user.subscription:
-            current_squads = user.subscription.connected_squads or []
-        
-        servers, _ = await get_all_server_squads(db, available_only=True)
-        
-        if not servers:
+            current_squads_list = list(user.subscription.connected_squads or [])
+
+        current_squads = set(current_squads_list)
+        servers, _ = await get_all_server_squads(db, available_only=False)
+
+        text, markup, has_servers = _build_server_selection_view(
+            user,
+            servers,
+            current_squads,
+            user_id,
+            limit=15,
+        )
+
+        if not has_servers:
             await callback.message.edit_text(
-                "❌ Доступные серверы не найдены",
+                "❌ Не найдено серверов для текущей промогруппы",
                 reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[
-                    [types.InlineKeyboardButton(text="⬅️ Назад", callback_data=f"admin_user_subscription_{user_id}")]
-                ])
+                    [
+                        types.InlineKeyboardButton(
+                            text="⬅️ Назад",
+                            callback_data=f"admin_user_subscription_{user_id}",
+                        )
+                    ]
+                ]),
             )
             return
-        
-        text = f"🌍 <b>Управление серверами</b>\n\n"
-        text += f"Нажмите на сервер чтобы добавить/убрать:\n\n"
-        
-        keyboard = []
-        for server in servers[:15]:
-            is_selected = server.squad_uuid in current_squads
-            emoji = "✅" if is_selected else "⚪"
-            
-            keyboard.append([
-                types.InlineKeyboardButton(
-                    text=f"{emoji} {server.display_name}",
-                    callback_data=f"admin_user_toggle_server_{user_id}_{server.id}"
-                )
-            ])
-        
-        if len(servers) > 15:
-            text += f"\n📝 Показано первых 15 из {len(servers)} серверов"
-        
-        keyboard.append([
-            types.InlineKeyboardButton(text="✅ Готово", callback_data=f"admin_user_subscription_{user_id}"),
-            types.InlineKeyboardButton(text="⬅️ Назад", callback_data=f"admin_user_subscription_{user_id}")
-        ])
-        
+
         await callback.message.edit_text(
             text,
-            reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+            reply_markup=markup,
         )
         
     except Exception as e:

--- a/app/states.py
+++ b/app/states.py
@@ -95,6 +95,7 @@ class AdminStates(StatesGroup):
     editing_server_country = State()
     editing_server_limit = State()
     editing_server_description = State()
+    editing_server_promo_groups = State()
     
     creating_server_uuid = State()
     creating_server_name = State()

--- a/app/utils/cache.py
+++ b/app/utils/cache.py
@@ -179,6 +179,17 @@ async def cached_function(key: str, expire: int = 300):
     return decorator
 
 
+async def invalidate_available_countries_cache() -> int:
+    keys = await cache.get_keys("available_countries*")
+    deleted_count = 0
+
+    for key in keys:
+        if await cache.delete(key):
+            deleted_count += 1
+
+    return deleted_count
+
+
 class UserCache:
     
     @staticmethod


### PR DESCRIPTION
## Summary
- filter the admin server management lists by the target user's promo group and surface restricted servers
- prevent adding servers from promo groups unavailable to the user while still allowing removals
- share helper logic to build the server selection view with updated legends and navigation rows
