### PR TITLE
Update miniapp app selection and connection flows

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -1,5 +1,16 @@
 {
-  "config": {},
+  "config": {
+    "additionalLocales": [
+      "ru",
+      "zh",
+      "fa"
+    ],
+    "branding": {
+      "name": "Subscription",
+      "logoUrl": "https://remna.st/img/logo.svg",
+      "supportUrl": "https://t.me"
+    }
+  },
   "platforms": {
     "ios": [
       {
@@ -12,19 +23,102 @@
             {
               "buttonLink": "https://apps.apple.com/us/app/happ-proxy-utility/id6504287215",
               "buttonText": {
-                "en": "App Store [EU]",
-                "fa": "App Store [EU]",
-                "ru": "App Store [EU]",
-                "zh": "App Store [EU]"
+                "en": "Open in App Store [EU]",
+                "fa": "باز کردن در App Store [EU]",
+                "ru": "Открыть в App Store [EU]",
+                "zh": "在 App Store 中打开 [EU]"
               }
             },
             {
               "buttonLink": "https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973",
               "buttonText": {
-                "en": "App Store [RU]",
-                "fa": "App Store [RU]",
-                "ru": "App Store [RU]",
-                "zh": "App Store [RU]"
+                "en": "Open in App Store [RU]",
+                "fa": "باز کردن در App Store [RU]",
+                "ru": "Открыть в App Store [RU]",
+                "zh": "在 App Store 中打开 [RU]"
+              }
+            }
+          ],
+          "description": {
+            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
+            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
+            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
+            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below — the app will open and the subscription will be added automatically",
+            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
+            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
+            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
+          }
+        }
+      },
+      {
+        "id": "streisand",
+        "name": "Streisand",
+        "isFeatured": false,
+        "urlScheme": "streisand://import/",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://apps.apple.com/ru/app/streisand/id6450534064",
+              "buttonText": {
+                "en": "Open in App Store",
+                "fa": "باز کردن در App Store",
+                "ru": "Открыть в App Store",
+                "zh": "在 App Store 中打开"
+              }
+            }
+          ],
+          "description": {
+            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
+            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
+            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
+            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below — the app will open and the subscription will be added automatically",
+            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
+            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
+            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
+          }
+        }
+      },
+      {
+        "id": "shadowrocket",
+        "name": "Shadowrocket",
+        "isFeatured": false,
+        "urlScheme": "sub://",
+        "isNeedBase64Encoding": true,
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://apps.apple.com/ru/app/shadowrocket/id932747118",
+              "buttonText": {
+                "en": "Open in App Store",
+                "fa": "باز کردن در App Store",
+                "ru": "Открыть в App Store",
+                "zh": "在 App Store 中打开"
               }
             }
           ],
@@ -64,10 +158,10 @@
             {
               "buttonLink": "https://play.google.com/store/apps/details?id=com.happproxy",
               "buttonText": {
-                "en": "Google Play",
-                "fa": "Google Play",
-                "ru": "Google Play",
-                "zh": "Google Play"
+                "en": "Open in Google Play",
+                "fa": "باز کردن در Google Play",
+                "ru": "Открыть в Google Play",
+                "zh": "在 Google Play 中打开"
               }
             },
             {
@@ -103,53 +197,210 @@
             "zh": "打开应用并连接到服务器"
           }
         }
