### PR TITLE
Fix installation guide modal scrolling

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -4288,6 +4288,7 @@
             display: flex;
             flex-direction: column;
             overflow: hidden;
+            min-height: 0;
         }
 
         .guide-modal-header {
@@ -4325,6 +4326,9 @@
             padding: 0 24px 24px;
             overflow-y: auto;
             flex: 1;
+            min-height: 0;
+            -webkit-overflow-scrolling: touch;
+            overscroll-behavior: contain;
         }
 
         .guide-modal-footer {


### PR DESCRIPTION
## Summary
- allow the installation guide modal content to shrink within the flex container
- enable touch-friendly scrolling so long instructions remain reachable