### PR TITLE
Fix Pal24 custom payload serialization

### DIFF
--- a/tests/services/test_pal24_service_adapter.py
+++ b/tests/services/test_pal24_service_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 import sys
@@ -77,6 +78,7 @@ async def test_create_bill_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.calls and client.calls[0]["amount"] == Decimal("500.00")
     assert client.calls[0]["shop_id"] == "shop42"
     assert client.calls[0]["description"] == "Пополнение"
+    assert client.calls[0]["custom"] == json.dumps({"extra": "value"}, ensure_ascii=False, separators=(",", ":"))
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- serialize Pal24 custom payloads to JSON before sending to the Pal24 API
- extend the Pal24 service adapter test to verify the serialized custom payload

