### PR TITLE
Fix installation modal truncation for PC app list

### DIFF
--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -4288,6 +4288,7 @@
             display: flex;
             flex-direction: column;
             overflow: hidden;
+            min-height: 0;
         }
 
         .guide-modal-header {
@@ -4325,6 +4326,9 @@
             padding: 0 24px 24px;
             overflow-y: auto;
             flex: 1;
+            min-height: 0;
+            -webkit-overflow-scrolling: touch;
+            overscroll-behavior: contain;
         }
 
         .guide-modal-footer {
@@ -4334,6 +4338,7 @@
             display: flex;
             flex-direction: column;
             gap: 12px;
+            flex-shrink: 0;
         }
 
         .guide-modal-footer .btn {
@@ -4363,6 +4368,7 @@
                 height: 100vh;
                 border-radius: 0;
                 box-shadow: none;
+                min-height: 0;
             }
 
             .guide-modal-header {
@@ -4386,6 +4392,12 @@
 
         .installation-card-content {
             padding: 0;
+        }
+
+        .installation-card .card-content,
+        .installation-card-content {
+            max-height: none;
+            overflow: visible;
         }
 
         .step-final-action {


### PR DESCRIPTION
## Summary
- prevent the installation modal card content from using the global max-height so long PC app lists stay visible