### PR TITLE
Fix subscription action spacing on narrow screens

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -1076,6 +1076,7 @@
             border-radius: var(--radius-lg);
             border: 1px solid rgba(var(--primary-rgb), 0.15);
             background: linear-gradient(135deg, rgba(var(--primary-rgb), 0.08), rgba(var(--primary-rgb), 0.02));
+            margin-bottom: 12px;
         }
 
         .subscription-purchase-summary-header {
@@ -1322,9 +1323,14 @@
                 align-items: flex-start;
             }
 
+            .subscription-purchase-summary {
+                margin-bottom: 20px;
+            }
+
             .subscription-purchase-actions {
-                margin: 16px -16px 0;
-                padding-bottom: calc(28px + env(safe-area-inset-bottom, 0));
+                margin: 22px -16px 0;
+                padding-top: 22px;
+                padding-bottom: calc(32px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-card .btn-primary {
@@ -1338,9 +1344,13 @@
                 padding: 0 12px 0;
             }
 
+            .subscription-purchase-summary {
+                margin-bottom: 22px;
+            }
+
             .subscription-purchase-actions {
-                margin: 14px -12px 0;
-                padding: 16px 12px calc(30px + env(safe-area-inset-bottom, 0));
+                margin: 20px -12px 0;
+                padding: 20px 12px calc(34px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-option-card,


### PR DESCRIPTION
## Summary
- add additional margin beneath the subscription total summary for better separation on compact layouts
- increase spacing and safe-area padding around the subscription action buttons on narrow viewports so they remain visible