-      }
-    ],
-    "macos": [
+      },
       {
-        "id": "happ",
-        "name": "Happ",
-        "isFeatured": true,
-        "urlScheme": "happ://add/",
+        "id": "clash-meta",
+        "name": "Clash Meta",
+        "isFeatured": false,
+        "urlScheme": "clash://install-config?url=",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://apps.apple.com/us/app/happ-proxy-utility/id6504287215",
+              "buttonLink": "https://github.com/MetaCubeX/ClashMetaForAndroid/releases/download/v2.11.7/cmfa-2.11.7-meta-universal-release.apk",
               "buttonText": {
-                "en": "App Store [EU]",
-                "fa": "App Store [EU]",
-                "ru": "App Store [EU]",
-                "zh": "App Store [EU]"
+                "en": "Download APK",
+                "fa": "دانلود APK",
+                "ru": "Скачать APK",
+                "zh": "下载 APK"
               }
             },
             {
-              "buttonLink": "https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973",
+              "buttonLink": "https://f-droid.org/packages/com.github.metacubex.clash.meta/",
               "buttonText": {
-                "en": "App Store [RU]",
-                "fa": "App Store [RU]",
-                "ru": "App Store [RU]",
-                "zh": "App Store [RU]"
+                "en": "Open in F-Droid",
+                "fa": "در F-Droid باز کنید",
+                "ru": "Открыть в F-Droid",
+                "zh": "在 F-Droid 中打开"
               }
             }
           ],
           "description": {
-            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
-            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
-            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
-            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+            "en": "Download and install Clash Meta APK",
+            "fa": "دانلود و نصب Clash Meta APK",
+            "ru": "Скачайте и установите Clash Meta APK",
+            "zh": "下载并安装 Clash Meta APK"
           }
         },
         "addSubscriptionStep": {
           "description": {
-            "en": "Click the button below — the app will open and the subscription will be added automatically",
-            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
-            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
-            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+            "en": "Tap the button to import configuration",
+            "fa": "برای وارد کردن پیکربندی روی دکمه ضربه بزنید",
+            "ru": "Нажмите кнопку, чтобы импортировать конфигурацию",
+            "zh": "点击按钮导入配置"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "en": "Open Clash Meta and tap on Connect",
+            "fa": "Clash Meta را باز کنید و روی اتصال ضربه بزنید",
+            "ru": "Откройте Clash Meta и нажмите Подключиться",
+            "zh": "打开 Clash Meta 并点击连接"
+          }
+        }
+      }
+    ],
+    "macos": [
+      {
+        "id": "clash-verge",
+        "name": "Clash Verge",
+        "isFeatured": true,
+        "urlScheme": "clash://install-config?url=",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64-setup.exe",
+              "buttonText": {
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64.dmg",
+              "buttonText": {
+                "en": "macOS (Intel)",
+                "fa": "مک (اینتل)",
+                "ru": "macOS (Intel)",
+                "zh": "macOS (Intel)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_aarch64.dmg",
+              "buttonText": {
+                "en": "macOS (Apple Silicon)",
+                "fa": "مک (Apple Silicon)",
+                "ru": "macOS (Apple Silicon)",
+                "zh": "macOS (Apple Silicon)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
+              }
+            }
+          ],
+          "description": {
+            "en": "Choose the version for your device, click the button below and install the app.",
+            "fa": "نسخه مناسب برای دستگاه خود را انتخاب کنید، دکمه زیر را فشار دهید و برنامه را نصب کنید",
+            "ru": "Выберите подходящую версию для вашего устройства, нажмите на кнопку ниже и установите приложение.",
+            "zh": "选择适合您设备的版本，点击下方按钮并安装应用。"
+          }
+        },
+        "additionalBeforeAddSubscriptionStep": {
+          "buttons": [],
+          "description": {
+            "en": "After launching the app, you can change the language in settings. In the left panel, find the gear icon, then navigate to Verge 设置 and select 语言设置.",
+            "fa": "پس از راه‌اندازی برنامه، می‌توانید زبان را در تنظیمات تغییر دهید. در پنل سمت چپ، نماد چرخ دنده را پیدا کنید، سپس به Verge 设置 بروید و 语言设置 را انتخاب کنید.",
+            "ru": "После запуска приложения вы можете сменить язык в настройках. В левой панели найдите иконку шестеренки, далее ориентируйтесь на Verge 设置 и выберите пункт 语言设置.",
+            "zh": "启动应用后，您可以在设置中更改语言。在左侧面板找到齿轮图标，然后导航到 Verge 设置并选择语言设置。"
+          },
+          "title": {
+            "en": "Change language",
+            "fa": "تغییر زبان",
+            "ru": "Смена языка",
+            "zh": "更改语言"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below to add subscription",
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "additionalAfterAddSubscriptionStep": {
+          "buttons": [],
+          "title": {
+            "en": "If the subscription is not added",
+            "fa": "اگر اشتراک در برنامه نصب نشده است",
+            "ru": "Если подписка не добавилась",
+            "zh": "如果订阅未添加"
+          },
+          "description": {
+            "en": "If nothing happens after clicking the button, add the subscription manually. Click the Get Link button in the top right corner of this page, copy the link. In Clash Verge, go to the Profiles section and paste the link in the text field, then click the Import button.",
+            "fa": "اگر پس از کلیک روی دکمه اتفاقی نیفتاد، اشتراک را به صورت دستی اضافه کنید. در گوشه بالا سمت راست این صفحه روی دکمه دریافت لینک کلیک کنید، لینک را کپی کنید. در Clash Verge به بخش پروفایل‌ها بروید و لینک را در فیلد متنی وارد کنید، سپس روی دکمه وارد کردن کلیک کنید.",
+            "ru": "Если после нажатия на кнопку ничего не произошло, добавьте подписку вручную. Нажмите на этой странице кнопку Получить ссылку в правом верхнем углу, скопируйте ссылку. В Clash Verge перейдите в раздел Профили и вставьте ссылку в текстовое поле, затем нажмите на кнопку Импорт.",
+            "zh": "如果点击按钮后没有反应，请手动添加订阅。点击此页面右上角的获取链接按钮，复制链接。在 Clash Verge 中，转到配置文件部分，将链接粘贴到文本字段中，然后点击导入按钮。"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "You can select a server in the Proxy section, and enable VPN in the Settings section. Set the TUN Mode switch to ON.",
+            "fa": "می‌توانید در بخش پروکسی سرور را انتخاب کنید و در بخش تنظیمات VPN را فعال کنید. کلید TUN Mode را در حالت روشن قرار دهید.",
+            "ru": "Выбрать сервер можно в разделе Прокси, включить VPN можно в разделе Настройки. Установите переключатель TUN Mode в положение ВКЛ.",
+            "zh": "您可以在代理部分选择服务器，在设置部分启用 VPN。将 TUN 模式开关设置为开启。"
+          }
+        }
+      },
+      {
+        "id": "hiddify",
+        "name": "Hiddify",
+        "isFeatured": false,
+        "urlScheme": "hiddify://import/",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Windows-Setup-x64.exe",
+              "buttonText": {
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-MacOS.dmg",
+              "buttonText": {
+                "en": "macOS",
+                "fa": "مک",
+                "ru": "macOS",
+                "zh": "macOS"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Linux-x64.AppImage",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
+              }
+            }
+          ],
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. If needed, select a different server in the Proxy section",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. در صورت نیاز، سرور دیگری را در بخش پروکسی انتخاب کنید",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. При необходимости выберите другой сервер в разделе Прокси.",
+            "zh": "在主界面中，点击中央的大电源按钮连接 VPN。如有需要，可在代理部分选择不同的服务器"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below to add subscription",
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, select a different server from the server list.",
             "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
             "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
             "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
@@ -159,75 +410,165 @@
     ],
     "windows": [
       {
-        "id": "happ",
-        "name": "Happ",
-        "isFeatured": false,
-        "urlScheme": "happ://add/",
+        "id": "clash-verge",
+        "name": "Clash Verge",
+        "isFeatured": true,
+        "urlScheme": "clash://install-config?url=",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://github.com/Happ-proxy/happ-desktop/releases/latest/download/setup-Happ.x86.exe",
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64-setup.exe",
               "buttonText": {
-                "en": "Download",
-                "ru": "Скачать"
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64.dmg",
+              "buttonText": {
+                "en": "macOS (Intel)",
+                "fa": "مک (اینتل)",
+                "ru": "macOS (Intel)",
+                "zh": "macOS (Intel)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_aarch64.dmg",
+              "buttonText": {
+                "en": "macOS (Apple Silicon)",
+                "fa": "مک (Apple Silicon)",
+                "ru": "macOS (Apple Silicon)",
+                "zh": "macOS (Apple Silicon)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
               }
             }
           ],
           "description": {
-            "en": "Download and install Happ.",
-            "ru": "Скачайте и установите Happ"
+            "en": "Choose the version for your device, click the button below and install the app.",
+            "fa": "نسخه مناسب برای دستگاه خود را انتخاب کنید، دکمه زیر را فشار دهید و برنامه را نصب کنید",
+            "ru": "Выберите подходящую версию для вашего устройства, нажмите на кнопку ниже и установите приложение.",
+            "zh": "选择适合您设备的版本，点击下方按钮并安装应用。"
+          }
+        },
+        "additionalBeforeAddSubscriptionStep": {
+          "buttons": [],
+          "description": {
+            "en": "After launching the app, you can change the language in settings. In the left panel, find the gear icon, then navigate to Verge 设置 and select 语言设置.",
+            "fa": "پس از راه‌اندازی برنامه، می‌توانید زبان را در تنظیمات تغییر دهید. در پنل سمت چپ، نماد چرخ دنده را پیدا کنید، سپس به Verge 设置 بروید و 语言设置 را انتخاب کنید.",
+            "ru": "После запуска приложения вы можете сменить язык в настройках. В левой панели найдите иконку шестеренки, далее ориентируйтесь на Verge 设置 и выберите пункт 语言设置.",
+            "zh": "启动应用后，您可以在设置中更改语言。在左侧面板找到齿轮图标，然后导航到 Verge 设置并选择语言设置。"
+          },
+          "title": {
+            "en": "Change language",
+            "fa": "تغییر زبان",
+            "ru": "Смена языка",
+            "zh": "更改语言"
           }
         },
         "addSubscriptionStep": {
           "description": {
             "en": "Click the button below to add subscription",
-            "ru": "Нажмите кнопку выше — (Подключить подписку) приложение откроется, и подписка добавится автоматически."
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "additionalAfterAddSubscriptionStep": {
+          "buttons": [],
+          "title": {
+            "en": "If the subscription is not added",
+            "fa": "اگر اشتراک در برنامه نصب نشده است",
+            "ru": "Если подписка не добавилась",
+            "zh": "如果订阅未添加"
+          },
+          "description": {
+            "en": "If nothing happens after clicking the button, add the subscription manually. Click the Get Link button in the top right corner of this page, copy the link. In Clash Verge, go to the Profiles section and paste the link in the text field, then click the Import button.",
+            "fa": "اگر پس از کلیک روی دکمه اتفاقی نیفتاد، اشتراک را به صورت دستی اضافه کنید. در گوشه بالا سمت راست این صفحه روی دکمه دریافت لینک کلیک کنید، لینک را کپی کنید. در Clash Verge به بخش پروفایل‌ها بروید و لینک را در فیلد متنی وارد کنید، سپس روی دکمه وارد کردن کلیک کنید.",
+            "ru": "Если после нажатия на кнопку ничего не произошло, добавьте подписку вручную. Нажмите на этой странице кнопку Получить ссылку в правом верхнем углу, скопируйте ссылку. В Clash Verge перейдите в раздел Профили и вставьте ссылку в текстовое поле, затем нажмите на кнопку Импорт.",
+            "zh": "如果点击按钮后没有反应，请手动添加订阅。点击此页面右上角的获取链接按钮，复制链接。在 Clash Verge 中，转到配置文件部分，将链接粘贴到文本字段中，然后点击导入按钮。"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "You can select a server",
-            "ru": "Выберете локацию, включить VPN"
+            "en": "You can select a server in the Proxy section, and enable VPN in the Settings section. Set the TUN Mode switch to ON.",
+            "fa": "می‌توانید در بخش پروکسی سرور را انتخاب کنید و در بخش تنظیمات VPN را فعال کنید. کلید TUN Mode را در حالت روشن قرار دهید.",
+            "ru": "Выбрать сервер можно в разделе Прокси, включить VPN можно в разделе Настройки. Установите переключатель TUN Mode в положение ВКЛ.",
+            "zh": "您可以在代理部分选择服务器，在设置部分启用 VPN。将 TUN 模式开关设置为开启。"
           }
         }
-      }
-    ],
-    "androidTV": [
+      },
       {
-        "id": "vpn4tv",
-        "name": "VPN4TV",
-        "isFeatured": true,
-        "urlScheme": "",
+        "id": "hiddify",
+        "name": "Hiddify",
+        "isFeatured": false,
+        "urlScheme": "hiddify://import/",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://play.google.com/store/apps/details?id=com.vpn4tv.hiddify",
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Windows-Setup-x64.exe",
               "buttonText": {
-                "en": "Google Play",
-                "ru": "Google Play"
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-MacOS.dmg",
+              "buttonText": {
+                "en": "macOS",
+                "fa": "مک",
+                "ru": "macOS",
+                "zh": "macOS"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Linux-x64.AppImage",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
               }
             }
           ],
           "description": {
-            "en": "Open the page in Google Play and install the app. Or install the app directly from the APK file if Google Play is not working.",
-            "ru": "Откройте страницу в Google Play и установите приложение"
+            "en": "In the main section, click the large power button in the center to connect to VPN. If needed, select a different server in the Proxy section",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. در صورت نیاز، سرور دیگری را در بخش پروکسی انتخاب کنید",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. При необходимости выберите другой сервер в разделе Прокси.",
+            "zh": "在主界面中，点击中央的大电源按钮连接 VPN。如有需要，可在代理部分选择不同的服务器"
           }
         },
         "addSubscriptionStep": {
           "description": {
             "en": "Click the button below to add subscription",
-            "ru": "Нажмите кнопку выше — (Скопировать ссылку подписки) ты скопируешь свою подписку, далее на телевизоре открой VPN4TV, следуя инструкция передай telegram боту ссылку, которую ты скопировал"
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "Open the app and connect to the server",
-            "ru": "Приложение автоматически обновится и загрузит нужные конфиги на твой телевизор, подключай VPN"
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, select a different server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
           }
         }
       }
     ],
     "linux": [],
