### PR TITLE
Add Remnawave component management API

### DIFF
--- a/app/external/remnawave_api.py
+++ b/app/external/remnawave_api.py
@@ -477,6 +477,47 @@ class RemnaWaveAPI:
         return response['response']['eventSent']
     
     
+    async def list_components(self) -> List[Dict[str, Any]]:
+        response = await self._make_request('GET', '/api/components')
+        components = response.get('response')
+
+        if isinstance(components, dict):
+            if 'components' in components:
+                components = components['components']
+            elif 'items' in components:
+                components = components['items']
+
+        if not components:
+            return []
+
+        if isinstance(components, list):
+            return components
+
+        return [components]
+
+    async def get_component(self, component_id: str) -> Dict[str, Any]:
+        response = await self._make_request('GET', f'/api/components/{component_id}')
+        component = response.get('response')
+
+        if isinstance(component, dict):
+            return component
+
+        return {}
+
+    async def perform_component_action(
+        self,
+        component_id: str,
+        action: str,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        endpoint = f'/api/components/{component_id}/actions/{action}'
+        response = await self._make_request('POST', endpoint, data=payload)
+        return response.get('response') or {}
+
+    async def update_component(self, component_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = await self._make_request('PATCH', f'/api/components/{component_id}', payload)
+        return response.get('response') or {}
+
     async def get_subscription_info(self, short_uuid: str) -> SubscriptionInfo:
         response = await self._make_request('GET', f'/api/sub/{short_uuid}/info')
         return self._parse_subscription_info(response['response'])

--- a/app/webapi/app.py
+++ b/app/webapi/app.py
@@ -10,6 +10,7 @@ from .routes import (
     config,
     health,
     promo_groups,
+    remnawave,
     stats,
     subscriptions,
     tickets,
@@ -51,6 +52,7 @@ def create_web_api_app() -> FastAPI:
     app.include_router(tickets.router, prefix="/tickets", tags=["support"])
     app.include_router(transactions.router, prefix="/transactions", tags=["transactions"])
     app.include_router(promo_groups.router, prefix="/promo-groups", tags=["promo-groups"])
+    app.include_router(remnawave.router, prefix="/remnawave", tags=["remnawave"])
     app.include_router(tokens.router, prefix="/tokens", tags=["auth"])
 
     return app

--- a/app/webapi/routes/remnawave.py
+++ b/app/webapi/routes/remnawave.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Security, status
+
+from app.external.remnawave_api import RemnaWaveAPIError
+from app.services.remnawave_service import (
+    RemnaWaveConfigurationError,
+    RemnaWaveService,
+)
+
+from ..dependencies import require_api_token
+from ..schemas.remnawave import (
+    ComponentActionRequest,
+    ComponentActionResponse,
+    ComponentInfo,
+    ComponentListResponse,
+    ComponentUpdateRequest,
+)
+
+router = APIRouter()
+
+
+def _map_api_error(error: RemnaWaveAPIError) -> HTTPException:
+    status_code = error.status_code or status.HTTP_502_BAD_GATEWAY
+    if status_code < 400 or status_code >= 600:
+        status_code = status.HTTP_502_BAD_GATEWAY
+    return HTTPException(status_code=status_code, detail=error.message)
+
+
+@router.get("/components", response_model=ComponentListResponse)
+async def list_components(
+    _: object = Security(require_api_token),
+) -> ComponentListResponse:
+    service = RemnaWaveService()
+
+    try:
+        components = await service.list_components()
+    except RemnaWaveConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error)
+        ) from error
+    except RemnaWaveAPIError as error:
+        raise _map_api_error(error)
+
+    items = [ComponentInfo(**component) for component in components]
+    return ComponentListResponse(items=items, total=len(items))
+
+
+@router.get("/components/{component_id}", response_model=ComponentInfo)
+async def get_component(
+    component_id: str,
+    _: object = Security(require_api_token),
+) -> ComponentInfo:
+    service = RemnaWaveService()
+
+    try:
+        component = await service.get_component_details(component_id)
+    except RemnaWaveConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error)
+        ) from error
+    except RemnaWaveAPIError as error:
+        raise _map_api_error(error)
+
+    if not component:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Компонент не найден")
+
+    return ComponentInfo(**component)
+
+
+@router.post(
+    "/components/{component_id}/actions/{action}",
+    response_model=ComponentActionResponse,
+)
+async def perform_component_action(
+    component_id: str,
+    action: str,
+    request: Optional[ComponentActionRequest] = None,
+    _: object = Security(require_api_token),
+) -> ComponentActionResponse:
+    service = RemnaWaveService()
+    payload = request.payload if request else None
+
+    try:
+        result = await service.perform_component_action(component_id, action, payload)
+    except RemnaWaveConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error)
+        ) from error
+    except RemnaWaveAPIError as error:
+        raise _map_api_error(error)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+
+    component_data = result.get("component")
+    component = ComponentInfo(**component_data) if isinstance(component_data, dict) else None
+
+    details = result.get("details")
+    if details is not None and not isinstance(details, dict):
+        details = {"response": details}
+
+    return ComponentActionResponse(
+        success=bool(result.get("success", True)),
+        message=result.get("message"),
+        component=component,
+        details=details,
+    )
+
+
+@router.patch(
+    "/components/{component_id}",
+    response_model=ComponentActionResponse,
+)
+async def update_component(
+    component_id: str,
+    request: ComponentUpdateRequest,
+    _: object = Security(require_api_token),
+) -> ComponentActionResponse:
+    service = RemnaWaveService()
+
+    if not request.payload:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Поле payload не может быть пустым",
+        )
+
+    try:
+        result = await service.update_component_settings(component_id, request.payload)
+    except RemnaWaveConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error)
+        ) from error
+    except RemnaWaveAPIError as error:
+        raise _map_api_error(error)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+
+    component_data = result.get("component")
+    component = ComponentInfo(**component_data) if isinstance(component_data, dict) else None
+
+    details = result.get("details")
+    if details is not None and not isinstance(details, dict):
+        details = {"response": details}
+
+    return ComponentActionResponse(
+        success=bool(result.get("success", True)),
+        message=result.get("message"),
+        component=component,
+        details=details,
+    )

