### PR TITLE
Track last auto promo group to avoid duplicate assignments

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -388,6 +388,16 @@ class User(Base):
     discount_offers = relationship("DiscountOffer", back_populates="user")
     lifetime_used_traffic_bytes = Column(BigInteger, default=0)
     auto_promo_group_assigned = Column(Boolean, nullable=False, default=False)
+    last_auto_promo_group_id = Column(
+        Integer,
+        ForeignKey("promo_groups.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    last_auto_promo_group = relationship(
+        "PromoGroup",
+        foreign_keys=[last_auto_promo_group_id],
+        post_update=True,
+    )
     last_remnawave_sync = Column(DateTime, nullable=True)
     trojan_password = Column(String(255), nullable=True)
     vless_uuid = Column(String(255), nullable=True)

--- a/app/database/universal_migration.py
+++ b/app/database/universal_migration.py
@@ -1025,6 +1025,37 @@ async def ensure_promo_groups_setup():
 
                 logger.info("Добавлена колонка users.auto_promo_group_assigned")
 
+            last_auto_group_column_exists = await check_column_exists(
+                "users", "last_auto_promo_group_id"
+            )
+
+            if not last_auto_group_column_exists:
+                if db_type == "sqlite":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN last_auto_promo_group_id INTEGER"
+                        )
+                    )
+                elif db_type == "postgresql":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN last_auto_promo_group_id INTEGER"
+                        )
+                    )
+                elif db_type == "mysql":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN last_auto_promo_group_id INT"
+                        )
+                    )
+                else:
+                    logger.error(
+                        f"Неподдерживаемый тип БД для users.last_auto_promo_group_id: {db_type}"
+                    )
+                    return False
+
+                logger.info("Добавлена колонка users.last_auto_promo_group_id")
+
             index_exists = await check_index_exists("users", "ix_users_promo_group_id")
 
             if not index_exists:
@@ -2044,6 +2075,7 @@ async def check_migration_status():
             "promo_groups_auto_assign_column": False,
             "promo_groups_addon_discount_column": False,
             "users_auto_promo_group_assigned_column": False,
+            "users_last_auto_promo_group_column": False,
             "subscription_crypto_link_column": False,
         }
         
@@ -2062,6 +2094,7 @@ async def check_migration_status():
         status["promo_groups_auto_assign_column"] = await check_column_exists('promo_groups', 'auto_assign_total_spent_kopeks')
         status["promo_groups_addon_discount_column"] = await check_column_exists('promo_groups', 'apply_discounts_to_addons')
         status["users_auto_promo_group_assigned_column"] = await check_column_exists('users', 'auto_promo_group_assigned')
+        status["users_last_auto_promo_group_column"] = await check_column_exists('users', 'last_auto_promo_group_id')
         status["subscription_crypto_link_column"] = await check_column_exists('subscriptions', 'subscription_crypto_link')
         
         media_fields_exist = (
@@ -2100,6 +2133,7 @@ async def check_migration_status():
             "promo_groups_auto_assign_column": "Колонка auto_assign_total_spent_kopeks у промо-групп",
             "promo_groups_addon_discount_column": "Колонка apply_discounts_to_addons у промо-групп",
             "users_auto_promo_group_assigned_column": "Флаг автоназначения промогруппы у пользователей",
+            "users_last_auto_promo_group_column": "Колонка последней автопромогруппы у пользователей",
             "subscription_crypto_link_column": "Колонка subscription_crypto_link в subscriptions",
         }
         

--- a/app/services/promo_group_assignment.py
+++ b/app/services/promo_group_assignment.py
@@ -53,16 +53,22 @@ async def maybe_assign_promo_group_by_total_spent(
 
     try:
         previous_group_id = user.promo_group_id
+        last_auto_group_id = getattr(user, "last_auto_promo_group_id", None)
 
-        if user.auto_promo_group_assigned and target_group.id == previous_group_id:
+        if (
+            last_auto_group_id == target_group.id
+            and previous_group_id != target_group.id
+        ):
             logger.debug(
-                "Пользователь %s уже находится в актуальной промогруппе '%s', повторная выдача не требуется",
+                "Пользователь %s ранее уже получал промогруппу '%s', пропускаем повторное назначение",
                 user.telegram_id,
                 target_group.name,
             )
             return target_group
 
         user.auto_promo_group_assigned = True
+        user.last_auto_promo_group_id = target_group.id
+        user.last_auto_promo_group = target_group
         user.updated_at = datetime.utcnow()
 
         if target_group.id != previous_group_id:

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -243,6 +243,7 @@ class UserService:
 
             user.promo_group_id = promo_group.id
             user.promo_group = promo_group
+            user.auto_promo_group_assigned = False
             user.updated_at = datetime.utcnow()
 
             await db.commit()

--- a/migrations/alembic/versions/9d7b1c7a3a4f_add_last_auto_promo_group_id.py
+++ b/migrations/alembic/versions/9d7b1c7a3a4f_add_last_auto_promo_group_id.py
@@ -1,0 +1,74 @@
+"""
+Add last_auto_promo_group_id column to users.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
+
+revision: str = "9d7b1c7a3a4f"
+down_revision: Union[str, None] = "8fd1e338eb45"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE_NAME = "users"
+COLUMN_NAME = "last_auto_promo_group_id"
+INDEX_NAME = "ix_users_last_auto_promo_group_id"
+FK_NAME = "fk_users_last_auto_promo_group_id"
+
+
+def _column_exists(inspector: Inspector) -> bool:
+    return COLUMN_NAME in {column["name"] for column in inspector.get_columns(TABLE_NAME)}
+
+
+def _index_exists(inspector: Inspector) -> bool:
+    return INDEX_NAME in {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+
+
+def _fk_exists(inspector: Inspector) -> bool:
+    return FK_NAME in {fk["name"] for fk in inspector.get_foreign_keys(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _column_exists(inspector):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(COLUMN_NAME, sa.Integer(), nullable=True),
+        )
+        inspector = sa.inspect(bind)
+
+    if _column_exists(inspector) and not _fk_exists(inspector):
+        op.create_foreign_key(
+            FK_NAME,
+            TABLE_NAME,
+            "promo_groups",
+            [COLUMN_NAME],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        inspector = sa.inspect(bind)
+
+    if _column_exists(inspector) and not _index_exists(inspector):
+        op.create_index(INDEX_NAME, TABLE_NAME, [COLUMN_NAME])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+        inspector = sa.inspect(bind)
+
+    if _fk_exists(inspector):
+        op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+        inspector = sa.inspect(bind)
+
+    if _column_exists(inspector):
+        op.drop_column(TABLE_NAME, COLUMN_NAME)


### PR DESCRIPTION
## Summary
- add tracking of the last automatically assigned promo group to the user model
- prevent reassigning the same promo group when it was already auto-issued and remember the last auto group even after manual changes
- extend migrations to create the new column (both alembic and universal migration helpers)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5288201088320b8b79b5a4b273ac9