### PR TITLE
Add promo group access control for servers

### DIFF
--- a/app/states.py
+++ b/app/states.py
@@ -95,6 +95,7 @@ class AdminStates(StatesGroup):
     editing_server_country = State()
     editing_server_limit = State()
     editing_server_description = State()
+    editing_server_promo_groups = State()
     
     creating_server_uuid = State()
     creating_server_name = State()

--- a/app/utils/cache.py
+++ b/app/utils/cache.py
@@ -67,13 +67,28 @@ class CacheService:
     async def delete(self, key: str) -> bool:
         if not self._connected:
             return False
-        
+
         try:
             deleted = await self.redis_client.delete(key)
             return deleted > 0
         except Exception as e:
             logger.error(f"Ошибка удаления из кеша {key}: {e}")
             return False
+
+    async def delete_pattern(self, pattern: str) -> int:
+        if not self._connected:
+            return 0
+
+        try:
+            keys = await self.redis_client.keys(pattern)
+            if not keys:
+                return 0
+
+            deleted = await self.redis_client.delete(*keys)
+            return int(deleted)
+        except Exception as e:
+            logger.error(f"Ошибка удаления ключей по шаблону {pattern}: {e}")
+            return 0
     
     async def exists(self, key: str) -> bool:
         if not self._connected:


### PR DESCRIPTION
## Summary
- add a server-to-promo-group association table with default assignments and CRUD helpers
- expose promo-group management in the admin server editor with cache invalidation helpers
- filter subscription country lists and pricing by the viewer's promo group and seed data via universal migration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3967dea588320913d28f2156cab61