### PR TITLE
Fix discount activation CTA to extend subscription

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -5265,8 +5265,8 @@ async def claim_discount_offer(
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text=texts.get("MENU_BUY_SUBSCRIPTION", "💎 Купить подписку"),
-                    callback_data="menu_buy",
+                    text=texts.get("SUBSCRIPTION_EXTEND", "💎 Продлить подписку"),
+                    callback_data="subscription_extend",
                 )
             ]
         ]


### PR DESCRIPTION
## Summary
- update the discount activation follow-up button to offer extending the subscription instead of buying a new one