### PR TITLE
Fix disabled subscription end date timezone

### DIFF
--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -635,7 +635,7 @@ class RemnaWaveService:
                             
                             subscription.status = SubscriptionStatus.DISABLED.value
                             subscription.is_trial = True 
-                            subscription.end_date = self._now_in_panel_timezone()
+                            subscription.end_date = datetime.utcnow()
                             subscription.traffic_limit_gb = 0
                             subscription.traffic_used_gb = 0.0
                             subscription.device_limit = 1


### PR DESCRIPTION
## Summary
- store disabled subscription end dates in UTC so status checks remain accurate
