### PR TITLE
Add WATA payment support to miniapp API

### DIFF
--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -392,6 +392,7 @@ class MiniAppPaymentCreateResponse(BaseModel):
 class MiniAppPaymentStatusQuery(BaseModel):
     method: str
     local_payment_id: Optional[int] = Field(default=None, alias="localPaymentId")
+    payment_link_id: Optional[str] = Field(default=None, alias="paymentLinkId")
     invoice_id: Optional[str] = Field(default=None, alias="invoiceId")
     payment_id: Optional[str] = Field(default=None, alias="paymentId")
     payload: Optional[str] = None


### PR DESCRIPTION
## Summary
- expose the WATA payment option through the miniapp payment methods list and creation/status flows
- extend the miniapp schemas to carry WATA payment link identifiers used for status lookups
- cover the new WATA miniapp paths with focused tests
