### PR TITLE
Fix server user counts when subscriptions are removed

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -38,6 +38,7 @@ from app.utils.promo_offer import (
     build_test_access_hint,
 )
 from app.database.crud.user_message import get_random_active_message
+from app.database.crud.subscription import decrement_subscription_server_counts
 
 
 logger = logging.getLogger(__name__)
@@ -371,6 +372,7 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             from sqlalchemy import delete
             
             if user.subscription:
+                await decrement_subscription_server_counts(db, user.subscription)
                 await db.execute(
                     delete(SubscriptionServer).where(
                         SubscriptionServer.subscription_id == user.subscription.id

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -13,7 +13,10 @@ from app.database.crud.user import (
 )
 from app.database.crud.promo_group import get_promo_group_by_id
 from app.database.crud.transaction import get_user_transactions_count
-from app.database.crud.subscription import get_subscription_by_user_id
+from app.database.crud.subscription import (
+    get_subscription_by_user_id,
+    decrement_subscription_server_counts,
+)
 from app.database.models import (
     User, UserStatus, Subscription, Transaction, PromoCode, PromoCodeUse,
     ReferralEarning, SubscriptionServer, YooKassaPayment, BroadcastHistory,
@@ -534,7 +537,13 @@ class UserService:
                         )
                     )
                     subscription_servers = subscription_servers_result.scalars().all()
-                    
+
+                    await decrement_subscription_server_counts(
+                        db,
+                        user.subscription,
+                        subscription_servers=subscription_servers,
+                    )
+
                     if subscription_servers:
                         logger.info(f"🔄 Удаляем {len(subscription_servers)} связей подписка-сервер")
                         await db.execute(


### PR DESCRIPTION
## Summary
- increment server usage counters immediately after creating a trial subscription
- add logging to highlight successful updates and warn about missing squads or update errors
- decrement server usage counters automatically when subscriptions or users are removed from the system