### PR TITLE
Add text-only main menu mode with miniapp profile shortcut

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -280,6 +280,9 @@ PAL24_REQUEST_TIMEOUT=30
 ENABLE_LOGO_MODE=true
 LOGO_FILE=vpn_logo.png
 
+# Режим главного меню (default - полное меню, text - только текст с базовыми кнопками)
+MAIN_MENU_MODE=default
+
 # Скрыть блок с ссылкой подключения в разделе с информацией о подписке
 HIDE_SUBSCRIPTION_LINK=false
 

--- a/README.md
+++ b/README.md
@@ -829,6 +829,9 @@ PAL24_REQUEST_TIMEOUT=30
 ENABLE_LOGO_MODE=true
 LOGO_FILE=vpn_logo.png
 
+# Режим главного меню (default - полное меню, text - только текст с базовыми кнопками)
+MAIN_MENU_MODE=default
+
 # Скрыть блок с ссылкой подключения в разделе с информацией о подписке
 HIDE_SUBSCRIPTION_LINK=false
 

--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -168,12 +168,14 @@ async def show_main_menu(
         db_user.telegram_id
     )
 
-    custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-        db,
-        is_admin=is_admin,
-        has_active_subscription=has_active_subscription,
-        subscription_is_active=subscription_is_active,
-    )
+    custom_buttons = []
+    if not settings.is_text_main_menu_mode():
+        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+            db,
+            is_admin=is_admin,
+            has_active_subscription=has_active_subscription,
+            subscription_is_active=subscription_is_active,
+        )
 
     await edit_or_answer_photo(
         callback=callback,
@@ -191,9 +193,26 @@ async def show_main_menu(
             custom_buttons=custom_buttons,
         ),
         parse_mode="HTML",
+        force_text=settings.is_text_main_menu_mode(),
     )
     if not skip_callback_answer:
         await callback.answer()
+
+
+async def handle_profile_unavailable(callback: types.CallbackQuery) -> None:
+    language = getattr(callback.from_user, "language_code", None) or settings.DEFAULT_LANGUAGE
+    try:
+        texts = get_texts(language)
+    except Exception:
+        texts = get_texts()
+
+    await callback.answer(
+        texts.t(
+            "MENU_PROFILE_UNAVAILABLE",
+            "❗️ Личный кабинет пока недоступен. Попробуйте позже.",
+        ),
+        show_alert=True,
+    )
 
 
 async def show_service_rules(
@@ -880,12 +899,14 @@ async def handle_back_to_menu(
         db_user.telegram_id
     )
 
-    custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-        db,
-        is_admin=is_admin,
-        has_active_subscription=has_active_subscription,
-        subscription_is_active=subscription_is_active,
-    )
+    custom_buttons = []
+    if not settings.is_text_main_menu_mode():
+        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+            db,
+            is_admin=is_admin,
+            has_active_subscription=has_active_subscription,
+            subscription_is_active=subscription_is_active,
+        )
 
     await edit_or_answer_photo(
         callback=callback,
@@ -903,6 +924,7 @@ async def handle_back_to_menu(
             custom_buttons=custom_buttons,
         ),
         parse_mode="HTML",
+        force_text=settings.is_text_main_menu_mode(),
     )
     await callback.answer()
 
@@ -1036,7 +1058,12 @@ def register_handlers(dp: Dispatcher):
         handle_back_to_menu,
         F.data == "back_to_menu"
     )
