### PR TITLE
Add desktop redirect fallback for Happ subscription links

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -2287,6 +2287,10 @@
             }
         }
 
+        function isDesktopPlatform() {
+            return currentPlatform === 'pc';
+        }
+
         function setActivePlatformButton() {
             document.querySelectorAll('.platform-btn').forEach(btn => {
                 btn.classList.toggle('active', btn.dataset.platform === currentPlatform);
@@ -2691,6 +2695,22 @@
             );
         }
 
+        function getDesktopRedirectLink() {
+            if (!userData) {
+                return null;
+            }
+
+            return (
+                userData.happ_cryptolink_redirect_link ||
+                getCurrentSubscriptionUrl() ||
+                null
+            );
+        }
+
+        function isHappScheme(link) {
+            return typeof link === 'string' && link.startsWith('happ://');
+        }
+
         function getConnectLink() {
             if (!userData) {
                 return null;
@@ -2729,27 +2749,36 @@
 
             const { openInMiniApp = false } = options;
 
+            let targetLink = link;
+
+            if (!openInMiniApp && isDesktopPlatform() && isHappScheme(targetLink)) {
+                const redirectLink = getDesktopRedirectLink();
+                if (redirectLink) {
+                    targetLink = redirectLink;
+                }
+            }
+
             if (openInMiniApp) {
-                window.location.href = link;
+                window.location.href = targetLink;
                 return;
             }
 
             if (typeof tg.openLink === 'function') {
                 try {
-                    tg.openLink(link, { try_instant_view: false });
+                    tg.openLink(targetLink, { try_instant_view: false });
                     return;
                 } catch (error) {
                     console.warn('tg.openLink failed:', error);
                 }
             }
 
-            const newWindow = window.open(link, '_blank', 'noopener,noreferrer');
+            const newWindow = window.open(targetLink, '_blank', 'noopener,noreferrer');
             if (newWindow) {
                 newWindow.opener = null;
                 return;
             }
 
-            window.location.href = link;
+            window.location.href = targetLink;
         }
 
         function updateActionButtons() {


### PR DESCRIPTION
## Summary
- detect desktop usage in the miniapp so Happ subscription links can fall back to web redirects
- route happ:// links through the provided redirect or subscription URL when opened on desktop devices
- ensure all external link openings reuse the resolved target across Telegram and browser contexts