### PR TITLE
Display active test access promo offers

### DIFF
--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -1,22 +1,40 @@
 from __future__ import annotations
 
 import logging
+import re
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.config import settings
-from app.database.crud.server_squad import get_server_squad_by_uuid
+from app.database.crud.discount_offer import (
+    get_latest_claimed_offer_for_user,
+    get_offer_by_id,
+    list_active_discount_offers_for_user,
+    mark_offer_claimed,
+)
 from app.database.crud.promo_group import get_auto_assign_promo_groups
+from app.database.crud.promo_offer_template import get_promo_offer_template_by_id
+from app.database.crud.server_squad import get_server_squad_by_uuid
 from app.database.crud.transaction import get_user_total_spent_kopeks
 from app.database.crud.user import get_user_by_telegram_id
-from app.database.models import PromoGroup, Subscription, Transaction, User
+from app.database.models import (
+    PromoGroup,
+    PromoOfferTemplate,
+    Subscription,
+    SubscriptionTemporaryAccess,
+    Transaction,
+    User,
+)
 from app.services.remnawave_service import (
     RemnaWaveConfigurationError,
     RemnaWaveService,
 )
+from app.services.promo_offer_service import promo_offer_service
 from app.services.subscription_service import SubscriptionService
 from app.utils.subscription_utils import get_happ_cryptolink_redirect_link
 from app.utils.telegram_webapp import (
@@ -26,10 +44,13 @@ from app.utils.telegram_webapp import (
 
 from ..dependencies import get_db_session
 from ..schemas.miniapp import (
+    MiniAppAutoPromoGroupLevel,
     MiniAppConnectedServer,
     MiniAppDevice,
-    MiniAppAutoPromoGroupLevel,
     MiniAppPromoGroup,
+    MiniAppPromoOffer,
+    MiniAppPromoOfferClaimRequest,
+    MiniAppPromoOfferClaimResponse,
     MiniAppSubscriptionRequest,
     MiniAppSubscriptionResponse,
     MiniAppSubscriptionUser,
@@ -64,6 +85,432 @@ def _format_limit_label(limit: Optional[int]) -> str:
     if not limit:
         return "Unlimited"
     return f"{limit} GB"
+
+
+_TEMPLATE_ID_PATTERN = re.compile(r"promo_template_(?P<template_id>\d+)$")
+_OFFER_TYPE_ICONS = {
+    "extend_discount": "💎",
+    "purchase_discount": "🎯",
+    "test_access": "🧪",
+}
+_EFFECT_TYPE_ICONS = {
+    "percent_discount": "🎁",
+    "test_access": "🧪",
+    "balance_bonus": "💰",
+}
+_DEFAULT_OFFER_ICON = "🎉"
+
+ActiveOfferContext = Tuple[Any, Optional[int], Optional[datetime]]
+
+
+def _extract_template_id(notification_type: Optional[str]) -> Optional[int]:
+    if not notification_type:
+        return None
+
+    match = _TEMPLATE_ID_PATTERN.match(notification_type)
+    if not match:
+        return None
+
+    try:
+        return int(match.group("template_id"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_offer_extra(offer: Any) -> Dict[str, Any]:
+    extra = getattr(offer, "extra_data", None)
+    return extra if isinstance(extra, dict) else {}
+
+
+def _extract_offer_type(offer: Any, template: Optional[PromoOfferTemplate]) -> Optional[str]:
+    extra = _extract_offer_extra(offer)
+    offer_type = extra.get("offer_type") if isinstance(extra.get("offer_type"), str) else None
+    if offer_type:
+        return offer_type
+    template_type = getattr(template, "offer_type", None)
+    return template_type if isinstance(template_type, str) else None
+
+
+def _normalize_effect_type(effect_type: Optional[str]) -> str:
+    normalized = (effect_type or "percent_discount").strip().lower()
+    if normalized == "balance_bonus":
+        return "percent_discount"
+    return normalized or "percent_discount"
+
+
+def _determine_offer_icon(offer_type: Optional[str], effect_type: str) -> str:
+    if offer_type and offer_type in _OFFER_TYPE_ICONS:
+        return _OFFER_TYPE_ICONS[offer_type]
+    if effect_type in _EFFECT_TYPE_ICONS:
+        return _EFFECT_TYPE_ICONS[effect_type]
+    return _DEFAULT_OFFER_ICON
+
+
+def _extract_offer_test_squad_uuids(offer: Any) -> List[str]:
+    extra = _extract_offer_extra(offer)
+    raw = extra.get("test_squad_uuids") or extra.get("squads") or []
+
+    if isinstance(raw, str):
+        raw = [raw]
+
+    uuids: List[str] = []
+    try:
+        for item in raw:
+            if not item:
+                continue
+            uuids.append(str(item))
+    except TypeError:
+        return []
+
+    return uuids
+
+
+def _format_offer_message(
+    template: Optional[PromoOfferTemplate],
+    offer: Any,
+    *,
+    server_name: Optional[str] = None,
+) -> Optional[str]:
+    message_template: Optional[str] = None
+
+    if template and isinstance(template.message_text, str):
+        message_template = template.message_text
+    else:
+        extra = _extract_offer_extra(offer)
+        raw_message = extra.get("message_text") or extra.get("text")
+        if isinstance(raw_message, str):
+            message_template = raw_message
+
+    if not message_template:
+        return None
+
+    extra = _extract_offer_extra(offer)
+    discount_percent = getattr(offer, "discount_percent", None)
+    try:
+        discount_percent = int(discount_percent)
+    except (TypeError, ValueError):
+        discount_percent = None
+
+    replacements: Dict[str, Any] = {}
+    if discount_percent is not None:
+        replacements.setdefault("discount_percent", discount_percent)
+
+    for key in ("valid_hours", "active_discount_hours", "test_duration_hours"):
+        value = extra.get(key)
+        if value is None and template is not None:
+            template_value = getattr(template, key, None)
+        else:
+            template_value = None
+        replacements.setdefault(key, value if value is not None else template_value)
+
+    if replacements.get("active_discount_hours") is None and template:
+        replacements["active_discount_hours"] = getattr(template, "valid_hours", None)
+
+    if replacements.get("test_duration_hours") is None and template:
+        replacements["test_duration_hours"] = getattr(template, "test_duration_hours", None)
+
+    if server_name:
+        replacements.setdefault("server_name", server_name)
+
+    for key, value in extra.items():
+        if (
+            isinstance(key, str)
+            and key not in replacements
+            and isinstance(value, (str, int, float))
+        ):
+            replacements[key] = value
+
+    try:
+        return message_template.format(**replacements)
+    except Exception:  # pragma: no cover - fallback for malformed templates
+        return message_template
+
+
+def _extract_offer_duration_hours(
+    offer: Any,
+    template: Optional[PromoOfferTemplate],
+    effect_type: str,
+) -> Optional[int]:
+    extra = _extract_offer_extra(offer)
+    if effect_type == "test_access":
+        source = extra.get("test_duration_hours")
+        if source is None and template is not None:
+            source = getattr(template, "test_duration_hours", None)
+    else:
+        source = extra.get("active_discount_hours")
+        if source is None and template is not None:
+            source = getattr(template, "active_discount_hours", None)
+
+    try:
+        if source is None:
+            return None
+        hours = int(float(source))
+        return hours if hours > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_bonus_label(amount_kopeks: int) -> Optional[str]:
+    if amount_kopeks <= 0:
+        return None
+    try:
+        return settings.format_price(amount_kopeks)
+    except Exception:  # pragma: no cover - defensive
+        return f"{amount_kopeks / 100:.2f}"
+
+
+async def _find_active_test_access_offers(
+    db: AsyncSession,
+    subscription: Optional[Subscription],
+) -> List[ActiveOfferContext]:
+    if not subscription or not getattr(subscription, "id", None):
+        return []
+
+    now = datetime.utcnow()
+    result = await db.execute(
+        select(SubscriptionTemporaryAccess)
+        .options(selectinload(SubscriptionTemporaryAccess.offer))
+        .where(
+            SubscriptionTemporaryAccess.subscription_id == subscription.id,
+            SubscriptionTemporaryAccess.is_active == True,  # noqa: E712
+            SubscriptionTemporaryAccess.expires_at > now,
+        )
+        .order_by(SubscriptionTemporaryAccess.expires_at.desc())
+    )
+
+    entries = list(result.scalars().all())
+    if not entries:
+        return []
+
+    offer_map: Dict[int, Tuple[Any, Optional[datetime]]] = {}
+    for entry in entries:
+        offer = getattr(entry, "offer", None)
+        if not offer:
+            continue
+
+        effect_type = _normalize_effect_type(getattr(offer, "effect_type", None))
+        if effect_type != "test_access":
+            continue
+
+        expires_at = getattr(entry, "expires_at", None)
+        if not expires_at or expires_at <= now:
+            continue
+
+        offer_id = getattr(offer, "id", None)
+        if not isinstance(offer_id, int):
+            continue
+
+        current = offer_map.get(offer_id)
+        if current is None:
+            offer_map[offer_id] = (offer, expires_at)
+        else:
+            _, current_expiry = current
+            if current_expiry is None or (expires_at and expires_at > current_expiry):
+                offer_map[offer_id] = (offer, expires_at)
+
+    contexts: List[ActiveOfferContext] = []
+    for offer_id, (offer, expires_at) in offer_map.items():
+        contexts.append((offer, None, expires_at))
+
+    contexts.sort(key=lambda item: item[2] or now, reverse=True)
+    return contexts
+
+
+async def _build_promo_offer_models(
+    db: AsyncSession,
+    available_offers: List[Any],
+    active_offers: Optional[List[ActiveOfferContext]],
+    *,
+    user: User,
+) -> List[MiniAppPromoOffer]:
+    promo_offers: List[MiniAppPromoOffer] = []
+    template_cache: Dict[int, Optional[PromoOfferTemplate]] = {}
+
+    candidates: List[Any] = [offer for offer in available_offers if offer]
+    active_offer_contexts: List[ActiveOfferContext] = []
+    if active_offers:
+        for offer, discount_override, expires_override in active_offers:
+            if not offer:
+                continue
+            active_offer_contexts.append((offer, discount_override, expires_override))
+            candidates.append(offer)
+
+    squad_map: Dict[str, MiniAppConnectedServer] = {}
+    if candidates:
+        all_uuids: List[str] = []
+        for offer in candidates:
+            all_uuids.extend(_extract_offer_test_squad_uuids(offer))
+        if all_uuids:
+            unique = list(dict.fromkeys(all_uuids))
+            resolved = await _resolve_connected_servers(db, unique)
+            squad_map = {server.uuid: server for server in resolved}
+
+    async def get_template(template_id: Optional[int]) -> Optional[PromoOfferTemplate]:
+        if not template_id:
+            return None
+        if template_id not in template_cache:
+            template_cache[template_id] = await get_promo_offer_template_by_id(db, template_id)
+        return template_cache[template_id]
+
+    def build_test_squads(offer: Any) -> List[MiniAppConnectedServer]:
+        test_squads: List[MiniAppConnectedServer] = []
+        for uuid in _extract_offer_test_squad_uuids(offer):
+            resolved = squad_map.get(uuid)
+            if resolved:
+                test_squads.append(
+                    MiniAppConnectedServer(uuid=resolved.uuid, name=resolved.name)
+                )
+            else:
+                test_squads.append(MiniAppConnectedServer(uuid=uuid, name=uuid))
+        return test_squads
+
+    def resolve_title(
+        offer: Any,
+        template: Optional[PromoOfferTemplate],
+        offer_type: Optional[str],
+    ) -> Optional[str]:
+        extra = _extract_offer_extra(offer)
+        if isinstance(extra.get("title"), str) and extra["title"].strip():
+            return extra["title"].strip()
+        if template and template.name:
+            return template.name
+        if offer_type:
+            return offer_type.replace("_", " ").title()
+        return None
+
+    for offer in available_offers:
+        template_id = _extract_template_id(getattr(offer, "notification_type", None))
+        template = await get_template(template_id)
+        effect_type = _normalize_effect_type(getattr(offer, "effect_type", None))
+        offer_type = _extract_offer_type(offer, template)
+        test_squads = build_test_squads(offer)
+        server_name = test_squads[0].name if test_squads else None
+        message_text = _format_offer_message(template, offer, server_name=server_name)
+        bonus_label = _format_bonus_label(int(getattr(offer, "bonus_amount_kopeks", 0) or 0))
+        discount_percent = getattr(offer, "discount_percent", 0)
+        try:
+            discount_percent = int(discount_percent)
+        except (TypeError, ValueError):
+            discount_percent = 0
+
+        extra = _extract_offer_extra(offer)
+        button_text = None
+        if isinstance(extra.get("button_text"), str) and extra["button_text"].strip():
+            button_text = extra["button_text"].strip()
+        elif template and isinstance(template.button_text, str):
+            button_text = template.button_text
+
+        promo_offers.append(
+            MiniAppPromoOffer(
+                id=int(getattr(offer, "id", 0) or 0),
+                status="pending",
+                notification_type=getattr(offer, "notification_type", None),
+                offer_type=offer_type,
+                effect_type=effect_type,
+                discount_percent=max(0, discount_percent),
+                bonus_amount_kopeks=int(getattr(offer, "bonus_amount_kopeks", 0) or 0),
+                bonus_amount_label=bonus_label,
+                expires_at=getattr(offer, "expires_at", None),
+                claimed_at=getattr(offer, "claimed_at", None),
+                is_active=bool(getattr(offer, "is_active", False)),
+                template_id=template_id,
+                template_name=getattr(template, "name", None),
+                button_text=button_text,
+                title=resolve_title(offer, template, offer_type),
+                message_text=message_text,
+                icon=_determine_offer_icon(offer_type, effect_type),
+                test_squads=test_squads,
+            )
+        )
+
+    if active_offer_contexts:
+        seen_active_ids: set[int] = set()
+        for active_offer_record, discount_override, expires_override in reversed(active_offer_contexts):
+            offer_id = int(getattr(active_offer_record, "id", 0) or 0)
+            if offer_id and offer_id in seen_active_ids:
+                continue
+            if offer_id:
+                seen_active_ids.add(offer_id)
+
+            template_id = _extract_template_id(getattr(active_offer_record, "notification_type", None))
+            template = await get_template(template_id)
+            effect_type = _normalize_effect_type(getattr(active_offer_record, "effect_type", None))
+            offer_type = _extract_offer_type(active_offer_record, template)
+            show_active = False
+            discount_value = discount_override if discount_override is not None else 0
+            if discount_value and discount_value > 0:
+                show_active = True
+            elif effect_type == "test_access":
+                show_active = True
+            if not show_active:
+                continue
+
+            test_squads = build_test_squads(active_offer_record)
+            server_name = test_squads[0].name if test_squads else None
+            message_text = _format_offer_message(
+                template,
+                active_offer_record,
+                server_name=server_name,
+            )
+            bonus_label = _format_bonus_label(
+                int(getattr(active_offer_record, "bonus_amount_kopeks", 0) or 0)
+            )
+
+            started_at = getattr(active_offer_record, "claimed_at", None)
+            expires_at = expires_override or getattr(active_offer_record, "expires_at", None)
+            duration_seconds: Optional[int] = None
+            duration_hours = _extract_offer_duration_hours(active_offer_record, template, effect_type)
+            if expires_at is None and duration_hours and started_at:
+                expires_at = started_at + timedelta(hours=duration_hours)
+            if expires_at and started_at:
+                try:
+                    duration_seconds = int((expires_at - started_at).total_seconds())
+                except Exception:  # pragma: no cover - defensive
+                    duration_seconds = None
+
+            if (discount_value is None or discount_value <= 0) and effect_type != "test_access":
+                try:
+                    discount_value = int(getattr(active_offer_record, "discount_percent", 0) or 0)
+                except (TypeError, ValueError):
+                    discount_value = 0
+            if discount_value is None:
+                discount_value = 0
+
+            extra = _extract_offer_extra(active_offer_record)
+            button_text = None
+            if isinstance(extra.get("button_text"), str) and extra["button_text"].strip():
+                button_text = extra["button_text"].strip()
+            elif template and isinstance(template.button_text, str):
+                button_text = template.button_text
+
+            promo_offers.insert(
+                0,
+                MiniAppPromoOffer(
+                    id=offer_id,
+                    status="active",
+                    notification_type=getattr(active_offer_record, "notification_type", None),
+                    offer_type=offer_type,
+                    effect_type=effect_type,
+                    discount_percent=max(0, discount_value or 0),
+                    bonus_amount_kopeks=int(getattr(active_offer_record, "bonus_amount_kopeks", 0) or 0),
+                    bonus_amount_label=bonus_label,
+                    expires_at=getattr(active_offer_record, "expires_at", None),
+                    claimed_at=started_at,
+                    is_active=False,
+                    template_id=template_id,
+                    template_name=getattr(template, "name", None),
+                    button_text=button_text,
+                    title=resolve_title(active_offer_record, template, offer_type),
+                    message_text=message_text,
+                    icon=_determine_offer_icon(offer_type, effect_type),
+                    test_squads=test_squads,
+                    active_discount_expires_at=expires_at,
+                    active_discount_started_at=started_at,
+                    active_discount_duration_seconds=duration_seconds,
+                ),
+            )
+
+    return promo_offers
 
 
 def _bytes_to_gb(bytes_value: Optional[int]) -> float:
@@ -361,6 +808,46 @@ async def get_subscription_details(
             )
         )
 
+    active_discount_percent = 0
+    try:
+        active_discount_percent = int(getattr(user, "promo_offer_discount_percent", 0) or 0)
+    except (TypeError, ValueError):
+        active_discount_percent = 0
+
+    active_discount_expires_at = getattr(user, "promo_offer_discount_expires_at", None)
+    now = datetime.utcnow()
+    if active_discount_expires_at and active_discount_expires_at <= now:
+        active_discount_expires_at = None
+        active_discount_percent = 0
+
+    available_promo_offers = await list_active_discount_offers_for_user(db, user.id)
+
+    promo_offer_source = getattr(user, "promo_offer_discount_source", None)
+    active_offer_contexts: List[ActiveOfferContext] = []
+    if promo_offer_source or active_discount_percent > 0:
+        active_discount_offer = await get_latest_claimed_offer_for_user(
+            db,
+            user.id,
+            promo_offer_source,
+        )
+        if active_discount_offer and active_discount_percent > 0:
+            active_offer_contexts.append(
+                (
+                    active_discount_offer,
+                    active_discount_percent,
+                    active_discount_expires_at,
+                )
+            )
+
+    active_offer_contexts.extend(await _find_active_test_access_offers(db, subscription))
+
+    promo_offers = await _build_promo_offer_models(
+        db,
+        available_promo_offers,
+        active_offer_contexts,
+        user=user,
+    )
+
     response_user = MiniAppSubscriptionUser(
         telegram_id=user.telegram_id,
         username=user.username,
@@ -387,6 +874,9 @@ async def get_subscription_details(
         traffic_limit_label=_format_limit_label(traffic_limit),
         lifetime_used_traffic_gb=lifetime_used,
         has_active_subscription=status_actual in {"active", "trial"},
+        promo_offer_discount_percent=active_discount_percent,
+        promo_offer_discount_expires_at=active_discount_expires_at,
+        promo_offer_discount_source=promo_offer_source,
     )
 
     return MiniAppSubscriptionResponse(
@@ -410,6 +900,7 @@ async def get_subscription_details(
         balance_rubles=round(user.balance_rubles, 2),
         balance_currency=balance_currency,
         transactions=[_serialize_transaction(tx) for tx in transactions],
+        promo_offers=promo_offers,
         promo_group=(
             MiniAppPromoGroup(
                 id=promo_group.id,
@@ -428,6 +919,151 @@ async def get_subscription_details(
         branding=settings.get_miniapp_branding(),
     )
 
+
+@router.post(
+    "/promo-offers/{offer_id}/claim",
+    response_model=MiniAppPromoOfferClaimResponse,
+)
+async def claim_promo_offer(
+    offer_id: int,
+    payload: MiniAppPromoOfferClaimRequest,
+    db: AsyncSession = Depends(get_db_session),
+) -> MiniAppPromoOfferClaimResponse:
+    try:
+        webapp_data = parse_webapp_init_data(payload.init_data, settings.BOT_TOKEN)
+    except TelegramWebAppAuthError as error:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "unauthorized", "message": str(error)},
+        ) from error
+
+    telegram_user = webapp_data.get("user")
+    if not isinstance(telegram_user, dict) or "id" not in telegram_user:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_user", "message": "Invalid Telegram user payload"},
+        )
+
+    try:
+        telegram_id = int(telegram_user["id"])
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_user", "message": "Invalid Telegram user identifier"},
+        ) from None
+
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if not user:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={"code": "user_not_found", "message": "User not found"},
+        )
+
+    offer = await get_offer_by_id(db, offer_id)
+    if not offer or offer.user_id != user.id:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={"code": "offer_not_found", "message": "Offer not found"},
+        )
+
+    now = datetime.utcnow()
+    if offer.claimed_at is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={"code": "already_claimed", "message": "Offer already claimed"},
+        )
+
+    if not offer.is_active or offer.expires_at <= now:
+        offer.is_active = False
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_410_GONE,
+            detail={"code": "offer_expired", "message": "Offer expired"},
+        )
+
+    effect_type = _normalize_effect_type(getattr(offer, "effect_type", None))
+
+    if effect_type == "test_access":
+        success, newly_added, expires_at, error_code = await promo_offer_service.grant_test_access(
+            db,
+            user,
+            offer,
+        )
+
+        if not success:
+            code = error_code or "claim_failed"
+            message_map = {
+                "subscription_missing": "Active subscription required",
+                "squads_missing": "No squads configured for test access",
+                "already_connected": "Servers already connected",
+                "remnawave_sync_failed": "Failed to apply servers",
+            }
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                detail={"code": code, "message": message_map.get(code, "Unable to activate offer")},
+            )
+
+        await mark_offer_claimed(
+            db,
+            offer,
+            details={
+                "context": "test_access_claim",
+                "new_squads": newly_added,
+                "expires_at": expires_at.isoformat() if expires_at else None,
+            },
+        )
+
+        return MiniAppPromoOfferClaimResponse(success=True, code="test_access_claimed")
+
+    discount_percent = int(getattr(offer, "discount_percent", 0) or 0)
+    if discount_percent <= 0:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_discount", "message": "Offer does not contain discount"},
+        )
+
+    user.promo_offer_discount_percent = discount_percent
+    user.promo_offer_discount_source = offer.notification_type
+    user.updated_at = now
+
+    extra_data = _extract_offer_extra(offer)
+    raw_duration = extra_data.get("active_discount_hours")
+    template_id = extra_data.get("template_id")
+
+    if raw_duration in (None, "") and template_id:
+        try:
+            template = await get_promo_offer_template_by_id(db, int(template_id))
+        except (TypeError, ValueError):
+            template = None
+        if template and template.active_discount_hours:
+            raw_duration = template.active_discount_hours
+    else:
+        template = None
+
+    try:
+        duration_hours = int(raw_duration) if raw_duration is not None else None
+    except (TypeError, ValueError):
+        duration_hours = None
+
+    if duration_hours and duration_hours > 0:
+        discount_expires_at = now + timedelta(hours=duration_hours)
+    else:
+        discount_expires_at = None
+
+    user.promo_offer_discount_expires_at = discount_expires_at
+
+    await mark_offer_claimed(
+        db,
+        offer,
+        details={
+            "context": "discount_claim",
+            "discount_percent": discount_percent,
+            "discount_expires_at": discount_expires_at.isoformat() if discount_expires_at else None,
+        },
+    )
+    await db.refresh(user)
+
+    return MiniAppPromoOfferClaimResponse(success=True, code="discount_claimed")
 def _safe_int(value: Any) -> int:
     try:
         return int(value)

