### PR TITLE
Fix Pal24 payment method values

### DIFF
--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -535,8 +535,8 @@ class Pal24PaymentMixin:
         """Преобразует нормализованный метод оплаты в значение для Pal24 API."""
 
         api_mapping = {
-            "sbp": "fast_payment",
-            "card": "bank_card",
+            "sbp": "SBP",
+            "card": "BANK_CARD",
         }
 
         return api_mapping.get(normalized_payment_method)

--- a/tests/services/test_pal24_service_adapter.py
+++ b/tests/services/test_pal24_service_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 import sys
@@ -70,13 +71,15 @@ async def test_create_bill_success(monkeypatch: pytest.MonkeyPatch) -> None:
         ttl_seconds=600,
         custom_payload={"extra": "value"},
         payer_email="user@example.com",
-        payment_method="card",
+        payment_method="BANK_CARD",
     )
 
     assert result["bill_id"] == "BILL42"
     assert client.calls and client.calls[0]["amount"] == Decimal("500.00")
     assert client.calls[0]["shop_id"] == "shop42"
     assert client.calls[0]["description"] == "Пополнение"
+    assert client.calls[0]["custom"] == json.dumps({"extra": "value"}, ensure_ascii=False, separators=(",", ":"))
+    assert client.calls[0]["payment_method"] == "BANK_CARD"
 
 
 @pytest.mark.anyio("asyncio")

--- a/tests/services/test_payment_service_pal24.py
+++ b/tests/services/test_payment_service_pal24.py
@@ -104,7 +104,7 @@ async def test_create_pal24_payment_success(monkeypatch: pytest.MonkeyPatch) -> 
     assert result["payment_method"] == "card"
     assert result["link_url"] == "https://pal24/sbp"
     assert result["card_url"] == "https://pal24/card"
-    assert stub.calls and stub.calls[0]["payment_method"] == "bank_card"
+    assert stub.calls and stub.calls[0]["payment_method"] == "BANK_CARD"
     assert stub.calls and stub.calls[0]["amount_kopeks"] == 50000
     assert "links" in captured_args["metadata"]
 
@@ -137,7 +137,7 @@ async def test_create_pal24_payment_default_method(monkeypatch: pytest.MonkeyPat
     )
 
     assert result is not None
-    assert stub.calls and stub.calls[0]["payment_method"] == "fast_payment"
+    assert stub.calls and stub.calls[0]["payment_method"] == "SBP"
     assert result["payment_method"] == "sbp"
 
 


### PR DESCRIPTION
## Summary
- update the Pal24 payment mixin to send the uppercase payment method identifiers expected by the API
- align Pal24 service and payment tests with the uppercase identifiers and verify the adapter forwards them