### PR TITLE
Convert Happ cryptolink message to happ scheme

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -68,6 +68,7 @@ from app.utils.pagination import paginate_list
 from app.utils.subscription_utils import (
     get_display_subscription_link,
     get_happ_cryptolink_redirect_link,
+    convert_subscription_link_to_happ_scheme,
 )
 
 logger = logging.getLogger(__name__)
@@ -5048,6 +5049,7 @@ async def handle_open_subscription_link(
 
     if settings.is_happ_cryptolink_mode():
         redirect_link = get_happ_cryptolink_redirect_link(subscription_link)
+        happ_scheme_link = convert_subscription_link_to_happ_scheme(subscription_link)
         happ_message = (
             texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_TITLE",
@@ -5057,12 +5059,12 @@ async def handle_open_subscription_link(
             + texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_LINK",
                 "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
-            ).format(subscription_link=subscription_link)
+            ).format(subscription_link=happ_scheme_link)
             + "\n\n"
             + texts.t(
                 "SUBSCRIPTION_HAPP_OPEN_HINT",
                 "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
-            ).format(subscription_link=subscription_link)
+            ).format(subscription_link=happ_scheme_link)
         )
 
         if redirect_link:
@@ -5070,6 +5072,11 @@ async def handle_open_subscription_link(
                 "SUBSCRIPTION_HAPP_OPEN_BUTTON_HINT",
                 "▶️ Нажмите кнопку \"Подключиться\" ниже, чтобы открыть Happ и добавить подписку автоматически.",
             )
+
+        happ_message += "\n\n" + texts.t(
+            "SUBSCRIPTION_HAPP_CRYPTOLINK_BLOCK",
+            "<blockquote expandable>🪙 CryptoLink: <code>{crypto_link}</code></blockquote>",
+        ).format(crypto_link=subscription_link)
 
         keyboard = get_happ_cryptolink_keyboard(
             subscription_link,

--- a/app/utils/subscription_utils.py
+++ b/app/utils/subscription_utils.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 from sqlalchemy import select, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database.models import Subscription, User
@@ -141,3 +141,18 @@ def get_happ_cryptolink_redirect_link(subscription_link: Optional[str]) -> Optio
         return f"{template}{encoded_link}"
 
     return f"{template}{encoded_link}"
+
+
+def convert_subscription_link_to_happ_scheme(subscription_link: Optional[str]) -> Optional[str]:
+    if not subscription_link:
+        return None
+
+    parsed_link = urlparse(subscription_link)
+
+    if parsed_link.scheme.lower() == "happ":
+        return subscription_link
+
+    if not parsed_link.scheme:
+        return subscription_link
+
+    return urlunparse(parsed_link._replace(scheme="happ"))

--- a/locales/en.json
+++ b/locales/en.json
@@ -423,6 +423,7 @@
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Open link in Happ</a>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 If the link doesn't open automatically, copy it manually: <code>{subscription_link}</code>",
   "SUBSCRIPTION_HAPP_OPEN_BUTTON_HINT": "▶️ Tap the \"Connect\" button below to open Happ and add the subscription automatically.",
+  "SUBSCRIPTION_HAPP_CRYPTOLINK_BLOCK": "<blockquote expandable>🪙 CryptoLink: <code>{crypto_link}</code></blockquote>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Subscription link:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Recommended app:</b> {app_name}",
   "SUBSCRIPTION_DEVICE_STEP_INSTALL_TITLE": "<b>Step 1 - Install:</b>",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -423,6 +423,7 @@
   "SUBSCRIPTION_HAPP_OPEN_LINK": "<a href=\"{subscription_link}\">🔓 Открыть ссылку в Happ</a>",
   "SUBSCRIPTION_HAPP_OPEN_HINT": "💡 Если ссылка не открывается автоматически, скопируйте её вручную: <code>{subscription_link}</code>",
   "SUBSCRIPTION_HAPP_OPEN_BUTTON_HINT": "▶️ Нажмите кнопку \"Подключиться\" ниже, чтобы открыть Happ и добавить подписку автоматически.",
+  "SUBSCRIPTION_HAPP_CRYPTOLINK_BLOCK": "<blockquote expandable>🪙 CryptoLink: <code>{crypto_link}</code></blockquote>",
   "SUBSCRIPTION_DEVICE_LINK_TITLE": "🔗 <b>Ссылка подписки:</b>",
   "SUBSCRIPTION_DEVICE_FEATURED_APP": "📋 <b>Рекомендуемое приложение:</b> {app_name}",
   "SUBSCRIPTION_DEVICE_STEP_INSTALL_TITLE": "<b>Шаг 1 - Установка:</b>",


### PR DESCRIPTION
## Summary
- show the Happ connection message with a happ:// subscription link and hide the raw CryptoLink inside an expandable blockquote
- add a helper to convert subscription links to the Happ scheme for reuse
- localize the new CryptoLink blockquote text in both Russian and English