### PR TITLE
Make DATABASE_URL optional for default setup

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     CHANNEL_LINK: Optional[str] = None
     CHANNEL_IS_REQUIRED_SUB: bool = False
     
-    DATABASE_URL: str = ""
+    DATABASE_URL: Optional[str] = None
     
     POSTGRES_HOST: str = "postgres"
     POSTGRES_PORT: int = 5432


### PR DESCRIPTION
## Summary
- allow the settings model to load without a DATABASE_URL when only BOT_TOKEN and ADMIN_IDS are provided
