### PR TITLE
Implement miniapp subscription renewal API

### DIFF
--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -26,11 +26,12 @@ from app.database.crud.rules import get_rules_by_language
 from app.database.crud.promo_offer_template import get_promo_offer_template_by_id
 from app.database.crud.server_squad import (
     get_available_server_squads,
+    get_server_ids_by_uuids,
     get_server_squad_by_uuid,
     add_user_to_servers,
     remove_user_from_servers,
 )
-from app.database.crud.subscription import add_subscription_servers, remove_subscription_servers
+from app.database.crud.subscription import add_subscription_servers, extend_subscription, remove_subscription_servers
 from app.database.crud.transaction import (
     create_transaction,
     get_user_total_spent_kopeks,
@@ -39,6 +40,7 @@ from app.database.crud.user import get_user_by_telegram_id, subtract_user_balanc
 from app.database.models import (
     PromoGroup,
     PromoOfferTemplate,
+    ServerSquad,
     Subscription,
     SubscriptionTemporaryAccess,
     Transaction,
@@ -75,9 +77,11 @@ from app.utils.user_utils import (
 )
 from app.utils.pricing_utils import (
     apply_percentage_discount,
+    calculate_months_from_days,
     calculate_prorated_price,
     get_remaining_months,
 )
+from app.utils.promo_offer import get_user_active_promo_discount_percent
 
 from ..dependencies import get_db_session
 from ..schemas.miniapp import (
@@ -118,6 +122,13 @@ from ..schemas.miniapp import (
     MiniAppTransaction,
     MiniAppSubscriptionSettingsRequest,
     MiniAppSubscriptionSettingsResponse,
+    MiniAppSubscriptionRenewalOption,
+    MiniAppSubscriptionRenewalOptions,
+    MiniAppSubscriptionRenewalOptionsRequest,
+    MiniAppSubscriptionRenewalOptionsResponse,
+    MiniAppSubscriptionRenewalPromoOffer,
+    MiniAppSubscriptionRenewalRequest,
+    MiniAppSubscriptionRenewalResponse,
     MiniAppSubscriptionSettings,
     MiniAppSubscriptionCurrentSettings,
     MiniAppSubscriptionServersSettings,
@@ -2779,6 +2790,210 @@ def _get_addon_discount_percent_for_user(
         return 0
 
 
+def _normalize_percent(value: Any) -> int:
+    try:
+        percent = int(value)
+    except (TypeError, ValueError):
+        return 0
+
+    return max(0, min(100, percent))
+
+
+def _get_period_discount_percent(user: Optional[User], period_days: Optional[int]) -> int:
+    if not user:
+        return 0
+
+    try:
+        percent = user.get_promo_discount("period", period_days)
+    except AttributeError:
+        return 0
+
+    return _normalize_percent(percent)
+
+
+def _apply_promo_offer_discount_for_user(
+    user: Optional[User],
+    amount: int,
+) -> Tuple[int, int, int]:
+    percent = _normalize_percent(get_user_active_promo_discount_percent(user))
+    if amount <= 0 or percent <= 0:
+        return amount, 0, percent
+
+    discounted, discount_value = apply_percentage_discount(amount, percent)
+    return discounted, discount_value, percent
+
+
+def _build_miniapp_renewal_promo_offer(
+    user: Optional[User],
+) -> Optional[MiniAppSubscriptionRenewalPromoOffer]:
+    percent = _normalize_percent(get_user_active_promo_discount_percent(user))
+    if percent <= 0:
+        return None
+
+    expires_at = getattr(user, "promo_offer_discount_expires_at", None)
+    title = None
+    message = None
+    source = getattr(user, "promo_offer_discount_source", None)
+    if source:
+        title = str(source)
+
+    return MiniAppSubscriptionRenewalPromoOffer(
+        percent=percent,
+        expires_at=expires_at,
+        title=title,
+        message=message,
+    )
+
+
+async def _calculate_subscription_renewal_option(
+    db: AsyncSession,
+    user: User,
+    subscription: Subscription,
+    period_days: int,
+) -> Tuple[Optional[MiniAppSubscriptionRenewalOption], Optional[Dict[str, Any]]]:
+    from app.config import PERIOD_PRICES
+
+    months = calculate_months_from_days(period_days)
+    months = max(1, months)
+
+    base_price_original = int(PERIOD_PRICES.get(period_days, 0) or 0)
+    period_discount_percent = _get_period_discount_percent(user, period_days)
+    base_price, base_discount_total = apply_percentage_discount(
+        base_price_original,
+        period_discount_percent,
+    )
+
+    subscription_service = SubscriptionService()
+
+    connected_squads = list(subscription.connected_squads or [])
+    servers_price_per_month = 0
+    per_server_monthly_prices: List[int] = []
+    if connected_squads:
+        servers_price_per_month, per_server_monthly_prices = await subscription_service.get_countries_price_by_uuids(
+            connected_squads,
+            db,
+            promo_group_id=getattr(user, "promo_group_id", None),
+        )
+
+    servers_discount_percent = _get_addon_discount_percent_for_user(user, "servers", period_days)
+    total_servers_price = 0
+    total_servers_discount = 0
+    server_uuid_prices: Dict[str, int] = {}
+    for index, squad_uuid in enumerate(connected_squads):
+        monthly_price = 0
+        if index < len(per_server_monthly_prices):
+            try:
+                monthly_price = int(per_server_monthly_prices[index])
+            except (TypeError, ValueError):
+                monthly_price = 0
+        discounted_per_month, discount_per_month = apply_percentage_discount(
+            monthly_price,
+            servers_discount_percent,
+        )
+        total_servers_price += discounted_per_month * months
+        total_servers_discount += discount_per_month * months
+        server_uuid_prices[squad_uuid] = discounted_per_month * months
+
+    default_device_limit = int(getattr(settings, "DEFAULT_DEVICE_LIMIT", 0) or 0)
+    current_devices = int(
+        subscription.device_limit
+        or default_device_limit
+        or 1
+    )
+    additional_devices = max(0, current_devices - default_device_limit)
+    devices_price_per_month = additional_devices * settings.PRICE_PER_DEVICE
+    devices_discount_percent = _get_addon_discount_percent_for_user(user, "devices", period_days)
+    discounted_devices_per_month, devices_discount_per_month = apply_percentage_discount(
+        devices_price_per_month,
+        devices_discount_percent,
+    )
+    total_devices_price = discounted_devices_per_month * months
+    total_devices_discount = devices_discount_per_month * months
+
+    traffic_price_per_month = settings.get_traffic_price(subscription.traffic_limit_gb)
+    traffic_discount_percent = _get_addon_discount_percent_for_user(user, "traffic", period_days)
+    discounted_traffic_per_month, traffic_discount_per_month = apply_percentage_discount(
+        traffic_price_per_month,
+        traffic_discount_percent,
+    )
+    total_traffic_price = discounted_traffic_per_month * months
+    total_traffic_discount = traffic_discount_per_month * months
+
+    total_original_price = (
+        base_price_original
+        + servers_price_per_month * months
+        + devices_price_per_month * months
+        + traffic_price_per_month * months
+    )
+
+    subtotal_without_promo = (
+        base_price
+        + total_servers_price
+        + total_devices_price
+        + total_traffic_price
+    )
+
+    final_price, promo_discount_value, promo_percent = _apply_promo_offer_discount_for_user(
+        user,
+        subtotal_without_promo,
+    )
+
+    overall_discount_value = max(0, total_original_price - final_price)
+    overall_discount_percent = 0
+    if total_original_price > 0 and overall_discount_value > 0:
+        overall_discount_percent = round(overall_discount_value * 100 / total_original_price)
+
+    price_per_month = final_price
+    if months > 0:
+        price_per_month = math.ceil(final_price / months)
+
+    option = MiniAppSubscriptionRenewalOption(
+        id=str(period_days),
+        days=period_days,
+        period_days=period_days,
+        months=months,
+        price_kopeks=final_price,
+        price_label=settings.format_price(final_price),
+        original_price_kopeks=total_original_price,
+        original_price_label=settings.format_price(total_original_price),
+        discount_percent=overall_discount_percent,
+        per_month_kopeks=price_per_month,
+        per_month_label=settings.format_price(price_per_month),
+    )
+
+    details = {
+        "period_days": period_days,
+        "months": months,
+        "base_price_original": base_price_original,
+        "base_price": base_price,
+        "base_discount_percent": period_discount_percent,
+        "base_discount_total": base_discount_total,
+        "servers_price_per_month": servers_price_per_month,
+        "total_servers_price": total_servers_price,
+        "servers_discount_percent": servers_discount_percent,
+        "servers_discount_total": total_servers_discount,
+        "devices_price_per_month": devices_price_per_month,
+        "total_devices_price": total_devices_price,
+        "devices_discount_percent": devices_discount_percent,
+        "devices_discount_total": total_devices_discount,
+        "traffic_price_per_month": traffic_price_per_month,
+        "total_traffic_price": total_traffic_price,
+        "traffic_discount_percent": traffic_discount_percent,
+        "traffic_discount_total": total_traffic_discount,
+        "subtotal": subtotal_without_promo,
+        "final_price": final_price,
+        "promo_discount_percent": promo_percent,
+        "promo_discount_value": promo_discount_value,
+        "total_original_price": total_original_price,
+        "overall_discount_percent": overall_discount_percent,
+        "overall_discount_value": overall_discount_value,
+        "price_per_month": price_per_month,
+        "server_uuid_prices": server_uuid_prices,
+        "consume_promo_offer": promo_discount_value > 0,
+    }
+
+    return option, details
+
 def _get_period_hint_from_subscription(
     subscription: Optional[Subscription],
 ) -> Optional[int]:
@@ -3142,6 +3357,275 @@ async def _build_subscription_settings(
     )
 
     return settings_payload
+
+
+@router.post(
+    "/subscription/renewal/options",
+    response_model=MiniAppSubscriptionRenewalOptionsResponse,
+)
+async def get_subscription_renewal_options_endpoint(
+    payload: MiniAppSubscriptionRenewalOptionsRequest,
+    db: AsyncSession = Depends(get_db_session),
+) -> MiniAppSubscriptionRenewalOptionsResponse:
+    user = await _authorize_miniapp_user(payload.init_data, db)
+    subscription = _ensure_paid_subscription(user)
+    _validate_subscription_id(payload.subscription_id, subscription)
+
+    available_periods = []
+    for raw_period in settings.get_available_renewal_periods():
+        try:
+            period_days = int(raw_period)
+        except (TypeError, ValueError):
+            continue
+        if period_days > 0:
+            available_periods.append(period_days)
+
+    currency = (getattr(user, "balance_currency", None) or "RUB").upper()
+    balance_kopeks = int(getattr(user, "balance_kopeks", 0) or 0)
+
+    options: List[MiniAppSubscriptionRenewalOption] = []
+    option_details: List[Dict[str, Any]] = []
+
+    for period_days in available_periods:
+        try:
+            option, details = await _calculate_subscription_renewal_option(
+                db,
+                user,
+                subscription,
+                period_days,
+            )
+        except Exception as error:  # pragma: no cover - defensive logging
+            logger.warning(
+                "Failed to calculate renewal option for %s days: %s",
+                period_days,
+                error,
+            )
+            continue
+        if not option or not details:
+            continue
+        options.append(option)
+        option_details.append(details)
+
+    recommended_id: Optional[str] = None
+    if options and option_details:
+        best_index = 0
+        best_score = (-1, -1, 0)
+        for idx, (option, details) in enumerate(zip(options, option_details)):
+            discount = int(details.get("overall_discount_percent", 0) or 0)
+            months = int(details.get("months", 0) or 0)
+            final_price = int(details.get("final_price", 0) or 0)
+            score = (discount, months, -final_price)
+            if score > best_score:
+                best_index = idx
+                best_score = score
+        recommended_id = options[best_index].id
+        options[best_index].is_recommended = True
+
+    default_period_id = recommended_id or (options[0].id if options else None)
+
+    missing_amount: Optional[int] = None
+    for option in options:
+        price = option.price_kopeks
+        if price is None:
+            continue
+        if balance_kopeks < price:
+            diff = price - balance_kopeks
+            if missing_amount is None or diff < missing_amount:
+                missing_amount = diff
+
+    promo_group = getattr(user, "promo_group", None)
+    promo_group_payload: Optional[MiniAppPromoGroup] = None
+    if promo_group:
+        promo_group_payload = MiniAppPromoGroup(
+            id=promo_group.id,
+            name=promo_group.name,
+            **_extract_promo_discounts(promo_group),
+        )
+
+    promo_offer = _build_miniapp_renewal_promo_offer(user)
+
+    return MiniAppSubscriptionRenewalOptionsResponse(
+        success=True,
+        currency=currency,
+        subscription_id=subscription.id,
+        balance_kopeks=balance_kopeks,
+        balance_label=settings.format_price(balance_kopeks),
+        periods=options,
+        default_period_id=default_period_id,
+        promo_group=promo_group_payload,
+        promo_offer=promo_offer,
+        missing_amount_kopeks=missing_amount,
+        status_message=None,
+    )
+
+
+@router.post(
+    "/subscription/renewal",
+    response_model=MiniAppSubscriptionRenewalResponse,
+)
+async def submit_subscription_renewal_endpoint(
+    payload: MiniAppSubscriptionRenewalRequest,
+    db: AsyncSession = Depends(get_db_session),
+) -> MiniAppSubscriptionRenewalResponse:
+    user = await _authorize_miniapp_user(payload.init_data, db)
+    subscription = _ensure_paid_subscription(user)
+    _validate_subscription_id(payload.subscription_id, subscription)
+
+    period_days: Optional[int] = None
+    if payload.period_days is not None:
+        try:
+            period_days = int(payload.period_days)
+        except (TypeError, ValueError):
+            period_days = None
+    if period_days is None and payload.period_id:
+        period_token = str(payload.period_id)
+        if ":" in period_token:
+            period_token = period_token.split(":")[-1]
+        try:
+            period_days = int(period_token)
+        except (TypeError, ValueError):
+            period_days = None
+
+    if not period_days or period_days <= 0:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_period",
+                "message": "Renewal period is required",
+            },
+        )
+
+    available_periods: set[int] = set()
+    for raw_period in settings.get_available_renewal_periods():
+        try:
+            value = int(raw_period)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            available_periods.add(value)
+
+    if period_days not in available_periods:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_period",
+                "message": "Selected renewal period is not available",
+            },
+        )
+
+    try:
+        option, details = await _calculate_subscription_renewal_option(
+            db,
+            user,
+            subscription,
+            period_days,
+        )
+    except Exception as error:  # pragma: no cover - defensive guard
+        logger.exception(
+            "Failed to calculate renewal option for %s days: %s",
+            period_days,
+            error,
+        )
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "code": "calculation_error",
+                "message": "Failed to calculate renewal price",
+            },
+        ) from error
+
+    if not option or not details:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "calculation_error",
+                "message": "Failed to calculate renewal price",
+            },
+        )
+
+    final_price = int(details.get("final_price", 0) or 0)
+    consume_promo = bool(details.get("consume_promo_offer"))
+    balance_before = int(getattr(user, "balance_kopeks", 0) or 0)
+
+    if final_price > balance_before:
+        missing = final_price - balance_before
+        raise HTTPException(
+            status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "insufficient_funds",
+                "message": (
+                    "Недостаточно средств на балансе. "
+                    f"Не хватает {settings.format_price(missing)}"
+                ),
+            },
+        )
+
+    if final_price > 0 or consume_promo:
+        success = await subtract_user_balance(
+            db,
+            user,
+            final_price,
+            f"Продление подписки на {period_days} дней",
+            consume_promo_offer=consume_promo,
+        )
+        if not success:
+            raise HTTPException(
+                status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "code": "balance_charge_failed",
+                    "message": "Failed to charge user balance",
+                },
+            )
+
+    subscription = await extend_subscription(db, subscription, period_days)
+    await db.refresh(user)
+
+    server_ids = await get_server_ids_by_uuids(db, list(subscription.connected_squads or []))
+    if server_ids:
+        result = await db.execute(
+            select(ServerSquad.id, ServerSquad.squad_uuid).where(ServerSquad.id.in_(server_ids))
+        )
+        id_to_uuid = {row.id: row.squad_uuid for row in result}
+        total_servers_price = int(details.get("total_servers_price", 0) or 0)
+        default_server_price = total_servers_price // len(server_ids) if server_ids else 0
+        server_uuid_prices = details.get("server_uuid_prices") or {}
+        server_prices = [
+            int(server_uuid_prices.get(id_to_uuid.get(server_id, ""), default_server_price) or 0)
+            for server_id in server_ids
+        ]
+        await add_subscription_servers(db, subscription, server_ids, server_prices)
+
+    subscription_service = SubscriptionService()
+    try:
+        await subscription_service.update_remnawave_user(
+            db,
+            subscription,
+            reset_traffic=settings.RESET_TRAFFIC_ON_PAYMENT,
+            reset_reason="miniapp renewal",
+        )
+    except Exception as error:  # pragma: no cover - best effort logging
+        logger.warning("Failed to update RemnaWave after renewal: %s", error)
+
+    months = int(details.get("months", 0) or 0)
+    await create_transaction(
+        db=db,
+        user_id=user.id,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=final_price,
+        description=f"Продление подписки на {period_days} дней ({months} мес)",
+    )
+
+    balance_after = int(getattr(user, "balance_kopeks", 0) or 0)
+
+    return MiniAppSubscriptionRenewalResponse(
+        success=True,
+        message=None,
+        balance_kopeks=balance_after,
+        balance_label=settings.format_price(balance_after),
+        subscription_id=subscription.id,
+        period_days=period_days,
+        renewed_until=subscription.end_date,
+    )
 
 
 @router.post(

--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -609,3 +609,78 @@ class MiniAppSubscriptionPurchaseResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+
+class MiniAppSubscriptionRenewalPromoOffer(BaseModel):
+    percent: int
+    expires_at: Optional[datetime] = Field(default=None, alias="expiresAt")
+    title: Optional[str] = None
+    message: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MiniAppSubscriptionRenewalOption(BaseModel):
+    id: str
+    days: Optional[int] = None
+    period_days: Optional[int] = Field(default=None, alias="periodDays")
+    months: Optional[int] = None
+    price_kopeks: Optional[int] = Field(default=None, alias="priceKopeks")
+    price_label: Optional[str] = Field(default=None, alias="priceLabel")
+    original_price_kopeks: Optional[int] = Field(default=None, alias="originalPriceKopeks")
+    original_price_label: Optional[str] = Field(default=None, alias="originalPriceLabel")
+    discount_percent: Optional[int] = Field(default=None, alias="discountPercent")
+    per_month_kopeks: Optional[int] = Field(default=None, alias="perMonthKopeks")
+    per_month_label: Optional[str] = Field(default=None, alias="perMonthLabel")
+    is_recommended: bool = Field(default=False, alias="isRecommended")
+    badge: Optional[str] = None
+    description: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MiniAppSubscriptionRenewalOptions(BaseModel):
+    currency: str
+    subscription_id: Optional[int] = Field(default=None, alias="subscriptionId")
+    balance_kopeks: Optional[int] = Field(default=None, alias="balanceKopeks")
+    balance_label: Optional[str] = Field(default=None, alias="balanceLabel")
+    periods: List[MiniAppSubscriptionRenewalOption] = Field(default_factory=list)
+    default_period_id: Optional[str] = Field(default=None, alias="defaultPeriodId")
+    promo_group: Optional[MiniAppPromoGroup] = Field(default=None, alias="promoGroup")
+    promo_offer: Optional[MiniAppSubscriptionRenewalPromoOffer] = Field(default=None, alias="promoOffer")
+    missing_amount_kopeks: Optional[int] = Field(default=None, alias="missingAmountKopeks")
+    status_message: Optional[str] = Field(default=None, alias="statusMessage")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MiniAppSubscriptionRenewalOptionsRequest(BaseModel):
+    init_data: str = Field(..., alias="initData")
+    subscription_id: Optional[int] = Field(default=None, alias="subscriptionId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MiniAppSubscriptionRenewalOptionsResponse(MiniAppSubscriptionRenewalOptions):
+    success: bool = True
+
+
+class MiniAppSubscriptionRenewalRequest(BaseModel):
+    init_data: str = Field(..., alias="initData")
+    subscription_id: Optional[int] = Field(default=None, alias="subscriptionId")
+    period_id: Optional[str] = Field(default=None, alias="periodId")
+    period_days: Optional[int] = Field(default=None, alias="periodDays")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MiniAppSubscriptionRenewalResponse(BaseModel):
+    success: bool = True
+    message: Optional[str] = None
+    balance_kopeks: Optional[int] = Field(default=None, alias="balanceKopeks")
+    balance_label: Optional[str] = Field(default=None, alias="balanceLabel")
+    subscription_id: Optional[int] = Field(default=None, alias="subscriptionId")
+    period_days: Optional[int] = Field(default=None, alias="periodDays")
+    renewed_until: Optional[datetime] = Field(default=None, alias="renewedUntil")
+
+    model_config = ConfigDict(populate_by_name=True)
+


### PR DESCRIPTION
## Summary
- add schemas to describe subscription renewal options and responses for the mini app
- implement miniapp endpoints to expose renewal options and process paid renewals with balance checks