--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -34,6 +34,9 @@ class MiniAppSubscriptionUser(BaseModel):
     traffic_limit_label: str
     lifetime_used_traffic_gb: float = 0.0
     has_active_subscription: bool = False
+    promo_offer_discount_percent: int = 0
+    promo_offer_discount_expires_at: Optional[datetime] = None
+    promo_offer_discount_source: Optional[str] = None
 
 
 class MiniAppPromoGroup(BaseModel):
@@ -87,6 +90,39 @@ class MiniAppTransaction(BaseModel):
     completed_at: Optional[datetime] = None
 
 
+class MiniAppPromoOffer(BaseModel):
+    id: int
+    status: str
+    notification_type: Optional[str] = None
+    offer_type: Optional[str] = None
+    effect_type: Optional[str] = None
+    discount_percent: int = 0
+    bonus_amount_kopeks: int = 0
+    bonus_amount_label: Optional[str] = None
+    expires_at: Optional[datetime] = None
+    claimed_at: Optional[datetime] = None
+    is_active: bool = False
+    template_id: Optional[int] = None
+    template_name: Optional[str] = None
+    button_text: Optional[str] = None
+    title: Optional[str] = None
+    message_text: Optional[str] = None
+    icon: Optional[str] = None
+    test_squads: List[MiniAppConnectedServer] = Field(default_factory=list)
+    active_discount_expires_at: Optional[datetime] = None
+    active_discount_started_at: Optional[datetime] = None
+    active_discount_duration_seconds: Optional[int] = None
+
+
+class MiniAppPromoOfferClaimRequest(BaseModel):
+    init_data: str = Field(..., alias="initData")
+
+
+class MiniAppPromoOfferClaimResponse(BaseModel):
+    success: bool = True
+    code: Optional[str] = None
+
+
 class MiniAppSubscriptionResponse(BaseModel):
     success: bool = True
     subscription_id: int
