### PR TITLE
Gracefully handle privacy-restricted ticket keyboards

### DIFF
--- a/app/utils/message_patch.py
+++ b/app/utils/message_patch.py
@@ -1,5 +1,11 @@
 from pathlib import Path
-from aiogram.types import Message, FSInputFile, InputMediaPhoto
+from aiogram.types import (
+    Message,
+    FSInputFile,
+    InputMediaPhoto,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
 from aiogram.exceptions import TelegramBadRequest
 
 from app.config import settings
@@ -15,6 +21,41 @@ _original_answer = Message.answer
 _original_edit_text = Message.edit_text
 
 
+def sanitize_keyboard_for_privacy(
+    keyboard: InlineKeyboardMarkup | None,
+) -> tuple[InlineKeyboardMarkup | None, bool]:
+    """Remove buttons that may be blocked by user privacy settings.
+
+    Currently Telegram returns BUTTON_USER_PRIVACY_RESTRICTED when sending inline buttons
+    that point directly to a user via ``tg://user`` links if the target user hides their
+    account. In such cases we strip these buttons and retry the message.
+    """
+
+    if keyboard is None or not isinstance(keyboard, InlineKeyboardMarkup):
+        return keyboard, False
+
+    changed = False
+    new_rows: list[list[InlineKeyboardButton]] = []
+
+    for row in keyboard.inline_keyboard:
+        new_row = []
+        for button in row:
+            url = getattr(button, "url", None)
+            if isinstance(url, str) and url.startswith("tg://user?id="):
+                changed = True
+                continue
+            new_row.append(button)
+        if new_row:
+            new_rows.append(new_row)
+        elif row:
+            changed = True
+
+    if not changed:
+        return keyboard, False
+
+    return InlineKeyboardMarkup(inline_keyboard=new_rows), True
+
+
 async def _answer_with_photo(self: Message, text: str = None, **kwargs):
     # Уважаем флаг в рантайме: если логотип выключен — не подменяем ответ
     if not settings.ENABLE_LOGO_MODE:
@@ -25,14 +66,35 @@ async def _answer_with_photo(self: Message, text: str = None, **kwargs):
             return await _original_answer(self, text, **kwargs)
     except Exception:
         pass
+    reply_markup = kwargs.get("reply_markup")
+    sanitized_keyboard, sanitized_applied = sanitize_keyboard_for_privacy(reply_markup)
     if LOGO_PATH.exists():
         try:
             # Отправляем caption как есть; при ошибке парсинга ниже сработает фоллбек
             return await self.answer_photo(FSInputFile(LOGO_PATH), caption=text, **kwargs)
+        except TelegramBadRequest as exc:
+            if sanitized_applied and "BUTTON_USER_PRIVACY_RESTRICTED" in str(exc):
+                safe_kwargs = dict(kwargs)
+                if sanitized_keyboard is None:
+                    safe_kwargs.pop("reply_markup", None)
+                else:
+                    safe_kwargs["reply_markup"] = sanitized_keyboard
+                try:
+                    return await self.answer_photo(
+                        FSInputFile(LOGO_PATH), caption=text, **safe_kwargs
+                    )
+                except TelegramBadRequest:
+                    pass
+            # Фоллбек, если Telegram ругается на caption или клавиатуру: отправим как текст
         except Exception:
-            # Фоллбек, если Telegram ругается на caption: отправим как текст
-            return await _original_answer(self, text, **kwargs)
-    return await _original_answer(self, text, **kwargs)
+            pass
+    safe_kwargs = dict(kwargs)
+    if sanitized_applied:
+        if sanitized_keyboard is None:
+            safe_kwargs.pop("reply_markup", None)
+        else:
+            safe_kwargs["reply_markup"] = sanitized_keyboard
+    return await _original_answer(self, text, **safe_kwargs)
 
 
 async def _edit_with_photo(self: Message, text: str, **kwargs):
@@ -64,15 +126,33 @@ async def _edit_with_photo(self: Message, text: str, **kwargs):
             media_kwargs["parse_mode"] = _pm if _pm is not None else "HTML"
         else:
             media_kwargs["parse_mode"] = "HTML"
+        reply_markup = kwargs.get("reply_markup")
+        sanitized_keyboard, sanitized_applied = sanitize_keyboard_for_privacy(reply_markup)
         try:
             return await self.edit_media(InputMediaPhoto(**media_kwargs), **kwargs)
-        except TelegramBadRequest:
-            # Фоллбек: удалим и отправим обычный текст без фото
-            try:
-                await self.delete()
-            except Exception:
-                pass
-            return await _original_answer(self, text, **kwargs)
+        except TelegramBadRequest as exc:
+            if sanitized_applied and "BUTTON_USER_PRIVACY_RESTRICTED" in str(exc):
+                safe_kwargs = dict(kwargs)
+                if sanitized_keyboard is None:
+                    safe_kwargs.pop("reply_markup", None)
+                else:
+                    safe_kwargs["reply_markup"] = sanitized_keyboard
+                try:
+                    return await self.edit_media(InputMediaPhoto(**media_kwargs), **safe_kwargs)
+                except TelegramBadRequest:
+                    pass
+        # Фоллбек: удалим и отправим обычный текст без фото
+        try:
+            await self.delete()
+        except Exception:
+            pass
+        safe_kwargs = dict(kwargs)
+        if sanitized_applied:
+            if sanitized_keyboard is None:
+                safe_kwargs.pop("reply_markup", None)
+            else:
+                safe_kwargs["reply_markup"] = sanitized_keyboard
+        return await _original_answer(self, text, **safe_kwargs)
     return await _original_edit_text(self, text, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- add a reusable sanitizer that strips `tg://user` inline buttons when Telegram rejects them because of privacy settings
- retry ticket message updates with the sanitized keyboard before falling back to plain text to keep the bot responsive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ee6e978c83208112542f66ccc3a7