### PR TITLE
Prevent auto promo group overrides after manual change

### DIFF
--- a/app/services/promo_group_assignment.py
+++ b/app/services/promo_group_assignment.py
@@ -54,13 +54,25 @@ async def maybe_assign_promo_group_by_total_spent(
     try:
         previous_group_id = user.promo_group_id
 
-        if user.auto_promo_group_assigned and target_group.id == previous_group_id:
+        if user.auto_promo_group_assigned:
+            if target_group.id == previous_group_id:
+                logger.debug(
+                    "Пользователь %s уже находится в актуальной промогруппе '%s', повторная выдача не требуется",
+                    user.telegram_id,
+                    target_group.name,
+                )
+                return target_group
+
+            current_group_name = (
+                user.promo_group.name if getattr(user, "promo_group", None) else str(previous_group_id)
+            )
             logger.debug(
-                "Пользователь %s уже находится в актуальной промогруппе '%s', повторная выдача не требуется",
+                "Пользователь %s уже получал автопромогруппу '%s', но сейчас установлена '%s' вручную — пропускаем переназначение",
                 user.telegram_id,
                 target_group.name,
+                current_group_name,
             )
-            return target_group
+            return None
 
         user.auto_promo_group_assigned = True
         user.updated_at = datetime.utcnow()


### PR DESCRIPTION
## Summary
- prevent the auto-assigner from overwriting promo groups that were changed manually after the first auto assignment
- add debug logging to explain why auto reassignment was skipped when a manual override is detected