@@ -109,6 +145,7 @@ class MiniAppSubscriptionResponse(BaseModel):
     balance_rubles: float = 0.0
     balance_currency: Optional[str] = None
     transactions: List[MiniAppTransaction] = Field(default_factory=list)
+    promo_offers: List[MiniAppPromoOffer] = Field(default_factory=list)
     promo_group: Optional[MiniAppPromoGroup] = None
     auto_assign_promo_groups: List[MiniAppAutoPromoGroupLevel] = Field(default_factory=list)
     total_spent_kopeks: int = 0

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -397,6 +397,209 @@
             padding: 0 16px 16px;
         }
 
+        .promo-offers {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            margin-bottom: 16px;
+        }
+
+        .promo-offer-card {
+            position: relative;
+            padding: 18px;
+            border-radius: var(--radius-lg);
+            border: 1px solid rgba(var(--primary-rgb), 0.12);
+            background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.12), rgba(var(--primary-rgb), 0.04));
+            color: var(--text-primary);
+            box-shadow: var(--shadow-md);
+            overflow: hidden;
+        }
+
+        .promo-offer-card.active {
+            background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.24), rgba(var(--primary-rgb), 0.08));
+            border-color: rgba(var(--primary-rgb), 0.2);
+        }
+
+        .promo-offer-header {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+
+        .promo-offer-icon {
+            width: 44px;
+            height: 44px;
+            border-radius: 14px;
+            background: rgba(var(--primary-rgb), 0.12);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 22px;
+        }
+
+        .promo-offer-card.active .promo-offer-icon {
+            background: rgba(255, 255, 255, 0.18);
+            color: #fff;
+        }
+
+        .promo-offer-heading {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .promo-offer-title {
+            font-size: 18px;
+            font-weight: 700;
+        }
+
+        .promo-offer-subtitle {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .promo-offer-card.active .promo-offer-subtitle {
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .promo-offer-badge {
+            font-weight: 700;
+            font-size: 16px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(var(--primary-rgb), 0.16);
+            color: var(--text-primary);
+        }
+
+        .promo-offer-card.active .promo-offer-badge {
+            background: rgba(255, 255, 255, 0.2);
+            color: #fff;
+        }
+
+        .promo-offer-message {
+            font-size: 14px;
+            line-height: 1.55;
+            color: inherit;
+        }
+
+        .promo-offer-details {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 12px;
+        }
+
+        .promo-offer-chip {
+            padding: 6px 10px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            background: rgba(var(--primary-rgb), 0.15);
+            color: var(--text-primary);
+        }
+
+        .promo-offer-footer {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-top: 16px;
+            flex-wrap: wrap;
+        }
+
+        .promo-offer-timer {
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+
+        .promo-offer-card.active .promo-offer-timer {
+            color: rgba(255, 255, 255, 0.9);
+        }
+
+        .promo-offer-action {
+            margin-left: auto;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .promo-offer-btn {
+            padding: 10px 20px;
+            border-radius: var(--radius-lg);
+            border: none;
+            font-weight: 700;
+            font-size: 14px;
+            cursor: pointer;
+            background: var(--primary);
+            color: var(--tg-theme-button-text-color);
+            transition: all 0.2s ease;
+            box-shadow: var(--shadow-sm);
+        }
+
+        .promo-offer-btn:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .promo-offer-btn:disabled {
+            opacity: 0.6;
+            cursor: default;
+            box-shadow: none;
+        }
+
+        .promo-offer-progress {
+            position: relative;
+            height: 6px;
+            border-radius: 999px;
+            overflow: hidden;
+            background: rgba(var(--primary-rgb), 0.18);
+            margin-top: 12px;
+        }
+
+        .promo-offer-progress-bar {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.55));
+            transform-origin: left;
+            transition: width 0.4s ease;
+        }
+
+        .promo-offer-card:not(.active) .promo-offer-progress {
+            background: rgba(var(--primary-rgb), 0.12);
+        }
+
+        .promo-offer-card:not(.active) .promo-offer-progress-bar {
+            background: linear-gradient(90deg, rgba(var(--primary-rgb), 0.6), rgba(var(--primary-rgb), 0.3));
+        }
+
+        :root[data-theme="dark"] .promo-offer-card {
+            background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.24), rgba(255, 255, 255, 0.04));
+            border-color: rgba(255, 255, 255, 0.08);
+        }
+
+        :root[data-theme="dark"] .promo-offer-card.active {
+            background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.4), rgba(var(--primary-rgb), 0.2));
+            border-color: rgba(255, 255, 255, 0.18);
+        }
+
+        :root[data-theme="dark"] .promo-offer-icon {
+            background: rgba(255, 255, 255, 0.12);
+        }
+
+        :root[data-theme="dark"] .promo-offer-card.active .promo-offer-icon {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        :root[data-theme="dark"] .promo-offer-chip {
+            background: rgba(255, 255, 255, 0.08);
+            color: rgba(255, 255, 255, 0.9);
+        }
+
         /* User Card Specific */
         .user-card {
             background: linear-gradient(135deg, var(--bg-secondary), rgba(var(--primary-rgb), 0.05));
@@ -1407,6 +1610,19 @@
                 padding: 12px;
             }
 
+            .promo-offer-card {
+                padding: 16px;
+            }
+
+            .promo-offer-title {
+                font-size: 16px;
+            }
+
+            .promo-offer-badge {
+                font-size: 14px;
+                padding: 5px 10px;
+            }
+
             .stats-grid {
                 grid-template-columns: repeat(3, 1fr);
                 gap: 8px;
@@ -1628,6 +1844,9 @@
 
         <!-- Main Content -->
         <div id="mainContent" class="hidden">
+            <!-- Promo Offers -->
+            <div id="promoOffersContainer" class="promo-offers hidden"></div>
+
             <!-- User Card -->
             <div class="card user-card animate-in">
                 <div class="user-header">
@@ -1856,6 +2075,10 @@
             showPopup: null,
         };
 
+        let hasAnimatedCards = false;
+        let promoOfferTimers = [];
+        let promoOfferTimerHandle = null;
+
         if (typeof tg.expand === 'function') {
             tg.expand();
         }
@@ -2067,7 +2290,33 @@
                 'platform.tv': 'TV',
                 'units.gb': 'GB',
                 'values.unlimited': 'Unlimited',
-                'values.not_available': 'Not available'
+                'values.not_available': 'Not available',
+                'promo_offer.status.active': 'Active promo offer',
+                'promo_offer.status.pending': 'Special offer',
+                'promo_offer.accept': 'Activate',
+                'promo_offer.accepting': 'Activating…',
+                'promo_offer.accept.success': 'Offer activated successfully!',
+                'promo_offer.timer.active': 'Ends in {time}',
+                'promo_offer.timer.pending': 'Expires in {time}',
+                'promo_offer.timer.expired': 'Expired',
+                'promo_offer.error.offer_not_found': 'Offer not found',
+                'promo_offer.error.already_claimed': 'Offer already activated',
+                'promo_offer.error.offer_expired': 'Offer has expired',
+                'promo_offer.error.subscription_missing': 'An active subscription is required.',
+                'promo_offer.error.squads_missing': 'No servers available for this test access.',
+                'promo_offer.error.already_connected': 'Servers are already connected.',
+                'promo_offer.error.remnawave_sync_failed': 'Failed to activate servers. Try again later.',
+                'promo_offer.error.claim_failed': 'Unable to activate the offer right now.',
+                'promo_offer.error.invalid_discount': 'Offer does not contain a discount.',
+                'promo_offer.error.generic': 'Failed to activate the offer. Please try again.',
+                'promo_offer.type.extend_discount': 'Renewal discount',
+                'promo_offer.type.purchase_discount': 'Welcome back discount',
+                'promo_offer.type.test_access': 'Test access',
+                'promo_offer.type.percent_discount': 'Discount offer',
+                'time.days_short': '{value}d',
+                'time.hours_short': '{value}h',
+                'time.minutes_short': '{value}m',
+                'time.less_than_minute': '<1m'
             },
             ru: {
                 'app.title': 'Подписка VPN',
@@ -2152,7 +2401,33 @@
                 'platform.tv': 'ТВ',
                 'units.gb': 'ГБ',
                 'values.unlimited': 'Безлимит',
-                'values.not_available': 'Недоступно'
+                'values.not_available': 'Недоступно',
+                'promo_offer.status.active': 'Активное предложение',
+                'promo_offer.status.pending': 'Специальное предложение',
+                'promo_offer.accept': 'Активировать',
+                'promo_offer.accepting': 'Активируем…',
+                'promo_offer.accept.success': 'Предложение успешно активировано!',
+                'promo_offer.timer.active': 'Действует ещё {time}',
+                'promo_offer.timer.pending': 'Истекает через {time}',
+                'promo_offer.timer.expired': 'Истекло',
+                'promo_offer.error.offer_not_found': 'Предложение не найдено',
+                'promo_offer.error.already_claimed': 'Предложение уже активировано',
+                'promo_offer.error.offer_expired': 'Срок действия предложения истёк',
+                'promo_offer.error.subscription_missing': 'Нужна активная подписка.',
+                'promo_offer.error.squads_missing': 'Для тестового доступа не настроены серверы.',
+                'promo_offer.error.already_connected': 'Серверы уже подключены.',
+                'promo_offer.error.remnawave_sync_failed': 'Не удалось подключить серверы. Попробуйте позже.',
+                'promo_offer.error.claim_failed': 'Не удалось активировать предложение.',
+                'promo_offer.error.invalid_discount': 'В предложении нет скидки.',
+                'promo_offer.error.generic': 'Не удалось активировать предложение. Попробуйте позже.',
+                'promo_offer.type.extend_discount': 'Скидка на продление',
+                'promo_offer.type.purchase_discount': 'Скидка на возвращение',
+                'promo_offer.type.test_access': 'Тестовый доступ',
+                'promo_offer.type.percent_discount': 'Скидка',
+                'time.days_short': '{value}д',
+                'time.hours_short': '{value}ч',
+                'time.minutes_short': '{value}м',
+                'time.less_than_minute': '<1м'
             }
         };
 
