### PR TITLE
Make RemnaWave settings configurable via admin panel

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     
     REDIS_URL: str = "redis://localhost:6379/0"
     
-    REMNAWAVE_API_URL: str
-    REMNAWAVE_API_KEY: str
+    REMNAWAVE_API_URL: str = ""
+    REMNAWAVE_API_KEY: str = ""
     REMNAWAVE_SECRET_KEY: Optional[str] = None
 
     REMNAWAVE_USERNAME: Optional[str] = None
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     TRIAL_DEVICE_LIMIT: int = 2
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
-    TRIAL_SQUAD_UUID: str
+    TRIAL_SQUAD_UUID: str = ""
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
     MAX_DEVICES_LIMIT: int = 20
     

--- a/app/handlers/admin/remnawave.py
+++ b/app/handlers/admin/remnawave.py
@@ -30,14 +30,22 @@ async def show_remnawave_menu(
 ):
    remnawave_service = RemnaWaveService()
    connection_test = await remnawave_service.test_api_connection()
-   
-   status_emoji = "✅" if connection_test["status"] == "connected" else "❌"
-   
+
+   status = connection_test.get("status")
+   if status == "connected":
+       status_emoji = "✅"
+   elif status == "not_configured":
+       status_emoji = "ℹ️"
+   else:
+       status_emoji = "❌"
+
+   api_url_display = settings.REMNAWAVE_API_URL or "—"
+
    text = f"""
 🖥️ <b>Управление Remnawave</b>
 
-📡 <b>Соединение:</b> {status_emoji} {connection_test["message"]}
-🌐 <b>URL:</b> <code>{settings.REMNAWAVE_API_URL}</code>
+📡 <b>Соединение:</b> {status_emoji} {connection_test.get("message", "Нет данных")}
+🌐 <b>URL:</b> <code>{api_url_display}</code>
 
 Выберите действие:
 """
@@ -194,7 +202,7 @@ async def show_traffic_stats(
     remnawave_service = RemnaWaveService()
     
     try:
-        async with remnawave_service.api as api:
+        async with remnawave_service.get_api_client() as api:
             bandwidth_stats = await api.get_bandwidth_stats()
             
             realtime_usage = await api.get_nodes_realtime_usage()

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -1988,7 +1988,7 @@ async def toggle_user_server(
         if user.remnawave_uuid:
             try:
                 remnawave_service = RemnaWaveService()
-                async with remnawave_service.api as api:
+                async with remnawave_service.get_api_client() as api:
                     await api.update_user(
                         uuid=user.remnawave_uuid,
                         active_internal_squads=current_squads,
@@ -2332,7 +2332,7 @@ async def reset_user_devices(
             return
         
         remnawave_service = RemnaWaveService()
-        async with remnawave_service.api as api:
+        async with remnawave_service.get_api_client() as api:
             success = await api.reset_user_devices(user.remnawave_uuid)
         
         if success:
@@ -2372,7 +2372,7 @@ async def _update_user_devices(db: AsyncSession, user_id: int, devices: int, adm
         if user.remnawave_uuid:
             try:
                 remnawave_service = RemnaWaveService()
-                async with remnawave_service.api as api:
+                async with remnawave_service.get_api_client() as api:
                     await api.update_user(
                         uuid=user.remnawave_uuid,
                         hwid_device_limit=devices,
@@ -2414,7 +2414,7 @@ async def _update_user_traffic(db: AsyncSession, user_id: int, traffic_gb: int, 
                 from app.external.remnawave_api import TrafficLimitStrategy
                 
                 remnawave_service = RemnaWaveService()
-                async with remnawave_service.api as api:
+                async with remnawave_service.get_api_client() as api:
                     await api.update_user(
                         uuid=user.remnawave_uuid,
                         traffic_limit_bytes=traffic_gb * (1024**3) if traffic_gb > 0 else 0,
@@ -2873,7 +2873,7 @@ async def admin_buy_subscription_execute(
                 remnawave_service = RemnaWaveService()
                 
                 if target_user.remnawave_uuid:
-                    async with remnawave_service.api as api:
+                    async with remnawave_service.get_api_client() as api:
                         remnawave_user = await api.update_user(
                             uuid=target_user.remnawave_uuid,
                             status=UserStatus.ACTIVE if subscription.is_active else UserStatus.EXPIRED,
@@ -2890,7 +2890,7 @@ async def admin_buy_subscription_execute(
                         )
                 else:
                     username = f"user_{target_user.telegram_id}"
-                    async with remnawave_service.api as api:
+                    async with remnawave_service.get_api_client() as api:
                         remnawave_user = await api.create_user(
                             username=username,
                             expire_at=subscription.end_date,

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -549,7 +549,7 @@ async def show_subscription_info(
             from app.services.remnawave_service import RemnaWaveService
             service = RemnaWaveService()
             
-            async with service.api as api:
+            async with service.get_api_client() as api:
                 response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
                 
                 if response and 'response' in response:
@@ -651,7 +651,7 @@ async def get_current_devices_detailed(db_user: User) -> dict:
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if response and 'response' in response:
@@ -724,7 +724,7 @@ async def get_current_devices_count(db_user: User) -> str:
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if response and 'response' in response:
@@ -1826,7 +1826,7 @@ async def handle_device_management(
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if response and 'response' in response:
@@ -1910,7 +1910,7 @@ async def handle_devices_page(
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if response and 'response' in response:
@@ -1953,7 +1953,7 @@ async def handle_single_device_reset(
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if response and 'response' in response:
@@ -2026,7 +2026,7 @@ async def handle_all_devices_reset_from_management(
         from app.services.remnawave_service import RemnaWaveService
         service = RemnaWaveService()
         
-        async with service.api as api:
+        async with service.get_api_client() as api:
             devices_response = await api._make_request('GET', f'/api/hwid/devices/{db_user.remnawave_uuid}')
             
             if not devices_response or 'response' not in devices_response:
@@ -2723,7 +2723,7 @@ async def confirm_reset_traffic(
         
         user = db_user
         if user.remnawave_uuid:
-            async with remnawave_service.api as api:
+            async with remnawave_service.get_api_client() as api:
                 await api.reset_user_traffic(user.remnawave_uuid)
         
         await create_transaction(

--- a/app/middlewares/auth.py
+++ b/app/middlewares/auth.py
@@ -23,7 +23,7 @@ async def _refresh_remnawave_description(
 ) -> None:
     try:
         remnawave_service = RemnaWaveService()
-        async with remnawave_service.api as api:
+        async with remnawave_service.get_api_client() as api:
             await api.update_user(uuid=remnawave_uuid, description=description)
         logger.info(
             f"✅ [Middleware] Описание пользователя {telegram_id} обновлено в RemnaWave"

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -360,7 +360,7 @@ class UserService:
                     
                     if delete_mode == "delete":
                         # Удаляем пользователя из панели Remnawave
-                        async with remnawave_service.api as api:
+                        async with remnawave_service.get_api_client() as api:
                             delete_success = await api.delete_user(user.remnawave_uuid)
                             if delete_success:
                                 logger.info(f"✅ RemnaWave пользователь {user.remnawave_uuid} удален из панели")


### PR DESCRIPTION
## Summary
- allow RemnaWave URL, API key and trial squad ID to be configured from the admin panel without environment variables
- add a RemnaWave connection test button in the configuration UI and show clearer status information in the RemnaWave admin menu
- centralize RemnaWave API usage through a guarded client helper so features fail gracefully when configuration is missing
