### PR TITLE
Add web admin API and integrate dashboard interface

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -251,6 +251,13 @@ class Settings(BaseSettings):
     BACKUP_SEND_CHAT_ID: Optional[str] = None
     BACKUP_SEND_TOPIC_ID: Optional[int] = None
 
+    WEBADMIN_ENABLED: bool = False
+    WEBADMIN_HOST: str = "0.0.0.0"
+    WEBADMIN_PORT: int = 8090
+    WEBADMIN_API_KEY: Optional[str] = None
+    WEBADMIN_ALLOWED_ORIGINS: str = ""
+    WEBADMIN_TITLE: str = "BedolagaAdmin"
+
     @field_validator('SERVER_STATUS_MODE', mode='before')
     @classmethod
     def normalize_server_status_mode(cls, value: Optional[str]) -> str:
@@ -954,21 +961,47 @@ class Settings(BaseSettings):
 
     def get_server_status_request_timeout(self) -> int:
         return max(1, self.SERVER_STATUS_REQUEST_TIMEOUT)
-    
+
     def get_support_system_mode(self) -> str:
         mode = (self.SUPPORT_SYSTEM_MODE or "both").strip().lower()
         return mode if mode in {"tickets", "contact", "both"} else "both"
-    
+
     def is_support_tickets_enabled(self) -> bool:
         return self.get_support_system_mode() in {"tickets", "both"}
-    
+
     def is_support_contact_enabled(self) -> bool:
         return self.get_support_system_mode() in {"contact", "both"}
-    
+
+    def is_webadmin_enabled(self) -> bool:
+        return self.WEBADMIN_ENABLED and bool((self.WEBADMIN_API_KEY or "").strip())
+
+    def get_webadmin_host(self) -> str:
+        host = (self.WEBADMIN_HOST or "").strip()
+        return host or "0.0.0.0"
+
+    def get_webadmin_port(self) -> int:
+        try:
+            return int(self.WEBADMIN_PORT)
+        except (TypeError, ValueError):
+            return 8090
+
+    def get_webadmin_allowed_origins(self) -> List[str]:
+        if not self.WEBADMIN_ALLOWED_ORIGINS:
+            return []
+
+        return [
+            origin.strip()
+            for origin in self.WEBADMIN_ALLOWED_ORIGINS.split(",")
+            if origin.strip()
+        ]
+
+    def get_webadmin_title(self) -> str:
+        return (self.WEBADMIN_TITLE or "BedolagaAdmin").strip() or "BedolagaAdmin"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",
-        "extra": "ignore"  
+        "extra": "ignore"
     }
 
 

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -100,6 +100,7 @@ class BotConfigurationService:
         "LOG": "Логирование",
         "WEBHOOK": "Вебхуки",
         "DEBUG": "Режим разработки",
