### PR TITLE
Route subscription reminders to miniapp in text mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -280,6 +280,9 @@ PAL24_REQUEST_TIMEOUT=30
 ENABLE_LOGO_MODE=true
 LOGO_FILE=vpn_logo.png
 
+# Режим главного меню (default - полное меню, text - только текст с базовыми кнопками)
+MAIN_MENU_MODE=default
+
 # Скрыть блок с ссылкой подключения в разделе с информацией о подписке
 HIDE_SUBSCRIPTION_LINK=false
 

--- a/README.md
+++ b/README.md
@@ -829,6 +829,9 @@ PAL24_REQUEST_TIMEOUT=30
 ENABLE_LOGO_MODE=true
 LOGO_FILE=vpn_logo.png
 
+# Режим главного меню (default - полное меню, text - только текст с базовыми кнопками)
+MAIN_MENU_MODE=default
+
 # Скрыть блок с ссылкой подключения в разделе с информацией о подписке
 HIDE_SUBSCRIPTION_LINK=false
 

--- a/app/handlers/admin/promo_offers.py
+++ b/app/handlers/admin/promo_offers.py
@@ -44,6 +44,7 @@ from app.states import AdminStates
 from app.utils.decorators import admin_required, error_handler
 from app.utils.subscription_utils import get_display_subscription_link
 from app.utils.formatters import format_datetime, format_duration
+from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 
 logger = logging.getLogger(__name__)
 
@@ -1920,7 +1921,12 @@ async def _send_offer_to_users(
 
             user_texts = get_texts(user.language or db_user.language)
             keyboard_rows: List[List[InlineKeyboardButton]] = [
-                [InlineKeyboardButton(text=template.button_text, callback_data=f"claim_discount_{offer_record.id}")]
+                [
+                    build_miniapp_or_callback_button(
+                        text=template.button_text,
+                        callback_data=f"claim_discount_{offer_record.id}",
+                    )
+                ]
             ]
 
             keyboard_rows.append([

--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -168,12 +168,14 @@ async def show_main_menu(
         db_user.telegram_id
     )
 
-    custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-        db,
-        is_admin=is_admin,
-        has_active_subscription=has_active_subscription,
-        subscription_is_active=subscription_is_active,
-    )
+    custom_buttons = []
+    if not settings.is_text_main_menu_mode():
+        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+            db,
+            is_admin=is_admin,
+            has_active_subscription=has_active_subscription,
+            subscription_is_active=subscription_is_active,
+        )
 
     await edit_or_answer_photo(
         callback=callback,
@@ -191,9 +193,26 @@ async def show_main_menu(
             custom_buttons=custom_buttons,
         ),
         parse_mode="HTML",
+        force_text=settings.is_text_main_menu_mode(),
     )
     if not skip_callback_answer:
         await callback.answer()
+
+
+async def handle_profile_unavailable(callback: types.CallbackQuery) -> None:
+    language = getattr(callback.from_user, "language_code", None) or settings.DEFAULT_LANGUAGE
+    try:
+        texts = get_texts(language)
+    except Exception:
+        texts = get_texts()
+
+    await callback.answer(
+        texts.t(
+            "MENU_PROFILE_UNAVAILABLE",
+            "❗️ Личный кабинет пока недоступен. Попробуйте позже.",
+        ),
+        show_alert=True,
+    )
 
 
 async def show_service_rules(
@@ -880,12 +899,14 @@ async def handle_back_to_menu(
         db_user.telegram_id
     )
 
-    custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-        db,
-        is_admin=is_admin,
-        has_active_subscription=has_active_subscription,
-        subscription_is_active=subscription_is_active,
-    )
+    custom_buttons = []
+    if not settings.is_text_main_menu_mode():
+        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+            db,
+            is_admin=is_admin,
+            has_active_subscription=has_active_subscription,
+            subscription_is_active=subscription_is_active,
+        )
 
     await edit_or_answer_photo(
         callback=callback,
@@ -903,6 +924,7 @@ async def handle_back_to_menu(
             custom_buttons=custom_buttons,
         ),
         parse_mode="HTML",
+        force_text=settings.is_text_main_menu_mode(),
     )
     await callback.answer()
 
@@ -1036,7 +1058,12 @@ def register_handlers(dp: Dispatcher):
         handle_back_to_menu,
         F.data == "back_to_menu"
     )
