### PR TITLE
Fix admin server user list query

### DIFF
--- a/app/database/crud/server_squad.py
+++ b/app/database/crud/server_squad.py
@@ -348,14 +348,16 @@ async def sync_with_remnawave(
 
 async def get_server_connected_users(
     db: AsyncSession,
-    server_id: int
+    server: ServerSquad
 ) -> List[User]:
+
+    if server is None or not server.squad_uuid:
+        return []
 
     result = await db.execute(
         select(User)
         .join(Subscription, Subscription.user_id == User.id)
-        .join(SubscriptionServer, SubscriptionServer.subscription_id == Subscription.id)
-        .where(SubscriptionServer.server_squad_id == server_id)
+        .where(Subscription.connected_squads.contains([server.squad_uuid]))
         .options(selectinload(User.subscription))
         .order_by(User.id)
     )

--- a/app/handlers/admin/servers.py
+++ b/app/handlers/admin/servers.py
@@ -365,7 +365,7 @@ async def show_server_users(
         await callback.answer("❌ Сервер не найден!", show_alert=True)
         return
 
-    users = await get_server_connected_users(db, server_id)
+    users = await get_server_connected_users(db, server)
 
     safe_name = html.escape(server.display_name or "—")
     safe_uuid = html.escape(server.squad_uuid or "—")


### PR DESCRIPTION
## Summary
- fetch server users by matching the server's UUID in subscription connected_squads
- reuse the loaded server object when building the admin user list