+    "androidTV": [],
     "appleTV": []
   }
 }

--- a/miniapp/app-config.json
+++ b/miniapp/app-config.json
@@ -1,5 +1,16 @@
 {
-  "config": {},
+  "config": {
+    "additionalLocales": [
+      "ru",
+      "zh",
+      "fa"
+    ],
+    "branding": {
+      "name": "Subscription",
+      "logoUrl": "https://remna.st/img/logo.svg",
+      "supportUrl": "https://t.me"
+    }
+  },
   "platforms": {
     "ios": [
       {
@@ -12,19 +23,102 @@
             {
               "buttonLink": "https://apps.apple.com/us/app/happ-proxy-utility/id6504287215",
               "buttonText": {
-                "en": "App Store [EU]",
-                "fa": "App Store [EU]",
-                "ru": "App Store [EU]",
-                "zh": "App Store [EU]"
+                "en": "Open in App Store [EU]",
+                "fa": "باز کردن در App Store [EU]",
+                "ru": "Открыть в App Store [EU]",
+                "zh": "在 App Store 中打开 [EU]"
               }
             },
             {
               "buttonLink": "https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973",
               "buttonText": {
-                "en": "App Store [RU]",
-                "fa": "App Store [RU]",
-                "ru": "App Store [RU]",
-                "zh": "App Store [RU]"
+                "en": "Open in App Store [RU]",
+                "fa": "باز کردن در App Store [RU]",
+                "ru": "Открыть в App Store [RU]",
+                "zh": "在 App Store 中打开 [RU]"
+              }
+            }
+          ],
+          "description": {
+            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
+            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
+            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
+            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below — the app will open and the subscription will be added automatically",
+            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
+            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
+            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
+          }
+        }
+      },
+      {
+        "id": "streisand",
+        "name": "Streisand",
+        "isFeatured": false,
+        "urlScheme": "streisand://import/",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://apps.apple.com/ru/app/streisand/id6450534064",
+              "buttonText": {
+                "en": "Open in App Store",
+                "fa": "باز کردن در App Store",
+                "ru": "Открыть в App Store",
+                "zh": "在 App Store 中打开"
+              }
+            }
+          ],
+          "description": {
+            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
+            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
+            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
+            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below — the app will open and the subscription will be added automatically",
+            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
+            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
+            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
+          }
+        }
+      },
+      {
+        "id": "shadowrocket",
+        "name": "Shadowrocket",
+        "isFeatured": false,
+        "urlScheme": "sub://",
+        "isNeedBase64Encoding": true,
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://apps.apple.com/ru/app/shadowrocket/id932747118",
+              "buttonText": {
+                "en": "Open in App Store",
+                "fa": "باز کردن در App Store",
+                "ru": "Открыть в App Store",
+                "zh": "在 App Store 中打开"
               }
             }
           ],
