### PR TITLE
Prevent repeated automatic promo group reassignment

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -388,6 +388,7 @@ class User(Base):
     discount_offers = relationship("DiscountOffer", back_populates="user")
     lifetime_used_traffic_bytes = Column(BigInteger, default=0)
     auto_promo_group_assigned = Column(Boolean, nullable=False, default=False)
+    auto_promo_group_threshold_kopeks = Column(BigInteger, nullable=False, default=0)
     last_remnawave_sync = Column(DateTime, nullable=True)
     trojan_password = Column(String(255), nullable=True)
     vless_uuid = Column(String(255), nullable=True)

--- a/app/database/universal_migration.py
+++ b/app/database/universal_migration.py
@@ -1025,6 +1025,39 @@ async def ensure_promo_groups_setup():
 
                 logger.info("Добавлена колонка users.auto_promo_group_assigned")
 
+            threshold_column_exists = await check_column_exists(
+                "users", "auto_promo_group_threshold_kopeks"
+            )
+
+            if not threshold_column_exists:
+                if db_type == "sqlite":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN auto_promo_group_threshold_kopeks INTEGER NOT NULL DEFAULT 0"
+                        )
+                    )
+                elif db_type == "postgresql":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN auto_promo_group_threshold_kopeks BIGINT NOT NULL DEFAULT 0"
+                        )
+                    )
+                elif db_type == "mysql":
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN auto_promo_group_threshold_kopeks BIGINT NOT NULL DEFAULT 0"
+                        )
+                    )
+                else:
+                    logger.error(
+                        f"Неподдерживаемый тип БД для users.auto_promo_group_threshold_kopeks: {db_type}"
+                    )
+                    return False
+
+                logger.info(
+                    "Добавлена колонка users.auto_promo_group_threshold_kopeks"
+                )
+
             index_exists = await check_index_exists("users", "ix_users_promo_group_id")
 
             if not index_exists:
@@ -2044,6 +2077,7 @@ async def check_migration_status():
             "promo_groups_auto_assign_column": False,
             "promo_groups_addon_discount_column": False,
             "users_auto_promo_group_assigned_column": False,
+            "users_auto_promo_group_threshold_column": False,
             "subscription_crypto_link_column": False,
         }
         
@@ -2062,6 +2096,7 @@ async def check_migration_status():
         status["promo_groups_auto_assign_column"] = await check_column_exists('promo_groups', 'auto_assign_total_spent_kopeks')
         status["promo_groups_addon_discount_column"] = await check_column_exists('promo_groups', 'apply_discounts_to_addons')
         status["users_auto_promo_group_assigned_column"] = await check_column_exists('users', 'auto_promo_group_assigned')
+        status["users_auto_promo_group_threshold_column"] = await check_column_exists('users', 'auto_promo_group_threshold_kopeks')
         status["subscription_crypto_link_column"] = await check_column_exists('subscriptions', 'subscription_crypto_link')
         
         media_fields_exist = (
@@ -2100,6 +2135,7 @@ async def check_migration_status():
             "promo_groups_auto_assign_column": "Колонка auto_assign_total_spent_kopeks у промо-групп",
             "promo_groups_addon_discount_column": "Колонка apply_discounts_to_addons у промо-групп",
             "users_auto_promo_group_assigned_column": "Флаг автоназначения промогруппы у пользователей",
+            "users_auto_promo_group_threshold_column": "Порог последней авто-промогруппы у пользователей",
             "subscription_crypto_link_column": "Колонка subscription_crypto_link в subscriptions",
         }
         


### PR DESCRIPTION
## Summary
- store the last auto-assigned promo group threshold for each user to avoid re-adding them to the same group
- update automatic promo group assignment logic to require crossing a higher spending threshold before moving users
- extend the universal migration to add the new column and include it in migration status checks
