### PR TITLE
Fix 204 responses for web API deletes

### DIFF
--- a/app/webapi/routes/promo_groups.py
+++ b/app/webapi/routes/promo_groups.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.promo_group import (
@@ -122,12 +122,16 @@ async def update_promo_group_endpoint(
     return _serialize(group, members_count=members_count)
 
 
-@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{group_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
 async def delete_promo_group_endpoint(
     group_id: int,
     _: Any = Depends(require_api_token),
     db: AsyncSession = Depends(get_db_session),
-) -> None:
+) -> Response:
     group = await get_promo_group_by_id(db, group_id)
     if not group:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Promo group not found")
@@ -136,4 +140,4 @@ async def delete_promo_group_endpoint(
     if not success:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Cannot delete default promo group")
 
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/webapi/routes/tokens.py
+++ b/app/webapi/routes/tokens.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.web_api_token import (
@@ -92,16 +92,20 @@ async def activate_token(
     return _serialize(token)
 
 
-@router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{token_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
 async def delete_token_endpoint(
     token_id: int,
     _: WebApiToken = Depends(require_api_token),
     db: AsyncSession = Depends(get_db_session),
-) -> None:
+) -> Response:
     token = await get_token_by_id(db, token_id)
     if not token:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Token not found")
 
     await delete_token(db, token)
     await db.commit()
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- ensure 204 delete endpoints in the administrative API use plain Response objects
- prevent FastAPI from attaching an empty JSON body to 204 responses so the server can start
