### PR TITLE
Adjust mobile spacing in mini app subscription purchase section

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -1323,8 +1323,9 @@
             }
 
             .subscription-purchase-actions {
-                margin: 16px -16px 0;
-                padding-bottom: calc(28px + env(safe-area-inset-bottom, 0));
+                margin: 22px -16px 0;
+                padding-top: 22px;
+                padding-bottom: calc(34px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-card .btn-primary {
@@ -1339,8 +1340,8 @@
             }
 
             .subscription-purchase-actions {
-                margin: 14px -12px 0;
-                padding: 16px 12px calc(30px + env(safe-area-inset-bottom, 0));
+                margin: 20px -12px 0;
+                padding: 20px 12px calc(36px + env(safe-area-inset-bottom, 0));
             }
 
             .subscription-purchase-option-card,


### PR DESCRIPTION
## Summary
- increase the spacing around the subscription purchase action buttons on narrow screens so they remain visible when discounts are shown