### PR TITLE
Allow admins to decrease user subscription days

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -110,7 +110,14 @@ async def extend_subscription(
     logger.info(f"🔄 Продление подписки {subscription.id} на {days} дней")
     logger.info(f"📊 Текущие параметры: статус={subscription.status}, окончание={subscription.end_date}")
     
-    if subscription.end_date > current_time:
+    if days < 0:
+        subscription.end_date = subscription.end_date + timedelta(days=days)
+        logger.info(
+            "📅 Срок подписки уменьшен на %s дней, новая дата окончания: %s",
+            abs(days),
+            subscription.end_date,
+        )
+    elif subscription.end_date > current_time:
         subscription.end_date = subscription.end_date + timedelta(days=days)
         logger.info(f"📅 Подписка активна, добавляем {days} дней к текущей дате окончания")
     else:
@@ -133,7 +140,7 @@ async def extend_subscription(
             if subscription.user:
                 subscription.user.has_had_paid_subscription = True
 
-    if subscription.status == SubscriptionStatus.EXPIRED.value:
+    if subscription.status == SubscriptionStatus.EXPIRED.value and days > 0:
         subscription.status = SubscriptionStatus.ACTIVE.value
         logger.info(f"🔄 Статус изменён с EXPIRED на ACTIVE")
 

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -2080,11 +2080,16 @@ async def extend_user_subscription(
     
     await callback.message.edit_text(
         "⏰ <b>Продление подписки</b>\n\n"
-        "Введите количество дней для продления:\n"
-        "• Например: 30, 7, 90\n"
-        "• Максимум: 365 дней\n\n"
+        "Введите количество дней для изменения:\n"
+        "• Положительные значения продлят подписку\n"
+        "• Отрицательные сократят срок подписки\n"
+        "• Диапазон: от -365 до 365 дней (0 недопустимо)\n\n"
         "Или нажмите /cancel для отмены",
         reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[
+            [
+                types.InlineKeyboardButton(text="-7 дней", callback_data=f"admin_sub_extend_days_{user_id}_-7"),
+                types.InlineKeyboardButton(text="-30 дней", callback_data=f"admin_sub_extend_days_{user_id}_-30")
+            ],
             [
                 types.InlineKeyboardButton(text="7 дней", callback_data=f"admin_sub_extend_days_{user_id}_7"),
                 types.InlineKeyboardButton(text="30 дней", callback_data=f"admin_sub_extend_days_{user_id}_30")
@@ -2114,11 +2119,19 @@ async def process_subscription_extension_days(
     user_id = int(parts[-2])
     days = int(parts[-1])
     
+    if days == 0 or days < -365 or days > 365:
+        await callback.answer("❌ Количество дней должно быть от -365 до 365, исключая 0", show_alert=True)
+        return
+
     success = await _extend_subscription_by_days(db, user_id, days, db_user.id)
-    
+
     if success:
+        if days > 0:
+            action_text = f"продлена на {days} дней"
+        else:
+            action_text = f"уменьшена на {abs(days)} дней"
         await callback.message.edit_text(
-            f"✅ Подписка пользователя продлена на {days} дней",
+            f"✅ Подписка пользователя {action_text}",
             reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[
                 [types.InlineKeyboardButton(text="📱 К подписке", callback_data=f"admin_user_subscription_{user_id}")]
             ])
@@ -2153,15 +2166,19 @@ async def process_subscription_extension_text(
     try:
         days = int(message.text.strip())
         
-        if days <= 0 or days > 365:
-            await message.answer("❌ Количество дней должно быть от 1 до 365")
+        if days == 0 or days < -365 or days > 365:
+            await message.answer("❌ Количество дней должно быть от -365 до 365, исключая 0")
             return
-        
+
         success = await _extend_subscription_by_days(db, user_id, days, db_user.id)
-        
+
         if success:
+            if days > 0:
+                action_text = f"продлена на {days} дней"
+            else:
+                action_text = f"уменьшена на {abs(days)} дней"
             await message.answer(
-                f"✅ Подписка пользователя продлена на {days} дней",
+                f"✅ Подписка пользователя {action_text}",
                 reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[
                     [types.InlineKeyboardButton(text="📱 К подписке", callback_data=f"admin_user_subscription_{user_id}")]
                 ])
@@ -3115,9 +3132,12 @@ async def _extend_subscription_by_days(db: AsyncSession, user_id: int, days: int
         subscription_service = SubscriptionService()
         await subscription_service.update_remnawave_user(db, subscription)
         
-        logger.info(f"Админ {admin_id} продлил подписку пользователя {user_id} на {days} дней")
+        if days > 0:
+            logger.info(f"Админ {admin_id} продлил подписку пользователя {user_id} на {days} дней")
+        else:
+            logger.info(f"Админ {admin_id} сократил подписку пользователя {user_id} на {abs(days)} дней")
         return True
-        
+
     except Exception as e:
         logger.error(f"Ошибка продления подписки: {e}")
         return False


### PR DESCRIPTION
## Summary
- allow admins to decrease or increase subscription duration by entering negative or positive day adjustments
- add quick-select buttons for decreasing days and validate the allowed range in admin handlers
- update subscription extension logic to handle negative adjustments without reactivating expired subscriptions
