### PR TITLE
Fix addon discounts for server/device/traffic purchases

### DIFF
--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -14,7 +14,8 @@ from app.utils.pricing_utils import (
     calculate_months_from_days,
     get_remaining_months,
     calculate_prorated_price,
-    validate_pricing_calculation
+    validate_pricing_calculation,
+    resolve_addon_discount_percent,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,12 +49,9 @@ def _resolve_addon_discount_percent(
 ) -> int:
     group = promo_group or (getattr(user, "promo_group", None) if user else None)
 
-    if group is not None and not getattr(group, "apply_discounts_to_addons", True):
-        return 0
-
-    return _resolve_discount_percent(
+    return resolve_addon_discount_percent(
         user,
-        promo_group,
+        group,
         category,
         period_days=period_days,
     )


### PR DESCRIPTION
## Summary
- centralize add-on discount resolution so promo-group flags are respected across pricing utilities and services
- ensure add-on cost calculations skip unavailable servers and apply percentage discounts for traffic, device, and server upgrades
- update subscription handlers to charge and display discounted amounts when users add countries, devices, or traffic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51b0aabcc8320ab77a705afaecd27