### PR TITLE
Fix subscription top-up button clipping

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -1148,11 +1148,13 @@
             display: flex;
             flex-direction: column;
             gap: 14px;
-            margin: 18px -16px -16px;
+            margin: 18px -16px 0;
             padding: 18px 16px calc(24px + env(safe-area-inset-bottom, 0));
             background: rgba(var(--primary-rgb), 0.08);
             border-top: 1px solid rgba(var(--primary-rgb), 0.12);
             box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.15);
+            border-bottom-left-radius: var(--radius-lg);
+            border-bottom-right-radius: var(--radius-lg);
         }
 
         .subscription-purchase-actions .btn {


### PR DESCRIPTION
## Summary
- prevent the subscription purchase action area from being clipped when it grows by removing the negative bottom margin
- add rounded corners so the action area keeps matching the card styling