+        "WEBADMIN": "Веб-админка",
     }
 
     CATEGORY_KEY_OVERRIDES: Dict[str, str] = {
@@ -194,6 +195,7 @@ class BotConfigurationService:
         "WEBHOOK_": "WEBHOOK",
         "LOG_": "LOG",
         "DEBUG": "DEBUG",
+        "WEBADMIN_": "WEBADMIN",
     }
 
     CHOICES: Dict[str, List[ChoiceOption]] = {

--- a/app/webadmin/__init__.py
+++ b/app/webadmin/__init__.py
@@ -1,0 +1,5 @@
+"""Web admin integration package."""
+
+from .server import WebAdminServer
+
+__all__ = ["WebAdminServer"]

--- a/app/webadmin/dashboard.py
+++ b/app/webadmin/dashboard.py
@@ -1,0 +1,300 @@
+"""Dashboard data helpers for the web admin API."""
+
+from __future__ import annotations
+"""Data aggregation helpers for the web admin dashboard."""
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database.models import (
+    ServerSquad,
+    Subscription,
+    SubscriptionConversion,
+    SubscriptionStatus,
+    Transaction,
+    TransactionType,
+    User,
+)
+from app.webadmin.serializers import (
+    serialize_server,
+    serialize_transaction,
+    serialize_user,
+)
+
+
+def _calculate_growth(current: int, previous: int) -> float:
+    if previous <= 0:
+        return 100.0 if current > 0 else 0.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+async def collect_dashboard_summary(session: AsyncSession) -> Dict[str, Any]:
+    """Collect key dashboard metrics."""
+
+    now = datetime.utcnow()
+    start_7 = now - timedelta(days=7)
+    prev_7 = now - timedelta(days=14)
+    start_30 = now - timedelta(days=30)
+    start_60 = now - timedelta(days=60)
+
+    total_users = await session.scalar(select(func.count(User.id))) or 0
+    new_users_last_7 = (
+        await session.scalar(select(func.count(User.id)).where(User.created_at >= start_7))
+    ) or 0
+    new_users_prev_7 = (
+        await session.scalar(
+            select(func.count(User.id)).where(
+                and_(User.created_at >= prev_7, User.created_at < start_7)
+            )
+        )
+    ) or 0
+
+    active_statuses = [
+        SubscriptionStatus.ACTIVE.value,
+        SubscriptionStatus.TRIAL.value,
+    ]
+    active_subscriptions = (
+        await session.scalar(
+            select(func.count(Subscription.id)).where(
+                Subscription.status.in_(active_statuses),
+                Subscription.end_date > now,
+            )
+        )
+    ) or 0
+    active_trials = (
+        await session.scalar(
+            select(func.count(Subscription.id)).where(
+                Subscription.status == SubscriptionStatus.TRIAL.value,
+                Subscription.end_date > now,
+            )
+        )
+    ) or 0
+    active_paid = max(0, active_subscriptions - active_trials)
+
+    revenue_types = [
+        TransactionType.SUBSCRIPTION_PAYMENT.value,
+        TransactionType.DEPOSIT.value,
+    ]
+    revenue_current = (
+        await session.scalar(
+            select(func.coalesce(func.sum(Transaction.amount_kopeks), 0)).where(
+                Transaction.created_at >= start_30,
+                Transaction.type.in_(revenue_types),
+                Transaction.amount_kopeks > 0,
+            )
+        )
+    ) or 0
+    revenue_previous = (
+        await session.scalar(
+            select(func.coalesce(func.sum(Transaction.amount_kopeks), 0)).where(
+                Transaction.created_at >= start_60,
+                Transaction.created_at < start_30,
+                Transaction.type.in_(revenue_types),
+                Transaction.amount_kopeks > 0,
+            )
+        )
+    ) or 0
+
+    new_trials_last_30 = (
+        await session.scalar(
+            select(func.count(Subscription.id)).where(
+                Subscription.is_trial.is_(True),
+                Subscription.created_at >= start_30,
+            )
+        )
+    ) or 0
+    conversions_last_30 = (
+        await session.scalar(
+            select(func.count(SubscriptionConversion.id)).where(
+                SubscriptionConversion.converted_at >= start_30
+            )
+        )
+    ) or 0
+
+    conversion_rate = (
+        round((conversions_last_30 / new_trials_last_30) * 100, 2)
+        if new_trials_last_30
+        else 0.0
+    )
+
+    total_servers = await session.scalar(select(func.count(ServerSquad.id))) or 0
+    available_servers = (
+        await session.scalar(
+            select(func.count(ServerSquad.id)).where(ServerSquad.is_available.is_(True))
+        )
+    ) or 0
+    active_servers_percent = (
+        round((available_servers / total_servers) * 100, 2)
+        if total_servers
+        else 0.0
+    )
+
+    return {
+        "total_users": int(total_users),
+        "new_users_last_7": int(new_users_last_7),
+        "new_users_prev_7": int(new_users_prev_7),
+        "user_growth_percent": _calculate_growth(new_users_last_7, new_users_prev_7),
+        "active_subscriptions": int(active_subscriptions),
+        "active_trials": int(active_trials),
+        "active_paid": int(active_paid),
+        "monthly_revenue_kopeks": int(revenue_current),
+        "monthly_revenue": round(revenue_current / 100, 2),
+        "monthly_revenue_change_percent": _calculate_growth(
+            revenue_current, revenue_previous
+        ),
+        "total_servers": int(total_servers),
+        "available_servers": int(available_servers),
+        "active_servers_percent": active_servers_percent,
+        "new_trials_last_30": int(new_trials_last_30),
+        "conversions_last_30": int(conversions_last_30),
+        "conversion_rate_percent": conversion_rate,
+    }
+
+
+async def collect_revenue_series(
+    session: AsyncSession,
+    *,
+    days: int = 14,
+) -> List[Dict[str, Any]]:
+    """Collect revenue per day for the specified period."""
+
+    days = max(1, min(days, 90))
+    now = datetime.utcnow()
+    start = (now - timedelta(days=days - 1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    revenue_types = [
+        TransactionType.SUBSCRIPTION_PAYMENT.value,
+        TransactionType.DEPOSIT.value,
+    ]
+
+    rows = await session.execute(
+        select(Transaction.created_at, Transaction.amount_kopeks)
+        .where(
+            Transaction.created_at >= start,
+            Transaction.type.in_(revenue_types),
+            Transaction.amount_kopeks > 0,
+        )
+        .order_by(Transaction.created_at.asc())
+    )
+
+    revenue_by_day: Dict[datetime, int] = defaultdict(int)
+    for offset in range(days):
+        revenue_by_day[(start + timedelta(days=offset)).date()] = 0
+
+    for created_at, amount in rows:
+        if not created_at:
+            continue
+        day = created_at.date()
+        revenue_by_day[day] += amount or 0
+
+    series = []
+    for day, amount in sorted(revenue_by_day.items()):
+        series.append(
+            {
+                "date": day.isoformat(),
+                "revenue_kopeks": int(amount),
+                "revenue": round(amount / 100, 2),
+            }
+        )
+
+    return series
+
+
+async def fetch_recent_users(
+    session: AsyncSession,
+    *,
+    limit: int = 8,
+) -> List[Dict[str, Any]]:
+    result = await session.execute(
+        select(User)
+        .options(selectinload(User.subscription))
+        .order_by(User.created_at.desc())
+        .limit(limit)
+    )
+    users = result.scalars().all()
+    return [serialize_user(user) for user in users]
+
+
+async def list_users(
+    session: AsyncSession,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    search: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], int]:
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+
+    base_query = select(User).options(selectinload(User.subscription))
+    count_query = select(func.count(User.id))
+
+    if search:
+        normalized = search.strip().lower()
+        pattern = f"%{normalized}%"
+        filters = [
+            func.lower(User.username).like(pattern),
+            func.lower(User.first_name).like(pattern),
+            func.lower(User.last_name).like(pattern),
+        ]
+        numeric_filters = []
+        if normalized.isdigit():
+            numeric_value = int(normalized)
+            numeric_filters.extend(
+                [User.telegram_id == numeric_value, User.id == numeric_value]
+            )
+
+        conditions = filters + numeric_filters
+        if conditions:
+            base_query = base_query.where(or_(*conditions))
+            count_query = count_query.where(or_(*conditions))
+
+    base_query = base_query.order_by(User.created_at.desc()).offset(offset).limit(limit)
+
+    result = await session.execute(base_query)
+    users = result.scalars().all()
+
+    total = await session.scalar(count_query) or 0
+    return [serialize_user(user) for user in users], int(total)
+
+
+async def get_user_details(
+    session: AsyncSession,
+    user_id: int,
+) -> Optional[Dict[str, Any]]:
+    result = await session.execute(
+        select(User)
+        .options(selectinload(User.subscription))
+        .where(User.id == user_id)
+        .limit(1)
+    )
+    user = result.scalar_one_or_none()
+    if not user:
+        return None
+
+    transactions_result = await session.execute(
+        select(Transaction)
+        .where(Transaction.user_id == user_id)
+        .order_by(Transaction.created_at.desc())
+        .limit(25)
+    )
+    transactions = transactions_result.scalars().all()
+
+    return {
+        "user": serialize_user(user),
+        "transactions": [serialize_transaction(tx) for tx in transactions],
+    }
+
+
+async def fetch_server_overview(session: AsyncSession) -> List[Dict[str, Any]]:
+    result = await session.execute(
+        select(ServerSquad).order_by(ServerSquad.sort_order.asc(), ServerSquad.display_name.asc())
+    )
+    servers = result.scalars().all()
+    return [serialize_server(server) for server in servers]

--- a/app/webadmin/serializers.py
+++ b/app/webadmin/serializers.py
@@ -1,0 +1,179 @@
+"""Serialization helpers for the web admin API."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Optional
+
+from app.database.models import ServerSquad, Subscription, Transaction, User
+
+
+def _isoformat(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=None).isoformat()
+    return value.isoformat()
+
+
+def _round_currency(kopeks: Optional[int]) -> float:
+    if not kopeks:
+        return 0.0
+    return round(kopeks / 100, 2)
+
+
+@dataclass(slots=True)
+class SubscriptionView:
+    id: int
+    status: str
+    status_display: str
+    is_trial: bool
+    start_date: Optional[str]
+    end_date: Optional[str]
+    days_left: Optional[int]
+    traffic_limit_gb: int
+    traffic_used_gb: float
+    device_limit: int
+    autopay_enabled: bool
+
+
+@dataclass(slots=True)
+class UserView:
+    id: int
+    telegram_id: int
+    username: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    full_name: str
+    status: str
+    language: Optional[str]
+    balance_kopeks: int
+    balance_rub: float
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    last_activity: Optional[str]
+    referral_code: Optional[str]
+    has_had_paid_subscription: bool
+    promo_group_id: Optional[int]
+    subscription: Optional[SubscriptionView]
+
+
+@dataclass(slots=True)
+class TransactionView:
+    id: int
+    type: str
+    amount_kopeks: int
+    amount_rub: float
+    description: Optional[str]
+    payment_method: Optional[str]
+    created_at: Optional[str]
+    is_completed: bool
+
+
+@dataclass(slots=True)
+class ServerView:
+    id: int
+    squad_uuid: str
+    name: str
+    original_name: Optional[str]
+    country_code: Optional[str]
+    is_available: bool
+    status_label: str
+    current_users: int
+    max_users: Optional[int]
+    price_kopeks: int
+    price_rub: float
+    description: Optional[str]
+    updated_at: Optional[str]
+    capacity_percent: float
+
+
+def serialize_subscription(subscription: Subscription) -> SubscriptionView:
+    now = datetime.utcnow()
+    end_date = subscription.end_date
+    days_left: Optional[int] = None
+    if end_date:
+        remaining = end_date - now
+        days_left = max(0, int(remaining.total_seconds() // 86400))
+
+    return SubscriptionView(
+        id=subscription.id,
+        status=subscription.status,
+        status_display=subscription.status_display,
+        is_trial=subscription.is_trial,
+        start_date=_isoformat(subscription.start_date),
+        end_date=_isoformat(subscription.end_date),
+        days_left=days_left,
+        traffic_limit_gb=subscription.traffic_limit_gb or 0,
+        traffic_used_gb=float(subscription.traffic_used_gb or 0.0),
+        device_limit=subscription.device_limit or 0,
+        autopay_enabled=bool(subscription.autopay_enabled),
+    )
+
+
+def serialize_user(user: User) -> dict:
+    subscription_view: Optional[SubscriptionView] = None
+    if user.subscription:
+        subscription_view = serialize_subscription(user.subscription)
+
+    view = UserView(
+        id=user.id,
+        telegram_id=user.telegram_id,
+        username=user.username,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        full_name=user.full_name,
+        status=user.status,
+        language=user.language,
+        balance_kopeks=user.balance_kopeks or 0,
+        balance_rub=_round_currency(user.balance_kopeks or 0),
+        created_at=_isoformat(user.created_at),
+        updated_at=_isoformat(user.updated_at),
+        last_activity=_isoformat(user.last_activity),
+        referral_code=user.referral_code,
+        has_had_paid_subscription=bool(user.has_had_paid_subscription),
+        promo_group_id=user.promo_group_id,
+        subscription=subscription_view,
+    )
+
+    return asdict(view)
+
+
+def serialize_transaction(transaction: Transaction) -> dict:
+    view = TransactionView(
+        id=transaction.id,
+        type=transaction.type,
+        amount_kopeks=transaction.amount_kopeks,
+        amount_rub=_round_currency(transaction.amount_kopeks),
+        description=transaction.description,
+        payment_method=transaction.payment_method,
+        created_at=_isoformat(transaction.created_at),
+        is_completed=bool(transaction.is_completed),
+    )
+    return asdict(view)
+
+
+def serialize_server(server: ServerSquad) -> dict:
+    max_users = server.max_users or 0
+    capacity_percent = 0.0
+    if max_users and server.current_users is not None:
+        capacity_percent = round(min(100.0, (server.current_users / max_users) * 100), 2)
+
+    view = ServerView(
+        id=server.id,
+        squad_uuid=server.squad_uuid,
+        name=server.display_name,
+        original_name=server.original_name,
+        country_code=server.country_code,
+        is_available=bool(server.is_available),
+        status_label=server.availability_status,
+        current_users=server.current_users or 0,
+        max_users=server.max_users,
+        price_kopeks=server.price_kopeks or 0,
+        price_rub=_round_currency(server.price_kopeks or 0),
+        description=server.description,
+        updated_at=_isoformat(server.updated_at),
+        capacity_percent=capacity_percent,
+    )
+    return asdict(view)

--- a/app/webadmin/server.py
+++ b/app/webadmin/server.py
@@ -1,0 +1,499 @@
+"""aiohttp server exposing the bot web admin API and UI."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from aiohttp import web
+from aiogram import Bot
+
+from app.config import settings
+from app.database.database import AsyncSessionLocal
+from app.services.backup_service import BackupService
+from app.services.maintenance_service import MaintenanceService
+from app.services.monitoring_service import MonitoringService
+from app.services.reporting_service import ReportPeriod, ReportingService
+from app.services.system_settings_service import bot_configuration_service
+from app.services.version_service import VersionService
+from app.webadmin.dashboard import (
+    collect_dashboard_summary,
+    collect_revenue_series,
+    fetch_recent_users,
+    fetch_server_overview,
+    get_user_details,
+    list_users,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebAdminServer:
+    """Expose a modern web admin backed by the bot data."""
+
+    _PUBLIC_PATHS: set[str] = {"/", "/api/auth/login", "/api/health"}
+
+    def __init__(
+        self,
+        bot: Bot,
+        *,
+        maintenance_service: MaintenanceService,
+        monitoring_service: MonitoringService,
+        reporting_service: ReportingService,
+        version_service: VersionService,
+        backup_service: BackupService,
+    ) -> None:
+        self.bot = bot
+        self.maintenance_service = maintenance_service
+        self.monitoring_service = monitoring_service
+        self.reporting_service = reporting_service
+        self.version_service = version_service
+        self.backup_service = backup_service
+
+        self.app: Optional[web.Application] = None
+        self.runner: Optional[web.AppRunner] = None
+        self.site: Optional[web.TCPSite] = None
+
+        project_root = Path(__file__).resolve().parents[2]
+        self._index_path = project_root / "webadmin" / "index.html"
+        try:
+            self._index_template = self._index_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            logger.error("Не найден шаблон веб-админки: %s", self._index_path)
+            self._index_template = "<h1>Web admin template not found</h1>"
+
+        self._allowed_origins = settings.get_webadmin_allowed_origins()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    async def create_app(self) -> web.Application:
+        if self.app:
+            return self.app
+
+        self.app = web.Application(middlewares=[self._cors_middleware, self._auth_middleware])
+        self._register_routes(self.app)
+        return self.app
+
+    async def start(self) -> None:
+        if not settings.is_webadmin_enabled():
+            logger.info("Веб-админка отключена настройками")
+            return
+
+        await self.create_app()
+
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+
+        host = settings.get_webadmin_host()
+        port = settings.get_webadmin_port()
+
+        self.site = web.TCPSite(self.runner, host=host, port=port)
+        await self.site.start()
+
+        logger.info("🌐 Веб-админка запущена на http://%s:%s", host, port)
+
+    async def stop(self) -> None:
+        if self.site:
+            await self.site.stop()
+            self.site = None
+
+        if self.runner:
+            await self.runner.cleanup()
+            self.runner = None
+
+    # ------------------------------------------------------------------
+    # Middlewares & helpers
+    # ------------------------------------------------------------------
+    async def _cors_middleware(self, request: web.Request, handler: web.Handler) -> web.StreamResponse:
+        try:
+            response = await handler(request)
+        except web.HTTPException as exc:
+            self._apply_cors(request, exc)
+            raise
+
+        self._apply_cors(request, response)
+        return response
+
+    async def _auth_middleware(self, request: web.Request, handler: web.Handler) -> web.StreamResponse:
+        if request.method == "OPTIONS":
+            return await handler(request)
+
+        path = request.path
+        if path in self._PUBLIC_PATHS or not path.startswith("/api/"):
+            return await handler(request)
+
+        expected = (settings.WEBADMIN_API_KEY or "").strip()
+        if not expected:
+            return self._error("Веб-админка не настроена", status=503)
+
+        token = self._extract_token(request)
+        if not token:
+            return self._error("Требуется авторизация", status=401)
+
+        if not hmac.compare_digest(expected, token):
+            return self._error("Неверный токен доступа", status=401)
+
+        request["webadmin_token"] = token
+        return await handler(request)
+
+    def _apply_cors(self, request: web.Request, response: web.StreamResponse) -> None:
+        origin = request.headers.get("Origin")
+        allow_origin = "*"
+        if self._allowed_origins:
+            if origin and origin in self._allowed_origins:
+                allow_origin = origin
+            elif "*" not in self._allowed_origins:
+                allow_origin = self._allowed_origins[0]
+
+        response.headers["Access-Control-Allow-Origin"] = allow_origin
+        response.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+        response.headers["Access-Control-Allow-Credentials"] = "false"
+
+    @staticmethod
+    def _extract_token(request: web.Request) -> Optional[str]:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            return auth_header.split(" ", 1)[1].strip()
+
+        token = request.cookies.get("webadmin_token")
+        if token:
+            return token.strip()
+
+        token = request.query.get("token")
+        if token:
+            return token.strip()
+
+        return None
+
+    def _register_routes(self, app: web.Application) -> None:
+        app.router.add_get("/", self.handle_index)
+        app.router.add_get("/api/health", self.handle_health)
+        app.router.add_post("/api/auth/login", self.handle_login)
+
+        app.router.add_get("/api/dashboard/summary", self.handle_dashboard_summary)
+        app.router.add_get("/api/dashboard/revenue", self.handle_dashboard_revenue)
+
+        app.router.add_get("/api/users/recent", self.handle_recent_users)
+        app.router.add_get("/api/users", self.handle_users)
+        app.router.add_get("/api/users/{user_id}", self.handle_user_details)
+
+        app.router.add_get("/api/servers", self.handle_servers)
+
+        app.router.add_get("/api/settings/categories", self.handle_settings_categories)
+        app.router.add_get("/api/settings/category/{category_key}", self.handle_settings_category)
+        app.router.add_put("/api/settings/{key}", self.handle_setting_update)
+        app.router.add_delete("/api/settings/{key}", self.handle_setting_reset)
+
+        app.router.add_post("/api/bot/control", self.handle_bot_control)
+
+        app.router.add_options("/{tail:.*}", self.handle_options)
+
+    def _render_index(self) -> str:
+        title = settings.get_webadmin_title()
+        return self._index_template.replace("{{WEBADMIN_TITLE}}", title)
+
+    @staticmethod
+    def _success(data: Any = None, **extra: Any) -> web.Response:
+        payload: Dict[str, Any] = {"status": "ok"}
+        if data is not None:
+            payload["data"] = data
+        if extra:
+            payload.update(extra)
+        return web.json_response(payload)
+
+    @staticmethod
+    def _error(message: str, *, status: int = 400, **extra: Any) -> web.Response:
+        payload: Dict[str, Any] = {"status": "error", "message": message}
+        if extra:
+            payload.update(extra)
+        return web.json_response(payload, status=status)
+
+    @staticmethod
+    def _serialize_value(value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, (list, dict)):
+            return value
+        return str(value)
+
+    # ------------------------------------------------------------------
+    # Route handlers
+    # ------------------------------------------------------------------
+    async def handle_index(self, request: web.Request) -> web.Response:
+        return web.Response(text=self._render_index(), content_type="text/html")
+
+    async def handle_health(self, request: web.Request) -> web.Response:
+        maintenance = self.maintenance_service.status
+        data = {
+            "webadmin": {
+                "enabled": settings.is_webadmin_enabled(),
+                "title": settings.get_webadmin_title(),
+            },
+            "bot": {
+                "running": True,
+                "maintenance": maintenance.is_active,
+                "maintenance_reason": maintenance.reason,
+                "version": self.version_service.current_version,
+            },
+            "services": {
+                "monitoring_running": bool(getattr(self.monitoring_service, "is_running", False)),
+                "reporting_running": self.reporting_service.is_running(),
+                "auto_backup_enabled": getattr(
+                    self.backup_service, "_settings", None
+                ).auto_backup_enabled
+                if getattr(self.backup_service, "_settings", None)
+                else False,
+            },
+        }
+        return self._success(data)
+
+    async def handle_login(self, request: web.Request) -> web.Response:
+        expected = (settings.WEBADMIN_API_KEY or "").strip()
+        if not expected:
+            return self._error("Веб-админка не настроена", status=503)
+
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            return self._error("Некорректный JSON", status=400)
+
+        token = str(payload.get("token", "")).strip()
+        if not token:
+            return self._error("Укажите токен доступа", status=400)
+
+        if not hmac.compare_digest(expected, token):
+            return self._error("Неверный токен доступа", status=401)
+
+        return self._success({"access_token": token, "token_type": "bearer"})
+
+    async def handle_dashboard_summary(self, request: web.Request) -> web.Response:
+        async with AsyncSessionLocal() as session:
+            data = await collect_dashboard_summary(session)
+        return self._success(data)
+
+    async def handle_dashboard_revenue(self, request: web.Request) -> web.Response:
+        try:
+            days = int(request.query.get("days", "14"))
+        except ValueError:
+            days = 14
+
+        async with AsyncSessionLocal() as session:
+            data = await collect_revenue_series(session, days=days)
+        return self._success(data)
+
+    async def handle_recent_users(self, request: web.Request) -> web.Response:
+        try:
+            limit = int(request.query.get("limit", "8"))
+        except ValueError:
+            limit = 8
+
+        async with AsyncSessionLocal() as session:
+            data = await fetch_recent_users(session, limit=limit)
+        return self._success(data)
+
+    async def handle_users(self, request: web.Request) -> web.Response:
+        try:
+            limit = int(request.query.get("limit", "20"))
+        except ValueError:
+            limit = 20
+        try:
+            offset = int(request.query.get("offset", "0"))
+        except ValueError:
+            offset = 0
+        search = request.query.get("search")
+
+        async with AsyncSessionLocal() as session:
+            items, total = await list_users(
+                session, limit=limit, offset=offset, search=search
+            )
+
+        return self._success({"items": items, "total": total, "limit": limit, "offset": offset})
+
+    async def handle_user_details(self, request: web.Request) -> web.Response:
+        try:
+            user_id = int(request.match_info["user_id"])
+        except (KeyError, ValueError):
+            return self._error("Некорректный идентификатор пользователя", status=400)
+
+        async with AsyncSessionLocal() as session:
+            data = await get_user_details(session, user_id)
+
+        if not data:
+            return self._error("Пользователь не найден", status=404)
+
+        return self._success(data)
+
+    async def handle_servers(self, request: web.Request) -> web.Response:
+        async with AsyncSessionLocal() as session:
+            data = await fetch_server_overview(session)
+        return self._success(data)
+
+    async def handle_settings_categories(self, request: web.Request) -> web.Response:
+        categories = [
+            {"key": key, "label": label, "count": count}
+            for key, label, count in bot_configuration_service.get_categories()
+        ]
+        categories.sort(key=lambda item: item["label"].lower())
+        return self._success(categories)
+
+    async def handle_settings_category(self, request: web.Request) -> web.Response:
+        category_key = request.match_info.get("category_key")
+        definitions = bot_configuration_service.get_settings_for_category(category_key)
+
+        items: List[Dict[str, Any]] = []
+        for definition in definitions:
+            key = definition.key
+            current_value = bot_configuration_service.get_current_value(key)
+            original_value = bot_configuration_service.get_original_value(key)
+            items.append(
+                {
+                    "key": key,
+                    "name": definition.display_name,
+                    "type": definition.type_label,
+                    "is_optional": definition.is_optional,
+                    "has_override": bot_configuration_service.has_override(key),
+                    "value": self._serialize_value(current_value),
+                    "value_formatted": bot_configuration_service.format_value(current_value),
+                    "original": self._serialize_value(original_value),
+                    "original_formatted": bot_configuration_service.format_value(original_value),
+                    "choices": [
+                        {
+                            "value": choice.value,
+                            "label": choice.label,
+                            "description": choice.description,
+                        }
+                        for choice in bot_configuration_service.get_choice_options(key)
+                    ],
+                }
+            )
+
+        return self._success(items)
+
+    async def handle_setting_update(self, request: web.Request) -> web.Response:
+        key = request.match_info.get("key")
+        if not key:
+            return self._error("Не указан ключ настройки", status=400)
+
+        try:
+            bot_configuration_service.get_definition(key)
+        except KeyError:
+            return self._error("Настройка не найдена", status=404)
+
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            return self._error("Некорректный JSON", status=400)
+
+        if "value" not in payload:
+            return self._error("Отсутствует поле value", status=400)
+
+        raw_value = payload.get("value")
+        try:
+            parsed_value = (
+                bot_configuration_service.parse_user_value(key, str(raw_value))
+                if raw_value is not None
+                else None
+            )
+        except ValueError as exc:
+            return self._error(str(exc), status=400)
+
+        async with AsyncSessionLocal() as session:
+            await bot_configuration_service.set_value(session, key, parsed_value)
+
+        updated = bot_configuration_service.get_current_value(key)
+        summary = {
+            "key": key,
+            "value": self._serialize_value(updated),
+            "value_formatted": bot_configuration_service.format_value(updated),
+            "has_override": bot_configuration_service.has_override(key),
+        }
+        return self._success(summary)
+
+    async def handle_setting_reset(self, request: web.Request) -> web.Response:
+        key = request.match_info.get("key")
+        if not key:
+            return self._error("Не указан ключ настройки", status=400)
+
+        try:
+            bot_configuration_service.get_definition(key)
+        except KeyError:
+            return self._error("Настройка не найдена", status=404)
+
+        async with AsyncSessionLocal() as session:
+            await bot_configuration_service.reset_value(session, key)
+
+        value = bot_configuration_service.get_current_value(key)
+        summary = {
+            "key": key,
+            "value": self._serialize_value(value),
+            "value_formatted": bot_configuration_service.format_value(value),
+            "has_override": bot_configuration_service.has_override(key),
+        }
+        return self._success(summary)
+
+    async def handle_bot_control(self, request: web.Request) -> web.Response:
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            return self._error("Некорректный JSON", status=400)
+
+        action = (payload.get("action") or "").strip()
+        if not action:
+            return self._error("Не указано действие", status=400)
+
+        try:
+            if action == "reload_configuration":
+                await bot_configuration_service.reload()
+                return self._success({"message": "Конфигурация перезагружена"})
+
+            if action == "enable_maintenance":
+                reason = payload.get("reason") or "Включено из веб-админки"
+                success = await self.maintenance_service.enable_maintenance(reason=reason)
+                if success:
+                    return self._success({"message": "Режим техработ включен"})
+                return self._error("Не удалось включить режим техработ", status=500)
+
+            if action == "disable_maintenance":
+                success = await self.maintenance_service.disable_maintenance()
+                if success:
+                    return self._success({"message": "Режим техработ выключен"})
+                return self._error("Не удалось выключить режим техработ", status=500)
+
+            if action == "create_backup":
+                success, message, file_path = await self.backup_service.create_backup()
+                status = "ok" if success else "error"
+                response = {
+                    "status": status,
+                    "message": message,
+                }
+                if file_path:
+                    response["file"] = file_path
+                if success:
+                    return self._success(response)
+                return self._error(message or "Не удалось создать бекап", status=500)
+
+            if action == "send_daily_report":
+                report_text = await self.reporting_service.send_report(ReportPeriod.DAILY)
+                return self._success(
+                    {
+                        "message": "Отчет сформирован",
+                        "preview": report_text,
+                    }
+                )
+
+            return self._error("Неизвестное действие", status=400)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ошибка выполнения действия %s", action)
+            return self._error(f"Ошибка выполнения действия: {exc}", status=500)
+
+    async def handle_options(self, request: web.Request) -> web.Response:
+        return web.Response(status=204)

--- a/webadmin/index.html
+++ b/webadmin/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BedolagaAdmin • Панель управления</title>
+    <title>{{WEBADMIN_TITLE}} • Панель управления</title>
     <style>
         * {
             margin: 0;
@@ -37,7 +37,6 @@
             overflow-x: hidden;
         }
 
-        /* Animated Background */
         .bg-animation {
             position: fixed;
             width: 100%;
@@ -59,13 +58,11 @@
             75% { transform: translate(-30px, 20px) scale(1.05); }
         }
 
-        /* Layout */
         .container {
             display: flex;
             min-height: 100vh;
         }
 
-        /* Sidebar */
         .sidebar {
             width: 280px;
             background: var(--bg-secondary);
@@ -219,14 +216,12 @@
             font-weight: 600;
         }
 
-        /* Main Content */
         .main {
             flex: 1;
             display: flex;
             flex-direction: column;
         }
 
-        /* Header */
         .header {
             background: var(--bg-secondary);
             border-bottom: 1px solid var(--border);
@@ -235,6 +230,9 @@
             align-items: center;
             justify-content: space-between;
             backdrop-filter: blur(10px);
+            position: sticky;
+            top: 0;
+            z-index: 5;
         }
 
         .header-left {
@@ -310,7 +308,7 @@
             color: white;
             font-size: 10px;
             border-radius: 50%;
-            display: flex;
+            display: none;
             align-items: center;
             justify-content: center;
             font-weight: 600;
@@ -337,14 +335,13 @@
             border-radius: 8px;
             background: var(--accent-gradient);
             display: flex;
-            align-items: center;
+            align.items: center;
             justify-content: center;
             font-weight: 600;
             font-size: 14px;
             color: white;
         }
 
-        /* Content Area */
         .content {
             flex: 1;
             padding: 32px;
@@ -365,8 +362,6 @@
             color: var(--text-secondary);
             margin-bottom: 32px;
         }
-
-        /* Stats Grid */
         .stats-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -448,6 +443,7 @@
             border-radius: 20px;
             font-size: 12px;
             font-weight: 600;
+            background: rgba(255, 255, 255, 0.05);
         }
 
         .stat-change.positive {
@@ -460,17 +456,13 @@
             color: var(--danger);
         }
 
-        /* Chart Container */
         .chart-container {
             background: var(--bg-secondary);
             border: 1px solid var(--border);
             border-radius: 16px;
             padding: 24px;
             margin-bottom: 32px;
-            height: 400px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            min-height: 320px;
             position: relative;
             overflow: hidden;
         }
@@ -494,7 +486,44 @@
             color: var(--text-tertiary);
         }
 
-        /* Quick Actions */
+        .chart-bars {
+            position: relative;
+            display: flex;
+            align-items: flex-end;
+            justify-content: flex-start;
+            gap: 16px;
+            height: 240px;
+            padding: 24px 12px 12px;
+        }
+
+        .chart-bar {
+            position: relative;
+            flex: 1;
+            min-width: 32px;
+            border-radius: 10px 10px 0 0;
+            background: linear-gradient(180deg, rgba(99, 102, 241, 0.85), rgba(139, 92, 246, 0.4));
+            overflow: hidden;
+        }
+
+        .chart-bar-value {
+            position: absolute;
+            top: -28px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .chart-bar-label {
+            position: absolute;
+            bottom: -24px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 11px;
+            color: var(--text-tertiary);
+            white-space: nowrap;
+        }
+
         .quick-actions {
             display: flex;
             gap: 16px;
@@ -517,135 +546,193 @@
             font-weight: 500;
         }
 
+        .action-btn.primary {
+            background: var(--accent-gradient);
+            color: white;
+            border: none;
+        }
+
         .action-btn:hover {
             background: var(--bg-tertiary);
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-        }
-
-        .action-btn.primary {
-            background: var(--accent-primary);
-            border-color: var(--accent-primary);
-            color: white;
         }
 
         .action-btn.primary:hover {
-            background: var(--accent-secondary);
-            border-color: var(--accent-secondary);
+            opacity: 0.95;
+            transform: translateY(-2px);
         }
 
-        /* Bot Control Dropdown */
-        .bot-control {
-            position: relative;
-        }
-        
-        .bot-control-btn {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 16px;
-            background: var(--bg-tertiary);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            color: var(--text-primary);
-            font-size: 14px;
-            font-weight: 500;
-        }
-        
-        .bot-control-btn:hover {
-            background: var(--bg-hover);
-            border-color: var(--accent-primary);
-        }
-        
-        .bot-status {
-            width: 8px;
-            height: 8px;
-            background: var(--success);
-            border-radius: 50%;
-            animation: pulse 2s infinite;
-        }
-        
-        .bot-dropdown {
-            position: absolute;
-            top: 100%;
-            right: 0;
-            margin-top: 8px;
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            padding: 8px;
-            min-width: 200px;
-            opacity: 0;
-            visibility: hidden;
-            transform: translateY(-10px);
-            transition: all 0.3s ease;
-            z-index: 1000;
-            box-shadow: var(--shadow);
-        }
-        
-        .bot-control:hover .bot-dropdown {
-            opacity: 1;
-            visibility: visible;
-            transform: translateY(0);
-        }
-        
-        .bot-dropdown-item {
+        .servers-section-title {
+            font-size: 20px;
+            font-weight: 600;
+            margin-bottom: 20px;
             display: flex;
             align-items: center;
             gap: 12px;
-            padding: 10px 12px;
-            border-radius: 8px;
-            color: var(--text-secondary);
-            cursor: pointer;
-            transition: all 0.2s ease;
-            font-size: 14px;
-        }
-        
-        .bot-dropdown-item:hover {
-            background: var(--bg-tertiary);
-            color: var(--text-primary);
-        }
-        
-        .bot-dropdown-item.danger {
-            color: var(--danger);
-        }
-        
-        .bot-dropdown-item.warning {
-            color: var(--warning);
-        }
-        
-        .bot-dropdown-divider {
-            height: 1px;
-            background: var(--border);
-            margin: 8px 0;
         }
 
-        /* Enhanced Table */
+        .server-card {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            margin-bottom: 16px;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+
+        .server-card.expanded {
+            border-color: rgba(99, 102, 241, 0.3);
+            box-shadow: var(--shadow);
+        }
+
+        .server-card-header {
+            padding: 20px 24px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .server-card-header:hover {
+            background: rgba(99, 102, 241, 0.05);
+        }
+
+        .server-info {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .server-flag {
+            font-size: 32px;
+        }
+
+        .server-name {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .server-status-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 10px;
+            font-size: 12px;
+            background: rgba(99, 102, 241, 0.12);
+            color: var(--accent-primary);
+        }
+
+        .server-status-badge.offline {
+            background: rgba(239, 68, 68, 0.12);
+            color: var(--danger);
+        }
+
+        .server-stats {
+            display: flex;
+            gap: 32px;
+            align-items: center;
+        }
+
+        .server-stat {
+            text-align: center;
+        }
+
+        .server-stat-value {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .server-stat-label {
+            font-size: 12px;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+        }
+
+        .expand-icon {
+            width: 32px;
+            height: 32px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 8px;
+            background: var(--bg-tertiary);
+            transition: transform 0.3s ease;
+        }
+
+        .server-card.expanded .expand-icon {
+            transform: rotate(180deg);
+        }
+
+        .server-expanded-content {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s ease;
+            border-top: 1px solid var(--border);
+        }
+
+        .server-card.expanded .server-expanded-content {
+            max-height: 400px;
+        }
+
+        .server-expanded-inner {
+            padding: 20px 24px 24px;
+        }
+
+        .server-details-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 16px;
+        }
+
+        .server-detail {
+            background: var(--bg-tertiary);
+            border-radius: 12px;
+            padding: 16px;
+            border: 1px solid rgba(99, 102, 241, 0.12);
+        }
+
+        .server-detail-title {
+            font-size: 12px;
+            text-transform: uppercase;
+            color: var(--text-tertiary);
+            margin-bottom: 6px;
+            letter-spacing: 0.5px;
+        }
+
+        .server-detail-value {
+            font-size: 16px;
+            font-weight: 600;
+        }
+
+        .server-description {
+            margin-top: 16px;
+            color: var(--text-secondary);
+            line-height: 1.5;
+        }
+
         .table-container {
             background: var(--bg-secondary);
             border: 1px solid var(--border);
             border-radius: 16px;
             overflow: hidden;
+            margin-bottom: 32px;
         }
 
         .table-header {
-            padding: 20px 24px;
-            border-bottom: 1px solid var(--border);
             display: flex;
             align-items: center;
             justify-content: space-between;
+            padding: 20px 24px;
+            border-bottom: 1px solid var(--border);
         }
 
-        .table-title {
+        .table-header h3 {
             font-size: 18px;
             font-weight: 600;
-        }
-
-        .table-actions {
-            display: flex;
-            gap: 12px;
         }
 
         table {
@@ -654,27 +741,21 @@
         }
 
         thead {
-            background: var(--bg-tertiary);
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        th, td {
+            padding: 16px 24px;
+            text-align: left;
+            font-size: 14px;
+            border-bottom: 1px solid var(--border);
         }
 
         th {
-            padding: 16px 24px;
-            text-align: left;
-            font-size: 12px;
+            color: var(--text-secondary);
             font-weight: 600;
             text-transform: uppercase;
-            color: var(--text-tertiary);
-            letter-spacing: 0.5px;
-        }
-
-        td {
-            padding: 16px 24px;
-            border-top: 1px solid var(--border);
-            font-size: 14px;
-        }
-
-        tbody tr {
-            transition: background 0.2s ease;
+            font-size: 12px;
         }
 
         tbody tr:hover {
@@ -721,11 +802,8 @@
             font-size: 12px;
             font-weight: 600;
             display: inline-block;
-        }
-
-        .status-badge.active {
-            background: rgba(16, 185, 129, 0.1);
-            color: var(--success);
+            background: rgba(99, 102, 241, 0.15);
+            color: var(--accent-primary);
         }
 
         .status-badge.trial {
@@ -761,32 +839,336 @@
             background: var(--bg-hover);
             transform: scale(1.1);
         }
+        .settings-section {
+            margin-bottom: 48px;
+        }
 
-        /* Floating Action Button */
-        .fab {
-            position: fixed;
-            bottom: 32px;
-            right: 32px;
-            width: 60px;
-            height: 60px;
+        .settings-section h2 {
+            font-size: 20px;
+            font-weight: 600;
+            margin-bottom: 12px;
+        }
+
+        .settings-section p {
+            color: var(--text-secondary);
+            margin-bottom: 24px;
+        }
+
+        .settings-container {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .setting-category {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            overflow: hidden;
+        }
+
+        .setting-category summary {
+            list-style: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 24px;
+            font-weight: 600;
+            transition: background 0.2s ease;
+        }
+
+        .setting-category summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .setting-category[open] summary {
+            background: rgba(99, 102, 241, 0.05);
+        }
+
+        .settings-count {
+            font-size: 12px;
+            background: rgba(99, 102, 241, 0.15);
+            color: var(--accent-primary);
+            padding: 4px 10px;
+            border-radius: 999px;
+        }
+
+        .setting-items {
+            border-top: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .setting-item {
+            display: grid;
+            grid-template-columns: minmax(220px, 1fr) minmax(200px, 1fr) 160px;
+            gap: 16px;
+            padding: 16px 24px;
+            border-bottom: 1px solid var(--border);
+            align-items: center;
+        }
+
+        .setting-item:last-child {
+            border-bottom: none;
+        }
+
+        .setting-name {
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .setting-key {
+            font-size: 12px;
+            color: var(--text-tertiary);
+        }
+
+        .setting-value {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .setting-actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+        }
+
+        .setting-button {
+            padding: 8px 14px;
+            border-radius: 10px;
+            border: 1px solid var(--border);
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+            font-size: 13px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .setting-button:hover:enabled {
+            background: var(--bg-hover);
+        }
+
+        .setting-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .setting-override {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 11px;
+            background: rgba(99, 102, 241, 0.15);
+            color: var(--accent-primary);
+            width: fit-content;
+        }
+
+        .settings-empty {
+            padding: 20px 24px;
+            color: var(--text-secondary);
+        }
+
+        .settings-empty small {
+            color: var(--text-tertiary);
+        }
+
+        .bot-control {
+            position: relative;
+        }
+
+        .bot-control-btn {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: var(--bg-tertiary);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .bot-control-btn:hover {
+            background: var(--bg-hover);
+        }
+
+        .bot-status {
+            width: 10px;
+            height: 10px;
             border-radius: 50%;
-            background: var(--accent-gradient);
+            background: var(--success);
+            box-shadow: 0 0 10px var(--success);
+        }
+
+        .bot-status.paused {
+            background: var(--warning);
+            box-shadow: 0 0 10px var(--warning);
+        }
+
+        .bot-status.stopped {
+            background: var(--danger);
+            box-shadow: 0 0 10px var(--danger);
+        }
+
+        .bot-dropdown {
+            position: absolute;
+            right: 0;
+            top: calc(100% + 8px);
+            width: 240px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            padding: 8px;
+            display: none;
+            flex-direction: column;
+            gap: 4px;
+            box-shadow: var(--shadow);
+            z-index: 10;
+        }
+
+        .bot-dropdown.open {
+            display: flex;
+        }
+
+        .bot-dropdown-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 12px;
+            border-radius: 10px;
+            cursor: pointer;
+            transition: background 0.2s ease;
+            color: var(--text-primary);
+        }
+
+        .bot-dropdown-item:hover {
+            background: var(--bg-tertiary);
+        }
+
+        .bot-dropdown-item.warning {
+            color: var(--warning);
+        }
+
+        .bot-dropdown-item.danger {
+            color: var(--danger);
+        }
+
+        .bot-dropdown-divider {
+            height: 1px;
+            background: var(--border);
+            margin: 4px 0;
+        }
+
+        .auth-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(10, 11, 13, 0.85);
+            backdrop-filter: blur(6px);
             display: flex;
             align-items: center;
             justify-content: center;
-            color: white;
-            font-size: 24px;
-            cursor: pointer;
+            z-index: 2000;
+        }
+
+        .auth-overlay.hidden {
+            display: none;
+        }
+
+        .auth-modal {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            padding: 32px;
+            width: min(420px, 92%);
             box-shadow: var(--shadow);
-            transition: all 0.3s ease;
-            z-index: 1000;
         }
 
-        .fab:hover {
-            transform: scale(1.1) rotate(90deg);
+        .auth-modal h2 {
+            font-size: 22px;
+            margin-bottom: 8px;
+            text-align: center;
         }
 
-        /* Responsive */
+        .auth-modal p {
+            color: var(--text-secondary);
+            margin-bottom: 20px;
+            text-align: center;
+        }
+
+        .auth-modal input {
+            width: 100%;
+            padding: 14px 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+            font-size: 14px;
+        }
+
+        .auth-modal button {
+            margin-top: 18px;
+            width: 100%;
+            padding: 14px 18px;
+            border-radius: 12px;
+            border: none;
+            background: var(--accent-gradient);
+            color: white;
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 14px;
+        }
+
+        .auth-error {
+            color: var(--danger);
+            margin-top: 12px;
+            text-align: center;
+            min-height: 20px;
+        }
+
+        .toast-container {
+            position: fixed;
+            right: 24px;
+            bottom: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            z-index: 2100;
+        }
+
+        .toast {
+            min-width: 220px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 14px 18px;
+            box-shadow: var(--shadow);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-size: 14px;
+        }
+
+        .toast.success {
+            border-color: rgba(16, 185, 129, 0.5);
+        }
+
+        .toast.error {
+            border-color: rgba(239, 68, 68, 0.5);
+        }
+
+        .toast.warning {
+            border-color: rgba(245, 158, 11, 0.5);
+        }
+
+        .maintenance-label {
+            font-weight: 600;
+            color: var(--accent-primary);
+        }
+
         @media (max-width: 1024px) {
             .sidebar {
                 position: fixed;
@@ -808,775 +1190,828 @@
             .stats-grid {
                 grid-template-columns: 1fr;
             }
-        }
 
-        /* Server Details Expansion */
-        .server-card {
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            margin-bottom: 24px;
-            overflow: hidden;
-            transition: all 0.3s ease;
-        }
-
-        .server-card-header {
-            padding: 20px 24px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            cursor: pointer;
-            transition: background 0.2s ease;
-        }
-
-        .server-card-header:hover {
-            background: rgba(99, 102, 241, 0.05);
-        }
-
-        .server-info {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-        }
-
-        .server-flag {
-            font-size: 32px;
-        }
-
-        .server-details {
-            flex: 1;
-        }
-
-        .server-name {
-            font-size: 18px;
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
-
-        .server-location {
-            color: var(--text-secondary);
-            font-size: 14px;
-        }
-
-        .server-stats {
-            display: flex;
-            gap: 32px;
-            align-items: center;
-        }
-
-        .server-stat {
-            text-align: center;
-        }
-
-        .server-stat-value {
-            font-size: 20px;
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
-
-        .server-stat-label {
-            font-size: 12px;
-            color: var(--text-tertiary);
-            text-transform: uppercase;
-        }
-
-        .expand-icon {
-            width: 32px;
-            height: 32px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 8px;
-            background: var(--bg-tertiary);
-            transition: transform 0.3s ease;
-        }
-
-        .server-card.expanded .expand-icon {
-            transform: rotate(180deg);
-        }
-
-        .server-expanded-content {
-            max-height: 0;
-            overflow: hidden;
-            transition: max-height 0.3s ease;
-            border-top: 1px solid var(--border);
-        }
-
-        .server-card.expanded .server-expanded-content {
-            max-height: 600px;
-        }
-
-        .server-expanded-inner {
-            padding: 24px;
-        }
-
-        .server-actions {
-            display: flex;
-            gap: 12px;
-            margin-bottom: 24px;
-        }
-
-        .speed-test-btn {
-            padding: 10px 20px;
-            background: var(--accent-gradient);
-            color: white;
-            border: none;
-            border-radius: 10px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .speed-test-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
-        }
-
-        .speed-test-btn.testing {
-            background: var(--warning);
-            animation: pulse 1s infinite;
-        }
-
-        .server-metrics-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 16px;
-            margin-bottom: 24px;
-        }
-
-        .metric-card {
-            background: var(--bg-tertiary);
-            padding: 16px;
-            border-radius: 12px;
-            text-align: center;
-        }
-
-        .metric-value {
-            font-size: 24px;
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
-
-        .metric-label {
-            font-size: 12px;
-            color: var(--text-secondary);
-        }
-
-        .server-chart {
-            background: var(--bg-tertiary);
-            border-radius: 12px;
-            padding: 20px;
-            height: 200px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .chart-grid {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-image: 
-                linear-gradient(rgba(99, 102, 241, 0.1) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(99, 102, 241, 0.1) 1px, transparent 1px);
-            background-size: 20px 20px;
-        }
-
-        .chart-line {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 60%;
-            background: linear-gradient(to top, rgba(99, 102, 241, 0.2), transparent);
-            clip-path: polygon(
-                0% 100%,
-                5% 85%, 10% 70%, 15% 75%, 20% 60%, 25% 65%,
-                30% 50%, 35% 55%, 40% 45%, 45% 50%, 50% 40%,
-                55% 45%, 60% 35%, 65% 40%, 70% 30%, 75% 35%,
-                80% 25%, 85% 30%, 90% 20%, 95% 25%, 100% 15%,
-                100% 100%
-            );
-        }
-
-        /* Loading Animation */
-        .loading {
-            display: inline-block;
-            width: 20px;
-            height: 20px;
-            border: 3px solid var(--border);
-            border-top-color: var(--accent-primary);
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-        }
-
-        @keyframes spin {
-            to { transform: rotate(360deg); }
-        }
-
-        /* Tooltips */
-        [data-tooltip] {
-            position: relative;
-        }
-
-        [data-tooltip]:hover::after {
-            content: attr(data-tooltip);
-            position: absolute;
-            bottom: 100%;
-            left: 50%;
-            transform: translateX(-50%);
-            padding: 8px 12px;
-            background: var(--bg-tertiary);
-            color: var(--text-primary);
-            font-size: 12px;
-            border-radius: 8px;
-            white-space: nowrap;
-            z-index: 1000;
-            pointer-events: none;
-            animation: fadeIn 0.3s ease;
-        }
-
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateX(-50%) translateY(4px); }
-            to { opacity: 1; transform: translateX(-50%) translateY(0); }
+            .setting-item {
+                grid-template-columns: 1fr;
+                gap: 12px;
+                align-items: flex-start;
+            }
         }
     </style>
 </head>
 <body>
-    <div class="bg-animation"></div>
-    
-    <div class="container">
-        <!-- Sidebar -->
-        <aside class="sidebar">
-            <div class="logo">
-                <h1>BedolagaAdmin <span class="status"></span></h1>
+<div class="bg-animation"></div>
+<div id="auth-overlay" class="auth-overlay hidden">
+    <div class="auth-modal">
+        <h2>Добро пожаловать</h2>
+        <p>Введите админ-токен для доступа к панели управления</p>
+        <form id="login-form">
+            <input id="login-token" type="password" placeholder="API токен" autocomplete="off" required>
+            <button type="submit">Войти</button>
+            <div id="login-error" class="auth-error"></div>
+        </form>
+    </div>
+</div>
+<div id="toast-container" class="toast-container"></div>
+<div class="container">
+    <aside class="sidebar">
+        <div class="logo">
+            <h1>
+                <span class="status"></span>
+                <span id="sidebar-title">{{WEBADMIN_TITLE}}</span>
+            </h1>
+        </div>
+        <nav class="nav">
+            <div class="nav-section">
+                <div class="nav-section-title">Обзор</div>
+                <a href="#" class="nav-item active">
+                    <span class="nav-icon">📊</span>
+                    <span>Панель управления</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">🧾</span>
+                    <span>История операций</span>
+                </a>
             </div>
-            
-            <nav class="nav">
-                <div class="nav-section">
-                    <div class="nav-section-title">Аналитика</div>
-                    <a href="#" class="nav-item active">
-                        <span class="nav-icon">📊</span>
-                        <span>Дашборд</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">💰</span>
-                        <span>Финансы</span>
-                        <span class="nav-badge">12</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">📈</span>
-                        <span>Статистика</span>
-                    </a>
+            <div class="nav-section">
+                <div class="nav-section-title">Управление</div>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">👥</span>
+                    <span>Пользователи</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">💳</span>
+                    <span>Подписки</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">🖥️</span>
+                    <span>Серверы</span>
+                    <span class="nav-badge" id="nav-servers-count">—</span>
+                </a>
+            </div>
+            <div class="nav-section">
+                <div class="nav-section-title">Система</div>
+                <a href="#settings" class="nav-item">
+                    <span class="nav-icon">⚙️</span>
+                    <span>Конфигурация бота</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="nav-icon">💾</span>
+                    <span>Бекапы</span>
+                </a>
+            </div>
+        </nav>
+    </aside>
+    <main class="main">
+        <header class="header">
+            <div class="header-left">
+                <div class="search-box">
+                    <input type="text" placeholder="Поиск пользователей, ID, email..." id="search-input">
                 </div>
-                
-                <div class="nav-section">
-                    <div class="nav-section-title">Управление</div>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">👥</span>
-                        <span>Пользователи</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">💳</span>
-                        <span>Подписки</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🎫</span>
-                        <span>Промокоды</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">👫</span>
-                        <span>Промогруппы</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🔗</span>
-                        <span>Рефералы</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🖥️</span>
-                        <span>Серверы</span>
-                        <span class="nav-badge" style="background: var(--success);">✓</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🌊</span>
-                        <span>Remnawave</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">📨</span>
-                        <span>Рассылки</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">📢</span>
-                        <span>Рекламные кампании</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🎫</span>
-                        <span>Тикеты</span>
-                        <span class="nav-badge">5</span>
-                    </a>
-                </div>
-                
-                <div class="nav-section">
-                    <div class="nav-section-title">Система</div>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">💳</span>
-                        <span>Платежные шлюзы</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">💸</span>
-                        <span>Настройка цен</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">💰</span>
-                        <span>Автоплатежи</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🌍</span>
-                        <span>Локализация</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">📑</span>
-                        <span>Отчеты</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">🗄️</span>
-                        <span>Бекапы</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">📋</span>
-                        <span>Логи</span>
-                    </a>
-                    <a href="#" class="nav-item">
-                        <span class="nav-icon">⚙️</span>
-                        <span>Настройки</span>
-                    </a>
-                </div>
-            </nav>
-        </aside>
-        
-        <!-- Main Content -->
-        <main class="main">
-            <!-- Header -->
-            <header class="header">
-                <div class="header-left">
-                    <div class="search-box">
-                        <input type="text" placeholder="Поиск пользователей, ID, email...">
-                    </div>
-                </div>
-                
-                <div class="header-right">
-                    <div class="bot-control">
-                        <button class="bot-control-btn">
-                            <span class="bot-status"></span>
-                            <span>Бот активен</span>
-                            <span style="font-size: 12px;">▼</span>
-                        </button>
-                        <div class="bot-dropdown">
-                            <div class="bot-dropdown-item">
-                                <span>🔄</span>
-                                <span>Перезапустить бота</span>
-                            </div>
-                            <div class="bot-dropdown-item warning">
-                                <span>⏸️</span>
-                                <span>Остановить бота</span>
-                            </div>
-                            <div class="bot-dropdown-item">
-                                <span>▶️</span>
-                                <span>Запустить бота</span>
-                            </div>
-                            <div class="bot-dropdown-divider"></div>
-                            <div class="bot-dropdown-item">
-                                <span>🔄</span>
-                                <span>Синхронизация</span>
-                            </div>
-                            <div class="bot-dropdown-item danger">
-                                <span>🚧</span>
-                                <span>Режим техработ</span>
-                            </div>
+            </div>
+            <div class="header-right">
+                <div class="bot-control">
+                    <button class="bot-control-btn" id="bot-control-btn" type="button">
+                        <span class="bot-status" id="bot-status-indicator"></span>
+                        <span data-bot-state>Бот активен</span>
+                        <span class="bot-control-caret">▼</span>
+                    </button>
+                    <div class="bot-dropdown" id="bot-dropdown">
+                        <div class="bot-dropdown-item" data-action="reload-config">
+                            <span>🔄</span>
+                            <span>Перезагрузить конфигурацию</span>
+                        </div>
+                        <div class="bot-dropdown-item" data-action="create-backup">
+                            <span>💾</span>
+                            <span>Создать бекап</span>
+                        </div>
+                        <div class="bot-dropdown-item" data-action="send-report">
+                            <span>📬</span>
+                            <span>Отправить дневной отчет</span>
+                        </div>
+                        <div class="bot-dropdown-divider"></div>
+                        <div class="bot-dropdown-item warning" data-action="toggle-maintenance">
+                            <span>🚧</span>
+                            <span>Режим техработ: <span class="maintenance-label" data-maintenance-label>Выкл</span></span>
+                        </div>
+                        <div class="bot-dropdown-divider"></div>
+                        <div class="bot-dropdown-item danger" data-action="logout">
+                            <span>🚪</span>
+                            <span>Выйти</span>
                         </div>
                     </div>
-                    <button class="header-btn" data-tooltip="Уведомления">
-                        <span>🔔</span>
-                        <span class="notification-badge">3</span>
-                    </button>
-                    <div class="user-menu">
-                        <div class="user-avatar">A</div>
+                </div>
+                <div class="user-menu" id="user-menu">
+                    <div class="user-avatar" id="user-avatar">A</div>
+                    <div>
+                        <div style="font-size: 14px; font-weight: 500;" id="user-name">Admin</div>
+                        <div style="font-size: 12px; color: var(--text-tertiary);">Супер админ</div>
+                    </div>
+                </div>
+            </div>
+        </header>
+        <div class="content">
+            <h1 class="page-title">Панель управления</h1>
+            <p class="page-subtitle">Добро пожаловать в систему управления VPN ботом</p>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-header">
                         <div>
-                            <div style="font-size: 14px; font-weight: 500;">Admin</div>
-                            <div style="font-size: 12px; color: var(--text-tertiary);">Супер админ</div>
+                            <div class="stat-value" id="stat-total-users">—</div>
+                            <div class="stat-label">Всего пользователей</div>
                         </div>
+                        <div class="stat-icon users">👥</div>
                     </div>
+                    <span class="stat-change" id="stat-users-change">—</span>
                 </div>
-            </header>
-            
-            <!-- Content Area -->
-            <div class="content">
-                <h1 class="page-title">Панель управления</h1>
-                <p class="page-subtitle">Добро пожаловать в систему управления VPN ботом</p>
-                
-                <!-- Stats Grid -->
-                <div class="stats-grid">
-                    <div class="stat-card">
-                        <div class="stat-header">
-                            <div>
-                                <div class="stat-value">1,284</div>
-                                <div class="stat-label">Всего пользователей</div>
-                            </div>
-                            <div class="stat-icon users">👥</div>
+                <div class="stat-card">
+                    <div class="stat-header">
+                        <div>
+                            <div class="stat-value" id="stat-revenue">—</div>
+                            <div class="stat-label">Доход за 30 дней</div>
                         </div>
-                        <span class="stat-change positive">↑ 12% за неделю</span>
+                        <div class="stat-icon money">💰</div>
                     </div>
-                    
-                    <div class="stat-card">
-                        <div class="stat-header">
-                            <div>
-                                <div class="stat-value">₽84,290</div>
-                                <div class="stat-label">Доход за месяц</div>
-                            </div>
-                            <div class="stat-icon money">💰</div>
-                        </div>
-                        <span class="stat-change positive">↑ 23% к прошлому</span>
-                    </div>
-                    
-                    <div class="stat-card">
-                        <div class="stat-header">
-                            <div>
-                                <div class="stat-value">8 / 8</div>
-                                <div class="stat-label">Активные серверы</div>
-                            </div>
-                            <div class="stat-icon servers">🖥️</div>
-                        </div>
-                        <span class="stat-change positive">100% uptime</span>
-                    </div>
-                    
-                    <div class="stat-card">
-                        <div class="stat-header">
-                            <div>
-                                <div class="stat-value">68%</div>
-                                <div class="stat-label">Конверсия триал → платная</div>
-                            </div>
-                            <div class="stat-icon chart">📈</div>
-                        </div>
-                        <span class="stat-change positive">↑ 5% за месяц</span>
-                    </div>
+                    <span class="stat-change" id="stat-revenue-change">—</span>
                 </div>
-                
-                <!-- Chart -->
-                <div class="chart-container">
-                    <div class="chart-placeholder">
-                        <div style="font-size: 48px; margin-bottom: 16px;">📊</div>
-                        <div style="font-size: 18px; font-weight: 500; margin-bottom: 8px;">График продаж</div>
-                        <div style="font-size: 14px;">Динамика подписок за последние 30 дней</div>
+                <div class="stat-card">
+                    <div class="stat-header">
+                        <div>
+                            <div class="stat-value" id="stat-servers">—</div>
+                            <div class="stat-label">Доступные серверы</div>
+                        </div>
+                        <div class="stat-icon servers">🖥️</div>
                     </div>
+                    <span class="stat-change" id="stat-servers-change">—</span>
                 </div>
-                
-                <!-- Quick Actions -->
-                <div class="quick-actions">
-                    <button class="action-btn primary">
-                        <span>➕</span>
-                        <span>Создать промокод</span>
-                    </button>
-                    <button class="action-btn">
-                        <span>📢</span>
-                        <span>Массовая рассылка</span>
-                    </button>
-                    <button class="action-btn">
-                        <span>💾</span>
-                        <span>Создать бекап</span>
-                    </button>
-                    <button class="action-btn">
+                <div class="stat-card">
+                    <div class="stat-header">
+                        <div>
+                            <div class="stat-value" id="stat-conversion">—</div>
+                            <div class="stat-label">Конверсия триал → платная</div>
+                        </div>
+                        <div class="stat-icon chart">📈</div>
+                    </div>
+                    <span class="stat-change" id="stat-conversion-change">—</span>
+                </div>
+            </div>
+            <div class="chart-container" id="revenue-chart">
+                <div class="chart-placeholder">
+                    <div style="font-size: 42px; margin-bottom: 12px;">📊</div>
+                    <div style="font-size: 18px; font-weight: 500; margin-bottom: 8px;">График продаж</div>
+                    <div style="font-size: 14px;">Динамика подписок за последние 30 дней</div>
+                </div>
+            </div>
+            <div class="quick-actions">
+                <button class="action-btn primary" data-action="refresh">
+                    <span>🔄</span>
+                    <span>Обновить данные</span>
+                </button>
+                <button class="action-btn" data-action="reload-config">
+                    <span>⚙️</span>
+                    <span>Перезагрузить конфигурацию</span>
+                </button>
+                <button class="action-btn" data-action="create-backup">
+                    <span>💾</span>
+                    <span>Создать бекап</span>
+                </button>
+                <button class="action-btn" data-action="toggle-maintenance">
+                    <span>🚧</span>
+                    <span id="maintenance-action-label">Включить техработы</span>
+                </button>
+            </div>
+            <section style="margin-bottom: 32px;">
+                <h2 class="servers-section-title">
+                    <span>🖥️</span>
+                    <span>Активные серверы</span>
+                    <span style="background: var(--success); color: white; font-size: 12px; padding: 4px 12px; border-radius: 20px;" id="servers-online-badge">— онлайн</span>
+                </h2>
+                <div id="servers-list"></div>
+            </section>
+            <section class="table-container">
+                <div class="table-header">
+                    <h3>Последние пользователи</h3>
+                    <button class="action-btn" data-action="refresh-users">
                         <span>🔄</span>
-                        <span>Синхронизация</span>
+                        <span>Обновить</span>
                     </button>
                 </div>
-                
-                <!-- Active Servers Section -->
-                <div style="margin-bottom: 32px;">
-                    <h2 style="font-size: 20px; font-weight: 600; margin-bottom: 20px; display: flex; align-items: center; gap: 12px;">
-                        <span>🖥️</span>
-                        <span>Активные серверы</span>
-                        <span style="background: var(--success); color: white; font-size: 12px; padding: 4px 12px; border-radius: 20px;">8 онлайн</span>
-                    </h2>
-                    
-                    <!-- Server Card 1 - Expanded Example -->
-                    <div class="server-card expanded">
-                        <div class="server-card-header" onclick="this.parentElement.classList.toggle('expanded')">
-                            <div class="server-info">
-                                <span class="server-flag">🇳🇱</span>
-                                <div class="server-details">
-                                    <div class="server-name">Netherlands-1</div>
-                                    <div class="server-location">Amsterdam, Digital Ocean</div>
-                                </div>
-                            </div>
-                            <div class="server-stats">
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">342</div>
-                                    <div class="server-stat-label">Пользователей</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value">45%</div>
-                                    <div class="server-stat-label">CPU</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value">2.4GB</div>
-                                    <div class="server-stat-label">RAM</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">99.9%</div>
-                                    <div class="server-stat-label">Uptime</div>
-                                </div>
-                                <div class="expand-icon">▼</div>
-                            </div>
-                        </div>
-                        
-                        <div class="server-expanded-content">
-                            <div class="server-expanded-inner">
-                                <div class="server-actions">
-                                    <button class="speed-test-btn">
-                                        <span>⚡</span>
-                                        <span>Speed Test</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>🔄</span>
-                                        <span>Перезагрузить</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>📊</span>
-                                        <span>Детальная статистика</span>
-                                    </button>
-                                    <button class="action-btn" style="background: rgba(239, 68, 68, 0.1); color: var(--danger);">
-                                        <span>⏸️</span>
-                                        <span>Остановить</span>
-                                    </button>
-                                </div>
-                                
-                                <div class="server-metrics-grid">
-                                    <div class="metric-card">
-                                        <div class="metric-value" style="color: var(--success);">12ms</div>
-                                        <div class="metric-label">Ping</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">945 Mbps</div>
-                                        <div class="metric-label">Download</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">892 Mbps</div>
-                                        <div class="metric-label">Upload</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">1.2TB</div>
-                                        <div class="metric-label">Трафик/день</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">28°C</div>
-                                        <div class="metric-label">Температура</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">14d 6h</div>
-                                        <div class="metric-label">Работает</div>
-                                    </div>
-                                </div>
-                                
-                                <div style="margin-bottom: 12px; color: var(--text-secondary); font-size: 14px;">
-                                    📈 Нагрузка сервера (последние 24 часа)
-                                </div>
-                                <div class="server-chart">
-                                    <div class="chart-grid"></div>
-                                    <div class="chart-line"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Server Card 2 -->
-                    <div class="server-card">
-                        <div class="server-card-header" onclick="this.parentElement.classList.toggle('expanded')">
-                            <div class="server-info">
-                                <span class="server-flag">🇩🇪</span>
-                                <div class="server-details">
-                                    <div class="server-name">Germany-2</div>
-                                    <div class="server-location">Frankfurt, Hetzner</div>
-                                </div>
-                            </div>
-                            <div class="server-stats">
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--warning);">298</div>
-                                    <div class="server-stat-label">Пользователей</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--warning);">68%</div>
-                                    <div class="server-stat-label">CPU</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value">3.1GB</div>
-                                    <div class="server-stat-label">RAM</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">100%</div>
-                                    <div class="server-stat-label">Uptime</div>
-                                </div>
-                                <div class="expand-icon">▼</div>
-                            </div>
-                        </div>
-                        
-                        <div class="server-expanded-content">
-                            <div class="server-expanded-inner">
-                                <div class="server-actions">
-                                    <button class="speed-test-btn">
-                                        <span>⚡</span>
-                                        <span>Speed Test</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>🔄</span>
-                                        <span>Перезагрузить</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>📊</span>
-                                        <span>Детальная статистика</span>
-                                    </button>
-                                    <button class="action-btn" style="background: rgba(239, 68, 68, 0.1); color: var(--danger);">
-                                        <span>⏸️</span>
-                                        <span>Остановить</span>
-                                    </button>
-                                </div>
-                                
-                                <div class="server-metrics-grid">
-                                    <div class="metric-card">
-                                        <div class="metric-value" style="color: var(--success);">8ms</div>
-                                        <div class="metric-label">Ping</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">1024 Mbps</div>
-                                        <div class="metric-label">Download</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">976 Mbps</div>
-                                        <div class="metric-label">Upload</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">980GB</div>
-                                        <div class="metric-label">Трафик/день</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">32°C</div>
-                                        <div class="metric-label">Температура</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">28d 12h</div>
-                                        <div class="metric-label">Работает</div>
-                                    </div>
-                                </div>
-                                
-                                <div style="margin-bottom: 12px; color: var(--text-secondary); font-size: 14px;">
-                                    📈 Нагрузка сервера (последние 24 часа)
-                                </div>
-                                <div class="server-chart">
-                                    <div class="chart-grid"></div>
-                                    <div class="chart-line"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Server Card 3 -->
-                    <div class="server-card">
-                        <div class="server-card-header" onclick="this.parentElement.classList.toggle('expanded')">
-                            <div class="server-info">
-                                <span class="server-flag">🇸🇪</span>
-                                <div class="server-details">
-                                    <div class="server-name">Sweden-1</div>
-                                    <div class="server-location">Stockholm, OVH</div>
-                                </div>
-                            </div>
-                            <div class="server-stats">
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">256</div>
-                                    <div class="server-stat-label">Пользователей</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">32%</div>
-                                    <div class="server-stat-label">CPU</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value">1.8GB</div>
-                                    <div class="server-stat-label">RAM</div>
-                                </div>
-                                <div class="server-stat">
-                                    <div class="server-stat-value" style="color: var(--success);">99.8%</div>
-                                    <div class="server-stat-label">Uptime</div>
-                                </div>
-                                <div class="expand-icon">▼</div>
-                            </div>
-                        </div>
-                        
-                        <div class="server-expanded-content">
-                            <div class="server-expanded-inner">
-                                <div class="server-actions">
-                                    <button class="speed-test-btn">
-                                        <span>⚡</span>
-                                        <span>Speed Test</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>🔄</span>
-                                        <span>Перезагрузить</span>
-                                    </button>
-                                    <button class="action-btn">
-                                        <span>📊</span>
-                                        <span>Детальная статистика</span>
-                                    </button>
-                                    <button class="action-btn" style="background: rgba(239, 68, 68, 0.1); color: var(--danger);">
-                                        <span>⏸️</span>
-                                        <span>Остановить</span>
-                                    </button>
-                                </div>
-                                
-                                <div class="server-metrics-grid">
-                                    <div class="metric-card">
-                                        <div class="metric-value" style="color: var(--success);">15ms</div>
-                                        <div class="metric-label">Ping</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">850 Mbps</div>
-                                        <div class="metric-label">Download</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">820 Mbps</div>
-                                        <div class="metric-label">Upload</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">650GB</div>
-                                        <div class="metric-label">Трафик/день</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">26°C</div>
-                                        <div class="metric-label">Температура</div>
-                                    </div>
-                                    <div class="metric-card">
-                                        <div class="metric-value">7d 18h</div>
-                                        <div class="metric-label">Работает</div>
-                                    </div>
-                                </div>
-                                
-                                <div style="margin-bottom: 12px; color: var(--text-secondary); font-size: 14px;">
-                                    📈 Нагрузка сервера (последние 24 часа)
-                                </div>
-                                <div class="server-chart">
-                                    <div class="chart-grid"></div>
-                                    <div class="chart-line"></div>
-                                </div>
-                            </div>
-                        </div>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>Пользователь</th>
+                        <th>Статус</th>
+                        <th>Подписка</th>
+                        <th>Баланс</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody id="recent-users-body">
+                    <tr>
+                        <td colspan="5" style="padding: 32px; text-align: center; color: var(--text-tertiary);">
+                            Нет данных
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </section>
+            <section class="settings-section" id="settings">
+                <h2>⚙️ Конфигурация бота</h2>
+                <p>Просматривайте и обновляйте ключевые параметры без перезапуска бота. Значения сохраняются в базе данных.</p>
+                <div id="settings-container" class="settings-container">
+                    <div class="settings-empty">Загрузка категорий настроек…</div>
+                </div>
+            </section>
+        </div>
+    </main>
+</div>
+</div>
+<script>
+(() => {
+    const state = {
+        token: localStorage.getItem('webadminToken') || '',
+        health: null,
+        settingsCache: new Map(),
+    };
+
+    const els = {
+        authOverlay: document.getElementById('auth-overlay'),
+        loginForm: document.getElementById('login-form'),
+        loginToken: document.getElementById('login-token'),
+        loginError: document.getElementById('login-error'),
+        toastContainer: document.getElementById('toast-container'),
+        botControlBtn: document.getElementById('bot-control-btn'),
+        botDropdown: document.getElementById('bot-dropdown'),
+        botStatusIndicator: document.getElementById('bot-status-indicator'),
+        maintenanceActionLabel: document.getElementById('maintenance-action-label'),
+        maintenanceLabel: document.querySelector('[data-maintenance-label]'),
+        statUsers: document.getElementById('stat-total-users'),
+        statUsersChange: document.getElementById('stat-users-change'),
+        statRevenue: document.getElementById('stat-revenue'),
+        statRevenueChange: document.getElementById('stat-revenue-change'),
+        statServers: document.getElementById('stat-servers'),
+        statServersChange: document.getElementById('stat-servers-change'),
+        statConversion: document.getElementById('stat-conversion'),
+        statConversionChange: document.getElementById('stat-conversion-change'),
+        revenueChart: document.getElementById('revenue-chart'),
+        serversList: document.getElementById('servers-list'),
+        serversBadge: document.getElementById('servers-online-badge'),
+        navServersCount: document.getElementById('nav-servers-count'),
+        recentUsersBody: document.getElementById('recent-users-body'),
+        settingsContainer: document.getElementById('settings-container'),
+        searchInput: document.getElementById('search-input'),
+    };
+
+    function toLocaleCurrency(value) {
+        return new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }).format(value || 0);
+    }
+
+    function toPercent(value) {
+        if (value === null || value === undefined || Number.isNaN(value)) {
+            return '—';
+        }
+        return `${value.toFixed(1)}%`;
+    }
+
+    function showToast(message, type = 'info') {
+        const toast = document.createElement('div');
+        toast.className = `toast ${type}`;
+        toast.textContent = message;
+        els.toastContainer.appendChild(toast);
+        setTimeout(() => {
+            toast.classList.add('fade');
+            setTimeout(() => toast.remove(), 200);
+        }, 4000);
+    }
+
+    function showLogin(message = '') {
+        els.authOverlay.classList.remove('hidden');
+        els.loginError.textContent = message;
+        setTimeout(() => els.loginToken.focus(), 50);
+    }
+
+    function hideLogin() {
+        els.authOverlay.classList.add('hidden');
+        els.loginError.textContent = '';
+        els.loginToken.value = '';
+    }
+
+    async function callApi(path, { method = 'GET', body, skipAuth = false } = {}) {
+        const headers = {};
+        if (!skipAuth && state.token) {
+            headers.Authorization = `Bearer ${state.token}`;
+        }
+        const options = { method, headers };
+        if (body !== undefined) {
+            headers['Content-Type'] = 'application/json';
+            options.body = JSON.stringify(body);
+        }
+
+        const response = await fetch(path, options).catch((error) => {
+            throw new Error(`Сеть недоступна: ${error.message}`);
+        });
+
+        let payload = {};
+        if (response.status !== 204) {
+            try {
+                payload = await response.json();
+            } catch (error) {
+                payload = {};
+            }
+        }
+
+        if (response.status === 401 && !skipAuth) {
+            state.token = '';
+            localStorage.removeItem('webadminToken');
+            showLogin('Требуется повторный вход');
+            throw new Error('Не авторизовано');
+        }
+
+        if (!response.ok || payload.status === 'error') {
+            const message = payload.message || `Ошибка ${response.status}`;
+            throw new Error(message);
+        }
+
+        return payload.data !== undefined ? payload.data : payload;
+    }
+
+    function applyTrend(element, value) {
+        element.classList.remove('positive', 'negative');
+        if (value === null || value === undefined) {
+            element.textContent = '—';
+            return;
+        }
+        const formatted = value > 0 ? `↑ ${value.toFixed(1)}%` : value < 0 ? `↓ ${(Math.abs(value)).toFixed(1)}%` : '0%';
+        element.textContent = formatted;
+        if (value > 0) {
+            element.classList.add('positive');
+        } else if (value < 0) {
+            element.classList.add('negative');
+        }
+    }
+
+    function countryCodeToEmoji(code) {
+        if (!code) return '🌍';
+        const upper = code.trim().slice(0, 2).toUpperCase();
+        return upper.replace(/./g, (char) => String.fromCodePoint(char.charCodeAt(0) + 127397));
+    }
+
+    function renderHealth(data) {
+        state.health = data;
+        const maintenance = data?.bot?.maintenance;
+        els.botStatusIndicator.classList.remove('paused', 'stopped');
+        if (maintenance) {
+            els.botStatusIndicator.classList.add('paused');
+        }
+        if (els.maintenanceLabel) {
+            els.maintenanceLabel.textContent = maintenance ? 'Вкл' : 'Выкл';
+        }
+        if (els.maintenanceActionLabel) {
+            els.maintenanceActionLabel.textContent = maintenance ? 'Выключить техработы' : 'Включить техработы';
+        }
+        if (data?.services?.auto_backup_enabled) {
+            els.navServersCount.classList.add('active');
+        }
+    }
+
+    function renderSummary(summary) {
+        if (!summary) return;
+        els.statUsers.textContent = summary.total_users?.toLocaleString('ru-RU') ?? '—';
+        applyTrend(els.statUsersChange, summary.user_growth_percent ?? 0);
+        els.statRevenue.textContent = toLocaleCurrency(summary.monthly_revenue);
+        applyTrend(els.statRevenueChange, summary.monthly_revenue_change_percent ?? 0);
+        els.statServers.textContent = `${summary.available_servers ?? 0} / ${summary.total_servers ?? 0}`;
+        applyTrend(els.statServersChange, summary.active_servers_percent ?? 0);
+        els.statConversion.textContent = toPercent(summary.conversion_rate_percent ?? 0);
+        applyTrend(els.statConversionChange, summary.conversion_rate_percent ?? 0);
+    }
+
+    function renderRevenue(series) {
+        if (!Array.isArray(series) || !series.length) {
+            return;
+        }
+        const chart = document.createElement('div');
+        chart.className = 'chart-bars';
+        const max = Math.max(...series.map((item) => item.revenue || 0));
+        series.forEach((item) => {
+            const bar = document.createElement('div');
+            bar.className = 'chart-bar';
+            const percent = max > 0 ? Math.max((item.revenue / max) * 100, 5) : 5;
+            bar.style.height = `${percent}%`;
+            const value = document.createElement('div');
+            value.className = 'chart-bar-value';
+            value.textContent = toLocaleCurrency(item.revenue);
+            const label = document.createElement('div');
+            label.className = 'chart-bar-label';
+            label.textContent = new Date(item.date).toLocaleDateString('ru-RU', { day: '2-digit', month: 'short' });
+            bar.appendChild(value);
+            bar.appendChild(label);
+            chart.appendChild(bar);
+        });
+        els.revenueChart.innerHTML = '';
+        els.revenueChart.appendChild(chart);
+    }
+
+    function renderServers(servers) {
+        els.serversList.innerHTML = '';
+        if (!Array.isArray(servers) || !servers.length) {
+            els.serversList.innerHTML = '<div class="settings-empty">Нет доступных серверов</div>';
+            els.serversBadge.textContent = '0 онлайн';
+            els.navServersCount.textContent = '0';
+            return;
+        }
+        els.serversBadge.textContent = `${servers.filter((s) => s.is_available).length} онлайн`;
+        els.navServersCount.textContent = servers.length.toString();
+        servers.forEach((server) => {
+            const card = document.createElement('div');
+            card.className = 'server-card';
+            const header = document.createElement('div');
+            header.className = 'server-card-header';
+            header.innerHTML = `
+                <div class="server-info">
+                    <span class="server-flag">${countryCodeToEmoji(server.country_code)}</span>
+                    <div>
+                        <div class="server-name">${server.name}</div>
+                        <div class="server-status-badge ${server.is_available ? '' : 'offline'}">${server.status_label}</div>
                     </div>
                 </div>
+                <div class="server-stats">
+                    <div class="server-stat">
+                        <div class="server-stat-value">${server.current_users}</div>
+                        <div class="server-stat-label">Пользователей</div>
+                    </div>
+                    <div class="server-stat">
+                        <div class="server-stat-value">${server.max_users ?? '∞'}</div>
+                        <div class="server-stat-label">Лимит</div>
+                    </div>
+                    <div class="server-stat">
+                        <div class="server-stat-value">${server.capacity_percent}%</div>
+                        <div class="server-stat-label">Заполнен</div>
+                    </div>
+                    <div class="expand-icon">▼</div>
+                </div>
+            `;
+            const expanded = document.createElement('div');
+            expanded.className = 'server-expanded-content';
+            expanded.innerHTML = `
+                <div class="server-expanded-inner">
+                    <div class="server-details-grid">
+                        <div class="server-detail">
+                            <div class="server-detail-title">Цена</div>
+                            <div class="server-detail-value">${toLocaleCurrency(server.price_rub)}</div>
+                        </div>
+                        <div class="server-detail">
+                            <div class="server-detail-title">UUID</div>
+                            <div class="server-detail-value" style="font-size: 12px; color: var(--text-tertiary);">${server.squad_uuid}</div>
+                        </div>
+                        <div class="server-detail">
+                            <div class="server-detail-title">Статус</div>
+                            <div class="server-detail-value">${server.status_label}</div>
+                        </div>
+                    </div>
+                    ${server.description ? `<div class="server-description">${server.description}</div>` : ''}
+                </div>
+            `;
+            header.addEventListener('click', () => {
+                card.classList.toggle('expanded');
+            });
+            card.appendChild(header);
+            card.appendChild(expanded);
+            els.serversList.appendChild(card);
+        });
+    }
 
-                <!-- Recent Users Table -->
-                <div class="table-container">
-                    <div class="table-header">
-                        <h3 class="table
+    function renderUsers(users) {
+        if (!Array.isArray(users) || !users.length) {
+            els.recentUsersBody.innerHTML = '<tr><td colspan="5" style="padding: 32px; text-align: center; color: var(--text-tertiary);">Нет данных</td></tr>';
+            return;
+        }
+        const fragment = document.createDocumentFragment();
+        users.forEach((user) => {
+            const row = document.createElement('tr');
+            const subscription = user.subscription;
+            let badgeClass = 'status-badge';
+            let badgeText = '—';
+            if (subscription) {
+                if (subscription.is_trial) {
+                    badgeClass += ' trial';
+                    badgeText = 'Триал';
+                } else if (subscription.status === 'expired') {
+                    badgeClass += ' expired';
+                    badgeText = 'Истекла';
+                } else {
+                    badgeText = 'Активна';
+                }
+            }
+            const balance = toLocaleCurrency(user.balance_rub ?? 0);
+            row.innerHTML = `
+                <td>
+                    <div class="user-cell">
+                        <div class="user-avatar-small">${(user.full_name || 'U').charAt(0).toUpperCase()}</div>
+                        <div class="user-info">
+                            <div class="user-name">${user.full_name || 'Без имени'}</div>
+                            <div class="user-id">ID ${user.id}</div>
+                        </div>
+                    </div>
+                </td>
+                <td><span class="status-badge">${user.status}</span></td>
+                <td><span class="${badgeClass}">${badgeText}</span></td>
+                <td>${balance}</td>
+                <td class="table-actions-cell">
+                    <button class="icon-btn" data-action="view-user" data-user-id="${user.id}" title="Подробнее">ℹ️</button>
+                </td>
+            `;
+            fragment.appendChild(row);
+        });
+        els.recentUsersBody.innerHTML = '';
+        els.recentUsersBody.appendChild(fragment);
+    }
+
+    function renderSettingsCategories(categories) {
+        els.settingsContainer.innerHTML = '';
+        if (!Array.isArray(categories) || !categories.length) {
+            els.settingsContainer.innerHTML = '<div class="settings-empty">Нет доступных настроек</div>';
+            return;
+        }
+        categories.forEach((category) => {
+            const details = document.createElement('details');
+            details.className = 'setting-category';
+            details.dataset.category = category.key;
+            const summary = document.createElement('summary');
+            summary.innerHTML = `<span>${category.label}</span><span class="settings-count">${category.count}</span>`;
+            const itemsContainer = document.createElement('div');
+            itemsContainer.className = 'setting-items';
+            itemsContainer.innerHTML = '<div class="settings-empty">Откройте категорию, чтобы загрузить настройки…</div>';
+            details.appendChild(summary);
+            details.appendChild(itemsContainer);
+            details.addEventListener('toggle', async () => {
+                if (details.open && !state.settingsCache.has(category.key)) {
+                    await loadSettingsCategory(category.key, itemsContainer);
+                }
+            });
+            els.settingsContainer.appendChild(details);
+        });
+    }
+
+    async function loadSettingsCategory(key, container) {
+        container.innerHTML = '<div class="settings-empty">Загрузка…</div>';
+        try {
+            const items = await callApi(`/api/settings/category/${key}`);
+            state.settingsCache.set(key, items);
+            renderSettingItems(key, items, container);
+        } catch (error) {
+            container.innerHTML = `<div class="settings-empty">${error.message}</div>`;
+        }
+    }
+
+    function renderSettingItems(categoryKey, items, container) {
+        if (!items.length) {
+            container.innerHTML = '<div class="settings-empty">Нет настроек в этой категории</div>';
+            return;
+        }
+        const fragment = document.createDocumentFragment();
+        items.forEach((item) => {
+            const row = document.createElement('div');
+            row.className = 'setting-item';
+            row.dataset.key = item.key;
+            row.innerHTML = `
+                <div>
+                    <div class="setting-name">${item.name}</div>
+                    <div class="setting-key">${item.key}</div>
+                </div>
+                <div class="setting-value">
+                    <span>${item.value_formatted}</span>
+                    ${item.has_override ? '<span class="setting-override">Изменено</span>' : ''}
+                </div>
+                <div class="setting-actions">
+                    <button class="setting-button" data-action="edit-setting" data-key="${item.key}" data-category="${categoryKey}">Изменить</button>
+                    <button class="setting-button" data-action="reset-setting" data-key="${item.key}" data-category="${categoryKey}" ${item.has_override ? '' : 'disabled'}>Сбросить</button>
+                </div>
+            `;
+            fragment.appendChild(row);
+        });
+        container.innerHTML = '';
+        container.appendChild(fragment);
+    }
+
+    async function editSetting(key, category) {
+        const items = state.settingsCache.get(category) || [];
+        const item = items.find((entry) => entry.key === key);
+        if (!item) return;
+        const choices = item.choices || [];
+        const hint = choices.length
+            ? `\nВозможные значения:\n${choices.map((choice) => `• ${choice.label} (${choice.value})`).join('\n')}`
+            : '';
+        const currentValue = item.value ?? '';
+        const input = prompt(`Введите новое значение для «${item.name}»${hint}`, currentValue);
+        if (input === null) {
+            return;
+        }
+        try {
+            const payload = { value: input };
+            if (input.trim().toLowerCase() === 'null' || input.trim() === '') {
+                payload.value = null;
+            }
+            const updated = await callApi(`/api/settings/${key}`, { method: 'PUT', body: payload });
+            showToast('Настройка обновлена', 'success');
+            state.settingsCache.delete(category);
+            const details = els.settingsContainer.querySelector(`details[data-category="${category}"]`);
+            if (details) {
+                const itemsContainer = details.querySelector('.setting-items');
+                await loadSettingsCategory(category, itemsContainer);
+            }
+        } catch (error) {
+            showToast(error.message, 'error');
+        }
+    }
+
+    async function resetSetting(key, category) {
+        if (!confirm('Сбросить настройку к значению по умолчанию?')) {
+            return;
+        }
+        try {
+            await callApi(`/api/settings/${key}`, { method: 'DELETE' });
+            showToast('Настройка сброшена', 'success');
+            state.settingsCache.delete(category);
+            const details = els.settingsContainer.querySelector(`details[data-category="${category}"]`);
+            if (details) {
+                const itemsContainer = details.querySelector('.setting-items');
+                await loadSettingsCategory(category, itemsContainer);
+            }
+        } catch (error) {
+            showToast(error.message, 'error');
+        }
+    }
+
+    async function viewUser(userId) {
+        try {
+            const details = await callApi(`/api/users/${userId}`);
+            const user = details.user;
+            const transactions = details.transactions || [];
+            const lastTransaction = transactions[0];
+            const info = [
+                `Имя: ${user.full_name}`,
+                `Баланс: ${toLocaleCurrency(user.balance_rub)}`,
+                lastTransaction ? `Последняя операция: ${toLocaleCurrency(lastTransaction.amount_rub)} (${new Date(lastTransaction.created_at).toLocaleString('ru-RU')})` : 'Последняя операция: —',
+            ].join('\n');
+            alert(info);
+        } catch (error) {
+            showToast(error.message, 'error');
+        }
+    }
+
+    async function refreshHealth() {
+        const data = await callApi('/api/health');
+        renderHealth(data);
+    }
+
+    async function loadAllData() {
+        const [health, summary, revenue, users, servers, categories] = await Promise.all([
+            callApi('/api/health'),
+            callApi('/api/dashboard/summary'),
+            callApi('/api/dashboard/revenue?days=14'),
+            callApi('/api/users/recent?limit=8'),
+            callApi('/api/servers'),
+            callApi('/api/settings/categories'),
+        ]);
+        renderHealth(health);
+        renderSummary(summary);
+        renderRevenue(revenue);
+        renderUsers(users);
+        renderServers(servers);
+        renderSettingsCategories(categories);
+    }
+
+    async function handleAction(action) {
+        try {
+            switch (action) {
+                case 'refresh':
+                    await loadAllData();
+                    showToast('Данные обновлены', 'success');
+                    break;
+                case 'refresh-users':
+                    renderUsers(await callApi('/api/users/recent?limit=8'));
+                    showToast('Список пользователей обновлен', 'success');
+                    break;
+                case 'reload-config':
+                    await callApi('/api/bot/control', { method: 'POST', body: { action: 'reload_configuration' } });
+                    showToast('Конфигурация перезагружена', 'success');
+                    break;
+                case 'create-backup':
+                    await callApi('/api/bot/control', { method: 'POST', body: { action: 'create_backup' } });
+                    showToast('Задача на бекап создана', 'success');
+                    break;
+                case 'send-report':
+                    await callApi('/api/bot/control', { method: 'POST', body: { action: 'send_daily_report' } });
+                    showToast('Отчет сформирован', 'success');
+                    break;
+                case 'toggle-maintenance':
+                    if (state.health?.bot?.maintenance) {
+                        await callApi('/api/bot/control', { method: 'POST', body: { action: 'disable_maintenance' } });
+                    } else {
+                        await callApi('/api/bot/control', { method: 'POST', body: { action: 'enable_maintenance' } });
+                    }
+                    showToast('Статус техработ обновлен', 'success');
+                    await refreshHealth();
+                    break;
+                default:
+                    break;
+            }
+        } catch (error) {
+            showToast(error.message, 'error');
+        }
+    }
+
+    function bindEvents() {
+        els.loginForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const token = els.loginToken.value.trim();
+            if (!token) {
+                els.loginError.textContent = 'Введите токен';
+                return;
+            }
+            try {
+                await callApi('/api/auth/login', { method: 'POST', body: { token }, skipAuth: true });
+                state.token = token;
+                localStorage.setItem('webadminToken', token);
+                hideLogin();
+                await loadAllData();
+            } catch (error) {
+                els.loginError.textContent = error.message;
+            }
+        });
+
+        document.addEventListener('click', (event) => {
+            if (!els.botDropdown.contains(event.target) && !els.botControlBtn.contains(event.target)) {
+                els.botDropdown.classList.remove('open');
+            }
+        });
+
+        els.botControlBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            els.botDropdown.classList.toggle('open');
+        });
+
+        els.botDropdown.addEventListener('click', async (event) => {
+            const action = event.target.closest('[data-action]')?.dataset.action;
+            if (!action) return;
+            els.botDropdown.classList.remove('open');
+            if (action === 'logout') {
+                state.token = '';
+                localStorage.removeItem('webadminToken');
+                showToast('Вы вышли из панели', 'success');
+                showLogin();
+                return;
+            }
+            await handleAction(action);
+        });
+
+        document.querySelectorAll('[data-action]').forEach((button) => {
+            button.addEventListener('click', async () => {
+                const action = button.dataset.action;
+                if (['reload-config', 'create-backup', 'toggle-maintenance', 'refresh', 'refresh-users'].includes(action)) {
+                    await handleAction(action);
+                }
+            });
+        });
+
+        els.recentUsersBody.addEventListener('click', async (event) => {
+            const button = event.target.closest('[data-action="view-user"]');
+            if (!button) return;
+            const userId = Number(button.dataset.userId);
+            if (!Number.isFinite(userId)) return;
+            await viewUser(userId);
+        });
+
+        els.settingsContainer.addEventListener('click', async (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) return;
+            const { action, key, category } = target.dataset;
+            if (!key || !category) return;
+            if (action === 'edit-setting') {
+                await editSetting(key, category);
+            } else if (action === 'reset-setting') {
+                await resetSetting(key, category);
+            }
+        });
+    }
+
+    async function init() {
+        bindEvents();
+        if (state.token) {
+            try {
+                await loadAllData();
+            } catch (error) {
+                showToast(error.message, 'error');
+                showLogin('Сессия истекла, выполните вход заново');
+            }
+        } else {
+            showLogin();
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add web admin configuration toggles and expose helper methods to load settings dynamically
- implement an aiohttp-based admin server with dashboard, user, server, and configuration endpoints
- wire the server into the main bot lifecycle and replace the static dashboard with a dynamic interface that consumes the new API

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d5d0eff7208320809a842d1c148df5