### PR TITLE
Allow admin Stars test invoices

### DIFF
--- a/app/handlers/stars_payments.py
+++ b/app/handlers/stars_payments.py
@@ -18,7 +18,9 @@ async def handle_pre_checkout_query(query: types.PreCheckoutQuery):
     try:
         logger.info(f"📋 Pre-checkout query от {query.from_user.id}: {query.total_amount} XTR, payload: {query.invoice_payload}")
 
-        if not query.invoice_payload or not query.invoice_payload.startswith("balance_"):
+        allowed_prefixes = ("balance_", "admin_stars_test_")
+
+        if not query.invoice_payload or not query.invoice_payload.startswith(allowed_prefixes):
             logger.warning(f"Невалидный payload: {query.invoice_payload}")
             await query.answer(
                 ok=False,


### PR DESCRIPTION
## Summary
- allow Telegram Stars pre-checkout validation to accept admin test invoices

