### PR TITLE
Fix stage skip message formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,9 +258,7 @@ async def main():
                 stage.success("Webhook сервера запущены")
             else:
                 stage.skip(
-                    "Tribute, "
-                    f"{settings.get_mulenpay_display_name()}"
-                    " и CryptoBot отключены"
+                    f"Tribute, {settings.get_mulenpay_display_name()} и CryptoBot отключены"
                 )
 
         async with timeline.stage(


### PR DESCRIPTION
## Summary
- ensure `stage.skip` receives a single message string when all webhook services are disabled