### PR TITLE
Handle missing Google Drive optional dependencies gracefully

### DIFF
--- a/app/services/gdrive_service.py
+++ b/app/services/gdrive_service.py
@@ -25,6 +25,27 @@ except ModuleNotFoundError:  # pragma: no cover - executed only when dependency 
 
     _GOOGLE_SDK_AVAILABLE = False
 
+_MISSING_DEPENDENCIES_MESSAGE = (
+    "Google Drive integration requires optional dependencies: "
+    "google-api-python-client, google-auth, google-auth-httplib2"
+)
+
+_missing_dependencies_logged = False
+
+
+def _log_missing_dependencies_once() -> None:
+    global _missing_dependencies_logged
+
+    if _missing_dependencies_logged:
+        return
+
+    logger.error(
+        "%s Install them with `pip install google-api-python-client google-auth "
+        "google-auth-httplib2` to enable this feature.",
+        _MISSING_DEPENDENCIES_MESSAGE,
+    )
+    _missing_dependencies_logged = True
+
 from app.config import settings
 
 if TYPE_CHECKING:
@@ -53,10 +74,7 @@ class GoogleDriveService:
             raise RuntimeError("Google Drive integration is not enabled")
 
         if not _GOOGLE_SDK_AVAILABLE:
-            raise RuntimeError(
-                "Google Drive integration requires optional dependencies: "
-                "google-api-python-client, google-auth, google-auth-httplib2"
-            )
+            raise RuntimeError(_MISSING_DEPENDENCIES_MESSAGE)
 
         self._credentials = None
         self._service = None
@@ -230,6 +248,10 @@ async def sync_subscription_to_gdrive(
     remnawave_user: "RemnaWaveUser",
 ) -> None:
     if not settings.is_gdrive_enabled():
+        return
+
+    if not _GOOGLE_SDK_AVAILABLE:
+        _log_missing_dependencies_once()
         return
 
     short_uuid = getattr(remnawave_user, "short_uuid", None)


### PR DESCRIPTION
## Summary
- add a shared missing-dependency message for the Google Drive integration
- log a clear installation hint once when the optional Google SDK packages are absent
- short-circuit Google Drive sync attempts when the SDK is unavailable to avoid noisy errors
