### PR TITLE
Fix admin web API bootstrap and transaction backups

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1309,6 +1309,21 @@ class TicketMessage(Base):
         return f"<TicketMessage(id={self.id}, ticket_id={self.ticket_id}, is_admin={self.is_from_admin}, text='{self.message_text[:30]}...')>"
 
 
+class AdminUser(Base):
+    __tablename__ = "admin_users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(64), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    email = Column(String(255), nullable=True)
+    name = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    def __repr__(self) -> str:
+        return f"<AdminUser id={self.id} username='{self.username}'>"
+
+
 class WebApiToken(Base):
     __tablename__ = "web_api_tokens"
 

--- a/app/database/utils.py
+++ b/app/database/utils.py
@@ -1,0 +1,91 @@
+"""Utility helpers for database maintenance tasks."""
+
+from __future__ import annotations
+
+import logging
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+_TRANSACTION_COLUMNS_READY = False
+
+
+async def ensure_transaction_columns(db: AsyncSession) -> None:
+    """Ensure optional columns of the ``transactions`` table exist.
+
+    Older installations might miss the ``status`` or ``currency`` columns.
+    Some services (backup export, web API) rely on them, so we add them on
+    the fly if the database schema is outdated.
+    """
+
+    global _TRANSACTION_COLUMNS_READY
+
+    if _TRANSACTION_COLUMNS_READY:
+        return
+
+    conn = await db.connection()
+    dialect = conn.dialect.name
+
+    async def column_exists(column: str) -> bool:
+        if dialect == "postgresql":
+            result = await conn.scalar(
+                text(
+                    """
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_name = 'transactions' AND column_name = :column
+                    LIMIT 1
+                    """
+                ),
+                {"column": column},
+            )
+            return result is not None
+
+        if dialect == "sqlite":
+            result = await conn.execute(text("PRAGMA table_info('transactions')"))
+            return any(row[1] == column for row in result)
+
+        if dialect == "mysql":
+            result = await conn.scalar(
+                text(
+                    """
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'transactions'
+                      AND column_name = :column
+                    LIMIT 1
+                    """
+                ),
+                {"column": column},
+            )
+            return result is not None
+
+        logger.warning(
+            "Неизвестный драйвер БД %s для проверки колонок transactions", dialect
+        )
+        return True
+
+    added = False
+
+    async def ensure_column(column: str, ddl_type: str) -> None:
+        nonlocal added
+        if await column_exists(column):
+            return
+        logger.info("Добавляем колонку transactions.%s", column)
+        await conn.execute(text(f"ALTER TABLE transactions ADD COLUMN {column} {ddl_type}"))
+        added = True
+
+    try:
+        await ensure_column("status", "VARCHAR(50)")
+        await ensure_column("currency", "VARCHAR(10)")
+        if added:
+            await db.commit()
+    except Exception as error:  # pragma: no cover - defensive
+        await db.rollback()
+        logger.error("Не удалось обновить таблицу transactions: %s", error)
+        raise
+    else:
+        _TRANSACTION_COLUMNS_READY = True
+

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -27,6 +27,7 @@ from app.database.models import (
     MulenPayPayment, Pal24Payment, DiscountOffer, WebApiToken,
     server_squad_promo_groups
 )
+from app.database.utils import ensure_transaction_columns
 
 logger = logging.getLogger(__name__)
 
@@ -189,12 +190,13 @@ class BackupService:
                         logger.info(f"📊 Экспортируем таблицу: {table_name}")
                         
                         query = select(model)
-                        
+
                         if model == User:
                             query = query.options(selectinload(User.subscription))
                         elif model == Subscription:
                             query = query.options(selectinload(Subscription.user))
                         elif model == Transaction:
+                            await ensure_transaction_columns(db)
                             query = query.options(selectinload(Transaction.user))
                         
                         result = await db.execute(query)

--- a/app/webapi/routes/transactions.py
+++ b/app/webapi/routes/transactions.py
@@ -6,10 +6,11 @@ from typing import Any, Optional
 import logging
 
 from fastapi import APIRouter, Depends, Query, Security
-from sqlalchemy import and_, func, select, text
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.models import Transaction
+from app.database.utils import ensure_transaction_columns
 
 from ..dependencies import get_db_session, require_api_token
 from ..schemas.transactions import TransactionListResponse, TransactionResponse
@@ -17,75 +18,6 @@ from ..schemas.transactions import TransactionListResponse, TransactionResponse
 router = APIRouter()
 
 logger = logging.getLogger(__name__)
-
-_TRANSACTION_COLUMNS_READY = False
-
-
-async def _ensure_transaction_columns(db: AsyncSession) -> None:
-    global _TRANSACTION_COLUMNS_READY
-    if _TRANSACTION_COLUMNS_READY:
-        return
-
-    conn = await db.connection()
-    dialect = conn.dialect.name
-
-    async def column_exists(column: str) -> bool:
-        if dialect == "postgresql":
-            result = await conn.scalar(
-                text(
-                    """
-                    SELECT 1
-                    FROM information_schema.columns
-                    WHERE table_name = 'transactions' AND column_name = :column
-                    LIMIT 1
-                    """
-                ),
-                {"column": column},
-            )
-            return result is not None
-        if dialect == "sqlite":
-            result = await conn.execute(text("PRAGMA table_info('transactions')"))
-            return any(row[1] == column for row in result)
-        if dialect == "mysql":
-            result = await conn.scalar(
-                text(
-                    """
-                    SELECT 1
-                    FROM information_schema.columns
-                    WHERE table_schema = DATABASE()
-                      AND table_name = 'transactions'
-                      AND column_name = :column
-                    LIMIT 1
-                    """
-                ),
-                {"column": column},
-            )
-            return result is not None
-
-        logger.warning("Неизвестный драйвер БД %s для проверки колонок transactions", dialect)
-        return True
-
-    added = False
-
-    async def ensure_column(column: str, ddl_type: str) -> None:
-        nonlocal added
-        if await column_exists(column):
-            return
-        logger.info("Добавляем колонку transactions.%s", column)
-        await conn.execute(text(f"ALTER TABLE transactions ADD COLUMN {column} {ddl_type}"))
-        added = True
-
-    try:
-        await ensure_column("status", "VARCHAR(50)")
-        await ensure_column("currency", "VARCHAR(10)")
-        if added:
-            await db.commit()
-    except Exception as error:
-        await db.rollback()
-        logger.error("Не удалось обновить таблицу transactions: %s", error)
-        raise
-    else:
-        _TRANSACTION_COLUMNS_READY = True
 
 
 def _serialize(transaction: Transaction) -> TransactionResponse:
@@ -123,7 +55,7 @@ async def list_transactions(
     amount_max: Optional[int] = Query(default=None),
     currency: Optional[str] = Query(default=None),
 ) -> TransactionListResponse:
-    await _ensure_transaction_columns(db)
+    await ensure_transaction_columns(db)
 
     base_query = select(Transaction)
     conditions = []


### PR DESCRIPTION
## Summary
- define the AdminUser ORM model so the administrative web API can start without import failures
- add a shared helper that backfills missing transaction columns and reuse it from the web API and backup service
- call the helper before transaction exports to keep automatic backups working on outdated schemas

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68e6fb2b9cbc832081dfcd419acdc47e