### PR TITLE
Prevent double counting server counters on paid subscriptions

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -124,9 +124,10 @@ async def create_paid_subscription(
     db: AsyncSession,
     user_id: int,
     duration_days: int,
-    traffic_limit_gb: int = 0, 
+    traffic_limit_gb: int = 0,
     device_limit: int = 1,
-    connected_squads: List[str] = None
+    connected_squads: List[str] = None,
+    update_server_counters: bool = False,
 ) -> Subscription:
     
     end_date = datetime.utcnow() + timedelta(days=duration_days)
@@ -149,6 +150,36 @@ async def create_paid_subscription(
     await db.refresh(subscription)
     
     logger.info(f"💎 Создана платная подписка для пользователя {user_id}")
+
+    squad_uuids = list(connected_squads or [])
+    if update_server_counters and squad_uuids:
+        try:
+            from app.database.crud.server_squad import (
+                get_server_ids_by_uuids,
+                add_user_to_servers,
+            )
+
+            server_ids = await get_server_ids_by_uuids(db, squad_uuids)
+            if server_ids:
+                await add_user_to_servers(db, server_ids)
+                logger.info(
+                    "📈 Обновлен счетчик пользователей для платной подписки пользователя %s (сквады: %s)",
+                    user_id,
+                    squad_uuids,
+                )
+            else:
+                logger.warning(
+                    "⚠️ Не удалось найти серверы для обновления счетчика платной подписки пользователя %s (сквады: %s)",
+                    user_id,
+                    squad_uuids,
+                )
+        except Exception as error:
+            logger.error(
+                "⚠️ Ошибка обновления счетчика пользователей серверов для платной подписки пользователя %s: %s",
+                user_id,
+                error,
+            )
+
     return subscription
 
 

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -3286,7 +3286,8 @@ async def _grant_paid_subscription(db: AsyncSession, user_id: int, days: int, ad
             duration_days=days,
             traffic_limit_gb=settings.DEFAULT_TRAFFIC_LIMIT_GB,
             device_limit=settings.DEFAULT_DEVICE_LIMIT,
-            connected_squads=trial_squads
+            connected_squads=trial_squads,
+            update_server_counters=True,
         )
         
         subscription_service = SubscriptionService()

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -4343,7 +4343,8 @@ async def create_paid_subscription_with_traffic_mode(
         duration_days=duration_days,
         traffic_limit_gb=traffic_limit_gb,
         device_limit=device_limit,
-        connected_squads=connected_squads
+        connected_squads=connected_squads,
+        update_server_counters=False,
     )
 
     logger.info(f"📋 Создана подписка с трафиком: {traffic_limit_gb} ГБ (режим: {settings.TRAFFIC_SELECTION_MODE})")

--- a/app/services/campaign_service.py
+++ b/app/services/campaign_service.py
@@ -151,6 +151,7 @@ class AdvertisingCampaignService:
             traffic_limit_gb=traffic_limit or 0,
             device_limit=device_limit,
             connected_squads=squads,
+            update_server_counters=True,
         )
 
         try:

--- a/app/services/promocode_service.py
+++ b/app/services/promocode_service.py
@@ -135,9 +135,10 @@ class PromoCodeService:
                     db=db,
                     user_id=user.id,
                     duration_days=promocode.subscription_days,
-                    traffic_limit_gb=0, 
+                    traffic_limit_gb=0,
                     device_limit=1,
-                    connected_squads=trial_squads 
+                    connected_squads=trial_squads,
+                    update_server_counters=True,
                 )
                 
                 await self.subscription_service.create_remnawave_user(db, new_subscription)

--- a/app/webapi/routes/subscriptions.py
+++ b/app/webapi/routes/subscriptions.py
@@ -131,6 +131,7 @@ async def create_subscription(
             traffic_limit_gb=payload.traffic_limit_gb or settings.DEFAULT_TRAFFIC_LIMIT_GB,
             device_limit=payload.device_limit or settings.DEFAULT_DEVICE_LIMIT,
             connected_squads=payload.connected_squads or [],
+            update_server_counters=True,
         )
 
     subscription = await _get_subscription(db, subscription.id)


### PR DESCRIPTION
## Summary
- gate server counter updates in create_paid_subscription behind an explicit flag to avoid double increments
- opt serverless flows (promo, campaign, admin, API) into counter updates while purchase flow keeps its existing update path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ec01b2e883209c43721c9344b73f