### PR TITLE
Fix WATA datetime timezone handling

### DIFF
--- a/app/services/wata_service.py
+++ b/app/services/wata_service.py
@@ -102,8 +102,11 @@ class WataService:
 
     @staticmethod
     def _format_datetime(value: datetime) -> str:
-        aware = value.astimezone(timezone.utc)
-        return aware.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+        if value.tzinfo is None:
+            aware = value.replace(tzinfo=timezone.utc)
+        else:
+            aware = value.astimezone(timezone.utc)
+        return aware.isoformat().replace("+00:00", "Z")
 
     @staticmethod
     def _parse_datetime(raw: Optional[str]) -> Optional[datetime]:
@@ -111,7 +114,10 @@ class WataService:
             return None
         try:
             normalized = raw.replace("Z", "+00:00")
-            return datetime.fromisoformat(normalized)
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                return parsed
+            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
         except (ValueError, TypeError):
             logger.debug("Failed to parse WATA datetime: %s", raw)
             return None

--- a/tests/services/test_payment_service_wata.py
+++ b/tests/services/test_payment_service_wata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import sys
 from typing import Any, Dict, Optional
@@ -16,6 +16,7 @@ if str(ROOT_DIR) not in sys.path:
 import app.services.payment_service as payment_service_module  # noqa: E402
 from app.config import settings  # noqa: E402
 from app.services.payment_service import PaymentService  # noqa: E402
+from app.services.wata_service import WataService  # noqa: E402
 
 
 @pytest.fixture
@@ -74,6 +75,22 @@ def _make_service(stub: Optional[StubWataService]) -> PaymentService:
     service.stars_service = None
     service.cryptobot_service = None
     return service
+
+
+def test_wata_service_format_datetime_accepts_naive_utc() -> None:
+    value = datetime(2024, 5, 20, 12, 30, 0)
+    formatted = WataService._format_datetime(value)
+    assert formatted == "2024-05-20T12:30:00Z"
+
+
+def test_wata_service_parse_datetime_returns_naive_utc() -> None:
+    parsed = WataService._parse_datetime("2024-05-20T12:30:00Z")
+    assert parsed == datetime(2024, 5, 20, 12, 30, 0)
+    assert parsed.tzinfo is None
+
+    parsed_with_offset = WataService._parse_datetime("2024-05-20T15:30:00+03:00")
+    assert parsed_with_offset == datetime(2024, 5, 20, 12, 30, 0)
+    assert parsed_with_offset.tzinfo is None
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- normalize timezone-aware and naive datetimes when formatting and parsing WATA timestamps
- add regression tests covering WATA datetime formatting and parsing helpers