### PR TITLE
Fix database URL initialization

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -10,7 +10,7 @@ from app.database.models import Base
 logger = logging.getLogger(__name__)
 
 engine = create_async_engine(
-    settings.DATABASE_URL,
+    settings.get_database_url(),
     poolclass=NullPool,
     echo=settings.DEBUG,
     future=True


### PR DESCRIPTION
## Summary
- use the computed database URL helper when creating the async engine so automatic selection between SQLite and PostgreSQL works in all environments
- ensure the database module ends with a trailing newline for clean formatting