### PR TITLE
Add Happ cryptolink keyboard with platform buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,6 +290,9 @@ MINIAPP_CUSTOM_URL=
 CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED=false
 HAPP_DOWNLOAD_LINK_IOS=
 HAPP_DOWNLOAD_LINK_ANDROID=
+HAPP_DOWNLOAD_LINK_MACOS=
+HAPP_DOWNLOAD_LINK_WINDOWS=
+# (опционально) устаревшее поле для Windows, будет использовано если HAPP_DOWNLOAD_LINK_WINDOWS не задан
 HAPP_DOWNLOAD_LINK_PC=
 
 # Пропустить принятие правил использования бота

--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ MINIAPP_CUSTOM_URL=
 CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED=false
 HAPP_DOWNLOAD_LINK_IOS=
 HAPP_DOWNLOAD_LINK_ANDROID=
+HAPP_DOWNLOAD_LINK_MACOS=
+HAPP_DOWNLOAD_LINK_WINDOWS=
+# (опционально) устаревшее поле для Windows, будет использовано если HAPP_DOWNLOAD_LINK_WINDOWS не задан
 HAPP_DOWNLOAD_LINK_PC=
 
 # Пропустить принятие правил использования бота

--- a/app/config.py
+++ b/app/config.py
@@ -212,6 +212,8 @@ class Settings(BaseSettings):
     CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED: bool = False
     HAPP_DOWNLOAD_LINK_IOS: Optional[str] = None
     HAPP_DOWNLOAD_LINK_ANDROID: Optional[str] = None
+    HAPP_DOWNLOAD_LINK_MACOS: Optional[str] = None
+    HAPP_DOWNLOAD_LINK_WINDOWS: Optional[str] = None
     HAPP_DOWNLOAD_LINK_PC: Optional[str] = None
     HIDE_SUBSCRIPTION_LINK: bool = False
     ENABLE_LOGO_MODE: bool = True
@@ -555,10 +557,18 @@ class Settings(BaseSettings):
 
     def get_happ_download_link(self, platform: str) -> Optional[str]:
         platform_key = platform.lower()
