### PR TITLE
Fix server management button for promo groups with multiple servers

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -4196,6 +4196,32 @@ async def handle_add_country_to_subscription(
 async def _should_show_countries_management(user: Optional[User] = None) -> bool:
     try:
         promo_group_id = user.promo_group_id if user else None
+
+        promo_group = getattr(user, "promo_group", None) if user else None
+        if promo_group and getattr(promo_group, "server_squads", None):
+            allowed_servers = [
+                server
+                for server in promo_group.server_squads
+                if server.is_available and not server.is_full
+            ]
+
+            if len(allowed_servers) > 1:
+                logger.debug(
+                    "Промогруппа %s имеет %s доступных серверов, показываем управление странами",
+                    promo_group.id,
+                    len(allowed_servers),
+                )
+                return True
+
+            if len(promo_group.server_squads) > 1:
+                logger.debug(
+                    "Промогруппа %s имеет %s серверов, но доступен только %s — показываем управление странами",
+                    promo_group.id,
+                    len(promo_group.server_squads),
+                    len(allowed_servers),
+                )
+                return True
+
         countries = await _get_available_countries(promo_group_id)
         available_countries = [c for c in countries if c.get('is_available', True)]
         return len(available_countries) > 1


### PR DESCRIPTION
## Summary
- ensure the subscription settings menu exposes server management whenever a promo group has more than one linked server
- add debug logging for easier tracing of promo group server availability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5237b71508320bea1559688264490