### PR TITLE
Fix addon discount calculations for extra services

### DIFF
--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -1313,8 +1313,10 @@ def get_manage_countries_keyboard(
     for country in countries:
         uuid = country['uuid']
         name = country['name']
-        price_per_month = country['price_kopeks']
-        
+        price_per_month = country.get('price_kopeks', 0)
+        discounted_price_per_month = country.get('discounted_price_kopeks', price_per_month)
+        discount_percent = country.get('discount_percent', 0)
+
         if uuid in current_subscription_countries:
             if uuid in selected:
                 icon = "✅"
@@ -1323,31 +1325,41 @@ def get_manage_countries_keyboard(
         else:
             if uuid in selected:
                 icon = "➕"
-                total_cost += price_per_month * months_multiplier
+                total_cost += discounted_price_per_month * months_multiplier
             else:
                 icon = "⚪"
         
         if uuid not in current_subscription_countries and uuid in selected:
-            total_price = price_per_month * months_multiplier
+            total_price = discounted_price_per_month * months_multiplier
             if months_multiplier > 1:
-                price_text = f" ({price_per_month//100}₽/мес × {months_multiplier} = {total_price//100}₽)"
-                logger.info(f"🔍 Сервер {name}: {price_per_month/100}₽/мес × {months_multiplier} мес = {total_price/100}₽")
+                price_text = (
+                    f" ({texts.format_price(discounted_price_per_month)} / мес × {months_multiplier}"
+                    f" = {texts.format_price(total_price)})"
+                )
+                logger.info(
+                    "🔍 Сервер %s: %s/мес × %s мес = %s (скидка %s%%)",
+                    name,
+                    texts.format_price(discounted_price_per_month),
+                    months_multiplier,
+                    texts.format_price(total_price),
+                    discount_percent,
+                )
             else:
-                price_text = f" ({total_price//100}₽)"
+                price_text = f" ({texts.format_price(total_price)})"
             display_name = f"{icon} {name}{price_text}"
         else:
             display_name = f"{icon} {name}"
-        
+
         buttons.append([
             InlineKeyboardButton(
                 text=display_name,
                 callback_data=f"country_manage_{uuid}"
             )
         ])
-    
+
     if total_cost > 0:
-        apply_text = f"✅ Применить изменения ({total_cost//100} ₽)"
-        logger.info(f"🔍 Общая стоимость новых серверов: {total_cost/100}₽")
+        apply_text = f"✅ Применить изменения ({texts.format_price(total_cost)})"
+        logger.info("🔍 Общая стоимость новых серверов: %s", texts.format_price(total_cost))
     else:
         apply_text = "✅ Применить изменения"
     

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -39,7 +39,7 @@ def _resolve_discount_percent(
     return 0
 
 
-def _resolve_addon_discount_percent(
+def resolve_addon_discount_percent(
     user: Optional[User],
     promo_group: Optional[PromoGroup],
     category: str,
@@ -878,7 +878,7 @@ class SubscriptionService:
 
         if additional_traffic_gb > 0:
             traffic_price_per_month = settings.get_traffic_price(additional_traffic_gb)
-            traffic_discount_percent = _resolve_addon_discount_percent(
+            traffic_discount_percent = resolve_addon_discount_percent(
                 user,
                 promo_group,
                 "traffic",
@@ -901,7 +901,7 @@ class SubscriptionService:
 
         if additional_devices > 0:
             devices_price_per_month = additional_devices * settings.PRICE_PER_DEVICE
-            devices_discount_percent = _resolve_addon_discount_percent(
+            devices_discount_percent = resolve_addon_discount_percent(
                 user,
                 promo_group,
                 "devices",
@@ -928,7 +928,7 @@ class SubscriptionService:
                 server = await get_server_squad_by_id(db, server_id)
                 if server and server.is_available:
                     server_price_per_month = server.price_kopeks
-                    servers_discount_percent = _resolve_addon_discount_percent(
+                    servers_discount_percent = resolve_addon_discount_percent(
                         user,
                         promo_group,
                         "servers",


### PR DESCRIPTION
## Summary
- ensure server add-on pricing honours promo discounts, filters out unavailable choices, and prorates by the remaining subscription period
- apply the same discounted prorated pricing to extra devices and traffic purchases and surface the savings in the UI
- expose the add-on discount resolver in the subscription service for reuse across handlers and update the management keyboard to show discounted costs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51b0aabcc8320ab77a705afaecd27