-    
+
+    dp.callback_query.register(
+        handle_profile_unavailable,
+        F.data == "menu_profile_unavailable",
+    )
+
     dp.callback_query.register(
         show_service_rules,
         F.data == "menu_rules"

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -335,12 +335,14 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             user.telegram_id
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         await message.answer(
             menu_text,
@@ -757,12 +759,14 @@ async def complete_registration_from_callback(
             and SupportSettingsService.is_moderator(existing_user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await callback.message.answer(
@@ -937,12 +941,14 @@ async def complete_registration_from_callback(
             and SupportSettingsService.is_moderator(user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await callback.message.answer(
@@ -1011,12 +1017,14 @@ async def complete_registration(
             and SupportSettingsService.is_moderator(existing_user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await message.answer(
@@ -1191,12 +1199,14 @@ async def complete_registration(
             and SupportSettingsService.is_moderator(user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await message.answer(

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -397,6 +397,8 @@
   "TRAFFIC_ALREADY_UNLIMITED": "⚠ You already have unlimited traffic",
   "ADD_TRAFFIC_PROMPT": "📈 <b>Add traffic to your subscription</b>\n\nCurrent limit: {current_traffic}\nChoose extra traffic:",
   "USER_NOT_FOUND": "❌ User not found",
+  "MENU_PROFILE": "👤 Personal account",
+  "MENU_PROFILE_UNAVAILABLE": "❗️ Personal account is not available yet. Please try again later.",
   "MENU_LANGUAGE": "🌐 Language",
   "SUBSCRIPTION_STATUS_EXPIRED": "Expired",
   "SUBSCRIPTION_STATUS_TRIAL": "Trial",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -256,6 +256,8 @@
   "PUBLIC_OFFER_EMPTY_ALERT": "Публичная оферта ещё не заполнена.",
   "PUBLIC_OFFER_HEADER": "📄 <b>Публичная оферта</b>",
   "PUBLIC_OFFER_PAGE_INFO": "Страница {current} из {total}",
+  "MENU_PROFILE": "👤 Личный кабинет",
+  "MENU_PROFILE_UNAVAILABLE": "❗️ Личный кабинет пока недоступен. Попробуйте позже.",
   "MENU_LANGUAGE": "🌐 Язык",
   "MENU_PROMOCODE": "🎫 Промокод",
   "MENU_REFERRALS": "🤝 Партнерка",

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -227,6 +227,7 @@ class BotConfigurationService:
         "ENABLE_LOGO_MODE": "INTERFACE_BRANDING",
         "LOGO_FILE": "INTERFACE_BRANDING",
         "HIDE_SUBSCRIPTION_LINK": "INTERFACE_SUBSCRIPTION",
+        "MAIN_MENU_MODE": "INTERFACE",
         "CONNECT_BUTTON_MODE": "CONNECT_BUTTON",
         "MINIAPP_CUSTOM_URL": "CONNECT_BUTTON",
         "APP_CONFIG_PATH": "ADDITIONAL",
@@ -320,6 +321,10 @@ class BotConfigurationService:
             ChoiceOption("miniapp_custom", "🧩 Mini App (ссылка)"),
             ChoiceOption("link", "🔗 Прямая ссылка"),
             ChoiceOption("happ_cryptolink", "🪙 Happ CryptoLink"),
+        ],
+        "MAIN_MENU_MODE": [
+            ChoiceOption("default", "📋 Полное меню"),
+            ChoiceOption("text", "📝 Текстовое меню"),
         ],
         "SERVER_STATUS_MODE": [
             ChoiceOption("disabled", "🚫 Отключено"),

--- a/app/utils/photo_message.py
+++ b/app/utils/photo_message.py
@@ -69,10 +69,12 @@ async def edit_or_answer_photo(
     caption: str,
     keyboard: types.InlineKeyboardMarkup,
     parse_mode: str | None = "HTML",
+    *,
+    force_text: bool = False,
 ) -> None:
     resolved_parse_mode = parse_mode or "HTML"
-    # Если режим логотипа выключен — работаем текстом
-    if not settings.ENABLE_LOGO_MODE:
+    # Если режим логотипа выключен или требуется текстовое сообщение — работаем текстом
+    if force_text or not settings.ENABLE_LOGO_MODE:
         try:
             if callback.message.photo:
                 await callback.message.delete()
@@ -84,7 +86,10 @@ async def edit_or_answer_photo(
                     parse_mode=resolved_parse_mode,
                 )
         except TelegramBadRequest as error:
-            await callback.message.delete()
+            try:
+                await callback.message.delete()
+            except Exception:
+                pass
             await _answer_text(callback, caption, keyboard, resolved_parse_mode, error)
         return
 


### PR DESCRIPTION
## Summary
- add a configurable `MAIN_MENU_MODE` with validation and admin settings integration
- render the main menu in text-only mode with a mini app profile button plus language, support, and admin controls
- update keyboard handling, localization strings, and callback responses for the simplified menu flow