### PR TITLE
Improve miniapp subscription metadata display

### DIFF
--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -10,6 +10,25 @@ class MiniAppSubscriptionRequest(BaseModel):
     init_data: str = Field(..., alias="initData")
 
 
+class MiniAppPromoGroup(BaseModel):
+    id: int
+    name: str
+    server_discount_percent: int
+    traffic_discount_percent: int
+    device_discount_percent: int
+    apply_discounts_to_addons: bool = True
+
+
+class MiniAppConnectedDevices(BaseModel):
+    count: Optional[int] = None
+    limit: Optional[int] = None
+
+
+class MiniAppServerInfo(BaseModel):
+    uuid: str
+    display_name: str
+
+
 class MiniAppSubscriptionUser(BaseModel):
     telegram_id: int
     username: Optional[str] = None
@@ -29,6 +48,9 @@ class MiniAppSubscriptionUser(BaseModel):
     traffic_limit_label: str
     lifetime_used_traffic_gb: float = 0.0
     has_active_subscription: bool = False
+    is_trial: bool = False
+    subscription_type: str = "paid"
+    promo_group: Optional[MiniAppPromoGroup] = None
 
 
 class MiniAppTransaction(BaseModel):
@@ -54,6 +76,10 @@ class MiniAppSubscriptionResponse(BaseModel):
     links: List[str] = Field(default_factory=list)
     ss_conf_links: Dict[str, str] = Field(default_factory=dict)
     connected_squads: List[str] = Field(default_factory=list)
+    connected_servers: List[MiniAppServerInfo] = Field(default_factory=list)
+    connected_devices: MiniAppConnectedDevices = Field(
+        default_factory=MiniAppConnectedDevices
+    )
     happ: Optional[Dict[str, Any]] = None
     happ_link: Optional[str] = None
     happ_crypto_link: Optional[str] = None
@@ -62,4 +88,6 @@ class MiniAppSubscriptionResponse(BaseModel):
     balance_rubles: float = 0.0
     balance_currency: Optional[str] = None
     transactions: List[MiniAppTransaction] = Field(default_factory=list)
+    autopay_enabled: bool = False
+    autopay_days_before: Optional[int] = None
 

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -302,7 +302,7 @@
         /* Stats Grid */
         .stats-grid {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
             gap: 12px;
             margin-bottom: 12px;
         }
@@ -606,6 +606,10 @@
                         <div class="stat-value" id="serversCount">-</div>
                         <div class="stat-label" data-i18n="stats.servers">Servers</div>
                     </div>
+                    <div class="stat-item">
+                        <div class="stat-value" id="devicesUsage">-</div>
+                        <div class="stat-label" data-i18n="stats.devices">Devices</div>
+                    </div>
                 </div>
 
                 <div class="info-item">
@@ -619,6 +623,18 @@
                 <div class="info-item">
                     <span class="info-label" data-i18n="info.traffic_limit">Traffic Limit</span>
                     <span class="info-value" id="trafficLimit">-</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label" data-i18n="info.subscription_type">Subscription Type</span>
+                    <span class="info-value" id="subscriptionType">-</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label" data-i18n="info.autopay_status">Autopay</span>
+                    <span class="info-value" id="autopayStatus">-</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label" data-i18n="info.promo_group">Promo Group</span>
+                    <span class="info-value" id="promoGroup">-</span>
                 </div>
             </div>
 
@@ -716,9 +732,13 @@
                 'error.default.message': 'Please contact support to activate your subscription.',
                 'stats.days_left': 'Days left',
                 'stats.servers': 'Servers',
+                'stats.devices': 'Devices',
                 'info.expires': 'Expires',
                 'info.traffic_used': 'Traffic used',
                 'info.traffic_limit': 'Traffic limit',
+                'info.subscription_type': 'Subscription type',
+                'info.autopay_status': 'Autopay',
+                'info.promo_group': 'Promo group',
                 'button.connect.default': 'Connect to VPN',
                 'button.connect.happ': 'Connect',
                 'button.copy': 'Copy subscription link',
@@ -750,6 +770,11 @@
                 'status.expired': 'Expired',
                 'status.disabled': 'Disabled',
                 'status.unknown': 'Unknown',
+                'subscriptions.type.trial': 'Trial',
+                'subscriptions.type.paid': 'Paid',
+                'autopay.enabled': 'Enabled',
+                'autopay.disabled': 'Disabled',
+                'autopay.days_before_suffix': 'days before renewal',
                 'platform.ios': 'iOS',
                 'platform.android': 'Android',
                 'platform.pc': 'PC',
@@ -766,9 +791,13 @@
                 'error.default.message': 'Свяжитесь с поддержкой, чтобы активировать подписку.',
                 'stats.days_left': 'Осталось дней',
                 'stats.servers': 'Серверы',
+                'stats.devices': 'Устройства',
                 'info.expires': 'Действует до',
                 'info.traffic_used': 'Использовано трафика',
                 'info.traffic_limit': 'Лимит трафика',
+                'info.subscription_type': 'Тип подписки',
+                'info.autopay_status': 'Автоплатеж',
+                'info.promo_group': 'Промогруппа',
                 'button.connect.default': 'Подключиться к VPN',
                 'button.connect.happ': 'Подключиться',
                 'button.copy': 'Скопировать ссылку подписки',
@@ -800,6 +829,11 @@
                 'status.expired': 'Истекла',
                 'status.disabled': 'Отключена',
                 'status.unknown': 'Неизвестно',
