### PR TITLE
Handle Happ cryptolink without unsupported Telegram URLs

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -64,7 +64,10 @@ from app.utils.pricing_utils import (
     format_period_description,
 )
 from app.utils.pagination import paginate_list
-from app.utils.subscription_utils import get_display_subscription_link
+from app.utils.subscription_utils import (
+    get_display_subscription_link,
+    get_subscription_button_link,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -4602,6 +4605,7 @@ async def handle_open_subscription_link(
     texts = get_texts(db_user.language)
     subscription = db_user.subscription
     subscription_link = get_display_subscription_link(subscription)
+    button_link = get_subscription_button_link(subscription)
 
     if not subscription_link:
         await callback.answer(
@@ -4611,16 +4615,24 @@ async def handle_open_subscription_link(
         return
 
     if settings.is_happ_cryptolink_mode():
+        if button_link:
+            open_link_text = texts.t(
+                "SUBSCRIPTION_HAPP_OPEN_LINK",
+                "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
+            ).format(subscription_link=button_link)
+        else:
+            open_link_text = texts.t(
+                "SUBSCRIPTION_HAPP_OPEN_LINK_MANUAL",
+                "🔓 Скопируйте ссылку ниже и откройте её вручную в Happ.",
+            )
+
         happ_message = (
             texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_TITLE",
                 "🔗 <b>Подключение через Happ</b>",
             )
             + "\n\n"
-            + texts.t(
-                "SUBSCRIPTION_HAPP_OPEN_LINK",
-                "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
-            ).format(subscription_link=subscription_link)
+            + open_link_text
             + "\n\n"
             + texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_HINT",
@@ -4628,7 +4640,10 @@ async def handle_open_subscription_link(
             ).format(subscription_link=subscription_link)
         )
 
-        keyboard = get_happ_cryptolink_keyboard(subscription_link, db_user.language)
+        keyboard = get_happ_cryptolink_keyboard(
+            button_link,
+            db_user.language,
+        )
 
         await callback.message.answer(
             happ_message,

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -255,48 +255,54 @@ def get_happ_download_button_row(texts) -> Optional[List[InlineKeyboardButton]]:
 
 
 def get_happ_cryptolink_keyboard(
-    subscription_link: str,
+    button_link: Optional[str],
     language: str = DEFAULT_LANGUAGE,
 ) -> InlineKeyboardMarkup:
     texts = get_texts(language)
-    buttons = [
-        [
+    buttons: List[List[InlineKeyboardButton]] = []
+
+    if button_link:
+        buttons.append([
             InlineKeyboardButton(
                 text=texts.t("CONNECT_BUTTON", "🔗 Подключиться"),
-                url=subscription_link,
+                url=button_link,
             )
-        ],
+        ])
+
+    buttons.extend(
         [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
-                callback_data="happ_download_ios",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
-                callback_data="happ_download_android",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
-                callback_data="happ_download_macos",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
-                callback_data="happ_download_windows",
-            )
-        ],
-        [
-            InlineKeyboardButton(
-                text=texts.t("BACK_TO_MAIN_MENU_BUTTON", "⬅️ В главное меню"),
-                callback_data="back_to_menu",
-            )
-        ],
-    ]
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_IOS", "🍎 iOS"),
+                    callback_data="happ_download_ios",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_ANDROID", "🤖 Android"),
+                    callback_data="happ_download_android",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_MACOS", "🖥️ Mac OS"),
+                    callback_data="happ_download_macos",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("HAPP_PLATFORM_WINDOWS", "💻 Windows"),
+                    callback_data="happ_download_windows",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=texts.t("BACK_TO_MAIN_MENU_BUTTON", "⬅️ В главное меню"),
+                    callback_data="back_to_menu",
+                )
+            ],
+        ]
+    )
 
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -408,6 +408,7 @@
   "SUBSCRIPTION_DEVICE_GUIDE_TITLE": "📱 <b>Setup for {device_name}</b>",
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Connect via Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Open link in Happ</a>",
+  "SUBSCRIPTION_HAPP_OPEN_LINK_MANUAL": "🔓 Copy the link below and open it manually in Happ.",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 If the link doesn't open automatically, copy it manually: <code>{subscription_link}</code>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Subscription link:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Recommended app:</b> {app_name}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -408,6 +408,7 @@
   "SUBSCRIPTION_DEVICE_GUIDE_TITLE": "📱 <b>Настройка для {device_name}</b>",
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Подключение через Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
+  "SUBSCRIPTION_HAPP_OPEN_LINK_MANUAL": "🔓 Скопируйте ссылку ниже и откройте её вручную в Happ.",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Ссылка подписки:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Рекомендуемое приложение:</b> {app_name}",


### PR DESCRIPTION
## Summary
- avoid attaching Happ cryptolinks with unsupported URL schemes to Telegram buttons by selecting only Telegram-compatible URLs
- update the Happ subscription flow to show manual copy instructions and adjust the inline keyboard when no safe URL is available
- add localized text for the manual link instruction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4fd8ed494832095430c805daf1ce2