### PR TITLE
Make installation modal full screen on mobile

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -2591,6 +2591,21 @@
             display: flex;
             flex-direction: column;
             gap: 18px;
+            overflow-y: auto;
+        }
+
+        @media (max-width: 600px) {
+            .modal-backdrop {
+                padding: 0;
+                align-items: stretch;
+            }
+
+            .modal {
+                max-width: none;
+                height: 100vh;
+                border-radius: 0;
+                box-shadow: none;
+            }
         }
 
         .modal-header {
@@ -4277,6 +4292,7 @@
         .guide-modal-body {
             padding: 0 24px 24px;
             overflow-y: auto;
+            flex: 1;
         }
 
         .guide-modal-footer {
@@ -4300,6 +4316,33 @@
 
             .guide-modal-footer .btn {
                 width: auto;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .guide-modal-backdrop {
+                align-items: stretch;
+                padding: 0;
+            }
+
+            .guide-modal {
+                width: 100vw;
+                max-height: none;
+                height: 100vh;
+                border-radius: 0;
+                box-shadow: none;
+            }
+
+            .guide-modal-header {
+                padding: calc(16px + env(safe-area-inset-top)) 16px 12px;
+            }
+
+            .guide-modal-body {
+                padding: 0 16px 16px;
+            }
+
+            .guide-modal-footer {
+                padding: 16px 16px calc(16px + env(safe-area-inset-bottom));
             }
         }
 


### PR DESCRIPTION
## Summary
- allow the installation guide modal backdrop to stretch edge-to-edge on phones
- make the modal occupy the full viewport with safe-area padding adjustments on mobile
- ensure the modal body flexes to fill the available space for better scrolling