@@ -64,10 +158,10 @@
             {
               "buttonLink": "https://play.google.com/store/apps/details?id=com.happproxy",
               "buttonText": {
-                "en": "Google Play",
-                "fa": "Google Play",
-                "ru": "Google Play",
-                "zh": "Google Play"
+                "en": "Open in Google Play",
+                "fa": "باز کردن در Google Play",
+                "ru": "Открыть в Google Play",
+                "zh": "在 Google Play 中打开"
               }
             },
             {
@@ -103,53 +197,210 @@
             "zh": "打开应用并连接到服务器"
           }
         }
-      }
-    ],
-    "macos": [
+      },
       {
-        "id": "happ",
-        "name": "Happ",
-        "isFeatured": true,
-        "urlScheme": "happ://add/",
+        "id": "clash-meta",
+        "name": "Clash Meta",
+        "isFeatured": false,
+        "urlScheme": "clash://install-config?url=",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://apps.apple.com/us/app/happ-proxy-utility/id6504287215",
+              "buttonLink": "https://github.com/MetaCubeX/ClashMetaForAndroid/releases/download/v2.11.7/cmfa-2.11.7-meta-universal-release.apk",
               "buttonText": {
-                "en": "App Store [EU]",
-                "fa": "App Store [EU]",
-                "ru": "App Store [EU]",
-                "zh": "App Store [EU]"
+                "en": "Download APK",
+                "fa": "دانلود APK",
+                "ru": "Скачать APK",
+                "zh": "下载 APK"
               }
             },
             {
-              "buttonLink": "https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973",
+              "buttonLink": "https://f-droid.org/packages/com.github.metacubex.clash.meta/",
               "buttonText": {
-                "en": "App Store [RU]",
-                "fa": "App Store [RU]",
-                "ru": "App Store [RU]",
-                "zh": "App Store [RU]"
+                "en": "Open in F-Droid",
+                "fa": "در F-Droid باز کنید",
+                "ru": "Открыть в F-Droid",
+                "zh": "在 F-Droid 中打开"
               }
             }
           ],
           "description": {
-            "en": "Open the page in App Store and install the app. Launch it, in the VPN configuration permission window click Allow and enter your passcode.",
-            "fa": "صفحه را در App Store باز کنید و برنامه را نصب کنید. آن را اجرا کنید، در پنجره مجوز پیکربندی VPN روی Allow کلیک کنید و رمز عبور خود را وارد کنید.",
-            "ru": "Откройте страницу в App Store и установите приложение. Запустите его, в окне разрешения VPN-конфигурации нажмите Allow и введите свой пароль.",
-            "zh": "在 App Store 中打开页面并安装应用。启动应用后，在 VPN 配置权限窗口中点击\"允许\"并输入您的密码。"
+            "en": "Download and install Clash Meta APK",
+            "fa": "دانلود و نصب Clash Meta APK",
+            "ru": "Скачайте и установите Clash Meta APK",
+            "zh": "下载并安装 Clash Meta APK"
           }
         },
         "addSubscriptionStep": {
           "description": {
-            "en": "Click the button below — the app will open and the subscription will be added automatically",
-            "fa": "برای افزودن خودکار اشتراک روی دکمه زیر کلیک کنید - برنامه باز خواهد شد",
-            "ru": "Нажмите кнопку ниже — приложение откроется, и подписка добавится автоматически.",
-            "zh": "点击下方按钮 — 应用将打开并自动添加订阅"
+            "en": "Tap the button to import configuration",
+            "fa": "برای وارد کردن پیکربندی روی دکمه ضربه بزنید",
+            "ru": "Нажмите кнопку, чтобы импортировать конфигурацию",
+            "zh": "点击按钮导入配置"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, choose another server from the server list.",
+            "en": "Open Clash Meta and tap on Connect",
+            "fa": "Clash Meta را باز کنید و روی اتصال ضربه بزنید",
+            "ru": "Откройте Clash Meta и нажмите Подключиться",
+            "zh": "打开 Clash Meta 并点击连接"
+          }
+        }
+      }
+    ],
+    "macos": [
+      {
+        "id": "clash-verge",
+        "name": "Clash Verge",
+        "isFeatured": true,
+        "urlScheme": "clash://install-config?url=",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64-setup.exe",
+              "buttonText": {
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64.dmg",
+              "buttonText": {
+                "en": "macOS (Intel)",
+                "fa": "مک (اینتل)",
+                "ru": "macOS (Intel)",
+                "zh": "macOS (Intel)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_aarch64.dmg",
+              "buttonText": {
+                "en": "macOS (Apple Silicon)",
+                "fa": "مک (Apple Silicon)",
+                "ru": "macOS (Apple Silicon)",
+                "zh": "macOS (Apple Silicon)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
+              }
+            }
+          ],
+          "description": {
+            "en": "Choose the version for your device, click the button below and install the app.",
+            "fa": "نسخه مناسب برای دستگاه خود را انتخاب کنید، دکمه زیر را فشار دهید و برنامه را نصب کنید",
+            "ru": "Выберите подходящую версию для вашего устройства, нажмите на кнопку ниже и установите приложение.",
+            "zh": "选择适合您设备的版本，点击下方按钮并安装应用。"
+          }
+        },
+        "additionalBeforeAddSubscriptionStep": {
+          "buttons": [],
+          "description": {
+            "en": "After launching the app, you can change the language in settings. In the left panel, find the gear icon, then navigate to Verge 设置 and select 语言设置.",
+            "fa": "پس از راه‌اندازی برنامه، می‌توانید زبان را در تنظیمات تغییر دهید. در پنل سمت چپ، نماد چرخ دنده را پیدا کنید، سپس به Verge 设置 بروید و 语言设置 را انتخاب کنید.",
+            "ru": "После запуска приложения вы можете сменить язык в настройках. В левой панели найдите иконку шестеренки, далее ориентируйтесь на Verge 设置 и выберите пункт 语言设置.",
+            "zh": "启动应用后，您可以在设置中更改语言。在左侧面板找到齿轮图标，然后导航到 Verge 设置并选择语言设置。"
+          },
+          "title": {
+            "en": "Change language",
+            "fa": "تغییر زبان",
+            "ru": "Смена языка",
+            "zh": "更改语言"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below to add subscription",
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "additionalAfterAddSubscriptionStep": {
+          "buttons": [],
+          "title": {
+            "en": "If the subscription is not added",
+            "fa": "اگر اشتراک در برنامه نصب نشده است",
+            "ru": "Если подписка не добавилась",
+            "zh": "如果订阅未添加"
+          },
+          "description": {
+            "en": "If nothing happens after clicking the button, add the subscription manually. Click the Get Link button in the top right corner of this page, copy the link. In Clash Verge, go to the Profiles section and paste the link in the text field, then click the Import button.",
+            "fa": "اگر پس از کلیک روی دکمه اتفاقی نیفتاد، اشتراک را به صورت دستی اضافه کنید. در گوشه بالا سمت راست این صفحه روی دکمه دریافت لینک کلیک کنید، لینک را کپی کنید. در Clash Verge به بخش پروفایل‌ها بروید و لینک را در فیلد متنی وارد کنید، سپس روی دکمه وارد کردن کلیک کنید.",
+            "ru": "Если после нажатия на кнопку ничего не произошло, добавьте подписку вручную. Нажмите на этой странице кнопку Получить ссылку в правом верхнем углу, скопируйте ссылку. В Clash Verge перейдите в раздел Профили и вставьте ссылку в текстовое поле, затем нажмите на кнопку Импорт.",
+            "zh": "如果点击按钮后没有反应，请手动添加订阅。点击此页面右上角的获取链接按钮，复制链接。在 Clash Verge 中，转到配置文件部分，将链接粘贴到文本字段中，然后点击导入按钮。"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "You can select a server in the Proxy section, and enable VPN in the Settings section. Set the TUN Mode switch to ON.",
+            "fa": "می‌توانید در بخش پروکسی سرور را انتخاب کنید و در بخش تنظیمات VPN را فعال کنید. کلید TUN Mode را در حالت روشن قرار دهید.",
+            "ru": "Выбрать сервер можно в разделе Прокси, включить VPN можно в разделе Настройки. Установите переключатель TUN Mode в положение ВКЛ.",
+            "zh": "您可以在代理部分选择服务器，在设置部分启用 VPN。将 TUN 模式开关设置为开启。"
+          }
+        }
+      },
+      {
+        "id": "hiddify",
+        "name": "Hiddify",
+        "isFeatured": false,
+        "urlScheme": "hiddify://import/",
+        "installationStep": {
+          "buttons": [
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Windows-Setup-x64.exe",
+              "buttonText": {
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-MacOS.dmg",
+              "buttonText": {
+                "en": "macOS",
+                "fa": "مک",
+                "ru": "macOS",
+                "zh": "macOS"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Linux-x64.AppImage",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
+              }
+            }
+          ],
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. If needed, select a different server in the Proxy section",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. در صورت نیاز، سرور دیگری را در بخش پروکسی انتخاب کنید",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. При необходимости выберите другой сервер в разделе Прокси.",
+            "zh": "在主界面中，点击中央的大电源按钮连接 VPN。如有需要，可在代理部分选择不同的服务器"
+          }
+        },
+        "addSubscriptionStep": {
+          "description": {
+            "en": "Click the button below to add subscription",
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "connectAndUseStep": {
+          "description": {
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, select a different server from the server list.",
             "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
             "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
             "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
@@ -159,75 +410,165 @@
     ],
     "windows": [
       {
-        "id": "happ",
-        "name": "Happ",
-        "isFeatured": false,
-        "urlScheme": "happ://add/",
+        "id": "clash-verge",
+        "name": "Clash Verge",
+        "isFeatured": true,
+        "urlScheme": "clash://install-config?url=",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://github.com/Happ-proxy/happ-desktop/releases/latest/download/setup-Happ.x86.exe",
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64-setup.exe",
               "buttonText": {
-                "en": "Download",
-                "ru": "Скачать"
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64.dmg",
+              "buttonText": {
+                "en": "macOS (Intel)",
+                "fa": "مک (اینتل)",
+                "ru": "macOS (Intel)",
+                "zh": "macOS (Intel)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_aarch64.dmg",
+              "buttonText": {
+                "en": "macOS (Apple Silicon)",
+                "fa": "مک (Apple Silicon)",
+                "ru": "macOS (Apple Silicon)",
+                "zh": "macOS (Apple Silicon)"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/clash-verge-rev/clash-verge-rev/releases",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
               }
             }
           ],
           "description": {
-            "en": "Download and install Happ.",
-            "ru": "Скачайте и установите Happ"
+            "en": "Choose the version for your device, click the button below and install the app.",
+            "fa": "نسخه مناسب برای دستگاه خود را انتخاب کنید، دکمه زیر را فشار دهید و برنامه را نصب کنید",
+            "ru": "Выберите подходящую версию для вашего устройства, нажмите на кнопку ниже и установите приложение.",
+            "zh": "选择适合您设备的版本，点击下方按钮并安装应用。"
+          }
+        },
+        "additionalBeforeAddSubscriptionStep": {
+          "buttons": [],
+          "description": {
+            "en": "After launching the app, you can change the language in settings. In the left panel, find the gear icon, then navigate to Verge 设置 and select 语言设置.",
+            "fa": "پس از راه‌اندازی برنامه، می‌توانید زبان را در تنظیمات تغییر دهید. در پنل سمت چپ، نماد چرخ دنده را پیدا کنید، سپس به Verge 设置 بروید و 语言设置 را انتخاب کنید.",
+            "ru": "После запуска приложения вы можете сменить язык в настройках. В левой панели найдите иконку шестеренки, далее ориентируйтесь на Verge 设置 и выберите пункт 语言设置.",
+            "zh": "启动应用后，您可以在设置中更改语言。在左侧面板找到齿轮图标，然后导航到 Verge 设置并选择语言设置。"
+          },
+          "title": {
+            "en": "Change language",
+            "fa": "تغییر زبان",
+            "ru": "Смена языка",
+            "zh": "更改语言"
           }
         },
         "addSubscriptionStep": {
           "description": {
             "en": "Click the button below to add subscription",
-            "ru": "Нажмите кнопку выше — (Подключить подписку) приложение откроется, и подписка добавится автоматически."
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
+          }
+        },
+        "additionalAfterAddSubscriptionStep": {
+          "buttons": [],
+          "title": {
+            "en": "If the subscription is not added",
+            "fa": "اگر اشتراک در برنامه نصب نشده است",
+            "ru": "Если подписка не добавилась",
+            "zh": "如果订阅未添加"
+          },
+          "description": {
+            "en": "If nothing happens after clicking the button, add the subscription manually. Click the Get Link button in the top right corner of this page, copy the link. In Clash Verge, go to the Profiles section and paste the link in the text field, then click the Import button.",
+            "fa": "اگر پس از کلیک روی دکمه اتفاقی نیفتاد، اشتراک را به صورت دستی اضافه کنید. در گوشه بالا سمت راست این صفحه روی دکمه دریافت لینک کلیک کنید، لینک را کپی کنید. در Clash Verge به بخش پروفایل‌ها بروید و لینک را در فیلد متنی وارد کنید، سپس روی دکمه وارد کردن کلیک کنید.",
+            "ru": "Если после нажатия на кнопку ничего не произошло, добавьте подписку вручную. Нажмите на этой странице кнопку Получить ссылку в правом верхнем углу, скопируйте ссылку. В Clash Verge перейдите в раздел Профили и вставьте ссылку в текстовое поле, затем нажмите на кнопку Импорт.",
+            "zh": "如果点击按钮后没有反应，请手动添加订阅。点击此页面右上角的获取链接按钮，复制链接。在 Clash Verge 中，转到配置文件部分，将链接粘贴到文本字段中，然后点击导入按钮。"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "You can select a server",
-            "ru": "Выберете локацию, включить VPN"
+            "en": "You can select a server in the Proxy section, and enable VPN in the Settings section. Set the TUN Mode switch to ON.",
+            "fa": "می‌توانید در بخش پروکسی سرور را انتخاب کنید و در بخش تنظیمات VPN را فعال کنید. کلید TUN Mode را در حالت روشن قرار دهید.",
+            "ru": "Выбрать сервер можно в разделе Прокси, включить VPN можно в разделе Настройки. Установите переключатель TUN Mode в положение ВКЛ.",
+            "zh": "您可以在代理部分选择服务器，在设置部分启用 VPN。将 TUN 模式开关设置为开启。"
           }
         }
-      }
-    ],
-    "androidTV": [
+      },
       {
-        "id": "vpn4tv",
-        "name": "VPN4TV",
-        "isFeatured": true,
-        "urlScheme": "",
+        "id": "hiddify",
+        "name": "Hiddify",
+        "isFeatured": false,
+        "urlScheme": "hiddify://import/",
         "installationStep": {
           "buttons": [
             {
-              "buttonLink": "https://play.google.com/store/apps/details?id=com.vpn4tv.hiddify",
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Windows-Setup-x64.exe",
               "buttonText": {
-                "en": "Google Play",
-                "ru": "Google Play"
+                "en": "Windows",
+                "fa": "ویندوز",
+                "ru": "Windows",
+                "zh": "Windows"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-MacOS.dmg",
+              "buttonText": {
+                "en": "macOS",
+                "fa": "مک",
+                "ru": "macOS",
+                "zh": "macOS"
+              }
+            },
+            {
+              "buttonLink": "https://github.com/hiddify/hiddify-app/releases/download/v2.5.7/Hiddify-Linux-x64.AppImage",
+              "buttonText": {
+                "en": "Linux",
+                "fa": "لینوکس",
+                "ru": "Linux",
+                "zh": "Linux"
               }
             }
           ],
           "description": {
-            "en": "Open the page in Google Play and install the app. Or install the app directly from the APK file if Google Play is not working.",
-            "ru": "Откройте страницу в Google Play и установите приложение"
+            "en": "In the main section, click the large power button in the center to connect to VPN. If needed, select a different server in the Proxy section",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. در صورت نیاز، سرور دیگری را در بخش پروکسی انتخاب کنید",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. При необходимости выберите другой сервер в разделе Прокси.",
+            "zh": "在主界面中，点击中央的大电源按钮连接 VPN。如有需要，可在代理部分选择不同的服务器"
           }
         },
         "addSubscriptionStep": {
           "description": {
             "en": "Click the button below to add subscription",
-            "ru": "Нажмите кнопку выше — (Скопировать ссылку подписки) ты скопируешь свою подписку, далее на телевизоре открой VPN4TV, следуя инструкция передай telegram боту ссылку, которую ты скопировал"
+            "fa": "برای افزودن اشتراک روی دکمه زیر کلیک کنید",
+            "ru": "Нажмите кнопку ниже, чтобы добавить подписку",
+            "zh": "点击下方按钮添加订阅"
           }
         },
         "connectAndUseStep": {
           "description": {
-            "en": "Open the app and connect to the server",
-            "ru": "Приложение автоматически обновится и загрузит нужные конфиги на твой телевизор, подключай VPN"
+            "en": "In the main section, click the large power button in the center to connect to VPN. Don't forget to select a server from the server list. If needed, select a different server from the server list.",
+            "fa": "در بخش اصلی، دکمه بزرگ روشن/خاموش در مرکز را برای اتصال به VPN کلیک کنید. فراموش نکنید که یک سرور را از لیست سرورها انتخاب کنید. در صورت نیاز، سرور دیگری را از لیست سرورها انتخاب کنید.",
+            "ru": "В главном разделе нажмите большую кнопку включения в центре для подключения к VPN. Не забудьте выбрать сервер в списке серверов. При необходимости выберите другой сервер из списка серверов.",
+            "zh": "在主界面中，点击中央的大电源按钮连接到 VPN。别忘了从服务器列表中选择一个服务器。如有需要，可从服务器列表中选择其他服务器。"
           }
         }
       }
     ],
     "linux": [],
+    "androidTV": [],
     "appleTV": []
   }
 }

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -959,6 +959,29 @@
             margin: 20px 0;
         }
 
+        .connect-scheme {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            margin-top: -4px;
+            margin-bottom: 16px;
+            word-break: break-word;
+        }
+
+        .connect-scheme-label {
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .connect-scheme-value {
+            background: rgba(var(--primary-rgb), 0.08);
+            color: var(--primary);
+            padding: 4px 8px;
+            border-radius: var(--radius-sm);
+        }
+
         /* App Installation */
         .platform-selector {
             display: grid;
@@ -1005,6 +1028,7 @@
             margin-bottom: 12px;
             border: 2px solid var(--border-color);
             transition: all 0.3s ease;
+            cursor: pointer;
         }
 
         .app-card:hover {
@@ -1015,6 +1039,25 @@
         .app-card.featured {
             border-color: var(--primary);
             background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.05), rgba(var(--primary-rgb), 0.02));
+        }
+
+        .app-card.selected {
+            border-color: var(--primary);
+            box-shadow: var(--shadow-md);
+        }
+
+        .selected-indicator {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--primary);
+            background: rgba(var(--primary-rgb), 0.08);
+            border-radius: 999px;
+            padding: 4px 10px;
+            margin-left: auto;
+            align-self: flex-start;
         }
 
         .app-header {
@@ -1408,6 +1451,11 @@
                 </button>
             </div>
 
+            <div class="connect-scheme hidden" id="connectSchemeContainer">
+                <span class="connect-scheme-label" data-i18n="button.connect.scheme_label">Connection scheme</span>
+                <code class="connect-scheme-value" id="connectSchemeValue"></code>
+            </div>
+
             <!-- Balance Card -->
             <div class="card balance-card" id="balanceCard">
                 <div class="balance-content">
@@ -1665,6 +1713,8 @@
                 'info.autopay': 'Auto-pay',
                 'button.connect.default': 'Connect to VPN',
                 'button.connect.happ': 'Connect',
+                'button.connect.open_in': 'Open in {{app}}',
+                'button.connect.scheme_label': 'Connection scheme',
                 'button.copy': 'Copy subscription link',
                 'button.buy_subscription': 'Buy Subscription',
                 'card.balance.title': 'Balance',
@@ -1674,6 +1724,7 @@
                 'apps.title': 'Installation guide',
                 'apps.no_data': 'No installation guide available for this platform yet.',
                 'apps.featured': 'Recommended',
+                'apps.selected': 'Selected',
                 'apps.step.download': 'Download & install',
                 'apps.step.add': 'Add subscription',
                 'apps.step.connect': 'Connect & use',
@@ -1729,6 +1780,8 @@
                 'info.autopay': 'Автоплатеж',
                 'button.connect.default': 'Подключиться к VPN',
                 'button.connect.happ': 'Подключиться',
+                'button.connect.open_in': 'Открыть в {{app}}',
+                'button.connect.scheme_label': 'Схема подключения',
                 'button.copy': 'Скопировать ссылку подписки',
                 'button.buy_subscription': 'Купить подписку',
                 'card.balance.title': 'Баланс',
@@ -1738,6 +1791,7 @@
                 'apps.title': 'Инструкция по установке',
                 'apps.no_data': 'Для этой платформы инструкция пока недоступна.',
                 'apps.featured': 'Рекомендуем',
+                'apps.selected': 'Выбрано',
                 'apps.step.download': 'Скачать и установить',
                 'apps.step.add': 'Добавить подписку',
                 'apps.step.connect': 'Подключиться и пользоваться',
@@ -1869,6 +1923,7 @@
         let preferredLanguage = 'en';
         let languageLockedByUser = false;
         let currentErrorState = null;
+        const selectedAppIds = {};
 
         function resolveLanguage(lang) {
             if (!lang) {
@@ -1929,6 +1984,51 @@
             return div.innerHTML;
         }
 
+        function formatString(template, replacements = {}) {
+            if (typeof template !== 'string') {
+                return '';
+            }
+            return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) => {
+                if (Object.prototype.hasOwnProperty.call(replacements, key)) {
+                    return replacements[key];
+                }
+                return '';
+            });
+        }
+
+        function base64Encode(value) {
+            if (typeof value !== 'string') {
+                return '';
+            }
+            try {
+                return btoa(value);
+            } catch (error) {
+                try {
+                    if (typeof TextEncoder !== 'undefined') {
+                        const encoder = new TextEncoder();
+                        const bytes = encoder.encode(value);
+                        let binary = '';
+                        bytes.forEach(byte => {
+                            binary += String.fromCharCode(byte);
+                        });
+                        return btoa(binary);
+                    }
+                    return btoa(unescape(encodeURIComponent(value)));
+                } catch (encoderError) {
+                    console.warn('Base64 encode failed:', encoderError);
+                    return '';
+                }
+            }
+        }
+
+        function extractScheme(value) {
+            if (typeof value !== 'string') {
+                return '';
+            }
+            const match = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+            return match ? `${match[1]}://` : '';
+        }
+
         function normalizeUrl(value) {
             if (typeof value !== 'string') {
                 return null;
@@ -1952,6 +2052,51 @@
             }
 
             return null;
+        }
+
+        function getSelectedAppId(platformKey = getPlatformKey(currentPlatform)) {
+            return selectedAppIds[platformKey] || null;
+        }
+
+        function setSelectedAppId(appId, platformKey = getPlatformKey(currentPlatform)) {
+            if (!appId) {
+                delete selectedAppIds[platformKey];
+                return;
+            }
+            selectedAppIds[platformKey] = String(appId);
+        }
+
+        function getSelectedApp(platformKey = getPlatformKey(currentPlatform)) {
+            const apps = appsConfig?.[platformKey] || [];
+            const selectedId = getSelectedAppId(platformKey);
+            return apps.find(app => String(app.id) === String(selectedId)) || null;
+        }
+
+        function getAppScheme(app) {
+            if (!app) {
+                return '';
+            }
+            if (app.id === 'happ') {
+                const happLink = getHappCryptoLink() || userData?.happ_cryptolink_redirect_link || app.urlScheme || '';
+                return extractScheme(happLink) || extractScheme(app.urlScheme || '');
+            }
+            return extractScheme(app.urlScheme || '');
+        }
+
+        function updateConnectScheme() {
+            const container = document.getElementById('connectSchemeContainer');
+            const valueElement = document.getElementById('connectSchemeValue');
+            if (!container || !valueElement) {
+                return;
+            }
+            const scheme = getAppScheme(getSelectedApp());
+            if (scheme) {
+                valueElement.textContent = scheme;
+                container.classList.remove('hidden');
+            } else {
+                valueElement.textContent = '';
+                container.classList.add('hidden');
+            }
         }
 
         function updateErrorTexts() {
@@ -1996,9 +2141,27 @@
             if (!label) {
                 return;
             }
-            const useHappLabel = Boolean(getHappCryptoLink() || userData?.happ_cryptolink_redirect_link);
-            const key = useHappLabel ? 'button.connect.happ' : 'button.connect.default';
-            label.textContent = t(key);
+            const selectedApp = getSelectedApp();
+            if (!selectedApp) {
+                label.textContent = t('button.connect.default');
+                return;
+            }
+
+            const hasHappLink = Boolean(getHappCryptoLink() || userData?.happ_cryptolink_redirect_link);
+            if (selectedApp.id === 'happ' && hasHappLink) {
+                label.textContent = t('button.connect.happ');
+                return;
+            }
+
+            const template = t('button.connect.open_in');
+            const appName = String(selectedApp.name || t('values.not_available'));
+            if (!template || template === 'button.connect.open_in') {
+                label.textContent = `Open in ${appName}`.trim();
+                return;
+            }
+
+            const formatted = formatString(template, { app: appName });
+            label.textContent = formatted || `${template} ${appName}`.trim();
         }
 
         function refreshAfterLanguageChange() {
@@ -2009,6 +2172,7 @@
                 updateConnectButtonLabel();
             }
             renderApps();