+                'subscriptions.type.trial': 'Триал',
+                'subscriptions.type.paid': 'Платная',
+                'autopay.enabled': 'Включен',
+                'autopay.disabled': 'Выключен',
+                'autopay.days_before_suffix': 'дн. до списания',
                 'platform.ios': 'iOS',
                 'platform.android': 'Android',
                 'platform.pc': 'ПК',
@@ -1085,17 +1119,71 @@
             document.getElementById('daysLeft').textContent = daysLeft;
             document.getElementById('expiresAt').textContent = formatDate(user.expires_at);
 
-            const serversCount = Array.isArray(userData.connected_squads)
-                ? userData.connected_squads.length
-                : Array.isArray(userData.links)
-                    ? userData.links.length
-                    : 0;
+            const connectedServers = Array.isArray(userData.connected_servers)
+                ? userData.connected_servers
+                : [];
+            const serversCount = connectedServers.length
+                || (Array.isArray(userData.connected_squads)
+                    ? userData.connected_squads.length
+                    : Array.isArray(userData.links)
+                        ? userData.links.length
+                        : 0);
             document.getElementById('serversCount').textContent = serversCount;
+
+            const connectedDevices = userData.connected_devices || {};
+            const deviceLimitRaw = connectedDevices.limit ?? user.device_limit;
+            const deviceLimit = Number.isFinite(Number(deviceLimitRaw))
+                ? Number(deviceLimitRaw)
+                : null;
+            const devicesCount = Number.isFinite(Number(connectedDevices.count))
+                ? Number(connectedDevices.count)
+                : null;
+            let devicesText = '—';
+            if (devicesCount !== null && deviceLimit !== null) {
+                devicesText = `${devicesCount}/${deviceLimit}`;
+            } else if (devicesCount !== null) {
+                devicesText = String(devicesCount);
+            } else if (deviceLimit !== null) {
+                devicesText = `—/${deviceLimit}`;
+            }
+            document.getElementById('devicesUsage').textContent = devicesText;
 
             document.getElementById('trafficUsed').textContent =
                 user.traffic_used_label || formatTraffic(user.traffic_used_gb);
             document.getElementById('trafficLimit').textContent =
                 user.traffic_limit_label || formatTrafficLimit(user.traffic_limit_gb);
+
+            const subscriptionTypeElement = document.getElementById('subscriptionType');
+            if (subscriptionTypeElement) {
+                const typeKey = user.subscription_type
+                    ? `subscriptions.type.${user.subscription_type}`
+                    : user.is_trial
+                        ? 'subscriptions.type.trial'
+                        : 'subscriptions.type.paid';
+                const typeLabel = t(typeKey);
+                subscriptionTypeElement.textContent =
+                    typeLabel === typeKey
+                        ? (user.subscription_type || (user.is_trial ? t('subscriptions.type.trial') : t('subscriptions.type.paid')))
+                        : typeLabel;
+            }
+
+            const autopayStatusElement = document.getElementById('autopayStatus');
+            if (autopayStatusElement) {
+                const autopayEnabled = userData.autopay_enabled === true;
+                const baseLabel = t(autopayEnabled ? 'autopay.enabled' : 'autopay.disabled');
+                const autopayDaysRaw = Number(userData.autopay_days_before);
+                const hasAutopayDays = autopayEnabled && Number.isFinite(autopayDaysRaw) && autopayDaysRaw > 0;
+                autopayStatusElement.textContent = hasAutopayDays
+                    ? `${baseLabel} • ${autopayDaysRaw} ${t('autopay.days_before_suffix')}`
+                    : baseLabel;
+            }
+
+            const promoGroupElement = document.getElementById('promoGroup');
+            if (promoGroupElement) {
+                promoGroupElement.textContent = (user.promo_group && user.promo_group.name)
+                    ? user.promo_group.name
+                    : '—';
+            }
 
             renderBalanceSection();
             renderTransactionHistory();
@@ -1432,7 +1520,13 @@
                 return;
             }
 
-            const servers = Array.isArray(userData?.connected_squads) ? userData.connected_squads : [];
+            const fallbackServers = Array.isArray(userData?.connected_squads)
+                ? userData.connected_squads.map(uuid => ({ uuid, display_name: uuid }))
+                : [];
+            const servers = Array.isArray(userData?.connected_servers) && userData.connected_servers.length
+                ? userData.connected_servers
+                : fallbackServers;
+
             if (!servers.length) {
                 list.innerHTML = '';
                 emptyState.textContent = t('servers.empty');
@@ -1441,7 +1535,14 @@
             }
 
             emptyState.classList.add('hidden');
-            list.innerHTML = servers.map(server => `<li class="server-item">${escapeHtml(server)}</li>`).join('');
+            list.innerHTML = servers
+                .map(server => {
+                    const name = typeof server === 'string'
+                        ? server
+                        : server?.display_name || server?.uuid || '';
+                    return `<li class="server-item">${escapeHtml(name)}</li>`;
+                })
+                .join('');
         }
 
         function getCurrentSubscriptionUrl() {


### PR DESCRIPTION
## Summary
- enrich the miniapp subscription API response with promo group, connected server names, device usage, and autopay details
- surface subscription type, device stats, promo group, and autopay status in the miniapp UI with updated translations
- render connected server display names on the client while falling back gracefully when names are unavailable
