### PR TITLE
Add Google Drive-aware subscription link normalization

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -15,6 +15,7 @@ from app.database.models import (
 from app.database.crud.notification import clear_notifications
 from app.utils.pricing_utils import calculate_months_from_days, get_remaining_months
 from app.config import settings
+from app.utils.link_utils import normalize_subscription_url
 
 logger = logging.getLogger(__name__)
 
@@ -974,6 +975,8 @@ async def create_subscription(
     if connected_squads is None:
         connected_squads = []
     
+    normalized_url = normalize_subscription_url(subscription_url)
+
     subscription = Subscription(
         user_id=user_id,
         status=status,
@@ -984,7 +987,7 @@ async def create_subscription(
         device_limit=device_limit,
         connected_squads=connected_squads,
         remnawave_short_uuid=remnawave_short_uuid,
-        subscription_url=subscription_url
+        subscription_url=normalized_url
     )
     
     db.add(subscription)

--- a/app/external/remnawave_api.py
+++ b/app/external/remnawave_api.py
@@ -1,15 +1,17 @@
 import asyncio
+import base64
 import json
-import ssl
-import base64 
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union, Any
-from urllib.parse import urlparse
-import aiohttp
 import logging
+import ssl
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from enum import Enum
-from urllib.parse import urlparse, urljoin
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+from app.utils.link_utils import normalize_subscription_url
 
 logger = logging.getLogger(__name__)
 
@@ -599,7 +601,7 @@ class RemnaWaveAPI:
             hwid_device_limit=user_data.get('hwidDeviceLimit'),
             description=user_data.get('description'),
             tag=user_data.get('tag'),
-            subscription_url=user_data['subscriptionUrl'],
+            subscription_url=normalize_subscription_url(user_data['subscriptionUrl']),
             active_internal_squads=user_data['activeInternalSquads'],
             created_at=datetime.fromisoformat(user_data['createdAt'].replace('Z', '+00:00')),
             updated_at=datetime.fromisoformat(user_data['updatedAt'].replace('Z', '+00:00')),
@@ -650,7 +652,7 @@ class RemnaWaveAPI:
             user=data.get('user'),
             links=data.get('links', []),
             ss_conf_links=data.get('ssConfLinks', {}),
-            subscription_url=data.get('subscriptionUrl', ''),
+            subscription_url=normalize_subscription_url(data.get('subscriptionUrl', '')),
             happ=data.get('happ')
         )
 

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -38,6 +38,7 @@ from app.localization.texts import get_texts
 from app.services.notification_settings_service import NotificationSettingsService
 from app.services.payment_service import PaymentService
 from app.services.subscription_service import SubscriptionService
+from app.utils.link_utils import normalize_subscription_url
 
 from app.external.remnawave_api import (
     RemnaWaveAPIError,
@@ -278,7 +279,9 @@ class MonitoringService:
                     active_internal_squads=subscription.connected_squads
                 )
                 
-                subscription.subscription_url = updated_user.subscription_url
+                normalized_url = normalize_subscription_url(updated_user.subscription_url)
+                subscription.subscription_url = normalized_url
+                updated_user.subscription_url = normalized_url
                 await db.commit()
                 
                 status_text = "активным" if is_active else "истёкшим"

--- a/app/utils/link_utils.py
+++ b/app/utils/link_utils.py
@@ -1,0 +1,76 @@
+"""Utility helpers for working with external links."""
+from __future__ import annotations
+
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+_GOOGLE_DRIVE_HOSTS = {
+    "drive.google.com",
+    "docs.google.com",
+    "drive.usercontent.google.com",
+}
+
+
+def _is_google_drive_host(host: str) -> bool:
+    host = host.lower()
+    for candidate in _GOOGLE_DRIVE_HOSTS:
+        if host == candidate or host.endswith(f".{candidate}"):
+            return True
+    return False
+
+
+def _extract_drive_file_id(parsed_url) -> Optional[str]:
+    """Extract a Google Drive file identifier from the parsed URL."""
+    path_match = re.search(r"/d/([^/]+)", parsed_url.path)
+    if path_match:
+        return path_match.group(1)
+
+    query_params = parse_qs(parsed_url.query)
+    for key in ("id", "file_id", "fileid", "resid"):
+        values = query_params.get(key)
+        if values:
+            return values[0]
+
+    # Handle cases like /uc/<id> without query params
+    uc_match = re.search(r"/uc/([^/?#]+)", parsed_url.path)
+    if uc_match:
+        return uc_match.group(1)
+
+    return None
+
+
+def normalize_subscription_url(url: Optional[str]) -> str:
+    """Normalize subscription links and add support for Google Drive sources.
+
+    Converts shared Google Drive links to a direct download URL that can be
+    consumed by VPN clients for automatic configuration updates.
+    """
+
+    if not url:
+        return ""
+
+    cleaned_url = url.strip()
+    if not cleaned_url:
+        return ""
+
+    parsed = urlparse(cleaned_url)
+
+    if not parsed.scheme:
+        # Assume HTTPS for bare hosts
+        parsed = urlparse(f"https://{cleaned_url}")
+
+    if not _is_google_drive_host(parsed.netloc):
+        return cleaned_url
+
+    file_id = _extract_drive_file_id(parsed)
+    if not file_id:
+        return cleaned_url
+
+    sanitized_id = file_id.strip().strip('/').split('?')[0].split('#')[0]
+    sanitized_id = re.sub(r"[^0-9A-Za-z_-]", "", sanitized_id)
+
+    if not sanitized_id:
+        return cleaned_url
+
+    return f"https://drive.google.com/uc?export=download&id={sanitized_id}"


### PR DESCRIPTION
## Summary
- add a link utility to normalize subscription URLs and convert Google Drive shares into direct download links
- normalize subscription links when parsing RemnaWave responses and when saving subscriptions in services and database layer
- ensure downstream consumers always receive Google Drive-compatible subscription URLs for automatic updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4762bf40883209e8e6ac507249e2c