### PR TITLE
Expose admin API port for docker deployments

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -72,6 +72,7 @@ services:
       # Логотип для сообщений
       - ./vpn_logo.png:/app/vpn_logo.png:ro
     ports:
+      - "${WEB_API_PORT:-8080}:8080"
       - "${TRIBUTE_WEBHOOK_PORT:-8081}:8081"
       - "${YOOKASSA_WEBHOOK_PORT:-8082}:8082"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       # Логотип для сообщений
       - ./vpn_logo.png:/app/vpn_logo.png:ro
     ports:
+      - "${WEB_API_PORT:-8080}:8080"
       - "${TRIBUTE_WEBHOOK_PORT:-8081}:8081"
       - "${YOOKASSA_WEBHOOK_PORT:-8082}:8082"
     networks:


### PR DESCRIPTION
## Summary
- map the admin FastAPI service port 8080 in both docker-compose configurations so the web docs are reachable