+
+        if platform_key == "pc":
+            platform_key = "windows"
+
         links = {
             "ios": (self.HAPP_DOWNLOAD_LINK_IOS or "").strip(),
             "android": (self.HAPP_DOWNLOAD_LINK_ANDROID or "").strip(),
-            "pc": (self.HAPP_DOWNLOAD_LINK_PC or "").strip(),
+            "macos": (self.HAPP_DOWNLOAD_LINK_MACOS or "").strip(),
+            "windows": (
+                (self.HAPP_DOWNLOAD_LINK_WINDOWS or "").strip()
+                or (self.HAPP_DOWNLOAD_LINK_PC or "").strip()
+            ),
         }
         link = links.get(platform_key)
         return link if link else None

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -39,6 +39,7 @@ from app.keyboards.inline import (
     get_extend_subscription_keyboard_with_prices, get_confirm_change_devices_keyboard,
     get_devices_management_keyboard, get_device_reset_confirm_keyboard,
     get_device_management_help_keyboard,
+    get_happ_cryptolink_keyboard,
     get_happ_download_platform_keyboard, get_happ_download_link_keyboard,
     get_happ_download_button_row,
     get_payment_methods_keyboard_with_cart,
@@ -4115,6 +4116,8 @@ async def handle_happ_download_platform_choice(
     db: AsyncSession
 ):
     platform = callback.data.split('_')[-1]
+    if platform == "pc":
+        platform = "windows"
     texts = get_texts(db_user.language)
     link = settings.get_happ_download_link(platform)
 
@@ -4128,7 +4131,8 @@ async def handle_happ_download_platform_choice(
     platform_names = {
         "ios": texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
         "android": texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
-        "pc": texts.t("HAPP_PLATFORM_PC", "💻 ПК"),
+        "macos": texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
+        "windows": texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
     }
 
     link_text = texts.t(
@@ -4624,10 +4628,13 @@ async def handle_open_subscription_link(
             ).format(subscription_link=subscription_link)
         )
 
+        keyboard = get_happ_cryptolink_keyboard(subscription_link, db_user.language)
+
         await callback.message.answer(
             happ_message,
             parse_mode="HTML",
             disable_web_page_preview=True,
+            reply_markup=keyboard,
         )
         await callback.answer()
         return
@@ -5340,7 +5347,13 @@ def register_handlers(dp: Dispatcher):
 
     dp.callback_query.register(
         handle_happ_download_platform_choice,
-        F.data.in_(["happ_download_ios", "happ_download_android", "happ_download_pc"])
+        F.data.in_([
+            "happ_download_ios",
+            "happ_download_android",
+            "happ_download_pc",
+            "happ_download_macos",
+            "happ_download_windows",
+        ])
     )
 
     dp.callback_query.register(

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -254,12 +254,60 @@ def get_happ_download_button_row(texts) -> Optional[List[InlineKeyboardButton]]:
     ]
 
 
+def get_happ_cryptolink_keyboard(
+    subscription_link: str,
+    language: str = DEFAULT_LANGUAGE,
+) -> InlineKeyboardMarkup:
+    texts = get_texts(language)
+    buttons = [
+        [
+            InlineKeyboardButton(
+                text=texts.t("CONNECT_BUTTON", "🔗 Подключиться"),
+                url=subscription_link,
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
+                callback_data="happ_download_ios",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
+                callback_data="happ_download_android",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
+                callback_data="happ_download_macos",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
+                callback_data="happ_download_windows",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=texts.t("BACK_TO_MAIN_MENU_BUTTON", "⬅️ В главное меню"),
+                callback_data="back_to_menu",
+            )
+        ],
+    ]
+
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
 def get_happ_download_platform_keyboard(language: str = DEFAULT_LANGUAGE) -> InlineKeyboardMarkup:
     texts = get_texts(language)
     buttons = [
         [InlineKeyboardButton(text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"), callback_data="happ_download_ios")],
         [InlineKeyboardButton(text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"), callback_data="happ_download_android")],
-        [InlineKeyboardButton(text=texts.t("HAPP_PLATFORM_PC", "💻 ПК"), callback_data="happ_download_pc")],
+        [InlineKeyboardButton(text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"), callback_data="happ_download_macos")],
+        [InlineKeyboardButton(text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"), callback_data="happ_download_windows")],
         [InlineKeyboardButton(text=texts.BACK, callback_data="happ_download_close")],
     ]
 

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -23,6 +23,8 @@
   "HAPP_DOWNLOAD_PROMPT": "📥 <b>Download Happ</b>\nChoose your device:",
   "HAPP_PLATFORM_IOS": "🍎 iOS",
   "HAPP_PLATFORM_ANDROID": "🤖 Android",
+  "HAPP_PLATFORM_MACOS": "🖥️ Mac OS",
+  "HAPP_PLATFORM_WINDOWS": "💻 Windows",
   "HAPP_PLATFORM_PC": "💻 PC",
   "HAPP_DOWNLOAD_LINK_MESSAGE": "⬇️ Download Happ for {platform}:",
   "HAPP_DOWNLOAD_LINK_NOT_SET": "❌ Download link for this device is not configured",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -103,6 +103,8 @@
   "HAPP_DOWNLOAD_PROMPT": "📥 <b>Скачать Happ</b>\nВыберите ваше устройство:",
   "HAPP_PLATFORM_IOS": "🍎 iOS",
   "HAPP_PLATFORM_ANDROID": "🤖 Android",
+  "HAPP_PLATFORM_MACOS": "🖥️ Mac OS",
+  "HAPP_PLATFORM_WINDOWS": "💻 Windows",
   "HAPP_PLATFORM_PC": "💻 ПК",
   "HAPP_DOWNLOAD_LINK_MESSAGE": "⬇️ Скачайте Happ для {platform}:",
   "HAPP_DOWNLOAD_LINK_NOT_SET": "❌ Ссылка для этого устройства не настроена",

--- a/locales/en.json
+++ b/locales/en.json
@@ -24,6 +24,8 @@
   "HAPP_DOWNLOAD_PROMPT": "📥 <b>Download Happ</b>\nChoose your device:",
   "HAPP_PLATFORM_IOS": "🍎 iOS",
   "HAPP_PLATFORM_ANDROID": "🤖 Android",
+  "HAPP_PLATFORM_MACOS": "🖥️ Mac OS",
+  "HAPP_PLATFORM_WINDOWS": "💻 Windows",
   "HAPP_PLATFORM_PC": "💻 PC",
   "HAPP_DOWNLOAD_LINK_MESSAGE": "⬇️ Download Happ for {platform}:",
   "HAPP_DOWNLOAD_LINK_NOT_SET": "❌ Download link for this device is not configured",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -187,6 +187,8 @@
   "HAPP_DOWNLOAD_PROMPT": "📥 <b>Скачать Happ</b>\nВыберите ваше устройство:",
   "HAPP_PLATFORM_IOS": "🍎 iOS",
   "HAPP_PLATFORM_ANDROID": "🤖 Android",
+  "HAPP_PLATFORM_MACOS": "🖥️ Mac OS",
+  "HAPP_PLATFORM_WINDOWS": "💻 Windows",
   "HAPP_PLATFORM_PC": "💻 ПК",
   "HAPP_DOWNLOAD_LINK_MESSAGE": "⬇️ Скачайте Happ для {platform}:",
   "HAPP_DOWNLOAD_LINK_NOT_SET": "❌ Ссылка для этого устройства не настроена",


### PR DESCRIPTION
## Summary
- show an inline keyboard for Happ cryptolink messages with a direct connect button, platform download shortcuts, and a return-to-menu action
- add macOS and Windows Happ download options with environment support and compatibility fallback for the legacy PC link
- update localizations and documentation to reflect the new Happ download targets

