### PR TITLE
Fix Telegram Stars payment state and add missing YooKassa SBP locales

### DIFF
--- a/app/handlers/balance/stars.py
+++ b/app/handlers/balance/stars.py
@@ -8,6 +8,7 @@ from app.database.models import User
 from app.keyboards.inline import get_back_keyboard, get_payment_methods_keyboard
 from app.localization.texts import get_texts
 from app.services.payment_service import PaymentService
+from app.states import BalanceStates
 from app.utils.decorators import error_handler
 from app.external.telegram_stars import TelegramStarsService
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -573,6 +573,8 @@
   "PAYMENT_METHOD_STARS_DESCRIPTION": "fast and convenient",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Bank card</b>",
   "PAYMENT_METHOD_YOOKASSA_DESCRIPTION": "via YooKassa",
+  "PAYMENT_METHOD_YOOKASSA_SBP_NAME": "🏦 <b>SBP (YooKassa)</b>",
+  "PAYMENT_METHOD_YOOKASSA_SBP_DESCRIPTION": "via YooKassa Fast Payment System",
   "PAYMENT_METHOD_TRIBUTE_NAME": "💳 <b>Bank card</b>",
   "PAYMENT_METHOD_TRIBUTE_DESCRIPTION": "via Tribute",
   "PAYMENT_METHOD_MULENPAY_NAME": "💳 <b>Bank card (Mulen Pay)</b>",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -575,6 +575,8 @@
   "PAYMENT_METHOD_STARS_DESCRIPTION": "быстро и удобно",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Банковская карта</b>",
   "PAYMENT_METHOD_YOOKASSA_DESCRIPTION": "через YooKassa",
+  "PAYMENT_METHOD_YOOKASSA_SBP_NAME": "🏦 <b>СБП (YooKassa)</b>",
+  "PAYMENT_METHOD_YOOKASSA_SBP_DESCRIPTION": "через систему быстрых платежей YooKassa",
   "PAYMENT_METHOD_TRIBUTE_NAME": "💳 <b>Банковская карта</b>",
   "PAYMENT_METHOD_TRIBUTE_DESCRIPTION": "через Tribute",
   "PAYMENT_METHOD_MULENPAY_NAME": "💳 <b>Банковская карта (Mulen Pay)</b>",


### PR DESCRIPTION
## Summary
- import the shared BalanceStates in the Telegram Stars top-up handler to prevent NameError during the amount prompt
- add the missing Russian and English localization strings for the YooKassa SBP payment method
