### PR TITLE
Fix MulenPay callback paid status handling

### DIFF
--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime
 from importlib import import_module
 from typing import Any, Dict, Optional
 
@@ -131,6 +132,7 @@ class MulenPayPaymentMixin:
     ) -> bool:
         """Обрабатывает callback от MulenPay, обновляет статус и начисляет баланс."""
         display_name = settings.get_mulenpay_display_name()
+        display_name_html = settings.get_mulenpay_display_name_html()
         try:
             payment_module = import_module("app.services.payment_service")
             uuid_value = callback_data.get("uuid")
@@ -186,6 +188,8 @@ class MulenPayPaymentMixin:
                     db,
                     payment=payment,
                     status="success",
+                    is_paid=True,
+                    paid_at=datetime.utcnow(),
                     callback_payload=callback_data,
                     mulen_payment_id=mulen_payment_id_int,
                 )
@@ -354,6 +358,7 @@ class MulenPayPaymentMixin:
                     db,
                     payment=payment,
                     status="canceled",
+                    is_paid=False,
                     callback_payload=callback_data,
                     mulen_payment_id=mulen_payment_id_int,
                 )
@@ -364,6 +369,7 @@ class MulenPayPaymentMixin:
                 db,
                 payment=payment,
                 status=payment_status or "unknown",
+                is_paid=False,
                 callback_payload=callback_data,
                 mulen_payment_id=mulen_payment_id_int,
             )
@@ -442,6 +448,8 @@ class MulenPayPaymentMixin:
                                 db,
                                 payment=payment,
                                 status=mapped_status,
+                                is_paid=mapped_status == "success",
+                                paid_at=datetime.utcnow() if mapped_status == "success" else None,
                                 mulen_payment_id=remote_data.get("id"),
                             )
                             payment = await payment_module.get_mulenpay_payment_by_local_id(

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -97,7 +97,7 @@ async def test_process_mulenpay_callback_success(monkeypatch: pytest.MonkeyPatch
 
     async def fake_update_status(db, payment=None, status=None, **kwargs):
         payment.status = status
-        payment.is_paid = status == "success"
+        payment.is_paid = kwargs.get("is_paid", payment.is_paid)
         updated_status.update({"status": status, "kwargs": kwargs})
 
     monkeypatch.setattr(payment_service_module, "update_mulenpay_payment_status", fake_update_status)
@@ -153,6 +153,8 @@ async def test_process_mulenpay_callback_success(monkeypatch: pytest.MonkeyPatch
     assert transactions and transactions[0]["user_id"] == 42
     assert payment.transaction_id == 777
     assert updated_status["status"] == "success"
+    assert updated_status["kwargs"].get("is_paid") is True
+    assert updated_status["kwargs"].get("paid_at") is not None
     assert user.balance_kopeks == 5000
     assert fake_session.commits >= 1
     assert bot.sent_messages  # сообщение пользователю отправлено


### PR DESCRIPTION
## Summary
- mark MulenPay payments as paid with timestamp when processing success callbacks
- ensure other callback status updates preserve paid state and expose display name for notifications
- adjust MulenPay webhook test to assert the paid flags are propagated
