### PR TITLE
Open HAPP cryptolink from miniapp externally

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -2519,6 +2519,20 @@
             updateActionButtons();
         }
 
+        function openLink(link, { external = false } = {}) {
+            if (!link) {
+                return;
+            }
+
+            if (external && typeof tg.openLink === 'function') {
+                tg.openLink(link, { try_instant_view: false });
+                return;
+            }
+
+            const target = external ? '_blank' : '_self';
+            window.open(link, target, 'noopener,noreferrer');
+        }
+
         document.querySelectorAll('.platform-btn').forEach(btn => {
             btn.addEventListener('click', () => {
                 currentPlatform = btn.dataset.platform;
@@ -2530,9 +2544,16 @@
 
         document.getElementById('connectBtn')?.addEventListener('click', () => {
             const link = getConnectLink();
-            if (link) {
-                window.location.href = link;
+            if (!link) {
+                return;
             }
+
+            const shouldOpenExternally = Boolean(
+                userData?.happ_cryptolink_redirect_link &&
+                link === userData.happ_cryptolink_redirect_link
+            );
+
+            openLink(link, { external: shouldOpenExternally });
         });
 
         document.getElementById('copyBtn')?.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- ensure the connect button opens the HAPP cryptolink via Telegram so it can launch an external browser
- add a helper to open links with a fallback to window.open when the Telegram API is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc93db187c8320b83d733ccdf059ba