### PR TITLE
Fix reactivation of subscriptions extended via promo codes

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -223,9 +223,17 @@ async def extend_subscription(
             if subscription.user:
                 subscription.user.has_had_paid_subscription = True
 
-    if subscription.status == SubscriptionStatus.EXPIRED.value and days > 0:
+    if days > 0 and subscription.status in (
+        SubscriptionStatus.EXPIRED.value,
+        SubscriptionStatus.DISABLED.value,
+    ):
+        previous_status = subscription.status
         subscription.status = SubscriptionStatus.ACTIVE.value
-        logger.info(f"🔄 Статус изменён с EXPIRED на ACTIVE")
+        logger.info(
+            "🔄 Статус подписки %s изменён с %s на ACTIVE",
+            subscription.id,
+            previous_status,
+        )
 
     if settings.RESET_TRAFFIC_ON_PAYMENT:
         subscription.traffic_used_gb = 0.0


### PR DESCRIPTION
## Summary
- reactivate subscriptions that receive additional days while expired or disabled
- add logging of the status transition when a subscription is re-enabled