### PR TITLE
Add subscription renewal UI to mini app

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -952,6 +952,266 @@
             background: rgba(var(--danger-rgb), 0.16);
         }
 
+        .subscription-renewal-card .card-title {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .subscription-renewal-card .card-title svg {
+            width: 20px;
+            height: 20px;
+            opacity: 0.8;
+        }
+
+        .subscription-renewal-summary-chip {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-left: auto;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: var(--bg-secondary);
+            color: var(--text-secondary);
+            font-weight: 600;
+        }
+
+        .subscription-renewal-content {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .subscription-renewal-body {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .subscription-renewal-meta {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .subscription-renewal-meta-block {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            padding: 12px;
+            border-radius: var(--radius-lg);
+            background: rgba(var(--primary-rgb), 0.06);
+        }
+
+        .subscription-renewal-meta-title {
+            font-size: 12px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-meta-body {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .subscription-renewal-meta-empty {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-offer {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .subscription-renewal-offer-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(var(--primary-rgb), 0.12);
+            color: var(--primary);
+            font-size: 12px;
+            font-weight: 700;
+        }
+
+        .subscription-renewal-offer-note {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-options {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .subscription-renewal-section {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .subscription-renewal-section-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+
+        .subscription-renewal-option .subscription-settings-toggle-label {
+            gap: 8px;
+        }
+
+        .subscription-renewal-option-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: rgba(var(--primary-rgb), 0.16);
+            color: var(--primary);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            font-weight: 700;
+        }
+
+        .subscription-settings-toggle.active .subscription-renewal-option-badge {
+            background: var(--primary);
+            color: var(--tg-theme-button-text-color);
+        }
+
+        .subscription-renewal-option-price {
+            display: flex;
+            align-items: baseline;
+            gap: 8px;
+            font-size: 14px;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+
+        .subscription-renewal-option-price-current {
+            color: var(--primary);
+        }
+
+        .subscription-renewal-option-price-original {
+            font-size: 12px;
+            text-decoration: line-through;
+            color: var(--text-secondary);
+            font-weight: 600;
+        }
+
+        .subscription-renewal-option-discount {
+            font-size: 12px;
+            font-weight: 700;
+            color: var(--success);
+        }
+
+        .subscription-renewal-option-note {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 2px;
+        }
+
+        .subscription-renewal-option-description {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 6px;
+        }
+
+        .subscription-renewal-summary {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            padding: 16px;
+            border-radius: var(--radius-lg);
+            background: var(--bg-secondary);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .subscription-renewal-summary-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+        }
+
+        .subscription-renewal-summary-prices {
+            display: flex;
+            align-items: baseline;
+            gap: 8px;
+        }
+
+        .subscription-renewal-summary-label {
+            font-size: 12px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-price-current {
+            font-size: 22px;
+            font-weight: 800;
+            color: var(--text-primary);
+        }
+
+        .subscription-renewal-price-original {
+            font-size: 14px;
+            text-decoration: line-through;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-price-discount {
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--success);
+        }
+
+        .subscription-renewal-price-note {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-balance-warning {
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--danger);
+        }
+
+        .subscription-renewal-status-text {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .subscription-renewal-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        :root[data-theme="dark"] .subscription-renewal-meta-block {
+            background: rgba(var(--primary-rgb), 0.12);
+        }
+
+        :root[data-theme="dark"] .subscription-renewal-summary {
+            background: rgba(15, 23, 42, 0.65);
+        }
+
         .promo-offers {
             display: flex;
             flex-direction: column;
@@ -3749,6 +4009,67 @@
                 </div>
             </div>
 
+            <!-- Subscription Renewal -->
+            <div class="card expandable subscription-renewal-card hidden" id="subscriptionRenewalCard">
+                <div class="card-header">
+                    <div class="card-title">
+                        <svg class="card-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c1.657 0 3 1.343 3 3s-1.343 3-3 3-3-1.343-3-3 1.343-3 3-3zm0-6a1 1 0 011 1v1.07a7.002 7.002 0 015.657 5.657H20a1 1 0 110 2h-1.07a7.002 7.002 0 01-5.657 5.657V20a1 1 0 11-2 0v-1.07a7.002 7.002 0 01-5.657-5.657H4a1 1 0 110-2h1.07A7.002 7.002 0 0111 4.07V3a1 1 0 011-1z"/>
+                        </svg>
+                        <span data-i18n="subscription_renewal.title">Продление подписки</span>
+                    </div>
+                    <div class="subscription-renewal-summary-chip" id="subscriptionRenewalSummaryChip"></div>
+                    <svg class="expand-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                    </svg>
+                </div>
+                <div class="card-content">
+                    <div class="subscription-renewal-content">
+                        <div class="subscription-settings-loading hidden" id="subscriptionRenewalLoading">
+                            <div class="subscription-settings-loading-line"></div>
+                            <div class="subscription-settings-loading-line" style="width: 70%;"></div>
+                            <div class="subscription-settings-loading-line" style="width: 55%;"></div>
+                        </div>
+                        <div class="subscription-renewal-status-text hidden" id="subscriptionRenewalStatus" data-i18n="subscription_renewal.status.loading">Загружаем доступные периоды...</div>
+                        <div class="subscription-settings-error hidden" id="subscriptionRenewalError">
+                            <div id="subscriptionRenewalErrorText" data-i18n="subscription_renewal.error.generic">Не удалось загрузить параметры продления. Попробуйте позже.</div>
+                            <button class="subscription-settings-retry" id="subscriptionRenewalRetry" type="button" data-i18n="subscription_renewal.action.retry">Повторить</button>
+                        </div>
+                        <div class="subscription-renewal-body hidden" id="subscriptionRenewalBody">
+                            <div class="subscription-renewal-meta">
+                                <div class="subscription-renewal-meta-block hidden" id="subscriptionRenewalPromoGroupBlock">
+                                    <div class="subscription-renewal-meta-title" data-i18n="subscription_renewal.meta.promo_group.title">Скидки промогруппы</div>
+                                    <div class="subscription-renewal-meta-body" id="subscriptionRenewalPromoGroup"></div>
+                                </div>
+                                <div class="subscription-renewal-meta-block hidden" id="subscriptionRenewalOfferBlock">
+                                    <div class="subscription-renewal-meta-title" data-i18n="subscription_renewal.meta.promo_offer.title">Промопредложение</div>
+                                    <div class="subscription-renewal-meta-body subscription-renewal-offer" id="subscriptionRenewalOffer"></div>
+                                </div>
+                            </div>
+                            <div class="subscription-renewal-section">
+                                <div class="subscription-renewal-section-title" data-i18n="subscription_renewal.subtitle">Выберите период продления.</div>
+                                <div class="subscription-renewal-options" id="subscriptionRenewalOptions"></div>
+                            </div>
+                            <div class="subscription-renewal-summary" id="subscriptionRenewalSummary">
+                                <div class="subscription-renewal-summary-header">
+                                    <div class="subscription-renewal-summary-label" data-i18n="subscription_renewal.summary.total">Итого</div>
+                                    <div class="subscription-renewal-summary-prices">
+                                        <div class="subscription-renewal-price-original hidden" id="subscriptionRenewalPriceOriginal">—</div>
+                                        <div class="subscription-renewal-price-current" id="subscriptionRenewalPriceCurrent">—</div>
+                                    </div>
+                                </div>
+                                <div class="subscription-renewal-price-discount hidden" id="subscriptionRenewalPriceDiscount"></div>
+                                <div class="subscription-renewal-price-note hidden" id="subscriptionRenewalPriceNote"></div>
+                                <div class="subscription-renewal-balance-warning hidden" id="subscriptionRenewalBalanceWarning"></div>
+                            </div>
+                            <div class="subscription-renewal-actions">
+                                <button class="btn btn-primary" id="subscriptionRenewalSubmit" type="button" data-i18n="subscription_renewal.submit">Продлить</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Subscription Settings -->
             <div class="card expandable subscription-settings-card hidden" id="subscriptionSettingsCard">
                 <div class="card-header">
@@ -4157,6 +4478,7 @@
 
         setupSubscriptionSettingsEvents();
         setupSubscriptionPurchaseEvents();
+        setupSubscriptionRenewalEvents();
 
         const themeToggle = document.getElementById('themeToggle');
         const THEME_STORAGE_KEY = 'remnawave-miniapp-theme';
@@ -4432,6 +4754,35 @@
                 'subscription_settings.confirm.devices.decrease': 'Device limit will change to {value}. No charges apply.',
                 'subscription_settings.confirm.months.one': '{count} month',
                 'subscription_settings.confirm.months.other': '{count} months',
+                'subscription_renewal.title': 'Renew subscription',
+                'subscription_renewal.subtitle': 'Choose how long you want to extend access.',
+                'subscription_renewal.status.loading': 'Loading renewal options…',
+                'subscription_renewal.status.empty': 'No renewal options are currently available.',
+                'subscription_renewal.error.generic': 'Unable to load renewal options. Please try again later.',
+                'subscription_renewal.error.unauthorized': 'Authorization required. Please reopen the mini app from Telegram.',
+                'subscription_renewal.error.validation': 'Please select a renewal period.',
+                'subscription_renewal.action.retry': 'Try again',
+                'subscription_renewal.summary.total': 'Total',
+                'subscription_renewal.summary.per_month': '{amount} per month',
+                'subscription_renewal.summary.discount': 'You save {percent}%',
+                'subscription_renewal.summary.insufficient': 'Not enough balance — missing {missing}.',
+                'subscription_renewal.submit': 'Renew',
+                'subscription_renewal.submit.loading': 'Processing…',
+                'subscription_renewal.confirm.title': 'Confirm renewal',
+                'subscription_renewal.confirm.message': 'Renew the subscription for {period} and pay {amount}?',
+                'subscription_renewal.confirm.balance': 'Current balance: {balance}',
+                'subscription_renewal.confirm.accept': 'Pay',
+                'subscription_renewal.confirm.cancel': 'Cancel',
+                'subscription_renewal.success': 'Subscription renewed successfully.',
+                'subscription_renewal.badge.recommended': 'Recommended',
+                'subscription_renewal.period.days': '{count} days',
+                'subscription_renewal.period.month_one': '{count} month',
+                'subscription_renewal.period.month_other': '{count} months',
+                'subscription_renewal.meta.promo_group.title': 'Promo group discounts',
+                'subscription_renewal.meta.promo_group.empty': 'No extra discounts',
+                'subscription_renewal.meta.promo_offer.title': 'Promo offer',
+                'subscription_renewal.meta.promo_offer.active': 'Extra discount {percent}%',
+                'subscription_renewal.meta.promo_offer.until': 'Valid until {date}',
                 'promo_code.title': 'Activate promo code',
                 'promo_code.subtitle': 'Enter a promo code to unlock rewards instantly.',
                 'promo_code.placeholder': 'Enter promo code',
@@ -4758,6 +5109,35 @@
                 'subscription_settings.confirm.devices.decrease': 'Лимит устройств изменится на {value}. Дополнительная оплата не требуется.',
                 'subscription_settings.confirm.months.one': '{count} месяц',
                 'subscription_settings.confirm.months.other': '{count} месяцев',
+                'subscription_renewal.title': 'Продление подписки',
+                'subscription_renewal.subtitle': 'Выберите период продления.',
+                'subscription_renewal.status.loading': 'Загружаем доступные периоды…',
+                'subscription_renewal.status.empty': 'Доступных периодов продления нет.',
+                'subscription_renewal.error.generic': 'Не удалось загрузить параметры продления. Попробуйте позже.',
+                'subscription_renewal.error.unauthorized': 'Требуется авторизация. Откройте мини-приложение из Telegram.',
+                'subscription_renewal.error.validation': 'Выберите период продления.',
+                'subscription_renewal.action.retry': 'Повторить',
+                'subscription_renewal.summary.total': 'Итого',
+                'subscription_renewal.summary.per_month': '{amount} в месяц',
+                'subscription_renewal.summary.discount': 'Выгода {percent}%',
+                'subscription_renewal.summary.insufficient': 'Недостаточно средств — не хватает {missing}.',
+                'subscription_renewal.submit': 'Продлить',
+                'subscription_renewal.submit.loading': 'Продление…',
+                'subscription_renewal.confirm.title': 'Подтвердите продление',
+                'subscription_renewal.confirm.message': 'Продлить подписку на {period} и списать {amount}?',
+                'subscription_renewal.confirm.balance': 'Текущий баланс: {balance}',
+                'subscription_renewal.confirm.accept': 'Оплатить',
+                'subscription_renewal.confirm.cancel': 'Отмена',
+                'subscription_renewal.success': 'Подписка успешно продлена.',
+                'subscription_renewal.badge.recommended': 'Рекомендуем',
+                'subscription_renewal.period.days': '{count} дней',
+                'subscription_renewal.period.month_one': '{count} месяц',
+                'subscription_renewal.period.month_other': '{count} месяцев',
+                'subscription_renewal.meta.promo_group.title': 'Скидки промогруппы',
+                'subscription_renewal.meta.promo_group.empty': 'Дополнительных скидок нет',
+                'subscription_renewal.meta.promo_offer.title': 'Промопредложение',
+                'subscription_renewal.meta.promo_offer.active': 'Дополнительная скидка {percent}%',
+                'subscription_renewal.meta.promo_offer.until': 'Действует до {date}',
                 'promo_code.title': 'Активировать промокод',
                 'promo_code.subtitle': 'Введите промокод и сразу получите бонусы.',
                 'promo_code.placeholder': 'Введите промокод',
@@ -5066,6 +5446,15 @@
             trafficValue: null,
             servers: new Set(),
             devices: null,
+        };
+
+        let subscriptionRenewalData = null;
+        let subscriptionRenewalPromise = null;
+        let subscriptionRenewalError = null;
+        let subscriptionRenewalLoading = false;
+        let subscriptionRenewalSubmitting = false;
+        const subscriptionRenewalSelection = {
+            periodId: null,
         };
 
         const PAYMENT_STATUS_INITIAL_DELAY_MS = 2000;
@@ -5904,6 +6293,9 @@
             userData.subscriptionCryptoLink = userData.subscription_crypto_link || null;
             userData.referral = userData.referral || null;
 
+            resetSubscriptionRenewalState(null);
+            prepareSubscriptionRenewalFromUserData();
+
             const normalizedPurchaseUrl = normalizeUrl(
                 userData.subscription_purchase_url
                 || userData.subscriptionPurchaseUrl
@@ -6111,6 +6503,7 @@
             }
 
             renderSubscriptionPurchaseCard();
+            renderSubscriptionRenewalCard();
             renderSubscriptionSettingsCard();
             renderPromoOffers();
             renderPromoSection();
@@ -10047,6 +10440,1056 @@
                     current: currentDeviceLimit,
                 },
             };
+        }
+
+        function resetSubscriptionRenewalSelection(data) {
+            if (!data || !Array.isArray(data.periods)) {
+                subscriptionRenewalSelection.periodId = null;
+                return;
+            }
+
+            const defaultId = data.defaultPeriodId ? String(data.defaultPeriodId) : null;
+            if (defaultId && data.periods.some(option => option?.id === defaultId)) {
+                subscriptionRenewalSelection.periodId = defaultId;
+                return;
+            }
+
+            const first = data.periods.find(option => option && option.id);
+            subscriptionRenewalSelection.periodId = first ? String(first.id) : null;
+        }
+
+        function resetSubscriptionRenewalState(data = null) {
+            subscriptionRenewalData = data;
+            subscriptionRenewalPromise = null;
+            subscriptionRenewalError = null;
+            subscriptionRenewalLoading = false;
+            subscriptionRenewalSubmitting = false;
+            if (data) {
+                resetSubscriptionRenewalSelection(data);
+            } else {
+                subscriptionRenewalSelection.periodId = null;
+            }
+        }
+
+        function normalizeRenewalPromoOffer(source) {
+            if (source && typeof source === 'object') {
+                const percent = coercePositiveInt(
+                    source.percent
+                        ?? source.discount_percent
+                        ?? source.discountPercent
+                        ?? source.value,
+                    null,
+                );
+                if (percent !== null) {
+                    const rawExpires = source.expires_at
+                        ?? source.expiresAt
+                        ?? source.valid_until
+                        ?? source.validUntil
+                        ?? null;
+                    const expiresAt = parseDate(rawExpires);
+                    return {
+                        percent,
+                        expiresAt,
+                        title: source.title || null,
+                        message: source.message || source.subtitle || null,
+                    };
+                }
+            }
+
+            const percent = coercePositiveInt(
+                userData?.user?.promo_offer_discount_percent
+                    ?? userData?.promo_offer_discount_percent,
+                null,
+            );
+            if (percent === null) {
+                return null;
+            }
+
+            const expiresAt = parseDate(
+                userData?.user?.promo_offer_discount_expires_at
+                    ?? userData?.promo_offer_discount_expires_at
+                    ?? null,
+            );
+
+            return {
+                percent,
+                expiresAt,
+            };
+        }
+
+        function normalizeRenewalOption(option, context = {}) {
+            if (!option || typeof option !== 'object') {
+                return null;
+            }
+
+            const currency = (context.currency || userData?.balance_currency || 'RUB').toString().toUpperCase();
+            const idCandidate = option.id
+                ?? option.period_id
+                ?? option.periodId
+                ?? option.key
+                ?? option.code
+                ?? null;
+            const days = coercePositiveInt(
+                option.days
+                    ?? option.period_days
+                    ?? option.periodDays
+                    ?? option.duration_days
+                    ?? option.durationDays,
+                null,
+            );
+            const months = coercePositiveInt(
+                option.months
+                    ?? option.period_months
+                    ?? option.periodMonths,
+                null,
+            );
+            const priceKopeks = coercePositiveInt(
+                option.price_kopeks
+                    ?? option.priceKopeks
+                    ?? option.price
+                    ?? option.amount_kopeks
+                    ?? option.amountKopeks,
+                null,
+            );
+            const originalPriceKopeks = coercePositiveInt(
+                option.original_price_kopeks
+                    ?? option.originalPriceKopeks
+                    ?? option.original_price
+                    ?? option.base_price_kopeks
+                    ?? option.basePriceKopeks,
+                null,
+            );
+            const priceLabel = option.price_label ?? option.priceLabel ?? null;
+            const originalPriceLabel = option.original_price_label
+                ?? option.originalPriceLabel
+                ?? option.base_price_label
+                ?? option.basePriceLabel
+                ?? null;
+            const discountPercent = coercePositiveInt(
+                option.discount_percent ?? option.discountPercent ?? option.discount ?? null,
+                null,
+            );
+            const perMonthKopeks = coercePositiveInt(
+                option.per_month_kopeks
+                    ?? option.perMonthKopeks
+                    ?? option.price_per_month_kopeks
+                    ?? null,
+                null,
+            );
+            const perMonthLabel = option.per_month_label
+                ?? option.perMonthLabel
+                ?? option.price_per_month_label
+                ?? null;
+            const isRecommended = coerceBoolean(
+                option.is_recommended ?? option.isRecommended ?? option.recommended,
+                false,
+            );
+            const description = option.description ?? option.subtitle ?? null;
+            const badge = option.badge || null;
+            const title = option.title ?? option.label ?? null;
+
+            const id = idCandidate != null
+                ? String(idCandidate)
+                : (days !== null ? `days:${days}` : null);
+            if (!id) {
+                return null;
+            }
+
+            let resolvedPriceLabel = priceLabel;
+            if (!resolvedPriceLabel && priceKopeks !== null) {
+                resolvedPriceLabel = formatPriceFromKopeks(priceKopeks, currency);
+            }
+
+            let resolvedOriginalLabel = originalPriceLabel;
+            if (!resolvedOriginalLabel && originalPriceKopeks !== null) {
+                resolvedOriginalLabel = formatPriceFromKopeks(originalPriceKopeks, currency);
+            }
+
+            let resolvedPerMonthLabel = perMonthLabel;
+            if (!resolvedPerMonthLabel && perMonthKopeks !== null) {
+                resolvedPerMonthLabel = formatPriceFromKopeks(perMonthKopeks, currency);
+            }
+
+            return {
+                id,
+                days,
+                months: months ?? (days ? Math.round(days / 30) : null),
+                priceKopeks,
+                priceLabel: resolvedPriceLabel,
+                originalPriceKopeks,
+                originalPriceLabel: resolvedOriginalLabel,
+                discountPercent,
+                pricePerMonthKopeks: perMonthKopeks,
+                pricePerMonthLabel: resolvedPerMonthLabel,
+                isRecommended,
+                description,
+                badge,
+                title,
+            };
+        }
+
+        function normalizeSubscriptionRenewal(payload) {
+            if (!payload || typeof payload !== 'object') {
+                return null;
+            }
+
+            const root = payload.renewal
+                || payload.data
+                || payload.options
+                || payload;
+            if (!root || typeof root !== 'object') {
+                return null;
+            }
+
+            const currency = (root.currency
+                ?? payload.currency
+                ?? userData?.balance_currency
+                ?? 'RUB').toString().toUpperCase();
+
+            const subscriptionId = coercePositiveInt(
+                root.subscription_id
+                    ?? root.subscriptionId
+                    ?? payload.subscription_id
+                    ?? payload.subscriptionId
+                    ?? userData?.subscription_id
+                    ?? userData?.subscriptionId,
+                null,
+            );
+
+            const balanceKopeks = coercePositiveInt(
+                root.balance_kopeks
+                    ?? root.balanceKopeks
+                    ?? payload.balance_kopeks
+                    ?? payload.balanceKopeks
+                    ?? userData?.balance_kopeks,
+                null,
+            );
+            const balanceLabel = root.balance_label
+                ?? root.balanceLabel
+                ?? payload.balance_label
+                ?? payload.balanceLabel
+                ?? (balanceKopeks !== null ? formatPriceFromKopeks(balanceKopeks, currency) : '');
+
+            const periodsRaw = ensureArray(
+                root.periods
+                    ?? root.options
+                    ?? root.available
+                    ?? root.renewal_options
+                    ?? root.renewalOptions
+                    ?? [],
+            );
+            const periods = periodsRaw
+                .map(option => normalizeRenewalOption(option, { currency }))
+                .filter(Boolean);
+
+            const defaultPeriodIdRaw = root.default_period_id
+                ?? root.defaultPeriodId
+                ?? root.default_option_id
+                ?? root.defaultOptionId
+                ?? null;
+            const defaultPeriodId = defaultPeriodIdRaw != null ? String(defaultPeriodIdRaw) : null;
+
+            const missingAmountKopeks = coercePositiveInt(
+                root.missing_amount_kopeks
+                    ?? root.missingAmountKopeks
+                    ?? null,
+                null,
+            );
+
+            const statusMessage = root.status_message
+                ?? root.statusMessage
+                ?? root.message
+                ?? null;
+
+            const promoGroup = root.promo_group
+                ?? root.promoGroup
+                ?? userData?.promo_group
+                ?? null;
+
+            const promoOffer = normalizeRenewalPromoOffer(root.promo_offer ?? root.promoOffer);
+
+            return {
+                subscriptionId,
+                currency,
+                balanceKopeks,
+                balanceLabel,
+                periods,
+                defaultPeriodId: defaultPeriodId || (periods.length ? periods[0].id : null),
+                promoGroup,
+                promoOffer,
+                missingAmountKopeks,
+                statusMessage,
+            };
+        }
+
+        function prepareSubscriptionRenewalFromUserData() {
+            const candidates = [
+                userData?.subscription_renewal,
+                userData?.subscriptionRenewal,
+                userData?.renewal,
+                userData?.renewal_options,
+                userData?.renewalOptions,
+            ];
+
+            for (const candidate of candidates) {
+                const normalized = normalizeSubscriptionRenewal(candidate);
+                if (normalized && Array.isArray(normalized.periods) && normalized.periods.length) {
+                    subscriptionRenewalData = normalized;
+                    resetSubscriptionRenewalSelection(normalized);
+                    return;
+                }
+            }
+
+            resetSubscriptionRenewalSelection(null);
+        }
+
+        function extractRenewalError(payload, status) {
+            if (status === 401) {
+                return t('subscription_renewal.error.unauthorized');
+            }
+            if (!payload || typeof payload !== 'object') {
+                return t('subscription_renewal.error.generic');
+            }
+            if (typeof payload.detail === 'string') {
+                return payload.detail;
+            }
+            if (payload.detail && typeof payload.detail === 'object') {
+                if (typeof payload.detail.message === 'string') {
+                    return payload.detail.message;
+                }
+                if (typeof payload.detail.error === 'string') {
+                    return payload.detail.error;
+                }
+            }
+            if (typeof payload.message === 'string') {
+                return payload.message;
+            }
+            if (typeof payload.error === 'string') {
+                return payload.error;
+            }
+            return t('subscription_renewal.error.generic');
+        }
+
+        function resolveRenewalErrorMessage(error, fallbackKey = 'subscription_renewal.error.generic') {
+            if (!error) {
+                return t(fallbackKey);
+            }
+            if (typeof error === 'string') {
+                return error;
+            }
+            if (typeof error.message === 'string' && error.message.trim()) {
+                return error.message;
+            }
+            if (error.detail) {
+                if (typeof error.detail === 'string' && error.detail.trim()) {
+                    return error.detail;
+                }
+                if (typeof error.detail.message === 'string' && error.detail.message.trim()) {
+                    return error.detail.message;
+                }
+            }
+            if (error.status === 401) {
+                return t('subscription_renewal.error.unauthorized');
+            }
+            return t(fallbackKey);
+        }
+
+        function ensureSubscriptionRenewalData(options = {}) {
+            const { force = false } = options;
+
+            if (!hasPaidSubscription()) {
+                resetSubscriptionRenewalState(null);
+                renderSubscriptionRenewalCard();
+                return Promise.resolve(null);
+            }
+
+            if (!force) {
+                if (subscriptionRenewalPromise) {
+                    return subscriptionRenewalPromise;
+                }
+                if (subscriptionRenewalData && !subscriptionRenewalError) {
+                    return Promise.resolve(subscriptionRenewalData);
+                }
+            }
+
+            const inlineNormalized = options.inline ? normalizeSubscriptionRenewal(options.inline) : null;
+            if (!force && inlineNormalized && inlineNormalized.periods.length) {
+                subscriptionRenewalData = inlineNormalized;
+                subscriptionRenewalError = null;
+                subscriptionRenewalLoading = false;
+                resetSubscriptionRenewalSelection(inlineNormalized);
+                renderSubscriptionRenewalCard();
+                return Promise.resolve(inlineNormalized);
+            }
+
+            const initData = tg.initData || '';
+            if (!initData) {
+                const error = createError('Authorization Error', t('subscription_renewal.error.unauthorized'));
+                subscriptionRenewalError = error;
+                subscriptionRenewalLoading = false;
+                renderSubscriptionRenewalCard();
+                return Promise.reject(error);
+            }
+
+            subscriptionRenewalLoading = true;
+            subscriptionRenewalError = null;
+            renderSubscriptionRenewalCard();
+
+            const payload = {
+                initData,
+                subscription_id: userData?.subscription_id ?? userData?.subscriptionId ?? null,
+                subscriptionId: userData?.subscription_id ?? userData?.subscriptionId ?? null,
+            };
+
+            const request = fetch('/miniapp/subscription/renewal/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            }).then(async response => {
+                const body = await parseJsonSafe(response);
+                if (!response.ok || (body && body.success === false)) {
+                    const message = extractRenewalError(body, response.status);
+                    throw createError('Subscription renewal error', message, response.status);
+                }
+                const normalized = normalizeSubscriptionRenewal(body);
+                subscriptionRenewalData = normalized;
+                subscriptionRenewalError = null;
+                subscriptionRenewalLoading = false;
+                subscriptionRenewalPromise = null;
+                resetSubscriptionRenewalSelection(normalized);
+                renderSubscriptionRenewalCard();
+                return normalized;
+            }).catch(error => {
+                subscriptionRenewalError = error;
+                subscriptionRenewalLoading = false;
+                subscriptionRenewalPromise = null;
+                renderSubscriptionRenewalCard();
+                throw error;
+            });
+
+            subscriptionRenewalPromise = request;
+            return request;
+        }
+
+        function buildRenewalPeriodLabel(option) {
+            if (!option) {
+                return '';
+            }
+            if (option.title) {
+                return option.title;
+            }
+
+            const months = coercePositiveInt(option.months, null);
+            if (months && months > 0) {
+                const key = months === 1
+                    ? 'subscription_renewal.period.month_one'
+                    : 'subscription_renewal.period.month_other';
+                const template = t(key);
+                if (template && template !== key && template.includes('{count}')) {
+                    return template.replace('{count}', String(months));
+                }
+                return `${months} mo`;
+            }
+
+            const days = coercePositiveInt(option.days, null);
+            if (days && days > 0) {
+                const template = t('subscription_renewal.period.days');
+                if (template && template !== 'subscription_renewal.period.days' && template.includes('{count}')) {
+                    return template.replace('{count}', String(days));
+                }
+                return `${days} days`;
+            }
+
+            return option.id || '';
+        }
+
+        function renderSubscriptionRenewalSummaryChip(data) {
+            const container = document.getElementById('subscriptionRenewalSummaryChip');
+            if (!container) {
+                return;
+            }
+            container.innerHTML = '';
+
+            if (!data) {
+                container.classList.add('hidden');
+                return;
+            }
+
+            const option = data.periods?.find(entry => entry?.id === subscriptionRenewalSelection.periodId) || null;
+            if (!option) {
+                container.classList.add('hidden');
+                return;
+            }
+
+            const periodLabel = buildRenewalPeriodLabel(option);
+            const amountLabel = option.priceLabel
+                || (option.priceKopeks !== null ? formatPriceFromKopeks(option.priceKopeks, data.currency) : null);
+
+            if (periodLabel) {
+                const chip = document.createElement('div');
+                chip.className = 'subscription-renewal-chip';
+                chip.textContent = periodLabel;
+                container.appendChild(chip);
+            }
+
+            if (amountLabel) {
+                const chip = document.createElement('div');
+                chip.className = 'subscription-renewal-chip';
+                chip.textContent = amountLabel;
+                container.appendChild(chip);
+            }
+
+            container.classList.toggle('hidden', container.children.length === 0);
+        }
+
+        function renderSubscriptionRenewalMeta(data) {
+            const promoBlock = document.getElementById('subscriptionRenewalPromoGroupBlock');
+            const promoContainer = document.getElementById('subscriptionRenewalPromoGroup');
+            if (promoBlock && promoContainer) {
+                promoContainer.innerHTML = '';
+                const hasDiscounts = populatePromoDiscounts(promoContainer, data?.promoGroup, { showEmptyMessage: false });
+                if (!hasDiscounts) {
+                    const template = t('subscription_renewal.meta.promo_group.empty');
+                    if (template && template !== 'subscription_renewal.meta.promo_group.empty') {
+                        const empty = document.createElement('span');
+                        empty.className = 'subscription-renewal-meta-empty';
+                        empty.textContent = template;
+                        promoContainer.appendChild(empty);
+                        promoBlock.classList.remove('hidden');
+                    } else {
+                        promoBlock.classList.add('hidden');
+                    }
+                } else {
+                    promoBlock.classList.remove('hidden');
+                }
+            }
+
+            const offerBlock = document.getElementById('subscriptionRenewalOfferBlock');
+            const offerContainer = document.getElementById('subscriptionRenewalOffer');
+            if (offerBlock && offerContainer) {
+                offerContainer.innerHTML = '';
+                const offer = data?.promoOffer || null;
+                if (offer && Number.isFinite(offer.percent) && offer.percent > 0) {
+                    const badge = document.createElement('div');
+                    badge.className = 'subscription-renewal-offer-badge';
+                    const template = t('subscription_renewal.meta.promo_offer.active');
+                    badge.textContent = template && template !== 'subscription_renewal.meta.promo_offer.active'
+                        ? template.replace('{percent}', `${offer.percent}%`)
+                        : `Extra discount ${offer.percent}%`;
+                    offerContainer.appendChild(badge);
+
+                    if (offer.message) {
+                        const message = document.createElement('div');
+                        message.className = 'subscription-renewal-offer-note';
+                        message.textContent = offer.message;
+                        offerContainer.appendChild(message);
+                    }
+
+                    if (offer.expiresAt) {
+                        const formatted = formatDateTime(offer.expiresAt) || formatDate(offer.expiresAt);
+                        if (formatted) {
+                            const expiresTemplate = t('subscription_renewal.meta.promo_offer.until');
+                            const expiresText = expiresTemplate && expiresTemplate !== 'subscription_renewal.meta.promo_offer.until'
+                                ? expiresTemplate.replace('{date}', formatted)
+                                : `Valid until ${formatted}`;
+                            const note = document.createElement('div');
+                            note.className = 'subscription-renewal-offer-note';
+                            note.textContent = expiresText;
+                            offerContainer.appendChild(note);
+                        }
+                    }
+
+                    offerBlock.classList.remove('hidden');
+                } else {
+                    offerBlock.classList.add('hidden');
+                }
+            }
+        }
+
+        function renderSubscriptionRenewalOptions(data) {
+            const container = document.getElementById('subscriptionRenewalOptions');
+            if (!container) {
+                return;
+            }
+            container.innerHTML = '';
+
+            const options = ensureArray(data?.periods);
+            if (!options.length) {
+                const statusText = document.getElementById('subscriptionRenewalStatus');
+                if (statusText) {
+                    const template = t('subscription_renewal.status.empty');
+                    statusText.textContent = template && template !== 'subscription_renewal.status.empty'
+                        ? template
+                        : 'No renewal options are currently available.';
+                    statusText.classList.remove('hidden');
+                }
+                renderSubscriptionRenewalSummary(data);
+                renderSubscriptionRenewalSummaryChip(data);
+                return;
+            }
+
+            const statusText = document.getElementById('subscriptionRenewalStatus');
+            statusText?.classList.add('hidden');
+
+            const selectedId = subscriptionRenewalSelection.periodId;
+
+            options.forEach(option => {
+                if (!option) {
+                    return;
+                }
+
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'subscription-settings-toggle subscription-renewal-option';
+                if (option.id === selectedId) {
+                    button.classList.add('active');
+                }
+                if (subscriptionRenewalSubmitting) {
+                    button.disabled = true;
+                }
+
+                const label = document.createElement('div');
+                label.className = 'subscription-settings-toggle-label';
+
+                if (option.isRecommended || option.badge) {
+                    const badge = document.createElement('div');
+                    badge.className = 'subscription-renewal-option-badge';
+                    if (option.badge && typeof option.badge === 'string') {
+                        badge.textContent = option.badge;
+                    } else {
+                        const template = t('subscription_renewal.badge.recommended');
+                        badge.textContent = template && template !== 'subscription_renewal.badge.recommended'
+                            ? template
+                            : 'Recommended';
+                    }
+                    label.appendChild(badge);
+                }
+
+                const title = document.createElement('div');
+                title.className = 'subscription-settings-toggle-title';
+                title.textContent = buildRenewalPeriodLabel(option);
+                label.appendChild(title);
+
+                if (option.description) {
+                    const description = document.createElement('div');
+                    description.className = 'subscription-renewal-option-description';
+                    description.textContent = option.description;
+                    label.appendChild(description);
+                }
+
+                const meta = document.createElement('div');
+                meta.className = 'subscription-settings-toggle-meta';
+
+                const priceRow = document.createElement('div');
+                priceRow.className = 'subscription-renewal-option-price';
+
+                if (option.priceLabel) {
+                    const current = document.createElement('span');
+                    current.className = 'subscription-renewal-option-price-current';
+                    current.textContent = option.priceLabel;
+                    priceRow.appendChild(current);
+                } else if (option.priceKopeks !== null) {
+                    const current = document.createElement('span');
+                    current.className = 'subscription-renewal-option-price-current';
+                    current.textContent = formatPriceFromKopeks(option.priceKopeks, data.currency);
+                    priceRow.appendChild(current);
+                }
+
+                const showOriginal = Boolean(option.originalPriceLabel && option.originalPriceLabel !== option.priceLabel)
+                    || (option.originalPriceKopeks !== null
+                        && option.priceKopeks !== null
+                        && option.originalPriceKopeks > option.priceKopeks);
+                if (showOriginal) {
+                    const original = document.createElement('span');
+                    original.className = 'subscription-renewal-option-price-original';
+                    original.textContent = option.originalPriceLabel
+                        || formatPriceFromKopeks(option.originalPriceKopeks, data.currency);
+                    priceRow.appendChild(original);
+                }
+
+                if (option.discountPercent) {
+                    const discount = document.createElement('span');
+                    discount.className = 'subscription-renewal-option-discount';
+                    discount.textContent = `-${option.discountPercent}%`;
+                    priceRow.appendChild(discount);
+                }
+
+                meta.appendChild(priceRow);
+
+                if (option.pricePerMonthLabel) {
+                    const note = document.createElement('div');
+                    note.className = 'subscription-renewal-option-note';
+                    const template = t('subscription_renewal.summary.per_month');
+                    note.textContent = template && template !== 'subscription_renewal.summary.per_month'
+                        ? template.replace('{amount}', option.pricePerMonthLabel)
+                        : `${option.pricePerMonthLabel} per month`;
+                    meta.appendChild(note);
+                } else if (option.pricePerMonthKopeks !== null) {
+                    const perMonthLabel = formatPriceFromKopeks(option.pricePerMonthKopeks, data.currency);
+                    const template = t('subscription_renewal.summary.per_month');
+                    const text = template && template !== 'subscription_renewal.summary.per_month'
+                        ? template.replace('{amount}', perMonthLabel)
+                        : `${perMonthLabel} per month`;
+                    const note = document.createElement('div');
+                    note.className = 'subscription-renewal-option-note';
+                    note.textContent = text;
+                    meta.appendChild(note);
+                }
+
+                label.appendChild(meta);
+                button.appendChild(label);
+
+                button.addEventListener('click', () => {
+                    if (subscriptionRenewalSubmitting) {
+                        return;
+                    }
+                    subscriptionRenewalSelection.periodId = option.id;
+                    renderSubscriptionRenewalOptions(data);
+                    renderSubscriptionRenewalSummary(data);
+                    renderSubscriptionRenewalSummaryChip(data);
+                });
+
+                container.appendChild(button);
+            });
+
+            if (!subscriptionRenewalSelection.periodId && options.length) {
+                subscriptionRenewalSelection.periodId = options[0].id;
+            }
+
+            renderSubscriptionRenewalSummary(data);
+        }
+
+        function renderSubscriptionRenewalSummary(data) {
+            const summary = document.getElementById('subscriptionRenewalSummary');
+            const priceCurrent = document.getElementById('subscriptionRenewalPriceCurrent');
+            const priceOriginal = document.getElementById('subscriptionRenewalPriceOriginal');
+            const priceDiscount = document.getElementById('subscriptionRenewalPriceDiscount');
+            const priceNote = document.getElementById('subscriptionRenewalPriceNote');
+            const balanceWarning = document.getElementById('subscriptionRenewalBalanceWarning');
+            const submitButton = document.getElementById('subscriptionRenewalSubmit');
+
+            if (!summary || !priceCurrent || !submitButton) {
+                return;
+            }
+
+            const option = data?.periods?.find(entry => entry?.id === subscriptionRenewalSelection.periodId) || null;
+
+            if (!option) {
+                priceCurrent.textContent = '—';
+                if (priceOriginal) {
+                    priceOriginal.textContent = '';
+                    priceOriginal.classList.add('hidden');
+                }
+                if (priceDiscount) {
+                    priceDiscount.textContent = '';
+                    priceDiscount.classList.add('hidden');
+                }
+                if (priceNote) {
+                    priceNote.textContent = '';
+                    priceNote.classList.add('hidden');
+                }
+                if (balanceWarning) {
+                    balanceWarning.textContent = '';
+                    balanceWarning.classList.add('hidden');
+                }
+                submitButton.disabled = true;
+                const submitLabel = t('subscription_renewal.submit');
+                submitButton.textContent = submitLabel === 'subscription_renewal.submit' ? 'Renew' : submitLabel;
+                renderSubscriptionRenewalSummaryChip(data);
+                return;
+            }
+
+            const amountLabel = option.priceLabel
+                || (option.priceKopeks !== null ? formatPriceFromKopeks(option.priceKopeks, data.currency) : null);
+            priceCurrent.textContent = amountLabel || '—';
+
+            const showOriginal = Boolean(option.originalPriceLabel && option.originalPriceLabel !== option.priceLabel)
+                || (option.originalPriceKopeks !== null
+                    && option.priceKopeks !== null
+                    && option.originalPriceKopeks > option.priceKopeks);
+            if (priceOriginal) {
+                if (showOriginal) {
+                    const label = option.originalPriceLabel
+                        || formatPriceFromKopeks(option.originalPriceKopeks, data.currency);
+                    priceOriginal.textContent = label;
+                    priceOriginal.classList.remove('hidden');
+                } else {
+                    priceOriginal.textContent = '';
+                    priceOriginal.classList.add('hidden');
+                }
+            }
+
+            if (priceDiscount) {
+                if (option.discountPercent) {
+                    const template = t('subscription_renewal.summary.discount');
+                    priceDiscount.textContent = template && template !== 'subscription_renewal.summary.discount'
+                        ? template.replace('{percent}', `${option.discountPercent}%`)
+                        : `You save ${option.discountPercent}%`;
+                    priceDiscount.classList.remove('hidden');
+                } else {
+                    priceDiscount.textContent = '';
+                    priceDiscount.classList.add('hidden');
+                }
+            }
+
+            if (priceNote) {
+                if (option.pricePerMonthLabel) {
+                    const template = t('subscription_renewal.summary.per_month');
+                    priceNote.textContent = template && template !== 'subscription_renewal.summary.per_month'
+                        ? template.replace('{amount}', option.pricePerMonthLabel)
+                        : `${option.pricePerMonthLabel} per month`;
+                    priceNote.classList.remove('hidden');
+                } else if (option.pricePerMonthKopeks !== null) {
+                    const perMonthLabel = formatPriceFromKopeks(option.pricePerMonthKopeks, data.currency);
+                    const template = t('subscription_renewal.summary.per_month');
+                    priceNote.textContent = template && template !== 'subscription_renewal.summary.per_month'
+                        ? template.replace('{amount}', perMonthLabel)
+                        : `${perMonthLabel} per month`;
+                    priceNote.classList.remove('hidden');
+                } else {
+                    priceNote.textContent = '';
+                    priceNote.classList.add('hidden');
+                }
+            }
+
+            const balanceKopeks = data?.balanceKopeks ?? coercePositiveInt(userData?.balance_kopeks, null);
+            const priceKopeks = option.priceKopeks;
+            let missing = data?.missingAmountKopeks ?? null;
+            if (missing === null && balanceKopeks !== null && priceKopeks !== null && balanceKopeks < priceKopeks) {
+                missing = priceKopeks - balanceKopeks;
+            }
+            if (balanceWarning) {
+                if (missing !== null && missing > 0) {
+                    const missingLabel = formatPriceFromKopeks(missing, data.currency);
+                    const template = t('subscription_renewal.summary.insufficient');
+                    balanceWarning.textContent = template && template !== 'subscription_renewal.summary.insufficient'
+                        ? template.replace('{missing}', missingLabel)
+                        : `Not enough balance — missing ${missingLabel}.`;
+                    balanceWarning.classList.remove('hidden');
+                } else {
+                    balanceWarning.textContent = '';
+                    balanceWarning.classList.add('hidden');
+                }
+            }
+
+            submitButton.disabled = subscriptionRenewalSubmitting || option.priceKopeks === null;
+            const submitKey = subscriptionRenewalSubmitting
+                ? 'subscription_renewal.submit.loading'
+                : 'subscription_renewal.submit';
+            const submitLabel = t(submitKey);
+            submitButton.textContent = submitLabel === submitKey
+                ? (subscriptionRenewalSubmitting ? 'Processing…' : 'Renew')
+                : submitLabel;
+
+            renderSubscriptionRenewalSummaryChip(data);
+        }
+
+        function renderSubscriptionRenewalCard() {
+            const card = document.getElementById('subscriptionRenewalCard');
+            if (!card) {
+                return;
+            }
+
+            const shouldShow = hasPaidSubscription();
+            card.classList.toggle('hidden', !shouldShow);
+            if (!shouldShow) {
+                return;
+            }
+
+            const loadingBlock = document.getElementById('subscriptionRenewalLoading');
+            const errorBlock = document.getElementById('subscriptionRenewalError');
+            const body = document.getElementById('subscriptionRenewalBody');
+            const statusText = document.getElementById('subscriptionRenewalStatus');
+
+            if (subscriptionRenewalLoading) {
+                loadingBlock?.classList.remove('hidden');
+                errorBlock?.classList.add('hidden');
+                body?.classList.add('hidden');
+                if (statusText) {
+                    const template = t('subscription_renewal.status.loading');
+                    statusText.textContent = template && template !== 'subscription_renewal.status.loading'
+                        ? template
+                        : 'Loading renewal options…';
+                    statusText.classList.remove('hidden');
+                }
+                return;
+            }
+
+            loadingBlock?.classList.add('hidden');
+
+            if (subscriptionRenewalError) {
+                body?.classList.add('hidden');
+                if (errorBlock) {
+                    const errorText = document.getElementById('subscriptionRenewalErrorText');
+                    if (errorText) {
+                        errorText.textContent = resolveRenewalErrorMessage(subscriptionRenewalError);
+                    }
+                    errorBlock.classList.remove('hidden');
+                }
+                statusText?.classList.add('hidden');
+                return;
+            }
+
+            errorBlock?.classList.add('hidden');
+
+            if (!subscriptionRenewalData) {
+                body?.classList.add('hidden');
+                statusText?.classList.add('hidden');
+                ensureSubscriptionRenewalData().catch(error => {
+                    console.warn('Failed to load subscription renewal options:', error);
+                });
+                return;
+            }
+
+            body?.classList.remove('hidden');
+
+            if (subscriptionRenewalData.statusMessage && statusText) {
+                statusText.textContent = subscriptionRenewalData.statusMessage;
+                statusText.classList.remove('hidden');
+            } else if (statusText) {
+                statusText.classList.add('hidden');
+            }
+
+            renderSubscriptionRenewalMeta(subscriptionRenewalData);
+            renderSubscriptionRenewalOptions(subscriptionRenewalData);
+            renderSubscriptionRenewalSummary(subscriptionRenewalData);
+        }
+
+        async function confirmSubscriptionRenewal(option, data) {
+            const amountLabel = option.priceLabel
+                || (option.priceKopeks !== null ? formatPriceFromKopeks(option.priceKopeks, data.currency) : '');
+            const periodLabel = buildRenewalPeriodLabel(option);
+
+            const messageTemplate = t('subscription_renewal.confirm.message');
+            const message = messageTemplate && messageTemplate !== 'subscription_renewal.confirm.message'
+                ? messageTemplate.replace('{period}', periodLabel).replace('{amount}', amountLabel)
+                : `Renew the subscription for ${periodLabel} and pay ${amountLabel}?`;
+
+            const balanceLabel = data?.balanceLabel
+                || (data.balanceKopeks !== null ? formatPriceFromKopeks(data.balanceKopeks, data.currency) : null);
+
+            let finalMessage = message;
+            if (balanceLabel) {
+                const balanceTemplate = t('subscription_renewal.confirm.balance');
+                const balanceText = balanceTemplate && balanceTemplate !== 'subscription_renewal.confirm.balance'
+                    ? balanceTemplate.replace('{balance}', balanceLabel)
+                    : `Current balance: ${balanceLabel}`;
+                finalMessage = `${message}\n${balanceText}`;
+            }
+
+            const titleKey = 'subscription_renewal.confirm.title';
+            const confirmKey = 'subscription_renewal.confirm.accept';
+            const cancelKey = 'subscription_renewal.confirm.cancel';
+
+            const title = t(titleKey);
+            const confirmText = t(confirmKey);
+            const cancelText = t(cancelKey);
+
+            return showConfirmationPopup({
+                title: title === titleKey ? 'Confirm renewal' : title,
+                message: finalMessage,
+                confirmText: confirmText === confirmKey ? 'Pay' : confirmText,
+                cancelText: cancelText === cancelKey ? 'Cancel' : cancelText,
+                destructive: true,
+            });
+        }
+
+        function handleSubscriptionRenewalError(error) {
+            const message = resolveRenewalErrorMessage(error);
+            const titleKey = 'subscription_renewal.title';
+            const title = t(titleKey);
+            showPopup(message, title === titleKey ? 'Subscription renewal' : title);
+        }
+
+        async function submitSubscriptionRenewal() {
+            if (subscriptionRenewalSubmitting || subscriptionRenewalLoading) {
+                return;
+            }
+
+            if (!hasPaidSubscription()) {
+                handleSubscriptionRenewalError(createError('Subscription renewal', t('subscription_renewal.error.validation')));
+                return;
+            }
+
+            const data = subscriptionRenewalData;
+            const option = data?.periods?.find(entry => entry?.id === subscriptionRenewalSelection.periodId) || null;
+            if (!option) {
+                handleSubscriptionRenewalError(createError('Validation', t('subscription_renewal.error.validation')));
+                return;
+            }
+
+            const initData = tg.initData || '';
+            if (!initData) {
+                handleSubscriptionRenewalError(createError('Authorization Error', t('subscription_renewal.error.unauthorized')));
+                return;
+            }
+
+            const confirmed = await confirmSubscriptionRenewal(option, data);
+            if (!confirmed) {
+                return;
+            }
+
+            const submitButton = document.getElementById('subscriptionRenewalSubmit');
+            subscriptionRenewalSubmitting = true;
+            if (submitButton) {
+                submitButton.disabled = true;
+                const label = t('subscription_renewal.submit.loading');
+                submitButton.textContent = label === 'subscription_renewal.submit.loading'
+                    ? 'Processing…'
+                    : label;
+            }
+
+            renderSubscriptionRenewalCard();
+
+            try {
+                const payload = {
+                    initData,
+                    subscription_id: data?.subscriptionId ?? userData?.subscription_id ?? userData?.subscriptionId ?? null,
+                    subscriptionId: data?.subscriptionId ?? userData?.subscription_id ?? userData?.subscriptionId ?? null,
+                    period_id: option.id,
+                    periodId: option.id,
+                    period_days: option.days ?? null,
+                    periodDays: option.days ?? null,
+                };
+
+                const response = await fetch('/miniapp/subscription/renewal', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const body = await parseJsonSafe(response);
+                if (!response.ok || (body && body.success === false)) {
+                    const message = extractRenewalError(body, response.status);
+                    throw createError('Subscription renewal error', message, response.status);
+                }
+
+                const successKey = 'subscription_renewal.success';
+                const successMessage = t(successKey);
+                const titleKey = 'subscription_renewal.title';
+                const title = t(titleKey);
+                showPopup(
+                    successMessage === successKey ? 'Subscription renewed successfully.' : successMessage,
+                    title === titleKey ? 'Subscription renewal' : title,
+                );
+
+                await refreshSubscriptionData({ silent: true });
+                await ensureSubscriptionRenewalData({ force: true });
+            } catch (error) {
+                console.error('Failed to renew subscription:', error);
+                handleSubscriptionRenewalError(error);
+            } finally {
+                subscriptionRenewalSubmitting = false;
+                renderSubscriptionRenewalCard();
+            }
+        }
+
+        function setupSubscriptionRenewalEvents() {
+            document.getElementById('subscriptionRenewalRetry')?.addEventListener('click', () => {
+                ensureSubscriptionRenewalData({ force: true }).catch(error => {
+                    console.warn('Failed to reload renewal options:', error);
+                });
+            });
+            document.getElementById('subscriptionRenewalSubmit')?.addEventListener('click', submitSubscriptionRenewal);
         }
 
         function extractSettingsError(payload, status) {


### PR DESCRIPTION
## Summary
- add an expandable renewal card above the subscription settings section
- render renewal periods, promo group details, and promo offers with localized strings
- hook up data loading, submission, and confirmation flows for renewing subscriptions
