### PR TITLE
Convert extended trials to paid subscriptions

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -116,7 +116,23 @@ async def extend_subscription(
     else:
         subscription.end_date = current_time + timedelta(days=days)
         logger.info(f"📅 Подписка истекла, устанавливаем новую дату окончания")
-    
+
+    if subscription.is_trial:
+        start_date = subscription.start_date or current_time
+        total_duration = subscription.end_date - start_date
+        max_trial_duration = timedelta(days=settings.TRIAL_DURATION_DAYS)
+
+        if total_duration > max_trial_duration:
+            subscription.is_trial = False
+            logger.info(
+                "🎯 Подписка %s автоматически переведена из триальной в платную после продления"
+                ", итоговая длительность: %s дней",
+                subscription.id,
+                total_duration.days,
+            )
+            if subscription.user:
+                subscription.user.has_had_paid_subscription = True
+
     if subscription.status == SubscriptionStatus.EXPIRED.value:
         subscription.status = SubscriptionStatus.ACTIVE.value
         logger.info(f"🔄 Статус изменён с EXPIRED на ACTIVE")


### PR DESCRIPTION
## Summary
- automatically flip subscriptions from trial to paid when manual extensions exceed the configured trial duration
- mark the related user as having had a paid subscription so the bot does not clean it up as a trial