### PR TITLE
feat: update Happ cryptolink subscription link handling

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -68,6 +68,7 @@ from app.utils.pagination import paginate_list
 from app.utils.subscription_utils import (
     get_display_subscription_link,
     get_happ_cryptolink_redirect_link,
+    build_happ_subscription_link,
 )
 
 logger = logging.getLogger(__name__)
@@ -5048,6 +5049,16 @@ async def handle_open_subscription_link(
 
     if settings.is_happ_cryptolink_mode():
         redirect_link = get_happ_cryptolink_redirect_link(subscription_link)
+        base_subscription_link = getattr(subscription, "subscription_url", None)
+        raw_crypto_link = getattr(subscription, "subscription_crypto_link", None)
+        crypto_link = raw_crypto_link or subscription_link
+        happ_subscription_link = (
+            build_happ_subscription_link(base_subscription_link)
+            or build_happ_subscription_link(subscription_link)
+        )
+
+        link_for_display = happ_subscription_link or crypto_link
+
         happ_message = (
             texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_TITLE",
@@ -5057,13 +5068,19 @@ async def handle_open_subscription_link(
             + texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_LINK",
                 "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
-            ).format(subscription_link=subscription_link)
+            ).format(subscription_link=link_for_display)
             + "\n\n"
             + texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_HINT",
                 "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
-            ).format(subscription_link=subscription_link)
+            ).format(subscription_link=link_for_display)
         )
+
+        if raw_crypto_link:
+            happ_message += "\n\n" + texts.t(
+                "SUBSCRIPTION_HAPP_OPEN_CRYPTOLINK",
+                "<blockquote expandable>🔐 CryptoLink: <code>{crypto_link}</code></blockquote>",
+            ).format(crypto_link=raw_crypto_link)
 
         if redirect_link:
             happ_message += "\n\n" + texts.t(

--- a/app/utils/subscription_utils.py
+++ b/app/utils/subscription_utils.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 from sqlalchemy import select, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database.models import Subscription, User
@@ -110,6 +110,31 @@ def get_display_subscription_link(subscription: Optional[Subscription]) -> Optio
         return crypto_link or base_link
 
     return base_link
+
+
+def build_happ_subscription_link(link: Optional[str]) -> Optional[str]:
+    if not link:
+        return None
+
+    if link.startswith("happ://"):
+        return link
+
+    parsed = urlparse(link)
+
+    if not parsed.scheme:
+        return f"happ://{link}"
+
+    if parsed.scheme == "happ":
+        return link
+
+    return urlunparse((
+        "happ",
+        parsed.netloc,
+        parsed.path,
+        parsed.params,
+        parsed.query,
+        parsed.fragment,
+    ))
 
 
 def get_happ_cryptolink_redirect_link(subscription_link: Optional[str]) -> Optional[str]:

--- a/locales/en.json
+++ b/locales/en.json
@@ -422,6 +422,7 @@
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Connect via Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Open link in Happ</a>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 If the link doesn't open automatically, copy it manually: <code>{subscription_link}</code>",
+  "SUBSCRIPTION_HAPP_OPEN_CRYPTOLINK": "<blockquote expandable>🔐 CryptoLink: <code>{crypto_link}</code></blockquote>",
   "SUBSCRIPTION_HAPP_OPEN_BUTTON_HINT": "▶️ Tap the \"Connect\" button below to open Happ and add the subscription automatically.",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Subscription link:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Recommended app:</b> {app_name}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -422,6 +422,7 @@
   "SUBSCRIPTION_HAPP_OPEN_TITLE": "🔗 <b>Подключение через Happ</b>",
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
+  "SUBSCRIPTION_HAPP_OPEN_CRYPTOLINK": "<blockquote expandable>🔐 CryptoLink: <code>{crypto_link}</code></blockquote>",
   "SUBSCRIPTION_HAPP_OPEN_BUTTON_HINT": "▶️ Нажмите кнопку \"Подключиться\" ниже, чтобы открыть Happ и добавить подписку автоматически.",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Ссылка подписки:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Рекомендуемое приложение:</b> {app_name}",


### PR DESCRIPTION
## Summary
- convert subscription URLs to the happ:// scheme when Happ cryptolink mode is active
- hide the raw CryptoLink behind an expandable blockquote and localize the new hint