### PR TITLE
Fix server user list counts

### DIFF
--- a/app/database/crud/server_squad.py
+++ b/app/database/crud/server_squad.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Iterable, List, Optional, Sequence, Tuple
 
-from sqlalchemy import select, and_, func, update, delete, text
+from sqlalchemy import select, and_, func, update, delete, text, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -348,14 +348,20 @@ async def sync_with_remnawave(
 
 async def get_server_connected_users(
     db: AsyncSession,
-    server_id: int
+    server_id: int,
+    server_uuid: Optional[str] = None,
 ) -> List[User]:
+
+    filters = [SubscriptionServer.server_squad_id == server_id]
+
+    if server_uuid:
+        filters.append(Subscription.connected_squads.contains([server_uuid]))
 
     result = await db.execute(
         select(User)
         .join(Subscription, Subscription.user_id == User.id)
-        .join(SubscriptionServer, SubscriptionServer.subscription_id == Subscription.id)
-        .where(SubscriptionServer.server_squad_id == server_id)
+        .outerjoin(SubscriptionServer, SubscriptionServer.subscription_id == Subscription.id)
+        .where(or_(*filters))
         .options(selectinload(User.subscription))
         .order_by(User.id)
     )

--- a/app/handlers/admin/servers.py
+++ b/app/handlers/admin/servers.py
@@ -365,7 +365,7 @@ async def show_server_users(
         await callback.answer("❌ Сервер не найден!", show_alert=True)
         return
 
-    users = await get_server_connected_users(db, server_id)
+    users = await get_server_connected_users(db, server_id, server.squad_uuid)
 
     safe_name = html.escape(server.display_name or "—")
     safe_uuid = html.escape(server.squad_uuid or "—")


### PR DESCRIPTION
## Summary
- include subscriptions stored in connected_squads when listing server users
- pass the server UUID to the query so both legacy and current storage methods are covered