### PR TITLE
Adjust subscription purchase card spacing

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -976,8 +976,12 @@
             margin-bottom: 6px;
         }
 
+        .card.subscription-purchase-card {
+            margin-bottom: 32px;
+        }
+
         .card.subscription-purchase-card:not(.as-modal) .card-content {
-            padding: 0 16px calc(28px + env(safe-area-inset-bottom, 0));
+            padding: 0 16px calc(64px + env(safe-area-inset-bottom, 0));
         }
 
         .subscription-purchase-actions {
@@ -1018,7 +1022,7 @@
 
         @media (max-width: 480px) {
             .card.subscription-purchase-card:not(.as-modal) .card-content {
-                padding: 0 16px calc(36px + env(safe-area-inset-bottom, 0));
+                padding: 0 16px calc(88px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-actions {


### PR DESCRIPTION
## Summary
- increase spacing around the subscription purchase card so the call-to-action button and balance warning are fully visible
- expand mobile and desktop bottom padding to account for safe areas
