### PR TITLE
Fix subscription period price updates in admin panel

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1061,24 +1061,51 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-PERIOD_PRICES = {
-    14: settings.PRICE_14_DAYS,
-    30: settings.PRICE_30_DAYS,
-    60: settings.PRICE_60_DAYS,
-    90: settings.PRICE_90_DAYS,
-    180: settings.PRICE_180_DAYS,
-    360: settings.PRICE_360_DAYS,
-}
+
+def get_period_prices() -> Dict[int, int]:
+    prices: Dict[int, int] = {}
+
+    for field_name in Settings.model_fields:
+        if not field_name.startswith("PRICE_"):
+            continue
+        if not field_name.endswith("_DAYS"):
+            continue
+        if "TRAFFIC" in field_name:
+            continue
+
+        try:
+            days = int(field_name.replace("PRICE_", "").replace("_DAYS", ""))
+        except ValueError:
+            continue
+
+        prices[days] = getattr(settings, field_name)
+
+    return prices
+
+
+PERIOD_PRICES: Dict[int, int] = {}
+
+
+def refresh_period_prices() -> None:
+    PERIOD_PRICES.clear()
+    PERIOD_PRICES.update(get_period_prices())
+
+
+refresh_period_prices()
+
 
 def get_traffic_prices() -> Dict[int, int]:
     packages = settings.get_traffic_packages()
     return {package["gb"]: package["price"] for package in packages}
 
+
 TRAFFIC_PRICES = get_traffic_prices()
+
 
 def refresh_traffic_prices():
     global TRAFFIC_PRICES
     TRAFFIC_PRICES = get_traffic_prices()
+
 
 refresh_traffic_prices()
 

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -9,7 +9,7 @@ from app.database.universal_migration import ensure_default_web_api_token
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import Settings, settings
+from app.config import Settings, refresh_period_prices, settings
 from app.database.crud.system_setting import (
     delete_system_setting,
     upsert_system_setting,
@@ -866,6 +866,9 @@ class BotConfigurationService:
         cls._overrides_raw[key] = raw_value
         cls._apply_to_settings(key, value)
 
+        if key.startswith("PRICE_") and key.endswith("_DAYS") and "TRAFFIC" not in key:
+            refresh_period_prices()
+
         if key in {"WEB_API_DEFAULT_TOKEN", "WEB_API_DEFAULT_TOKEN_NAME"}:
             await cls._sync_default_web_api_token()
 
@@ -875,6 +878,9 @@ class BotConfigurationService:
         cls._overrides_raw.pop(key, None)
         original = cls.get_original_value(key)
         cls._apply_to_settings(key, original)
+
+        if key.startswith("PRICE_") and key.endswith("_DAYS") and "TRAFFIC" not in key:
+            refresh_period_prices()
 
         if key in {"WEB_API_DEFAULT_TOKEN", "WEB_API_DEFAULT_TOKEN_NAME"}:
             await cls._sync_default_web_api_token()


### PR DESCRIPTION
## Summary
- rebuild the cached subscription period price map from the current settings
- refresh cached period prices whenever an admin updates or resets a subscription price