### PR TITLE
Handle Happ cryptolink without unsupported Telegram URL

### DIFF
--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -1,16 +1,21 @@
 from typing import List, Optional
-from aiogram import types
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+import logging
 from datetime import datetime
-from app.database.models import User
+
+from aiogram import types
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings, PERIOD_PRICES, TRAFFIC_PRICES
+from app.config import PERIOD_PRICES, TRAFFIC_PRICES, settings
+from app.database.models import User
 from app.localization.loader import DEFAULT_LANGUAGE
 from app.localization.texts import get_texts
 from app.utils.pricing_utils import format_period_description
-from app.utils.subscription_utils import get_display_subscription_link
-import logging
+from app.utils.subscription_utils import (
+    get_display_subscription_link,
+    is_supported_telegram_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -255,48 +260,54 @@ def get_happ_download_button_row(texts) -> Optional[List[InlineKeyboardButton]]:
 
 
 def get_happ_cryptolink_keyboard(
-    subscription_link: str,
+    subscription_link: Optional[str],
     language: str = DEFAULT_LANGUAGE,
 ) -> InlineKeyboardMarkup:
     texts = get_texts(language)
-    buttons = [
-        [
+    buttons: List[List[InlineKeyboardButton]] = []
+
+    if is_supported_telegram_url(subscription_link):
+        buttons.append([
             InlineKeyboardButton(
                 text=texts.t("CONNECT_BUTTON", "🔗 Подключиться"),
                 url=subscription_link,
             )
-        ],
+        ])
+
+    buttons.extend(
         [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
-                callback_data="happ_download_ios",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
-                callback_data="happ_download_android",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
-                callback_data="happ_download_macos",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
-                callback_data="happ_download_windows",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("BACK_TO_MAIN_MENU_BUTTON", "⬅️ В главное меню"),
-                callback_data="back_to_menu",
-            )
-        ],
-    ]
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
+                    callback_data="happ_download_ios",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
+                    callback_data="happ_download_android",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
+                    callback_data="happ_download_macos",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
+                    callback_data="happ_download_windows",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("BACK_TO_MAIN_MENU_BUTTON", "⬅️ В главное меню"),
+                    callback_data="back_to_menu",
+                )
+            ],
+        ]
+    )
 
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 

--- a/app/utils/subscription_utils.py
+++ b/app/utils/subscription_utils.py
@@ -1,10 +1,13 @@
 import logging
 from datetime import datetime
 from typing import Optional
-from sqlalchemy import select, delete, func
+from urllib.parse import urlsplit
+
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.database.models import Subscription, User
+
 from app.config import settings
+from app.database.models import Subscription, User
 
 logger = logging.getLogger(__name__)
 
@@ -109,3 +112,17 @@ def get_display_subscription_link(subscription: Optional[Subscription]) -> Optio
         return crypto_link or base_link
 
     return base_link
+
+
+def is_supported_telegram_url(url: Optional[str]) -> bool:
+    """Check whether Telegram allows using the given URL in inline buttons."""
+
+    if not url:
+        return False
+
+    try:
+        scheme = urlsplit(url).scheme
+    except ValueError:
+        return False
+
+    return scheme in {"http", "https", "tg", "ton"}

--- a/locales/en.json
+++ b/locales/en.json
@@ -408,6 +408,7 @@
   "SUBSCRIPTION_DEVICE_GUIDE_TITLE": "📱 <b>Setup for {device_name}</b>",
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Connect via Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Open link in Happ</a>",
+  "SUBSCRIPTION_HAPP_OPEN_COPY": "🔓 Copy the link and open it in Happ: <code>{subscription_link}</code>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 If the link doesn't open automatically, copy it manually: <code>{subscription_link}</code>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Subscription link:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Recommended app:</b> {app_name}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -408,6 +408,7 @@
   "SUBSCRIPTION_DEVICE_GUIDE_TITLE": "📱 <b>Настройка для {device_name}</b>",
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Подключение через Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
+  "SUBSCRIPTION_HAPP_OPEN_COPY": "🔓 Скопируйте ссылку и откройте в Happ: <code>{subscription_link}</code>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Ссылка подписки:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Рекомендуемое приложение:</b> {app_name}",


### PR DESCRIPTION
## Summary
- avoid using Happ cryptolinks with unsupported schemes in inline buttons
- provide copy instructions with escaped links when Happ deep links cannot be opened directly
- add a helper to detect Telegram-supported URL schemes
