### PR TITLE
Display promo level discounts in mini app

### DIFF
--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.crud.server_squad import get_server_squad_by_uuid
+from app.database.crud.promo_group import get_auto_assign_promo_groups
+from app.database.crud.transaction import get_user_total_spent_kopeks
 from app.database.crud.user import get_user_by_telegram_id
 from app.database.models import Subscription, Transaction, User
 from app.services.remnawave_service import (
@@ -26,7 +28,9 @@ from ..dependencies import get_db_session
 from ..schemas.miniapp import (
     MiniAppConnectedServer,
     MiniAppDevice,
+    MiniAppAutoPromoGroupLevel,
     MiniAppPromoGroup,
+    MiniAppPromoGroupDiscounts,
     MiniAppSubscriptionRequest,
     MiniAppSubscriptionResponse,
     MiniAppSubscriptionUser,
@@ -336,6 +340,53 @@ async def get_subscription_details(
         balance_currency = balance_currency.upper()
 
     promo_group = getattr(user, "promo_group", None)
+    total_spent_kopeks = await get_user_total_spent_kopeks(db, user.id)
+    auto_assign_groups = await get_auto_assign_promo_groups(db)
+
+    auto_promo_levels: List[MiniAppAutoPromoGroupLevel] = []
+    for group in auto_assign_groups:
+        threshold = group.auto_assign_total_spent_kopeks or 0
+        if threshold <= 0:
+            continue
+
+        period_discounts_map: Dict[int, int] = {}
+        normalized_periods: List[Tuple[int, int]] = []
+        if isinstance(group.period_discounts, dict):
+            for raw_days, raw_percent in group.period_discounts.items():
+                try:
+                    days = int(raw_days)
+                    percent = int(raw_percent)
+                except (TypeError, ValueError):
+                    continue
+
+                normalized_percent = max(0, min(100, percent))
+                if normalized_percent > 0 and days > 0:
+                    normalized_periods.append((days, normalized_percent))
+
+        if normalized_periods:
+            normalized_periods.sort(key=lambda item: item[0])
+            period_discounts_map = {days: percent for days, percent in normalized_periods}
+
+        discounts = MiniAppPromoGroupDiscounts(
+            servers_percent=max(0, group.server_discount_percent or 0),
+            traffic_percent=max(0, group.traffic_discount_percent or 0),
+            devices_percent=max(0, group.device_discount_percent or 0),
+            period_discounts=period_discounts_map,
+            applies_to_addons=bool(group.apply_discounts_to_addons),
+        )
+
+        auto_promo_levels.append(
+            MiniAppAutoPromoGroupLevel(
+                id=group.id,
+                name=group.name,
+                threshold_kopeks=threshold,
+                threshold_rubles=round(threshold / 100, 2),
+                threshold_label=settings.format_price(threshold),
+                is_reached=total_spent_kopeks >= threshold,
+                is_current=bool(promo_group and promo_group.id == group.id),
+                discounts=discounts,
+            )
+        )
 
     response_user = MiniAppSubscriptionUser(
         telegram_id=user.telegram_id,
@@ -389,6 +440,10 @@ async def get_subscription_details(
         promo_group=MiniAppPromoGroup(id=promo_group.id, name=promo_group.name)
         if promo_group
         else None,
+        auto_assign_promo_groups=auto_promo_levels,
+        total_spent_kopeks=total_spent_kopeks,
+        total_spent_rubles=round(total_spent_kopeks / 100, 2),
+        total_spent_label=settings.format_price(total_spent_kopeks),
         subscription_type="trial" if subscription.is_trial else "paid",
         autopay_enabled=bool(subscription.autopay_enabled),
         branding=settings.get_miniapp_branding(),

--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -41,6 +41,27 @@ class MiniAppPromoGroup(BaseModel):
     name: str
 
 
+class MiniAppPromoGroupDiscounts(BaseModel):
+    servers_percent: int = 0
+    traffic_percent: int = 0
+    devices_percent: int = 0
+    period_discounts: Dict[int, int] = Field(default_factory=dict)
+    applies_to_addons: bool = True
+
+
+class MiniAppAutoPromoGroupLevel(BaseModel):
+    id: int
+    name: str
+    threshold_kopeks: int
+    threshold_rubles: float
+    threshold_label: str
+    is_reached: bool = False
+    is_current: bool = False
+    discounts: MiniAppPromoGroupDiscounts = Field(
+        default_factory=MiniAppPromoGroupDiscounts
+    )
+
+
 class MiniAppConnectedServer(BaseModel):
     uuid: str
     name: str
@@ -90,6 +111,10 @@ class MiniAppSubscriptionResponse(BaseModel):
     balance_currency: Optional[str] = None
     transactions: List[MiniAppTransaction] = Field(default_factory=list)
     promo_group: Optional[MiniAppPromoGroup] = None
+    auto_assign_promo_groups: List[MiniAppAutoPromoGroupLevel] = Field(default_factory=list)
+    total_spent_kopeks: int = 0
+    total_spent_rubles: float = 0.0
+    total_spent_label: Optional[str] = None
     subscription_type: str
     autopay_enabled: bool = False
     branding: Optional[MiniAppBranding] = None

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -576,6 +576,139 @@
             text-align: right;
         }
 
+        /* Promo levels */
+        .promo-levels-card .card-content {
+            opacity: 1;
+            max-height: 2000px;
+            padding-bottom: 16px;
+        }
+
+        .promo-level-summary {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 20px 12px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .promo-level-summary-label {
+            color: var(--text-secondary);
+            font-size: 13px;
+        }
+
+        .promo-level-summary-value {
+            font-size: 16px;
+        }
+
+        .promo-level-list {
+            list-style: none;
+            padding: 0 20px 8px;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .promo-level-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            padding: 14px 16px;
+            border-radius: var(--radius);
+            border: 1px solid var(--border-color);
+            background: var(--bg-secondary);
+            transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+        }
+
+        .promo-level-item:hover {
+            border-color: rgba(var(--primary-rgb), 0.4);
+            box-shadow: var(--shadow-sm);
+            transform: translateY(-1px);
+        }
+
+        .promo-level-item.current {
+            border-color: var(--primary);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .promo-level-info {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .promo-level-discounts {
+            margin-top: 6px;
+            list-style: none;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .promo-level-discount-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .promo-level-discount-label {
+            font-weight: 600;
+        }
+
+        .promo-level-discount-value {
+            padding: 2px 8px;
+            border-radius: var(--radius-sm);
+            background: rgba(var(--primary-rgb), 0.12);
+            color: var(--text-primary);
+            font-weight: 600;
+            letter-spacing: 0.2px;
+        }
+
+        .promo-level-discount-item.is-empty {
+            justify-content: flex-start;
+            font-style: italic;
+            padding: 0;
+        }
+
+        .promo-level-name {
+            font-weight: 700;
+            color: var(--text-primary);
+            font-size: 15px;
+        }
+
+        .promo-level-threshold {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .promo-level-badge {
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+        }
+
+        .promo-level-item.current .promo-level-badge {
+            background: rgba(var(--primary-rgb), 0.18);
+            color: var(--primary);
+        }
+
+        .promo-level-item.reached .promo-level-badge {
+            background: rgba(16, 185, 129, 0.18);
+            color: var(--success);
+        }
+
+        .promo-level-item.locked .promo-level-badge {
+            background: rgba(148, 163, 184, 0.18);
+            color: var(--text-secondary);
+        }
+
         /* Balance Card */
         .balance-card {
             background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.1), rgba(var(--primary-rgb), 0.05));
@@ -1381,12 +1514,38 @@
                         <span class="info-value" id="subscriptionType">-</span>
                     </div>
                     <div class="info-item">
+                        <span class="info-label" data-i18n="info.promo_group">Promo group</span>
+                        <span class="info-value" id="promoGroupValue">-</span>
+                    </div>
+                    <div class="info-item">
                         <span class="info-label" data-i18n="info.device_limit">Device Limit</span>
                         <span class="info-value" id="deviceLimit">-</span>
                     </div>
                     <div class="info-item">
                         <span class="info-label" data-i18n="info.autopay">Auto-Pay</span>
                         <span class="info-value" id="autopayStatus">-</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Promo Levels Card -->
+            <div class="card promo-levels-card" id="promoLevelsCard">
+                <div class="card-header">
+                    <div class="card-title">
+                        <svg class="card-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm0 0v13m-4-5l4 2 4-2"/>
+                        </svg>
+                        <span data-i18n="card.promo_levels.title">Promo Levels</span>
+                    </div>
+                </div>
+                <div class="card-content">
+                    <div class="promo-level-summary">
+                        <span class="promo-level-summary-label" data-i18n="promo_levels.total_spent">Total spent</span>
+                        <span class="promo-level-summary-value" id="promoLevelsSpent">—</span>
+                    </div>
+                    <ul class="promo-level-list" id="promoLevelsList"></ul>
+                    <div class="empty-state hidden" id="promoLevelsEmpty" data-i18n="promo_levels.empty">
+                        Automatic promo levels are not configured yet
                     </div>
                 </div>
             </div>
@@ -1671,6 +1830,7 @@
                 'card.history.title': 'Transaction History',
                 'card.servers.title': 'Connected Servers',
                 'card.devices.title': 'Connected Devices',
+                'card.promo_levels.title': 'Promo Levels',
                 'apps.title': 'Installation guide',
                 'apps.no_data': 'No installation guide available for this platform yet.',
                 'apps.featured': 'Recommended',
@@ -1687,6 +1847,20 @@
                 'history.type.referral_reward': 'Referral reward',
                 'servers.empty': 'No servers connected yet',
                 'devices.empty': 'No devices connected yet',
+                'promo_levels.total_spent': 'Total spent',
+                'promo_levels.threshold': 'from {amount}',
+                'promo_levels.badge.current': 'Current level',
+                'promo_levels.badge.unlocked': 'Unlocked',
+                'promo_levels.badge.locked': 'Locked',
+                'promo_levels.empty': 'Automatic promo levels are not configured yet',
+                'promo_levels.discount.labels.servers': 'Servers',
+                'promo_levels.discount.labels.traffic': 'Traffic',
+                'promo_levels.discount.labels.devices': 'Devices',
+                'promo_levels.discount.labels.periods': 'Periods',
+                'promo_levels.discount.labels.addons': 'Add-ons',
+                'promo_levels.discount.period_entry': '{days} days: -{percent}%',
+                'promo_levels.discount.addons_disabled': 'No discount for add-ons',
+                'promo_levels.discount.none': 'Discounts are not configured yet',
                 'language.ariaLabel': 'Select interface language',
                 'notifications.copy.success': 'Subscription link copied to clipboard.',
                 'notifications.copy.failure': 'Unable to copy the subscription link automatically. Please copy it manually.',
@@ -1735,6 +1909,7 @@
                 'card.history.title': 'История операций',
                 'card.servers.title': 'Подключённые серверы',
                 'card.devices.title': 'Подключенные устройства',
+                'card.promo_levels.title': 'Уровни промогрупп',
                 'apps.title': 'Инструкция по установке',
                 'apps.no_data': 'Для этой платформы инструкция пока недоступна.',
                 'apps.featured': 'Рекомендуем',
@@ -1751,6 +1926,20 @@
                 'history.type.referral_reward': 'Реферальное вознаграждение',
                 'servers.empty': 'Подключённых серверов пока нет',
                 'devices.empty': 'Подключённых устройств пока нет',
+                'promo_levels.total_spent': 'Всего потрачено',
+                'promo_levels.threshold': 'от {amount}',
+                'promo_levels.badge.current': 'Текущий уровень',
+                'promo_levels.badge.unlocked': 'Получен',
+                'promo_levels.badge.locked': 'Недоступен',
+                'promo_levels.empty': 'Автовыдача промогрупп ещё не настроена',
+                'promo_levels.discount.labels.servers': 'Серверы',
+                'promo_levels.discount.labels.traffic': 'Трафик',
+                'promo_levels.discount.labels.devices': 'Устройства',
+                'promo_levels.discount.labels.periods': 'Периоды',
+                'promo_levels.discount.labels.addons': 'Доп. услуги',
+                'promo_levels.discount.period_entry': '{days} дн.: -{percent}%',
+                'promo_levels.discount.addons_disabled': 'Скидка не действует на доп. услуги',
+                'promo_levels.discount.none': 'Скидки не настроены',
                 'language.ariaLabel': 'Выберите язык интерфейса',
                 'notifications.copy.success': 'Ссылка подписки скопирована.',
                 'notifications.copy.failure': 'Не удалось автоматически скопировать ссылку. Пожалуйста, сделайте это вручную.',
@@ -2289,6 +2478,8 @@
                     : autopayLabel;
             }
 
+            renderPromoGroupInfo();
+            renderPromoLevels();
             renderBalanceSection();
             renderTransactionHistory();
             renderServersList();
@@ -2495,6 +2686,21 @@
             }
         }
 
+        function formatPriceFromKopeks(kopeks, currency) {
+            const normalized = typeof kopeks === 'number'
+                ? kopeks
+                : Number.parseInt(String(kopeks ?? '').trim() || '0', 10);
+            const currencyCode = currency
+                ? String(currency).toUpperCase()
+                : String(userData?.balance_currency || 'RUB').toUpperCase();
+
+            if (!Number.isFinite(normalized)) {
+                return formatCurrency(0, currencyCode);
+            }
+
+            return formatCurrency(normalized / 100, currencyCode);
+        }
+
         function formatDate(value) {
             if (!value) {
                 return '—';
@@ -2693,6 +2899,191 @@
                     </li>
                 `;
             }).join('');
+        }
+
+        function renderPromoGroupInfo() {
+            const valueElement = document.getElementById('promoGroupValue');
+            if (!valueElement) {
+                return;
+            }
+
+            const promoGroupName = userData?.promo_group?.name;
+            valueElement.textContent = promoGroupName || t('values.not_available');
+        }
+
+        function renderPromoLevels() {
+            const list = document.getElementById('promoLevelsList');
+            const emptyState = document.getElementById('promoLevelsEmpty');
+            const totalSpentElement = document.getElementById('promoLevelsSpent');
+            const card = document.getElementById('promoLevelsCard');
+
+            if (!list || !emptyState || !totalSpentElement) {
+                return;
+            }
+
+            const levels = Array.isArray(userData?.auto_assign_promo_groups)
+                ? userData.auto_assign_promo_groups
+                : [];
+
+            const totalSpentKopeksRaw = typeof userData?.total_spent_kopeks === 'number'
+                ? userData.total_spent_kopeks
+                : Number.parseInt(userData?.total_spent_kopeks ?? '0', 10);
+            const totalSpentKopeks = Number.isFinite(totalSpentKopeksRaw) ? totalSpentKopeksRaw : 0;
+            totalSpentElement.textContent = userData?.total_spent_label
+                || formatPriceFromKopeks(totalSpentKopeks);
+
+            list.innerHTML = '';
+
+            if (!levels.length) {
+                emptyState.textContent = t('promo_levels.empty');
+                emptyState.classList.remove('hidden');
+                if (card) {
+                    card.classList.add('hidden');
+                }
+                return;
+            }
+
+            if (card) {
+                card.classList.remove('hidden');
+            }
+            emptyState.classList.add('hidden');
+
+            const currencyCode = (userData?.balance_currency || 'RUB').toUpperCase();
+            const thresholdTemplate = t('promo_levels.threshold');
+
+            levels.forEach(level => {
+                const classes = ['promo-level-item'];
+                if (level?.is_current) {
+                    classes.push('current', 'reached');
+                } else if (level?.is_reached) {
+                    classes.push('reached');
+                } else {
+                    classes.push('locked');
+                }
+
+                const item = document.createElement('li');
+                item.className = classes.join(' ');
+
+                const info = document.createElement('div');
+                info.className = 'promo-level-info';
+
+                const name = document.createElement('div');
+                name.className = 'promo-level-name';
+                name.textContent = level?.name || t('values.not_available');
+                info.appendChild(name);
+
+                const threshold = document.createElement('div');
+                threshold.className = 'promo-level-threshold';
+                const thresholdLabel = level?.threshold_label
+                    || formatPriceFromKopeks(level?.threshold_kopeks, currencyCode);
+                threshold.textContent = thresholdTemplate.includes('{amount}')
+                    ? thresholdTemplate.replace('{amount}', thresholdLabel)
+                    : `${thresholdTemplate} ${thresholdLabel}`;
+                info.appendChild(threshold);
+
+                const discountsContainer = document.createElement('ul');
+                discountsContainer.className = 'promo-level-discounts';
+                const discounts = level?.discounts || {};
+
+                const appendDiscountItem = (labelKey, valueText) => {
+                    if (!valueText) {
+                        return;
+                    }
+
+                    const item = document.createElement('li');
+                    item.className = 'promo-level-discount-item';
+
+                    const label = document.createElement('span');
+                    label.className = 'promo-level-discount-label';
+                    label.textContent = t(labelKey);
+
+                    const value = document.createElement('span');
+                    value.className = 'promo-level-discount-value';
+                    value.textContent = valueText;
+
+                    item.appendChild(label);
+                    item.appendChild(value);
+                    discountsContainer.appendChild(item);
+                };
+
+                const appendPercentDiscount = (field, labelKey) => {
+                    const raw = discounts?.[field];
+                    const percent = Number.parseInt(raw, 10);
+                    if (!Number.isFinite(percent) || percent <= 0) {
+                        return;
+                    }
+                    appendDiscountItem(labelKey, `-${percent}%`);
+                };
+
+                appendPercentDiscount('servers_percent', 'promo_levels.discount.labels.servers');
+                appendPercentDiscount('traffic_percent', 'promo_levels.discount.labels.traffic');
+                appendPercentDiscount('devices_percent', 'promo_levels.discount.labels.devices');
+
+                const periodEntries = Object.entries(discounts?.period_discounts || {})
+                    .map(([days, percent]) => ({
+                        days: Number.parseInt(days, 10),
+                        percent: Number.parseInt(percent, 10),
+                    }))
+                    .filter(entry => (
+                        Number.isFinite(entry.days)
+                        && entry.days > 0
+                        && Number.isFinite(entry.percent)
+                        && entry.percent > 0
+                    ))
+                    .sort((a, b) => a.days - b.days);
+
+                if (periodEntries.length) {
+                    const periodTemplate = t('promo_levels.discount.period_entry');
+                    const periodValue = periodEntries.map(entry => {
+                        let formatted = periodTemplate;
+                        if (typeof formatted !== 'string') {
+                            formatted = '{days}: -{percent}%';
+                        }
+                        if (formatted.includes('{days}')) {
+                            formatted = formatted.replace('{days}', entry.days);
+                        }
+                        if (formatted.includes('{percent}')) {
+                            formatted = formatted.replace('{percent}', entry.percent);
+                        }
+                        if (!formatted.includes('%')) {
+                            formatted = `${formatted} -${entry.percent}%`;
+                        }
+                        return formatted;
+                    }).join(', ');
+
+                    appendDiscountItem('promo_levels.discount.labels.periods', periodValue);
+                }
+
+                if (discounts?.applies_to_addons === false) {
+                    appendDiscountItem(
+                        'promo_levels.discount.labels.addons',
+                        t('promo_levels.discount.addons_disabled'),
+                    );
+                }
+
+                if (!discountsContainer.children.length) {
+                    const emptyItem = document.createElement('li');
+                    emptyItem.className = 'promo-level-discount-item is-empty';
+                    emptyItem.textContent = t('promo_levels.discount.none');
+                    discountsContainer.appendChild(emptyItem);
+                }
+
+                info.appendChild(discountsContainer);
+
+                const badge = document.createElement('div');
+                badge.className = 'promo-level-badge';
+                let badgeKey = 'promo_levels.badge.locked';
+                if (level?.is_current) {
+                    badgeKey = 'promo_levels.badge.current';
+                } else if (level?.is_reached) {
+                    badgeKey = 'promo_levels.badge.unlocked';
+                }
+                badge.textContent = t(badgeKey);
+
+                item.appendChild(info);
+                item.appendChild(badge);
+                list.appendChild(item);
+            });
         }
 
         function getCurrentSubscriptionUrl() {


### PR DESCRIPTION
## Summary
- include detailed discount information for automatically assigned promo groups in the mini app subscription response
- render promo group discount breakdowns in the subscription UI and hide the promo levels section when no auto-assignment levels exist