### PR TITLE
Fix server squad user counters on removal

### DIFF
--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -621,7 +621,24 @@ class RemnaWaveService:
                             try:
                                 from sqlalchemy import delete
                                 from app.database.models import SubscriptionServer
-                                
+                                from app.database.crud.subscription import get_subscription_server_ids
+                                from app.database.crud.server_squad import (
+                                    get_server_ids_by_uuids,
+                                    remove_user_from_servers,
+                                )
+
+                                removed_server_ids = set(
+                                    await get_subscription_server_ids(db, subscription.id)
+                                )
+
+                                if subscription.connected_squads:
+                                    removed_server_ids.update(
+                                        await get_server_ids_by_uuids(db, subscription.connected_squads)
+                                    )
+
+                                if removed_server_ids:
+                                    await remove_user_from_servers(db, list(removed_server_ids))
+
                                 await db.execute(
                                     delete(SubscriptionServer).where(
                                         SubscriptionServer.subscription_id == subscription.id
@@ -1174,6 +1191,42 @@ class RemnaWaveService:
                 user.updated_at = self._now_in_panel_timezone()
                 
                 if user.subscription:
+                    try:
+                        from sqlalchemy import delete
+                        from app.database.models import SubscriptionServer
+                        from app.database.crud.subscription import get_subscription_server_ids
+                        from app.database.crud.server_squad import (
+                            get_server_ids_by_uuids,
+                            remove_user_from_servers,
+                        )
+
+                        removed_server_ids = set(
+                            await get_subscription_server_ids(db, user.subscription.id)
+                        )
+
+                        if user.subscription.connected_squads:
+                            removed_server_ids.update(
+                                await get_server_ids_by_uuids(
+                                    db, user.subscription.connected_squads
+                                )
+                            )
+
+                        if removed_server_ids:
+                            await remove_user_from_servers(db, list(removed_server_ids))
+
+                        await db.execute(
+                            delete(SubscriptionServer).where(
+                                SubscriptionServer.subscription_id == user.subscription.id
+                            )
+                        )
+                        logger.info(
+                            f"🗑️ Удалены привязанные серверы подписки для пользователя {user.telegram_id}"
+                        )
+                    except Exception as servers_error:
+                        logger.error(
+                            f"❌ Ошибка удаления серверов подписки при очистке пользователя {user.telegram_id}: {servers_error}"
+                        )
+
                     user.subscription.status = SubscriptionStatus.DISABLED.value
                     user.subscription.is_trial = True
                     user.subscription.end_date = self._now_in_panel_timezone()

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -537,6 +537,31 @@ class UserService:
                     
                     if subscription_servers:
                         logger.info(f"🔄 Удаляем {len(subscription_servers)} связей подписка-сервер")
+
+                        try:
+                            from app.database.crud.server_squad import (
+                                get_server_ids_by_uuids,
+                                remove_user_from_servers,
+                            )
+
+                            removed_server_ids = {
+                                sub_server.server_squad_id for sub_server in subscription_servers
+                            }
+
+                            if user.subscription.connected_squads:
+                                removed_server_ids.update(
+                                    await get_server_ids_by_uuids(
+                                        db, user.subscription.connected_squads
+                                    )
+                                )
+
+                            if removed_server_ids:
+                                await remove_user_from_servers(db, list(removed_server_ids))
+                        except Exception as counter_error:
+                            logger.error(
+                                f"❌ Ошибка обновления счетчиков серверов при удалении пользователя {user.telegram_id}: {counter_error}"
+                            )
+
                         await db.execute(
                             delete(SubscriptionServer).where(
                                 SubscriptionServer.subscription_id == user.subscription.id


### PR DESCRIPTION
## Summary
- ensure server user counters are decremented when countries are removed from subscriptions and when user subscriptions are cleared
- adjust RemnaWave cleanup and user deletion flows to keep squad counters accurate

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e5d83fb8888320a44ab99362bd1db6