### PR TITLE
Fix missing defaults for optional Remnawave settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     
     REDIS_URL: str = "redis://localhost:6379/0"
     
-    REMNAWAVE_API_URL: Optional[str] = Field(default=None)
-    REMNAWAVE_API_KEY: Optional[str] = Field(default=None)
+    REMNAWAVE_API_URL: str = Field(default="")
+    REMNAWAVE_API_KEY: str = Field(default="")
     REMNAWAVE_SECRET_KEY: Optional[str] = None
 
     REMNAWAVE_USERNAME: Optional[str] = None
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     TRIAL_DEVICE_LIMIT: int = 2
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
-    TRIAL_SQUAD_UUID: Optional[str] = Field(default=None)
+    TRIAL_SQUAD_UUID: str = Field(default="")
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
     MAX_DEVICES_LIMIT: int = 20
     


### PR DESCRIPTION
## Summary
- provide empty-string defaults for Remnawave API URL, API key, and trial squad UUID so the bot can start without them configured