+            updateConnectButtonLabel();
             updateActionButtons();
         }
 
@@ -2336,27 +2500,46 @@
                 return;
             }
 
-            const apps = getAppsForCurrentPlatform();
+            const platformKey = getPlatformKey(currentPlatform);
+            const apps = appsConfig?.[platformKey] || [];
 
             if (!apps.length) {
                 container.innerHTML = `<div class="step-description">${escapeHtml(t('apps.no_data'))}</div>`;
+                updateConnectScheme();
                 return;
+            }
+
+            let selectedAppId = getSelectedAppId(platformKey);
+            if (!apps.some(app => String(app.id) === String(selectedAppId))) {
+                const defaultApp = apps.find(app => app.isFeatured) || apps[0];
+                selectedAppId = defaultApp ? String(defaultApp.id) : null;
+                if (selectedAppId) {
+                    setSelectedAppId(selectedAppId, platformKey);
+                } else {
+                    setSelectedAppId(null, platformKey);
+                }
             }
 
             container.innerHTML = apps.map(app => {
                 const iconChar = (app.name?.[0] || 'A').toUpperCase();
                 const appName = escapeHtml(app.name || 'App');
+                const appId = String(app.id ?? '');
                 const featuredBadge = app.isFeatured
                     ? `<span class="featured-badge">${escapeHtml(t('apps.featured'))}</span>`
                     : '';
+                const isSelected = String(app.id) === String(selectedAppId);
+                const selectedBadge = isSelected
+                    ? `<span class="selected-indicator">${escapeHtml(t('apps.selected'))}</span>`
+                    : '';
                 return `
-                    <div class="app-card ${app.isFeatured ? 'featured' : ''}">
+                    <div class="app-card ${app.isFeatured ? 'featured' : ''} ${isSelected ? 'selected' : ''}" data-app-id="${escapeHtml(appId)}">
                         <div class="app-header">
                             <div class="app-icon">${escapeHtml(iconChar)}</div>
                             <div class="app-info">
                                 <div class="app-name">${appName}</div>
                                 ${featuredBadge}
                             </div>
+                            ${selectedBadge}
                         </div>
                         <div class="app-steps">
                             ${renderAppSteps(app)}
@@ -2364,6 +2547,8 @@
                     </div>
                 `;
             }).join('');
