### PR TITLE
Fix admin topup notifications without DB session

### DIFF
--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -39,6 +39,7 @@ async def get_user_by_id(db: AsyncSession, user_id: int) -> Optional[User]:
         .options(
             selectinload(User.subscription),
             selectinload(User.promo_group),
+            selectinload(User.referrer),
         )
         .where(User.id == user_id)
     )
@@ -56,6 +57,7 @@ async def get_user_by_telegram_id(db: AsyncSession, telegram_id: int) -> Optiona
         .options(
             selectinload(User.subscription),
             selectinload(User.promo_group),
+            selectinload(User.referrer),
         )
         .where(User.telegram_id == telegram_id)
     )

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -24,6 +24,7 @@ from app.external.cryptobot import CryptoBotService
 from app.utils.currency_converter import currency_converter
 from app.database.database import get_db
 from app.localization.texts import get_texts
+from app.utils.user_utils import format_referrer_info
 from app.services.subscription_checkout_service import (
     has_subscription_checkout_draft,
     should_offer_checkout_resume,
@@ -178,10 +179,19 @@ class PaymentService:
             user = await get_user_by_id(db, user_id)
             if user:
                 old_balance = user.balance_kopeks
-                
+                was_first_topup = not user.has_made_first_topup
+
                 user.balance_kopeks += amount_kopeks
                 user.updated_at = datetime.utcnow()
-                
+
+                if was_first_topup:
+                    user.has_made_first_topup = True
+
+                promo_group = getattr(user, "promo_group", None)
+                subscription = getattr(user, "subscription", None)
+                referrer_info = format_referrer_info(user)
+                topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
                 await db.commit()
                 await db.refresh(user)
                 
@@ -207,7 +217,13 @@ class PaymentService:
                         from app.services.admin_notification_service import AdminNotificationService
                         notification_service = AdminNotificationService(self.bot)
                         await notification_service.send_balance_topup_notification(
-                            db, user, transaction, old_balance
+                            user,
+                            transaction,
+                            old_balance,
+                            topup_status=topup_status,
+                            referrer_info=referrer_info,
+                            subscription=subscription,
+                            promo_group=promo_group,
                         )
                     except Exception as e:
                         logger.error(f"Ошибка отправки уведомления о пополнении Stars: {e}")
@@ -475,10 +491,19 @@ class PaymentService:
                 user = await get_user_by_id(db, updated_payment.user_id)
                 if user:
                     old_balance = user.balance_kopeks
-                    
+                    was_first_topup = not user.has_made_first_topup
+
                     user.balance_kopeks += updated_payment.amount_kopeks
                     user.updated_at = datetime.utcnow()
-                    
+
+                    if was_first_topup:
+                        user.has_made_first_topup = True
+
+                    promo_group = getattr(user, "promo_group", None)
+                    subscription = getattr(user, "subscription", None)
+                    referrer_info = format_referrer_info(user)
+                    topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
                     await db.commit()
                     await db.refresh(user)
                     
@@ -493,7 +518,13 @@ class PaymentService:
                             from app.services.admin_notification_service import AdminNotificationService
                             notification_service = AdminNotificationService(self.bot)
                             await notification_service.send_balance_topup_notification(
-                                db, user, transaction, old_balance
+                                user,
+                                transaction,
+                                old_balance,
+                                topup_status=topup_status,
+                                referrer_info=referrer_info,
+                                subscription=subscription,
+                                promo_group=promo_group,
                             )
                         except Exception as e:
                             logger.error(f"Ошибка отправки уведомления о пополнении YooKassa: {e}")
@@ -1075,8 +1106,18 @@ class PaymentService:
                     return False
 
                 old_balance = user.balance_kopeks
+                was_first_topup = not user.has_made_first_topup
+
                 user.balance_kopeks += payment.amount_kopeks
                 user.updated_at = datetime.utcnow()
+
+                if was_first_topup:
+                    user.has_made_first_topup = True
+
+                promo_group = getattr(user, "promo_group", None)
+                subscription = getattr(user, "subscription", None)
+                referrer_info = format_referrer_info(user)
+                topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
 
                 await db.commit()
                 await db.refresh(user)
@@ -1107,10 +1148,13 @@ class PaymentService:
 
                         notification_service = AdminNotificationService(self.bot)
                         await notification_service.send_balance_topup_notification(
-                            db,
                             user,
                             transaction,
                             old_balance,
+                            topup_status=topup_status,
+                            referrer_info=referrer_info,
+                            subscription=subscription,
+                            promo_group=promo_group,
                         )
                     except Exception as notify_error:
                         logger.error(
@@ -1268,8 +1312,19 @@ class PaymentService:
             await link_pal24_payment_to_transaction(db, payment, transaction.id)
 
             old_balance = user.balance_kopeks
+            was_first_topup = not user.has_made_first_topup
+
             user.balance_kopeks += payment.amount_kopeks
             user.updated_at = datetime.utcnow()
+
+            if was_first_topup:
+                user.has_made_first_topup = True
+
+            promo_group = getattr(user, "promo_group", None)
+            subscription = getattr(user, "subscription", None)
+            referrer_info = format_referrer_info(user)
+            topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
             await db.commit()
             await db.refresh(user)
 
@@ -1286,10 +1341,13 @@ class PaymentService:
 
                     notification_service = AdminNotificationService(self.bot)
                     await notification_service.send_balance_topup_notification(
-                        db,
                         user,
                         transaction,
                         old_balance,
+                        topup_status=topup_status,
+                        referrer_info=referrer_info,
+                        subscription=subscription,
+                        promo_group=promo_group,
                     )
                 except Exception as notify_error:
                     logger.error("Ошибка отправки админ уведомления Pal24: %s", notify_error)
@@ -1524,10 +1582,19 @@ class PaymentService:
                 user = await get_user_by_id(db, updated_payment.user_id)
                 if user:
                     old_balance = user.balance_kopeks
-                    
+                    was_first_topup = not user.has_made_first_topup
+
                     user.balance_kopeks += amount_kopeks
                     user.updated_at = datetime.utcnow()
-                    
+
+                    if was_first_topup:
+                        user.has_made_first_topup = True
+
+                    promo_group = getattr(user, "promo_group", None)
+                    subscription = getattr(user, "subscription", None)
+                    referrer_info = format_referrer_info(user)
+                    topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
                     await db.commit()
                     await db.refresh(user)
                     
@@ -1542,7 +1609,13 @@ class PaymentService:
                             from app.services.admin_notification_service import AdminNotificationService
                             notification_service = AdminNotificationService(self.bot)
                             await notification_service.send_balance_topup_notification(
-                                db, user, transaction, old_balance
+                                user,
+                                transaction,
+                                old_balance,
+                                topup_status=topup_status,
+                                referrer_info=referrer_info,
+                                subscription=subscription,
+                                promo_group=promo_group,
                             )
                         except Exception as e:
                             logger.error(f"Ошибка отправки уведомления о пополнении CryptoBot: {e}")

--- a/app/services/tribute_service.py
+++ b/app/services/tribute_service.py
@@ -11,9 +11,10 @@ from app.database.models import Transaction, TransactionType, PaymentMethod
 from app.database.crud.transaction import (
     create_transaction, get_transaction_by_external_id, complete_transaction
 )
-from app.database.crud.user import get_user_by_telegram_id, add_user_balance
+from app.database.crud.user import get_user_by_telegram_id
 from app.external.tribute import TributeService as TributeAPI
 from app.services.payment_service import PaymentService
+from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
 
@@ -120,14 +121,27 @@ class TributeService:
                     amount_kopeks=amount_kopeks,
                     description=f"Пополнение через Tribute: {amount_kopeks/100}₽ (ID: {payment_id})"
                 )
-                
+
                 old_balance = user.balance_kopeks
+                was_first_topup = not user.has_made_first_topup
+
                 user.balance_kopeks += amount_kopeks
                 user.updated_at = datetime.utcnow()
-                
+
+                if was_first_topup:
+                    user.has_made_first_topup = True
+
+                promo_group = getattr(user, "promo_group", None)
+                subscription = getattr(user, "subscription", None)
+                referrer_info = format_referrer_info(user)
+                topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
                 await session.commit()
-                
-                logger.info(f"✅ Баланс пользователя {user_telegram_id} обновлен: {old_balance} -> {user.balance_kopeks} коп (+{amount_kopeks})")
+                await session.refresh(user)
+
+                logger.info(
+                    f"✅ Баланс пользователя {user_telegram_id} обновлен: {old_balance} -> {user.balance_kopeks} коп (+{amount_kopeks})"
+                )
                 logger.info(f"✅ Создана транзакция ID: {transaction.id}")
                 
                 try:
@@ -136,8 +150,7 @@ class TributeService:
                 except Exception as e:
                     logger.error(f"Ошибка обработки реферального пополнения Tribute: {e}")
                     
-                if not user.has_made_first_topup:
-                    user.has_made_first_topup = True
+                if was_first_topup:
                     logger.info(f"Отмечен первый топап для пользователя {user_telegram_id}")
                 
                 
@@ -145,7 +158,13 @@ class TributeService:
                     from app.services.admin_notification_service import AdminNotificationService
                     notification_service = AdminNotificationService(self.bot)
                     await notification_service.send_balance_topup_notification(
-                        session, user, transaction, old_balance
+                        user,
+                        transaction,
+                        old_balance,
+                        topup_status=topup_status,
+                        referrer_info=referrer_info,
+                        subscription=subscription,
+                        promo_group=promo_group,
                     )
                 except Exception as e:
                     logger.error(f"Ошибка отправки уведомления о Tribute пополнении: {e}")

--- a/app/utils/user_utils.py
+++ b/app/utils/user_utils.py
@@ -12,6 +12,25 @@ from app.database.models import User, ReferralEarning, Transaction, TransactionT
 logger = logging.getLogger(__name__)
 
 
+def format_referrer_info(user: User) -> str:
+    """Return formatted referrer info for admin notifications."""
+
+    referred_by_id = getattr(user, "referred_by_id", None)
+
+    if not referred_by_id:
+        return "Нет"
+
+    referrer = getattr(user, "referrer", None)
+
+    if not referrer:
+        return f"ID {referred_by_id} (не найден)"
+
+    if referrer.username:
+        return f"@{referrer.username} (ID: {referred_by_id})"
+
+    return f"ID {referrer.telegram_id}"
+
+
 async def generate_unique_referral_code(db: AsyncSession, telegram_id: int) -> str:
     max_attempts = 10
     


### PR DESCRIPTION
## Summary
- preload user referrers when fetching users to avoid extra lookups during notifications
- add a reusable referrer formatter and update admin notifications to accept precomputed context instead of querying the database
- adjust payment and tribute top-up flows to build notification context, mark first top-ups, and reuse the new notification signature