--- a/app/webapi/schemas/remnawave.py
+++ b/app/webapi/schemas/remnawave.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ComponentInfo(BaseModel):
+    """Normalized representation of a Remnawave component."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    uuid: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    status: Optional[str] = None
+    installed_version: Optional[str] = Field(default=None, alias="installedVersion")
+    latest_version: Optional[str] = Field(default=None, alias="latestVersion")
+    category: Optional[str] = None
+    description: Optional[str] = None
+    is_installed: Optional[bool] = Field(default=None, alias="isInstalled")
+    is_enabled: Optional[bool] = Field(default=None, alias="isEnabled")
+    installed_at: Optional[str] = Field(default=None, alias="installedAt")
+    updated_at: Optional[str] = Field(default=None, alias="updatedAt")
+    tags: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class ComponentListResponse(BaseModel):
+    items: List[ComponentInfo]
+    total: int
+
+
+class ComponentActionRequest(BaseModel):
+    payload: Optional[Dict[str, Any]] = None
+
+
+class ComponentUpdateRequest(BaseModel):
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ComponentActionResponse(BaseModel):
+    success: bool
+    message: Optional[str] = None
+    component: Optional[ComponentInfo] = None
+    details: Optional[Dict[str, Any]] = None

--- a/docs/web-admin-integration.md
+++ b/docs/web-admin-integration.md
@@ -126,6 +126,10 @@ curl -X POST "http://127.0.0.1:8080/tokens" \
 | `POST` | `/promo-groups` | Создать промо-группу.
 | `PATCH` | `/promo-groups/{id}` | Обновить промо-группу.
 | `DELETE` | `/promo-groups/{id}` | Удалить промо-группу.
+| `GET` | `/remnawave/components` | Список компонентов Remnawave.
+| `GET` | `/remnawave/components/{id}` | Детали конкретного компонента.
+| `POST` | `/remnawave/components/{id}/actions/{action}` | Выполнить действие над компонентом (install, update, restart и т.д.).
+| `PATCH` | `/remnawave/components/{id}` | Обновить настройки компонента.
 | `GET` | `/tokens` | Управление токенами доступа.
 
 > Все списковые эндпоинты поддерживают пагинацию (`limit`, `offset`) и фильтры, описанные в OpenAPI спецификации. Если `WEB_API_DOCS_ENABLED=true`, документация доступна по `/docs`. В ответах `/settings` поле `choices` всегда массив: пустой список означает отсутствие предопределённых значений.


### PR DESCRIPTION
## Summary
- extend the Remnawave API client and service layer to normalize and handle component metadata and actions
- expose new `/remnawave/components` endpoints in the embedded web API and document them in the admin integration guide

## Testing
- python -m compileall app/webapi app/services app/external

------
https://chatgpt.com/codex/tasks/task_e_68d89007cdcc8320b06eeed1464a1ff7