### PR TITLE
Fix FastAPI 204 delete endpoints to return empty responses

### DIFF
--- a/app/webapi/routes/promo_groups.py
+++ b/app/webapi/routes/promo_groups.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.promo_group import (
@@ -127,7 +127,7 @@ async def delete_promo_group_endpoint(
     group_id: int,
     _: Any = Depends(require_api_token),
     db: AsyncSession = Depends(get_db_session),
-) -> None:
+) -> Response:
     group = await get_promo_group_by_id(db, group_id)
     if not group:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Promo group not found")
@@ -136,4 +136,4 @@ async def delete_promo_group_endpoint(
     if not success:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Cannot delete default promo group")
 
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/webapi/routes/tokens.py
+++ b/app/webapi/routes/tokens.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.web_api_token import (
@@ -97,11 +97,11 @@ async def delete_token_endpoint(
     token_id: int,
     _: WebApiToken = Depends(require_api_token),
     db: AsyncSession = Depends(get_db_session),
-) -> None:
+) -> Response:
     token = await get_token_by_id(db, token_id)
     if not token:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Token not found")
 
     await delete_token(db, token)
     await db.commit()
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- ensure the promo group and token delete endpoints return empty Response objects for 204 statuses

## Testing
- python -m compileall app/webapi/routes

------
https://chatgpt.com/codex/tasks/task_e_68d8715c44c08320b93d7360e59e6872