-    
+
+    dp.callback_query.register(
+        handle_profile_unavailable,
+        F.data == "menu_profile_unavailable",
+    )
+
     dp.callback_query.register(
         show_service_rules,
         F.data == "menu_rules"

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -335,12 +335,14 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             user.telegram_id
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         await message.answer(
             menu_text,
@@ -757,12 +759,14 @@ async def complete_registration_from_callback(
             and SupportSettingsService.is_moderator(existing_user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await callback.message.answer(
@@ -937,12 +941,14 @@ async def complete_registration_from_callback(
             and SupportSettingsService.is_moderator(user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await callback.message.answer(
@@ -1011,12 +1017,14 @@ async def complete_registration(
             and SupportSettingsService.is_moderator(existing_user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await message.answer(
@@ -1191,12 +1199,14 @@ async def complete_registration(
             and SupportSettingsService.is_moderator(user.telegram_id)
         )
 
-        custom_buttons = await MainMenuButtonService.get_buttons_for_user(
-            db,
-            is_admin=is_admin,
-            has_active_subscription=has_active_subscription,
-            subscription_is_active=subscription_is_active,
-        )
+        custom_buttons = []
+        if not settings.is_text_main_menu_mode():
+            custom_buttons = await MainMenuButtonService.get_buttons_for_user(
+                db,
+                is_admin=is_admin,
+                has_active_subscription=has_active_subscription,
+                subscription_is_active=subscription_is_active,
+            )
 
         try:
             await message.answer(

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -58,6 +58,7 @@ from app.services.subscription_checkout_service import (
     should_offer_checkout_resume,
 )
 from app.services.subscription_service import SubscriptionService
+from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 from app.services.promo_offer_service import promo_offer_service
 from app.states import SubscriptionStates
 from app.utils.pagination import paginate_list
@@ -5487,7 +5488,7 @@ async def claim_discount_offer(
     buy_keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
             [
-                InlineKeyboardButton(
+                build_miniapp_or_callback_button(
                     text=button_text,
                     callback_data=button_callback,
                 )

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -397,6 +397,8 @@
   "TRAFFIC_ALREADY_UNLIMITED": "⚠ You already have unlimited traffic",
   "ADD_TRAFFIC_PROMPT": "📈 <b>Add traffic to your subscription</b>\n\nCurrent limit: {current_traffic}\nChoose extra traffic:",
   "USER_NOT_FOUND": "❌ User not found",
+  "MENU_PROFILE": "👤 Personal account",
+  "MENU_PROFILE_UNAVAILABLE": "❗️ Personal account is not available yet. Please try again later.",
   "MENU_LANGUAGE": "🌐 Language",
   "SUBSCRIPTION_STATUS_EXPIRED": "Expired",
   "SUBSCRIPTION_STATUS_TRIAL": "Trial",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -256,6 +256,8 @@
   "PUBLIC_OFFER_EMPTY_ALERT": "Публичная оферта ещё не заполнена.",
   "PUBLIC_OFFER_HEADER": "📄 <b>Публичная оферта</b>",
   "PUBLIC_OFFER_PAGE_INFO": "Страница {current} из {total}",
+  "MENU_PROFILE": "👤 Личный кабинет",
+  "MENU_PROFILE_UNAVAILABLE": "❗️ Личный кабинет пока недоступен. Попробуйте позже.",
   "MENU_LANGUAGE": "🌐 Язык",
   "MENU_PROMOCODE": "🎫 Промокод",
   "MENU_REFERRALS": "🤝 Партнерка",

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -45,6 +45,7 @@ from app.services.payment_service import PaymentService
 from app.services.subscription_service import SubscriptionService
 from app.services.promo_offer_service import promo_offer_service
 from app.utils.pricing_utils import apply_percentage_discount
+from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 
 from app.external.remnawave_api import (
     RemnaWaveAPIError,
@@ -977,10 +978,10 @@ class MonitoringService:
 """
             
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-            
+
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text="💎 Купить подписку", callback_data="menu_buy")],
-                [InlineKeyboardButton(text="💳 Пополнить баланс", callback_data="balance_topup")]
+                [build_miniapp_or_callback_button(text="💎 Купить подписку", callback_data="menu_buy")],
+                [build_miniapp_or_callback_button(text="💳 Пополнить баланс", callback_data="balance_topup")],
             ])
 
             await self._send_message_with_logo(
@@ -1033,11 +1034,11 @@ class MonitoringService:
 """
             
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-            
+
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text="⏰ Продлить подписку", callback_data="subscription_extend")],
-                [InlineKeyboardButton(text="💳 Пополнить баланс", callback_data="balance_topup")],
-                [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")]
+                [build_miniapp_or_callback_button(text="⏰ Продлить подписку", callback_data="subscription_extend")],
+                [build_miniapp_or_callback_button(text="💳 Пополнить баланс", callback_data="balance_topup")],
+                [build_miniapp_or_callback_button(text="📱 Моя подписка", callback_data="menu_subscription")],
             ])
 
             await self._send_message_with_logo(
@@ -1087,10 +1088,10 @@ class MonitoringService:
 """
             
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-            
+
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text="💎 Купить подписку", callback_data="menu_buy")],
-                [InlineKeyboardButton(text="💰 Пополнить баланс", callback_data="balance_topup")]
+                [build_miniapp_or_callback_button(text="💎 Купить подписку", callback_data="menu_buy")],
+                [build_miniapp_or_callback_button(text="💰 Пополнить баланс", callback_data="balance_topup")],
             ])
 
             await self._send_message_with_logo(
@@ -1147,8 +1148,14 @@ class MonitoringService:
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text=texts.t("CONNECT_BUTTON", "🔗 Подключиться"), callback_data="subscription_connect")],
-                [InlineKeyboardButton(text=texts.t("MY_SUBSCRIPTION_BUTTON", "📱 Моя подписка"), callback_data="menu_subscription")],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("CONNECT_BUTTON", "🔗 Подключиться"),
+                    callback_data="subscription_connect",
+                )],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("MY_SUBSCRIPTION_BUTTON", "📱 Моя подписка"),
+                    callback_data="menu_subscription",
+                )],
                 [InlineKeyboardButton(text=texts.t("SUPPORT_BUTTON", "🆘 Поддержка"), callback_data="menu_support")],
             ])
 
@@ -1258,8 +1265,14 @@ class MonitoringService:
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text=texts.t("SUBSCRIPTION_EXTEND", "💎 Продлить подписку"), callback_data="subscription_extend")],
-                [InlineKeyboardButton(text=texts.t("BALANCE_TOPUP", "💳 Пополнить баланс"), callback_data="balance_topup")],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("SUBSCRIPTION_EXTEND", "💎 Продлить подписку"),
+                    callback_data="subscription_extend",
+                )],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("BALANCE_TOPUP", "💳 Пополнить баланс"),
+                    callback_data="balance_topup",
+                )],
                 [InlineKeyboardButton(text=texts.t("SUPPORT_BUTTON", "🆘 Поддержка"), callback_data="menu_support")],
             ])
 
@@ -1329,9 +1342,15 @@ class MonitoringService:
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text="🎁 Получить скидку", callback_data=f"claim_discount_{offer_id}")],
-                [InlineKeyboardButton(text=texts.t("SUBSCRIPTION_EXTEND", "💎 Продлить подписку"), callback_data="subscription_extend")],
-                [InlineKeyboardButton(text=texts.t("BALANCE_TOPUP", "💳 Пополнить баланс"), callback_data="balance_topup")],
+                [build_miniapp_or_callback_button(text="🎁 Получить скидку", callback_data=f"claim_discount_{offer_id}")],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("SUBSCRIPTION_EXTEND", "💎 Продлить подписку"),
+                    callback_data="subscription_extend",
+                )],
+                [build_miniapp_or_callback_button(
+                    text=texts.t("BALANCE_TOPUP", "💳 Пополнить баланс"),
+                    callback_data="balance_topup",
+                )],
                 [InlineKeyboardButton(text=texts.t("SUPPORT_BUTTON", "🆘 Поддержка"), callback_data="menu_support")],
             ])
 
@@ -1394,11 +1413,11 @@ class MonitoringService:
                 required=settings.format_price(required)
             )
             
-            from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-            
+            from aiogram.types import InlineKeyboardMarkup
+
             keyboard = InlineKeyboardMarkup(inline_keyboard=[
-                [InlineKeyboardButton(text="💳 Пополнить баланс", callback_data="balance_topup")],
-                [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")]
+                [build_miniapp_or_callback_button(text="💳 Пополнить баланс", callback_data="balance_topup")],
+                [build_miniapp_or_callback_button(text="📱 Моя подписка", callback_data="menu_subscription")],
             ])
             
             await self._send_message_with_logo(

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -31,6 +31,7 @@ from app.services.subscription_checkout_service import (
 )
 from app.services.mulenpay_service import MulenPayService
 from app.services.pal24_service import Pal24Service, Pal24APIError
+from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 from app.database.crud.mulenpay import (
     create_mulenpay_payment,
     get_mulenpay_payment_by_local_id,
@@ -71,7 +72,7 @@ class PaymentService:
             and user.subscription.is_active
         )
 
-        first_button = InlineKeyboardButton(
+        first_button = build_miniapp_or_callback_button(
             text=(
                 texts.MENU_EXTEND_SUBSCRIPTION
                 if has_active_subscription
@@ -88,14 +89,14 @@ class PaymentService:
             draft_exists = await has_subscription_checkout_draft(user.id)
             if should_offer_checkout_resume(user, draft_exists):
                 keyboard_rows.append([
-                    InlineKeyboardButton(
+                    build_miniapp_or_callback_button(
                         text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
                         callback_data="subscription_resume_checkout",
                     )
                 ])
 
         keyboard_rows.append([
-            InlineKeyboardButton(text="💰 Мой баланс", callback_data="menu_balance")
+            build_miniapp_or_callback_button(text="💰 Мой баланс", callback_data="menu_balance")
         ])
         keyboard_rows.append([
             InlineKeyboardButton(text="🏠 Главное меню", callback_data="back_to_menu")

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -227,6 +227,7 @@ class BotConfigurationService:
         "ENABLE_LOGO_MODE": "INTERFACE_BRANDING",
         "LOGO_FILE": "INTERFACE_BRANDING",
         "HIDE_SUBSCRIPTION_LINK": "INTERFACE_SUBSCRIPTION",
+        "MAIN_MENU_MODE": "INTERFACE",
         "CONNECT_BUTTON_MODE": "CONNECT_BUTTON",
         "MINIAPP_CUSTOM_URL": "CONNECT_BUTTON",
         "APP_CONFIG_PATH": "ADDITIONAL",
@@ -320,6 +321,10 @@ class BotConfigurationService:
             ChoiceOption("miniapp_custom", "🧩 Mini App (ссылка)"),
             ChoiceOption("link", "🔗 Прямая ссылка"),
             ChoiceOption("happ_cryptolink", "🪙 Happ CryptoLink"),
+        ],
+        "MAIN_MENU_MODE": [
+            ChoiceOption("default", "📋 Полное меню"),
+            ChoiceOption("text", "📝 Текстовое меню"),
         ],
         "SERVER_STATUS_MODE": [
             ChoiceOption("disabled", "🚫 Отключено"),

--- a/app/utils/miniapp_buttons.py
+++ b/app/utils/miniapp_buttons.py
@@ -1,0 +1,35 @@
+from aiogram import types
+from aiogram.types import InlineKeyboardButton
+
+from app.config import settings
+
+
+DEFAULT_UNAVAILABLE_CALLBACK = "menu_profile_unavailable"
+
+
+def build_miniapp_or_callback_button(
+    text: str,
+    *,
+    callback_data: str,
+    unavailable_callback: str = DEFAULT_UNAVAILABLE_CALLBACK,
+) -> InlineKeyboardButton:
+    """Create a button that opens the miniapp in text menu mode.
+
+    When the simplified text menu mode is enabled we should avoid exposing
+    deep bot flows and redirect the user to the configured miniapp instead.
+    If the miniapp URL is missing we fall back to a safe callback that shows
+    an alert about the unavailable profile rather than opening disabled
+    sections of the bot.
+    """
+
+    if settings.is_text_main_menu_mode():
+        miniapp_url = settings.get_main_menu_miniapp_url()
+        if miniapp_url:
+            return InlineKeyboardButton(
+                text=text,
+                web_app=types.WebAppInfo(url=miniapp_url),
+            )
+        safe_callback = unavailable_callback or DEFAULT_UNAVAILABLE_CALLBACK
+        return InlineKeyboardButton(text=text, callback_data=safe_callback)
+
+    return InlineKeyboardButton(text=text, callback_data=callback_data)

--- a/app/utils/photo_message.py
+++ b/app/utils/photo_message.py
@@ -69,10 +69,12 @@ async def edit_or_answer_photo(
     caption: str,
     keyboard: types.InlineKeyboardMarkup,
     parse_mode: str | None = "HTML",
+    *,
+    force_text: bool = False,
 ) -> None:
     resolved_parse_mode = parse_mode or "HTML"
-    # Если режим логотипа выключен — работаем текстом
-    if not settings.ENABLE_LOGO_MODE:
+    # Если режим логотипа выключен или требуется текстовое сообщение — работаем текстом
+    if force_text or not settings.ENABLE_LOGO_MODE:
         try:
             if callback.message.photo:
                 await callback.message.delete()
@@ -84,7 +86,10 @@ async def edit_or_answer_photo(
                     parse_mode=resolved_parse_mode,
                 )
         except TelegramBadRequest as error:
-            await callback.message.delete()
+            try:
+                await callback.message.delete()
+            except Exception:
+                pass
             await _answer_text(callback, caption, keyboard, resolved_parse_mode, error)
         return
 


### PR DESCRIPTION
## Summary
- reuse the miniapp redirect helper for the autopay and subscription expiring keyboards so balance, extend, and profile buttons launch the miniapp when the text menu mode is active