### PR TITLE
Fix default handling for DATABASE_URL setting

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     CHANNEL_LINK: Optional[str] = None
     CHANNEL_IS_REQUIRED_SUB: bool = False
     
-    DATABASE_URL: Optional[str] = None
+    DATABASE_URL: Optional[str] = Field(default=None)
     
     POSTGRES_HOST: str = "postgres"
     POSTGRES_PORT: int = 5432


### PR DESCRIPTION
## Summary
- ensure the DATABASE_URL setting uses an explicit optional default so pydantic no longer treats it as required when the env var is absent