@@ -2436,6 +2711,154 @@
             return error;
         }
 
+        function animateCardsOnce() {
+            if (hasAnimatedCards) {
+                return;
+            }
+
+            const cards = document.querySelectorAll('.card');
+            if (!cards.length) {
+                hasAnimatedCards = true;
+                return;
+            }
+
+            cards.forEach((card, index) => {
+                card.classList.remove('animate-in');
+                void card.offsetWidth;
+                setTimeout(() => {
+                    card.classList.add('animate-in');
+                }, index * 100);
+            });
+
+            hasAnimatedCards = true;
+        }
+
+        async function fetchSubscriptionPayload(initData) {
+            const response = await fetch('/miniapp/subscription', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ initData })
+            });
+
+            if (response.ok) {
+                return response.json();
+            }
+
+            let detail = response.status === 401
+                ? 'Authorization failed. Please open the mini app from Telegram.'
+                : 'Subscription not found';
+            let title = response.status === 401 ? 'Authorization Error' : 'Subscription Not Found';
+            let purchaseUrl = null;
+
+            try {
+                const errorPayload = await response.json();
+                if (errorPayload?.detail) {
+                    if (typeof errorPayload.detail === 'string') {
+                        detail = errorPayload.detail;
+                    } else if (typeof errorPayload.detail === 'object') {
+                        if (typeof errorPayload.detail.message === 'string') {
+                            detail = errorPayload.detail.message;
+                        }
+                        purchaseUrl = errorPayload.detail.purchase_url
+                            || errorPayload.detail.purchaseUrl
+                            || purchaseUrl;
+                    }
+                } else if (typeof errorPayload?.message === 'string') {
+                    detail = errorPayload.message;
+                }
+
+                if (typeof errorPayload?.title === 'string') {
+                    title = errorPayload.title;
+                }
+
+                purchaseUrl = purchaseUrl
+                    || errorPayload?.purchase_url
+                    || errorPayload?.purchaseUrl
+                    || null;
+            } catch (parseError) {
+                // ignore JSON parsing errors
+            }
+
+            const errorObject = createError(title, detail, response.status);
+            const normalizedPurchaseUrl = normalizeUrl(purchaseUrl);
+            if (normalizedPurchaseUrl) {
+                errorObject.purchaseUrl = normalizedPurchaseUrl;
+            }
+            throw errorObject;
+        }
+
+        function applySubscriptionData(payload) {
+            if (!payload || typeof payload !== 'object') {
+                return null;
+            }
+
+            userData = payload;
+            userData.subscriptionUrl = userData.subscription_url || null;
+            userData.subscriptionCryptoLink = userData.subscription_crypto_link || null;
+
+            const normalizedPurchaseUrl = normalizeUrl(
+                userData.subscription_purchase_url
+                || userData.subscriptionPurchaseUrl
+            );
+            subscriptionPurchaseUrl = normalizedPurchaseUrl;
+            userData.subscriptionPurchaseUrl = normalizedPurchaseUrl || null;
+
+            if (userData.branding) {
+                applyBrandingOverrides(userData.branding);
+            }
+
+            const responseLanguage = resolveLanguage(userData?.user?.language);
+            if (responseLanguage && !languageLockedByUser) {
+                preferredLanguage = responseLanguage;
+            }
+
+            currentErrorState = null;
+            updateErrorTexts();
+
+            const errorState = document.getElementById('errorState');
+            if (errorState) {
+                errorState.classList.add('hidden');
+            }
+
+            const loadingState = document.getElementById('loadingState');
+            if (loadingState) {
+                loadingState.classList.add('hidden');
+            }
+
+            const mainContent = document.getElementById('mainContent');
+            if (mainContent) {
+                mainContent.classList.remove('hidden');
+            }
+
+            detectPlatform();
+            setActivePlatformButton();
+            refreshAfterLanguageChange();
+
+            animateCardsOnce();
+
+            return userData;
+        }
+
+        async function refreshSubscriptionData(options = {}) {
+            const { silent = false } = options;
+            const initData = tg.initData || '';
+
+            if (!initData) {
+                throw createError('Authorization Error', 'Missing Telegram ID');
+            }
+
+            if (!silent) {
+                document.getElementById('errorState')?.classList.add('hidden');
+                document.getElementById('mainContent')?.classList.add('hidden');
+                document.getElementById('loadingState')?.classList.remove('hidden');
+            }
+
+            const payload = await fetchSubscriptionPayload(initData);
+            return applySubscriptionData(payload);
+        }
+
         async function init() {
             try {
                 const telegramUser = tg.initDataUnsafe?.user;
@@ -2449,96 +2872,7 @@
                 }
 
                 await loadAppsConfig();
-
-                const initData = tg.initData || '';
-                if (!initData) {
-                    throw createError('Authorization Error', 'Missing Telegram ID');
-                }
-
-                const response = await fetch('/miniapp/subscription', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ initData })
-                });
-
-                if (!response.ok) {
-                    let detail = response.status === 401
-                        ? 'Authorization failed. Please open the mini app from Telegram.'
-                        : 'Subscription not found';
-                    let title = response.status === 401 ? 'Authorization Error' : 'Subscription Not Found';
-                    let purchaseUrl = null;
-
-                    try {
-                        const errorPayload = await response.json();
-                        if (errorPayload?.detail) {
-                            if (typeof errorPayload.detail === 'string') {
-                                detail = errorPayload.detail;
-                            } else if (typeof errorPayload.detail === 'object') {
-                                if (typeof errorPayload.detail.message === 'string') {
-                                    detail = errorPayload.detail.message;
-                                }
-                                purchaseUrl = errorPayload.detail.purchase_url
-                                    || errorPayload.detail.purchaseUrl
-                                    || purchaseUrl;
-                            }
-                        } else if (typeof errorPayload?.message === 'string') {
-                            detail = errorPayload.message;
-                        }
-
-                        if (typeof errorPayload?.title === 'string') {
-                            title = errorPayload.title;
-                        }
-
-                        purchaseUrl = purchaseUrl
-                            || errorPayload?.purchase_url
-                            || errorPayload?.purchaseUrl
-                            || null;
-                    } catch (parseError) {
-                        // ignore
-                    }
-
-                    const errorObject = createError(title, detail, response.status);
-                    const normalizedPurchaseUrl = normalizeUrl(purchaseUrl);
-                    if (normalizedPurchaseUrl) {
-                        errorObject.purchaseUrl = normalizedPurchaseUrl;
-                    }
-                    throw errorObject;
-                }
-
-                userData = await response.json();
-                userData.subscriptionUrl = userData.subscription_url || null;
-                userData.subscriptionCryptoLink = userData.subscription_crypto_link || null;
-                subscriptionPurchaseUrl = normalizeUrl(
-                    userData.subscription_purchase_url
-                    || userData.subscriptionPurchaseUrl
-                );
-                if (subscriptionPurchaseUrl) {
-                    userData.subscriptionPurchaseUrl = subscriptionPurchaseUrl;
-                }
-                if (userData.branding) {
-                    applyBrandingOverrides(userData.branding);
-                }
-
-                const responseLanguage = resolveLanguage(userData?.user?.language);
-                if (responseLanguage && !languageLockedByUser) {
-                    preferredLanguage = responseLanguage;
-                }
-
-                detectPlatform();
-                setActivePlatformButton();
-                refreshAfterLanguageChange();
-
-                document.getElementById('loadingState').classList.add('hidden');
-                document.getElementById('mainContent').classList.remove('hidden');
-                
-                // Add animation to cards
-                document.querySelectorAll('.card').forEach((card, index) => {
-                    setTimeout(() => {
-                        card.classList.add('animate-in');
-                    }, index * 100);
-                });
+                await refreshSubscriptionData();
             } catch (error) {
                 console.error('Initialization error:', error);
                 showError(error);
@@ -2670,6 +3004,7 @@
                     : autopayLabel;
             }
 
