### PR TITLE
Add miniapp subscription purchase flow

### DIFF
--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -421,6 +421,138 @@ class MiniAppSubscriptionBillingContext(BaseModel):
     renews_at: Optional[datetime] = None
 
 
+class MiniAppSubscriptionPurchaseOptionsRequest(BaseModel):
+    init_data: str = Field(..., alias="initData")
+
+
+class MiniAppSubscriptionPurchaseSelection(BaseModel):
+    period_id: Optional[str] = Field(default=None, alias="periodId")
+    period_key: Optional[str] = Field(default=None, alias="periodKey")
+    period: Optional[str] = None
+    period_days: Optional[int] = Field(default=None, alias="periodDays")
+    duration_days: Optional[int] = Field(default=None, alias="durationDays")
+    months: Optional[int] = None
+    traffic_value: Optional[int] = Field(default=None, alias="trafficValue")
+    traffic_gb: Optional[int] = Field(default=None, alias="trafficGb")
+    traffic: Optional[int] = None
+    limit: Optional[int] = None
+    servers: List[str] = Field(default_factory=list)
+    server_uuids: List[str] = Field(default_factory=list, alias="serverUuids")
+    countries: List[str] = Field(default_factory=list)
+    devices: Optional[int] = None
+    device_limit: Optional[int] = Field(default=None, alias="deviceLimit")
+
+
+class MiniAppSubscriptionPurchaseOptionsResponse(BaseModel):
+    success: bool = True
+    currency: str = "RUB"
+    balance_kopeks: int = 0
+    balance_label: str = ""
+    subscription_id: Optional[int] = None
+    periods: List[Dict[str, Any]] = Field(default_factory=list)
+    traffic: Dict[str, Any] = Field(default_factory=dict)
+    servers: Dict[str, Any] = Field(default_factory=dict)
+    devices: Dict[str, Any] = Field(default_factory=dict)
+    selection: Dict[str, Any] = Field(default_factory=dict)
+    promo: Optional[Dict[str, Any]] = None
+
+
+class MiniAppSubscriptionPurchasePreviewRequest(BaseModel):
+    init_data: str = Field(..., alias="initData")
+    subscription_id: Optional[int] = Field(default=None, alias="subscriptionId")
+    selection: Optional[MiniAppSubscriptionPurchaseSelection] = None
+
+    period_id: Optional[str] = Field(default=None, alias="periodId")
+    period_key: Optional[str] = Field(default=None, alias="periodKey")
+    period: Optional[str] = None
+    period_days: Optional[int] = Field(default=None, alias="periodDays")
+    duration_days: Optional[int] = Field(default=None, alias="durationDays")
+    months: Optional[int] = None
+    traffic: Optional[int] = None
+    traffic_value: Optional[int] = Field(default=None, alias="trafficValue")
+    traffic_gb: Optional[int] = Field(default=None, alias="trafficGb")
+    limit: Optional[int] = None
+    servers: Optional[List[str]] = None
+    server_uuids: Optional[List[str]] = Field(default=None, alias="serverUuids")
+    countries: Optional[List[str]] = None
+    devices: Optional[int] = None
+    device_limit: Optional[int] = Field(default=None, alias="deviceLimit")
+
+    def build_selection(self) -> MiniAppSubscriptionPurchaseSelection:
+        data: Dict[str, Any] = {}
+        if self.selection:
+            data.update(self.selection.dict(exclude_none=True))
+
+        scalar_fields = [
+            ("period_id", self.period_id),
+            ("period_key", self.period_key),
+            ("period", self.period),
+            ("period_days", self.period_days),
+            ("duration_days", self.duration_days),
+            ("months", self.months),
+            ("traffic", self.traffic),
+            ("traffic_value", self.traffic_value),
+            ("traffic_gb", self.traffic_gb),
+            ("limit", self.limit),
+            ("devices", self.devices),
+            ("device_limit", self.device_limit),
+        ]
+
+        for field, value in scalar_fields:
+            if value is not None:
+                data[field] = value
+
+        list_fields = {
+            "servers": self.servers,
+            "countries": self.countries,
+            "server_uuids": self.server_uuids,
+        }
+
+        for field, values in list_fields.items():
+            if not values:
+                continue
+            existing = list(data.get(field) or [])
+            for value in values:
+                if value is None:
+                    continue
+                if value not in existing:
+                    existing.append(value)
+            data[field] = existing
+
+        return MiniAppSubscriptionPurchaseSelection(**data)
+
+
+class MiniAppSubscriptionPurchasePreview(BaseModel):
+    total_price_kopeks: int = 0
+    total_price_label: str = ""
+    original_price_kopeks: Optional[int] = None
+    original_price_label: Optional[str] = None
+    per_month_price_kopeks: Optional[int] = None
+    per_month_price_label: Optional[str] = None
+    discount_percent: Optional[int] = None
+    discount_label: Optional[str] = None
+    discount_lines: List[str] = Field(default_factory=list)
+    breakdown: List[Dict[str, Any]] = Field(default_factory=list)
+    balance_kopeks: int = 0
+    balance_label: str = ""
+    missing_amount_kopeks: int = 0
+    missing_amount_label: Optional[str] = None
+    can_purchase: bool = True
+    status_message: Optional[str] = None
+
+
+class MiniAppSubscriptionPurchasePreviewResponse(BaseModel):
+    success: bool = True
+    preview: MiniAppSubscriptionPurchasePreview
+
+
+class MiniAppSubscriptionPurchaseSubmitRequest(MiniAppSubscriptionPurchasePreviewRequest):
+    pass
+
+
+class MiniAppSubscriptionPurchaseSubmitResponse(BaseModel):
+    success: bool = True
+    message: Optional[str] = None
 class MiniAppSubscriptionSettings(BaseModel):
     subscription_id: int
     currency: str = "RUB"


### PR DESCRIPTION
## Summary
- add miniapp subscription purchase schemas to support selection, preview, and submission payloads
- implement purchase helpers plus options, preview, and submission endpoints for the miniapp subscription page
- handle balance checks, trial conversions, RemnaWave sync, and admin notifications when creating subscriptions