### PR TITLE
Add active trial segment to purchase discount offer

### DIFF
--- a/app/database/crud/promo_offer_template.py
+++ b/app/database/crud/promo_offer_template.py
@@ -188,7 +188,7 @@ async def update_promo_offer_template(
         template.discount_percent = discount_percent
     if bonus_amount_kopeks is not None:
         template.bonus_amount_kopeks = bonus_amount_kopeks
-    if test_duration_hours is not None or template.offer_type == "test_access":
+    if test_duration_hours is not None:
         template.test_duration_hours = test_duration_hours
     if test_squad_uuids is not None:
         template.test_squad_uuids = list(test_squad_uuids)

--- a/app/handlers/admin/promo_offers.py
+++ b/app/handlers/admin/promo_offers.py
@@ -82,6 +82,7 @@ OFFER_TYPE_CONFIG = {
         "allowed_segments": [
             ("paid_expired", "🔴 Истёкшие платные"),
             ("trial_expired", "🥶 Истёкшие триалы"),
+            ("trial_active", "🎁 Активные триалы"),
         ],
         "effect_type": "percent_discount",
     },
@@ -791,7 +792,15 @@ async def _handle_edit_field(
                 parse_mode="HTML",
             )
         except TelegramBadRequest as exc:
-            logger.warning("Не удалось обновить сообщение редактирования промо: %s", exc)
+            error_text = str(exc).lower()
+            if "there is no text in the message to edit" in error_text:
+                logger.debug("Сообщение промо без текста, пересылаем обновлённую версию")
+                try:
+                    await message.bot.delete_message(chat_id=edit_chat_id, message_id=edit_message_id)
+                except TelegramBadRequest:
+                    logger.debug("Не удалось удалить сообщение промо без текста")
+            else:
+                logger.warning("Не удалось обновить сообщение редактирования промо: %s", exc)
             await message.answer(description, reply_markup=reply_markup, parse_mode="HTML")
     else:
         await message.answer(description, reply_markup=reply_markup, parse_mode="HTML")


### PR DESCRIPTION
## Summary
- allow purchase discount promo offers to target users with active trials
- keep test access duration unchanged when modifying other template fields
- gracefully handle Telegram missing-text errors when refreshing the promo edit message