### PR TITLE
Fix RemnaWave API docs registration

### DIFF
--- a/app/webapi/app.py
+++ b/app/webapi/app.py
@@ -101,6 +101,6 @@ def create_web_api_app() -> FastAPI:
     app.include_router(transactions.router, prefix="/transactions", tags=["transactions"])
     app.include_router(promo_groups.router, prefix="/promo-groups", tags=["promo-groups"])
     app.include_router(tokens.router, prefix="/tokens", tags=["auth"])
-    app.include_router(remnawave.router)
+    app.include_router(remnawave.router, prefix="/remnawave", tags=["remnawave"])
 
     return app

--- a/app/webapi/routes/remnawave.py
+++ b/app/webapi/routes/remnawave.py
@@ -32,7 +32,7 @@ from ..schemas.remnawave import (
 )
 
 
-router = APIRouter(prefix="/remnawave", tags=["remnawave"])
+router = APIRouter()
 
 
 def _ensure_service_configured(service: RemnaWaveService) -> None:


### PR DESCRIPTION
## Summary
- register the RemnaWave router with an explicit prefix and tag so it appears in the API docs like the other sections
- remove the embedded prefix from the RemnaWave router to avoid conflicting configuration