+
+            updateConnectScheme();
         }
 
         function renderAppSteps(app) {
@@ -2717,45 +2902,45 @@
                 return null;
             }
 
-            const happCryptoLink = getHappCryptoLink();
-            const isPC = currentPlatform === 'pc' || (!['ios', 'android', 'tv'].includes(currentPlatform));
-            
-            // For PC, prefer direct subscription URL if no Happ redirect link
-            if (isPC) {
-                if (userData.happ_cryptolink_redirect_link) {
-                    return userData.happ_cryptolink_redirect_link;
-                }
+            const selectedApp = getSelectedApp();
+            const subscriptionUrl = getCurrentSubscriptionUrl();
+
+            if (!selectedApp) {
+                return subscriptionUrl || null;
+            }
+
+            if (selectedApp.id === 'happ') {
+                const happCryptoLink = getHappCryptoLink();
                 if (happCryptoLink) {
                     return happCryptoLink;
                 }
-                // Return plain subscription URL for PC
-                return getCurrentSubscriptionUrl();
-            }
-            
-            // Original logic for mobile platforms
-            if (happCryptoLink) {
-                return happCryptoLink;
+                if (userData.happ_cryptolink_redirect_link) {
+                    return userData.happ_cryptolink_redirect_link;
+                }
+                if (selectedApp.urlScheme && subscriptionUrl) {
+                    return `${selectedApp.urlScheme}${subscriptionUrl}`;
+                }
+                if (userData?.happ_link) {
+                    return userData.happ_link;
+                }
+                return subscriptionUrl || null;
             }
 
-            if (userData.happ_cryptolink_redirect_link) {
-                return userData.happ_cryptolink_redirect_link;
-            }
-
-            const subscriptionUrl = getCurrentSubscriptionUrl();
             if (!subscriptionUrl) {
                 return null;
             }
 
-            const apps = getAppsForCurrentPlatform();
-            const featuredApp = apps.find(app => app.isFeatured) || apps[0];
+            let payload = subscriptionUrl;
+            if (selectedApp.isNeedBase64Encoding) {
+                const encoded = base64Encode(subscriptionUrl);
+                payload = encoded || subscriptionUrl;
+            }
 
-            if (featuredApp?.urlScheme) {
-                return `${featuredApp.urlScheme}${subscriptionUrl}`;
+            if (selectedApp.urlScheme) {
+                return `${selectedApp.urlScheme}${payload}`;
             }
-            if (userData?.happ_link && featuredApp?.id === 'happ') {
-                return userData.happ_link;
-            }
-            return subscriptionUrl;
+
+            return payload;
         }
 
         function openExternalLink(link, options = {}) {
@@ -2926,6 +3111,8 @@
                 const hasUrl = Boolean(subscriptionUrl);
                 copyBtn.disabled = !hasUrl || !navigator.clipboard;
             }
+
+            updateConnectScheme();
         }
 
         function showPopup(message, title = 'Info') {
@@ -2958,8 +3145,28 @@
                 currentPlatform = btn.dataset.platform;
                 setActivePlatformButton();
                 renderApps();
+                updateConnectButtonLabel();
                 updateActionButtons();
             });
+        });
+
+        document.getElementById('appsContainer')?.addEventListener('click', event => {
+            const card = event.target.closest('.app-card');
+            if (!card) {
+                return;
+            }
+            const appId = card.dataset.appId;
+            if (!appId) {
+                return;
+            }
+            const platformKey = getPlatformKey(currentPlatform);
+            if (appId === getSelectedAppId(platformKey)) {
+                return;
+            }
+            setSelectedAppId(appId, platformKey);
+            renderApps();
+            updateConnectButtonLabel();
+            updateActionButtons();
         });
 
         document.getElementById('connectBtn')?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- allow selecting installation apps per platform and highlight the active choice in the miniapp UI
- update the connect button to build links using each app's URL scheme (including Happ-only cryptolinks and optional base64 encoding) and show the detected scheme to the user
- refresh app configuration with the latest platform definitions and branding data
