### PR TITLE
Fix subscription price refresh in admin panel

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1061,14 +1061,23 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-PERIOD_PRICES = {
-    14: settings.PRICE_14_DAYS,
-    30: settings.PRICE_30_DAYS,
-    60: settings.PRICE_60_DAYS,
-    90: settings.PRICE_90_DAYS,
-    180: settings.PRICE_180_DAYS,
-    360: settings.PRICE_360_DAYS,
-}
+def get_period_prices() -> Dict[int, int]:
+    return {
+        14: settings.PRICE_14_DAYS,
+        30: settings.PRICE_30_DAYS,
+        60: settings.PRICE_60_DAYS,
+        90: settings.PRICE_90_DAYS,
+        180: settings.PRICE_180_DAYS,
+        360: settings.PRICE_360_DAYS,
+    }
+
+
+def refresh_period_prices() -> None:
+    global PERIOD_PRICES
+    PERIOD_PRICES = get_period_prices()
+
+
+PERIOD_PRICES = get_period_prices()
 
 def get_traffic_prices() -> Dict[int, int]:
     packages = settings.get_traffic_packages()


### PR DESCRIPTION
## Summary
- add helpers in the config to rebuild the period price mapping from the current settings
- refresh period prices automatically when subscription costs are changed through the admin panel