### PR TITLE
Fix base period discount rounding and summary formatting

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -292,13 +292,15 @@ async def _prepare_subscription_summary(
         else:
             traffic_display = f"{summary_data.get('traffic_gb', 0)} ГБ"
 
-    base_line = f"- Базовый период: {texts.format_price(base_price_original)}"
     if base_discount_total > 0:
-        base_line += (
-            f" → {texts.format_price(base_price)}"
+        base_line = (
+            f"- Базовый период: <s>{texts.format_price(base_price_original)}</s> "
+            f"{texts.format_price(base_price)}"
             f" (скидка {period_discount_percent}%:"
             f" -{texts.format_price(base_discount_total)})"
         )
+    else:
+        base_line = f"- Базовый период: {texts.format_price(base_price_original)}"
 
     details_lines = [base_line]
 

--- a/app/utils/pricing_utils.py
+++ b/app/utils/pricing_utils.py
@@ -50,6 +50,13 @@ def apply_percentage_discount(amount: int, percent: int) -> Tuple[int, int]:
     discount_value = amount * clamped_percent // 100
     discounted_amount = amount - discount_value
 
+    # Round the discounted price up to the nearest full ruble (100 kopeks)
+    # to avoid undercharging users because of fractional kopeks.
+    if discount_value >= 100 and discounted_amount % 100:
+        discounted_amount += 100 - (discounted_amount % 100)
+        discounted_amount = min(discounted_amount, amount)
+        discount_value = amount - discounted_amount
+
     logger.debug(
         "Применена скидка %s%%: %s → %s (скидка %s)",
         clamped_percent,


### PR DESCRIPTION
## Summary
- round discounted prices up to the nearest whole ruble to avoid fractional totals when promo discounts apply
- adjust the subscription summary to strike through the original base period price instead of displaying malformed characters

