### PR TITLE
Use configured Happ redirect template in miniapp

### DIFF
--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -2559,6 +2559,7 @@ async def get_subscription_details(
         happ_link=links_payload.get("happ_link") if subscription else None,
         happ_crypto_link=links_payload.get("happ_crypto_link") if subscription else None,
         happ_cryptolink_redirect_link=happ_redirect_link,
+        happ_cryptolink_redirect_template=settings.get_happ_cryptolink_redirect_template(),
         balance_kopeks=user.balance_kopeks,
         balance_rubles=round(user.balance_rubles, 2),
         balance_currency=balance_currency,

--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -439,6 +439,7 @@ class MiniAppSubscriptionResponse(BaseModel):
     happ_link: Optional[str] = None
     happ_crypto_link: Optional[str] = None
     happ_cryptolink_redirect_link: Optional[str] = None
+    happ_cryptolink_redirect_template: Optional[str] = None
     balance_kopeks: int = 0
     balance_rubles: float = 0.0
     balance_currency: Optional[str] = None

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -17954,7 +17954,11 @@
             }
 
             if (isPCDevice && !redirectTemplate) {
-                redirectTemplate = 'https://miniapp.fring.tech/redirect/?redirect_to=';
+                redirectTemplate = normalizeUrl(
+                    userData?.happ_cryptolink_redirect_template
+                    || userData?.happCryptolinkRedirectTemplate
+                    || null,
+                );
             }
 
             const templatedRedirectLink = (isPCDevice && redirectTemplate && redirectTarget)


### PR DESCRIPTION
## Summary
- expose the Happ CryptoLink redirect template from settings in the miniapp subscription response
- update the miniapp frontend to rely on the configured template instead of a hard-coded redirect URL