### PR TITLE
Add setting to roll remaining trial time into paid subscriptions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     TRIAL_DURATION_DAYS: int = 3
     TRIAL_TRAFFIC_LIMIT_GB: int = 10
     TRIAL_DEVICE_LIMIT: int = 2
+    TRIAL_ADD_REMAINING_DAYS_TO_PAID: bool = False
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
     TRIAL_SQUAD_UUID: str = ""


### PR DESCRIPTION
## Summary
- add a TRIAL_ADD_REMAINING_DAYS_TO_PAID configuration flag to control trial rollover behavior
- apply the rollover when a trial user buys a subscription and when admins convert trial users
