### PR TITLE
Fix promo segment join for no subscription users

### DIFF
--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -526,7 +526,10 @@ async def get_users_for_promo_segment(db: AsyncSession, segment: str) -> List[Us
     )
 
     if segment == "no_subscription":
-        query = base_query.outerjoin(Subscription).where(Subscription.id.is_(None))
+        query = (
+            base_query.outerjoin(Subscription, Subscription.user_id == User.id)
+            .where(Subscription.id.is_(None))
+        )
     else:
         query = base_query.join(Subscription)
 


### PR DESCRIPTION
## Summary
- ensure the no-subscription promo segment performs a left join on subscriptions using the user relationship
- allow selection of users without active subscriptions for promo broadcasts