### PR TITLE
Allow optional Remnawave integration settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     CHANNEL_LINK: Optional[str] = None
     CHANNEL_IS_REQUIRED_SUB: bool = False
     
-    DATABASE_URL: Optional[str] = None
+    DATABASE_URL: Optional[str] = Field(default=None)
     
     POSTGRES_HOST: str = "postgres"
     POSTGRES_PORT: int = 5432
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     
     REDIS_URL: str = "redis://localhost:6379/0"
     
-    REMNAWAVE_API_URL: str = ""
-    REMNAWAVE_API_KEY: str = ""
+    REMNAWAVE_API_URL: Optional[str] = Field(default=None)
+    REMNAWAVE_API_KEY: Optional[str] = Field(default=None)
     REMNAWAVE_SECRET_KEY: Optional[str] = None
 
     REMNAWAVE_USERNAME: Optional[str] = None
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     TRIAL_DEVICE_LIMIT: int = 2
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
-    TRIAL_SQUAD_UUID: str = ""
+    TRIAL_SQUAD_UUID: Optional[str] = Field(default=None)
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
     MAX_DEVICES_LIMIT: int = 20
     
@@ -389,8 +389,8 @@ class Settings(BaseSettings):
 
     def get_remnawave_auth_params(self) -> Dict[str, Optional[str]]:
         return {
-            "base_url": self.REMNAWAVE_API_URL,
-            "api_key": self.REMNAWAVE_API_KEY,
+            "base_url": (self.REMNAWAVE_API_URL or "").strip(),
+            "api_key": (self.REMNAWAVE_API_KEY or "").strip(),
             "secret_key": self.REMNAWAVE_SECRET_KEY,
             "username": self.REMNAWAVE_USERNAME,
             "password": self.REMNAWAVE_PASSWORD,

--- a/app/services/maintenance_service.py
+++ b/app/services/maintenance_service.py
@@ -443,10 +443,12 @@ API снова отвечает на запросы.""", "success")
             
             emoji = status_emojis.get(status, "ℹ️")
             
+            api_url_display = settings.REMNAWAVE_API_URL or "—"
+
             message = f"""Статус панели Remnawave изменился
 
 {emoji} <b>Статус:</b> {status.upper()}
-🔗 <b>URL:</b> {settings.REMNAWAVE_API_URL}
+🔗 <b>URL:</b> {api_url_display}
 {details}"""
             
             alert_type = "error" if status in ["offline", "error"] else "info"


### PR DESCRIPTION
## Summary
- allow the Remnawave API configuration values to default to `None` so the settings model no longer requires them at startup
- normalize the values returned in auth params to keep downstream consumers expecting strings working
- display a placeholder in maintenance notifications when the Remnawave URL is not configured
