### PR TITLE
Expire server cache after counter updates

### DIFF
--- a/app/database/crud/server_squad.py
+++ b/app/database/crud/server_squad.py
@@ -540,6 +540,7 @@ async def add_user_to_servers(
             )
         
         await db.commit()
+        await db.expire_all()
         logger.info(f"✅ Увеличен счетчик пользователей для серверов: {server_squad_ids}")
         return True
         
@@ -563,6 +564,7 @@ async def remove_user_from_servers(
             )
         
         await db.commit()
+        await db.expire_all()
         logger.info(f"✅ Уменьшен счетчик пользователей для серверов: {server_squad_ids}")
         return True
         


### PR DESCRIPTION
## Summary
- expire the SQLAlchemy session after committing server user counter increments and decrements so subsequent queries read fresh values