### PR TITLE
Fix spacing around subscription purchase actions

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -86,7 +86,7 @@
             max-width: 480px;
             margin: 0 auto;
             padding: 16px;
-            padding-bottom: 32px;
+            padding-bottom: calc(48px + env(safe-area-inset-bottom, 0));
         }
 
         /* Animations */
@@ -987,6 +987,10 @@
             margin-top: 8px;
         }
 
+        #subscriptionPurchaseCardWrapper {
+            margin-bottom: calc(32px + env(safe-area-inset-bottom, 0));
+        }
+
         .subscription-purchase-card .btn-secondary {
             justify-content: center;
         }
@@ -1023,6 +1027,10 @@
 
             .subscription-purchase-actions {
                 gap: 14px;
+            }
+
+            #subscriptionPurchaseCardWrapper {
+                margin-bottom: calc(40px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-card .btn-primary {


### PR DESCRIPTION
## Summary
- increase the mini app container bottom padding to account for safe-area insets and ensure the subscription CTA can scroll fully into view
- add responsive bottom margins to the subscription purchase card wrapper so the submit button and balance warning are no longer clipped on desktop or mobile