### PR TITLE
Adjust subscription modal layout on mobile

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -2593,6 +2593,22 @@
             gap: 18px;
         }
 
+        @media (max-width: 600px) {
+            #subscriptionPurchaseModal {
+                padding: 0;
+                align-items: stretch;
+                justify-content: flex-start;
+            }
+
+            #subscriptionPurchaseModal .modal {
+                max-width: none;
+                border-radius: 0;
+                min-height: 100vh;
+                height: 100vh;
+                overflow-y: auto;
+            }
+        }
+
         .modal-header {
             text-align: center;
         }


### PR DESCRIPTION
## Summary
- ensure the subscription purchase modal stretches to full height on mobile viewports by overriding the modal backdrop layout