+            renderPromoOffers();
             renderPromoSection();
             renderBalanceSection();
             renderTransactionHistory();
@@ -2677,6 +3012,499 @@
             renderDevicesList();
             updateConnectButtonLabel();
             updateActionButtons();
+        }
+
+        function resolvePromoOfferIcon(offer) {
+            if (offer?.icon && typeof offer.icon === 'string') {
+                return offer.icon;
+            }
+
+            const offerType = String(offer?.offer_type || '').toLowerCase();
+            const effectType = String(offer?.effect_type || '').toLowerCase();
+
+            if (offerType === 'extend_discount') {
+                return '💎';
+            }
+            if (offerType === 'purchase_discount') {
+                return '🎯';
+            }
+            if (offerType === 'test_access' || effectType === 'test_access') {
+                return '🧪';
+            }
+            if (effectType === 'percent_discount') {
+                return '🎁';
+            }
+            return '🎉';
+        }
+
+        function resolvePromoOfferTitle(offer) {
+            if (offer?.title) {
+                return offer.title;
+            }
+            if (offer?.template_name) {
+                return offer.template_name;
+            }
+
+            const offerType = String(offer?.offer_type || '').toLowerCase();
+            if (offerType) {
+                const key = `promo_offer.type.${offerType}`;
+                const value = t(key);
+                if (value !== key) {
+                    return value;
+                }
+            }
+
+            const effectType = String(offer?.effect_type || '').toLowerCase();
+            if (effectType) {
+                const key = `promo_offer.type.${effectType}`;
+                const value = t(key);
+                if (value !== key) {
+                    return value;
+                }
+            }
+
+            const fallbackKey = offer?.status === 'active'
+                ? 'promo_offer.status.active'
+                : 'promo_offer.status.pending';
+            const fallback = t(fallbackKey);
+            if (fallback !== fallbackKey) {
+                return fallback;
+            }
+
+            return offerType || effectType || (offer?.status === 'active' ? 'Active offer' : 'Offer');
+        }
+
+        function parseDate(value) {
+            if (!value) {
+                return null;
+            }
+
+            if (value instanceof Date) {
+                return Number.isNaN(value.getTime()) ? null : value;
+            }
+
+            let candidate = value;
+
+            if (typeof candidate === 'number') {
+                const direct = new Date(candidate);
+                if (!Number.isNaN(direct.getTime())) {
+                    return direct;
+                }
+
+                const fromSeconds = new Date(candidate * 1000);
+                return Number.isNaN(fromSeconds.getTime()) ? null : fromSeconds;
+            }
+
+            if (typeof candidate !== 'string') {
+                return null;
+            }
+
+            let normalized = candidate.trim();
+            if (!normalized) {
+                return null;
+            }
+
+            if (/^\d+$/.test(normalized)) {
+                const timestamp = Number(normalized);
+                if (Number.isFinite(timestamp)) {
+                    const millis = normalized.length === 10 ? timestamp * 1000 : timestamp;
+                    const asDate = new Date(millis);
+                    if (!Number.isNaN(asDate.getTime())) {
+                        return asDate;
+                    }
+                }
+            }
+
+            normalized = normalized.replace(' ', 'T');
+            normalized = normalized.replace('+00:00+00:00', '+00:00');
+
+            const hasTimezone = /([zZ]|[+-]\d{2}:?\d{2})$/.test(normalized);
+            if (!hasTimezone && /T\d{2}:\d{2}:\d{2}(\.\d+)?$/.test(normalized)) {
+                normalized = `${normalized}Z`;
+            }
+
+            const parsed = new Date(normalized);
+            if (!Number.isNaN(parsed.getTime())) {
+                return parsed;
+            }
+
+            return null;
+        }
+
+        function sanitizePromoOfferHtml(input) {
+            if (!input || typeof input !== 'string') {
+                return '';
+            }
+
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(`<div>${input}</div>`, 'text/html');
+            const allowedTags = new Set(['B', 'STRONG', 'I', 'EM', 'U', 'BR', 'SPAN', 'CODE', 'A']);
+            const elements = [];
+            const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null);
+            while (walker.nextNode()) {
+                elements.push(walker.currentNode);
+            }
+
+            elements.forEach(node => {
+                const tagName = node.tagName;
+                if (!allowedTags.has(tagName)) {
+                    node.replaceWith(document.createTextNode(node.textContent || ''));
+                    return;
+                }
+
+                if (tagName === 'A') {
+                    const href = node.getAttribute('href') || '';
+                    if (!/^https?:\/\//i.test(href)) {
+                        node.replaceWith(document.createTextNode(node.textContent || ''));
+                        return;
+                    }
+                    node.setAttribute('target', '_blank');
+                    node.setAttribute('rel', 'noopener noreferrer');
+                } else {
+                    Array.from(node.attributes).forEach(attr => node.removeAttribute(attr.name));
+                }
+            });
+
+            return doc.body.innerHTML.replace(/\n/g, '<br>');
+        }
+
+        function formatShortDuration(seconds) {
+            if (!Number.isFinite(seconds) || seconds <= 0) {
+                return t('time.less_than_minute');
+            }
+
+            if (seconds < 60) {
+                return t('time.less_than_minute');
+            }
+
+            const totalMinutes = Math.round(seconds / 60);
+            const days = Math.floor(totalMinutes / (60 * 24));
+            const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+            const minutes = totalMinutes % 60;
+
+            const parts = [];
+            if (days) {
+                parts.push(t('time.days_short').replace('{value}', days));
+            }
+            if (hours) {
+                parts.push(t('time.hours_short').replace('{value}', hours));
+            }
+            if (minutes || !parts.length) {
+                parts.push(t('time.minutes_short').replace('{value}', minutes || 1));
+            }
+
+            return parts.join(' ');
+        }
+
+        function registerPromoOfferTimers(timers) {
+            promoOfferTimers = timers.filter(timer => timer && timer.expiresAt instanceof Date && !Number.isNaN(timer.expiresAt.getTime()));
+            if (promoOfferTimerHandle) {
+                clearInterval(promoOfferTimerHandle);
+                promoOfferTimerHandle = null;
+            }
+
+            if (!promoOfferTimers.length) {
+                return;
+            }
+
+            const tick = () => {
+                const now = new Date();
+                promoOfferTimers = promoOfferTimers.filter(timer => {
+                    const diffSeconds = Math.floor((timer.expiresAt.getTime() - now.getTime()) / 1000);
+                    if (!Number.isFinite(diffSeconds) || diffSeconds <= 0) {
+                        timer.element.textContent = t('promo_offer.timer.expired');
+                        if (timer.progressElement) {
+                            timer.progressElement.style.width = '0%';
+                        }
+                        if (typeof timer.onExpire === 'function') {
+                            try {
+                                timer.onExpire();
+                            } catch (error) {
+                                console.warn('Failed to handle promo offer timer expire:', error);
+                            }
+                        }
+                        return false;
+                    }
+
+                    const formatted = formatShortDuration(diffSeconds);
+                    const templateKey = timer.labelKey || 'promo_offer.timer.pending';
+                    const template = t(templateKey);
+                    timer.element.textContent = template.includes('{time}')
+                        ? template.replace('{time}', formatted)
+                        : `${template} ${formatted}`;
+
+                    if (timer.progressElement && Number.isFinite(timer.totalSeconds) && timer.totalSeconds > 0) {
+                        const ratio = Math.max(0, Math.min(1, diffSeconds / timer.totalSeconds));
+                        timer.progressElement.style.width = `${ratio * 100}%`;
+                    }
+
+                    return true;
+                });
+
+                if (!promoOfferTimers.length && promoOfferTimerHandle) {
+                    clearInterval(promoOfferTimerHandle);
+                    promoOfferTimerHandle = null;
+                }
+            };
+
+            tick();
+            promoOfferTimerHandle = window.setInterval(tick, 1000);
+        }
+
+        function buildPromoOfferCard(offer, options = {}) {
+            if (!offer) {
+                return null;
+            }
+
+            const isActive = Boolean(options.isActive || String(offer.status || '').toLowerCase() === 'active');
+            const timers = options.timers || [];
+
+            const card = document.createElement('div');
+            card.className = `promo-offer-card ${isActive ? 'active' : 'pending'}`;
+
+            const header = document.createElement('div');
+            header.className = 'promo-offer-header';
+
+            const icon = document.createElement('div');
+            icon.className = 'promo-offer-icon';
+            icon.textContent = resolvePromoOfferIcon(offer);
+            header.appendChild(icon);
+
+            const heading = document.createElement('div');
+            heading.className = 'promo-offer-heading';
+
+            const title = document.createElement('div');
+            title.className = 'promo-offer-title';
+            title.textContent = resolvePromoOfferTitle(offer);
+            heading.appendChild(title);
+
+            const subtitle = document.createElement('div');
+            subtitle.className = 'promo-offer-subtitle';
+            const statusKey = isActive ? 'promo_offer.status.active' : 'promo_offer.status.pending';
+            const statusLabel = t(statusKey);
+            subtitle.textContent = statusLabel === statusKey ? (isActive ? 'Active offer' : 'Special offer') : statusLabel;
+            heading.appendChild(subtitle);
+
+            header.appendChild(heading);
+
+            const badgeText = (() => {
+                const discountValue = Number(offer.discount_percent || 0);
+                if (Number.isFinite(discountValue) && discountValue > 0) {
+                    return `-${Math.round(discountValue)}%`;
+                }
+                if (offer.bonus_amount_label) {
+                    return offer.bonus_amount_label;
+                }
+                if (String(offer.effect_type || '').toLowerCase() === 'test_access') {
+                    const label = t('promo_offer.type.test_access');
+                    return label === 'promo_offer.type.test_access' ? 'Test access' : label;
+                }
+                return null;
+            })();
+
+            if (badgeText) {
+                const badge = document.createElement('div');
+                badge.className = 'promo-offer-badge';
+                badge.textContent = badgeText;
+                header.appendChild(badge);
+            }
+
+            card.appendChild(header);
+
+            if (offer.message_text) {
+                const message = document.createElement('div');
+                message.className = 'promo-offer-message';
+                message.innerHTML = sanitizePromoOfferHtml(offer.message_text);
+                card.appendChild(message);
+            }
+
+            const details = document.createElement('div');
+            details.className = 'promo-offer-details';
+
+            if (offer.bonus_amount_label && offer.bonus_amount_label !== badgeText) {
+                const chip = document.createElement('span');
+                chip.className = 'promo-offer-chip';
+                chip.textContent = offer.bonus_amount_label;
+                details.appendChild(chip);
+            }
+
+            if (Array.isArray(offer.test_squads)) {
+                offer.test_squads.slice(0, 3).forEach(server => {
+                    if (!server) {
+                        return;
+                    }
+                    const chip = document.createElement('span');
+                    chip.className = 'promo-offer-chip';
+                    chip.textContent = server.name || server.uuid || '';
+                    details.appendChild(chip);
+                });
+            }
+
+            if (details.children.length) {
+                card.appendChild(details);
+            }
+
+            const expiresAt = parseDate(isActive ? offer.active_discount_expires_at : offer.expires_at);
+            const startedAt = isActive ? parseDate(offer.active_discount_started_at) : null;
+            let totalSeconds = Number(offer.active_discount_duration_seconds);
+            if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) {
+                totalSeconds = null;
+            }
+            if ((totalSeconds === null || totalSeconds <= 0) && expiresAt && startedAt) {
+                totalSeconds = Math.max(0, Math.floor((expiresAt.getTime() - startedAt.getTime()) / 1000));
+            }
+
+            let progressElement = null;
+            if (isActive && expiresAt) {
+                const progress = document.createElement('div');
+                progress.className = 'promo-offer-progress';
+                const bar = document.createElement('div');
+                bar.className = 'promo-offer-progress-bar';
+                progress.appendChild(bar);
+                progressElement = bar;
+                card.appendChild(progress);
+            }
+
+            const footer = document.createElement('div');
+            footer.className = 'promo-offer-footer';
+
+            const timerLabel = document.createElement('div');
+            timerLabel.className = 'promo-offer-timer';
+            footer.appendChild(timerLabel);
+
+            let button = null;
+            if (!isActive && offer.id) {
+                const action = document.createElement('div');
+                action.className = 'promo-offer-action';
+                button = document.createElement('button');
+                button.className = 'promo-offer-btn';
+                button.type = 'button';
+                button.textContent = t('promo_offer.accept');
+                button.addEventListener('click', () => handlePromoOfferAccept(offer.id, button));
+                action.appendChild(button);
+                footer.appendChild(action);
+            }
+
+            if (expiresAt) {
+                const diffSeconds = Math.floor((expiresAt.getTime() - Date.now()) / 1000);
+                if (diffSeconds > 0) {
+                    const templateKey = isActive ? 'promo_offer.timer.active' : 'promo_offer.timer.pending';
+                    const template = t(templateKey);
+                    const durationText = formatShortDuration(diffSeconds);
+                    timerLabel.textContent = template.includes('{time}')
+                        ? template.replace('{time}', durationText)
+                        : `${template} ${durationText}`;
+                } else {
+                    timerLabel.textContent = t('promo_offer.timer.expired');
+                }
+
+                timers.push({
+                    element: timerLabel,
+                    expiresAt,
+                    labelKey: isActive ? 'promo_offer.timer.active' : 'promo_offer.timer.pending',
+                    progressElement,
+                    totalSeconds,
+                    onExpire: () => {
+                        if (button) {
+                            button.disabled = true;
+                            button.textContent = t('promo_offer.timer.expired');
+                        }
+                        card.classList.add('expired');
+                    },
+                });
+            } else {
+                timerLabel.textContent = '';
+            }
+
+            if (footer.children.length) {
+                card.appendChild(footer);
+            }
+
+            return card;
+        }
+
+        function renderPromoOffers() {
+            const container = document.getElementById('promoOffersContainer');
+            if (!container) {
+                return;
+            }
+
+            const offers = Array.isArray(userData?.promo_offers) ? userData.promo_offers : [];
+
+            container.innerHTML = '';
+            const timers = [];
+            let hasContent = false;
+
+            offers.forEach(offer => {
+                const isActive = String(offer?.status || '').toLowerCase() === 'active';
+                const card = buildPromoOfferCard(offer, { isActive, timers });
+                if (card) {
+                    container.appendChild(card);
+                    hasContent = true;
+                }
+            });
+
+            container.classList.toggle('hidden', !hasContent);
+            registerPromoOfferTimers(hasContent ? timers : []);
+        }
+
+        async function handlePromoOfferAccept(offerId, button) {
+            if (!offerId) {
+                return;
+            }
+
+            const initData = tg.initData || '';
+            if (!initData) {
+                return;
+            }
+
+            const originalText = button?.textContent;
+            if (button) {
+                button.disabled = true;
+                button.textContent = t('promo_offer.accepting');
+            }
+
+            try {
+                const response = await fetch(`/miniapp/promo-offers/${offerId}/claim`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ initData }),
+                });
+
+                const payload = await response.json().catch(() => ({}));
+
+                if (!response.ok) {
+                    const code = payload?.detail?.code || payload?.code;
+                    const messageKey = code ? `promo_offer.error.${code}` : 'promo_offer.error.generic';
+                    const translated = t(messageKey);
+                    const message = translated === messageKey
+                        ? (payload?.detail?.message || t('promo_offer.error.generic'))
+                        : translated;
+                    showPopup(message);
+                    if (button) {
+                        button.disabled = false;
+                        button.textContent = originalText || t('promo_offer.accept');
+                    }
+                    return;
+                }
+
+                const successKey = payload?.code === 'test_access_claimed'
+                    ? 'promo_offer.accept.success'
+                    : 'promo_offer.accept.success';
+                const successMessage = t(successKey);
+                showPopup(successMessage === successKey ? 'Offer activated successfully!' : successMessage);
+
+                await refreshSubscriptionData({ silent: true });
+            } catch (error) {
+                console.error('Failed to activate promo offer:', error);
+                const message = t('promo_offer.error.generic');
+                showPopup(message === 'promo_offer.error.generic' ? 'Failed to activate the offer. Please try again.' : message);
+                if (button) {
+                    button.disabled = false;
+                    button.textContent = originalText || t('promo_offer.accept');
+                }
+                return;
+            }
         }
 
         function detectPlatform() {


### PR DESCRIPTION
## Summary
- surface claimed test access offers in the miniapp subscription payload by resolving active temporary access entries
- generalize promo offer rendering to handle multiple active cards and show test access activations alongside discounts