### PR TITLE
Fix Pal24 payment method mapping

### DIFF
--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -64,6 +64,7 @@ class Pal24PaymentMixin:
         }
 
         normalized_payment_method = self._normalize_payment_method(payment_method)
+        pal24_payment_method = self._map_payment_method_for_api(normalized_payment_method)
 
         payment_module = import_module("app.services.payment_service")
 
@@ -76,7 +77,7 @@ class Pal24PaymentMixin:
                 ttl_seconds=ttl_seconds,
                 custom_payload=custom_payload,
                 payer_email=payer_email,
-                payment_method=normalized_payment_method,
+                payment_method=pal24_payment_method,
             )
         except Pal24APIError as error:
             logger.error("Ошибка Pal24 API при создании счета: %s", error)
@@ -528,3 +529,12 @@ class Pal24PaymentMixin:
 
         normalized = payment_method.strip().lower()
         return mapping.get(normalized, "sbp")
+
+    @staticmethod
+    def _map_payment_method_for_api(normalized_method: str) -> Optional[str]:
+        mapping = {
+            "sbp": "fast_payment",
+            "card": "bank_card",
+        }
+
+        return mapping.get(normalized_method)

--- a/tests/services/test_payment_service_pal24.py
+++ b/tests/services/test_payment_service_pal24.py
@@ -105,7 +105,39 @@ async def test_create_pal24_payment_success(monkeypatch: pytest.MonkeyPatch) -> 
     assert result["link_url"] == "https://pal24/sbp"
     assert result["card_url"] == "https://pal24/card"
     assert stub.calls and stub.calls[0]["amount_kopeks"] == 50000
+    assert stub.calls[0]["payment_method"] == "bank_card"
     assert "links" in captured_args["metadata"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_pal24_payment_default_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = StubPal24Service()
+    service = _make_service(stub)
+    db = DummySession()
+
+    async def fake_create_pal24_payment(*args: Any, **kwargs: Any) -> DummyLocalPayment:
+        return DummyLocalPayment(payment_id=111)
+
+    monkeypatch.setattr(
+        payment_service_module,
+        "create_pal24_payment",
+        fake_create_pal24_payment,
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "PAL24_MIN_AMOUNT_KOPEKS", 1000, raising=False)
+    monkeypatch.setattr(settings, "PAL24_MAX_AMOUNT_KOPEKS", 1_000_000, raising=False)
+
+    result = await service.create_pal24_payment(
+        db=db,
+        user_id=42,
+        amount_kopeks=150000,
+        description="Пополнение",
+        language="ru",
+    )
+
+    assert result is not None
+    assert result["payment_method"] == "sbp"
+    assert stub.calls and stub.calls[0]["payment_method"] == "fast_payment"
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- map PayPalych payment methods to the provider-specific identifiers before creating a bill
- add automated coverage for default and explicit payment method mapping
