### PR TITLE
Allow bot to boot without RemnaWave API settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     
     REDIS_URL: str = "redis://localhost:6379/0"
     
-    REMNAWAVE_API_URL: str = ""
-    REMNAWAVE_API_KEY: str = ""
+    REMNAWAVE_API_URL: Optional[str] = None
+    REMNAWAVE_API_KEY: Optional[str] = None
     REMNAWAVE_SECRET_KEY: Optional[str] = None
 
     REMNAWAVE_USERNAME: Optional[str] = None
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     TRIAL_DEVICE_LIMIT: int = 2
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
-    TRIAL_SQUAD_UUID: str = ""
+    TRIAL_SQUAD_UUID: Optional[str] = None
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
     MAX_DEVICES_LIMIT: int = 20
     

--- a/app/services/maintenance_service.py
+++ b/app/services/maintenance_service.py
@@ -443,10 +443,11 @@ API снова отвечает на запросы.""", "success")
             
             emoji = status_emojis.get(status, "ℹ️")
             
+            api_url = settings.REMNAWAVE_API_URL or "—"
             message = f"""Статус панели Remnawave изменился
 
 {emoji} <b>Статус:</b> {status.upper()}
-🔗 <b>URL:</b> {settings.REMNAWAVE_API_URL}
+🔗 <b>URL:</b> {api_url}
 {details}"""
             
             alert_type = "error" if status in ["offline", "error"] else "info"


### PR DESCRIPTION
## Summary
- treat RemnaWave API URL, API key, and trial squad UUID as optional settings so the bot can load without them
- show a placeholder in maintenance notifications when the RemnaWave URL is not configured

