### PR TITLE
Fix subscription period price cache update

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1061,14 +1061,28 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-PERIOD_PRICES = {
-    14: settings.PRICE_14_DAYS,
-    30: settings.PRICE_30_DAYS,
-    60: settings.PRICE_60_DAYS,
-    90: settings.PRICE_90_DAYS,
-    180: settings.PRICE_180_DAYS,
-    360: settings.PRICE_360_DAYS,
+_PERIOD_PRICE_FIELDS: Dict[int, str] = {
+    14: "PRICE_14_DAYS",
+    30: "PRICE_30_DAYS",
+    60: "PRICE_60_DAYS",
+    90: "PRICE_90_DAYS",
+    180: "PRICE_180_DAYS",
+    360: "PRICE_360_DAYS",
 }
+
+
+def refresh_period_prices() -> None:
+    """Rebuild cached period price mapping using the latest settings."""
+
+    global PERIOD_PRICES
+    PERIOD_PRICES = {
+        days: getattr(settings, field_name, 0)
+        for days, field_name in _PERIOD_PRICE_FIELDS.items()
+    }
+
+
+PERIOD_PRICES: Dict[int, int] = {}
+refresh_period_prices()
 
 def get_traffic_prices() -> Dict[int, int]:
     packages = settings.get_traffic_packages()

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -9,7 +9,7 @@ from app.database.universal_migration import ensure_default_web_api_token
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import Settings, settings
+from app.config import Settings, settings, refresh_period_prices, refresh_traffic_prices
 from app.database.crud.system_setting import (
     delete_system_setting,
     upsert_system_setting,
@@ -883,6 +883,17 @@ class BotConfigurationService:
     def _apply_to_settings(cls, key: str, value: Any) -> None:
         try:
             setattr(settings, key, value)
+            if key in {
+                "PRICE_14_DAYS",
+                "PRICE_30_DAYS",
+                "PRICE_60_DAYS",
+                "PRICE_90_DAYS",
+                "PRICE_180_DAYS",
+                "PRICE_360_DAYS",
+            }:
+                refresh_period_prices()
+            elif key.startswith("PRICE_TRAFFIC_") or key == "TRAFFIC_PACKAGES_CONFIG":
+                refresh_traffic_prices()
         except Exception as error:
             logger.error("Не удалось применить значение %s=%s: %s", key, value, error)
 


### PR DESCRIPTION
## Summary
- rebuild the cached subscription period price mapping from the latest settings values
- refresh cached period and traffic prices when administrators change the corresponding configuration keys