### PR TITLE
Handle alternative MulenPay webhook status fields

### DIFF
--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -131,10 +131,16 @@ class MulenPayPaymentMixin:
     ) -> bool:
         """Обрабатывает callback от MulenPay, обновляет статус и начисляет баланс."""
         display_name = settings.get_mulenpay_display_name()
+        display_name_html = settings.get_mulenpay_display_name_html()
         try:
             payment_module = import_module("app.services.payment_service")
             uuid_value = callback_data.get("uuid")
-            payment_status = (callback_data.get("payment_status") or "").lower()
+            payment_status_raw = (
+                callback_data.get("payment_status")
+                or callback_data.get("status")
+                or callback_data.get("paymentStatus")
+            )
+            payment_status = (payment_status_raw or "").lower()
             mulen_payment_id_raw = callback_data.get("id")
             mulen_payment_id_int: Optional[int] = None
             if mulen_payment_id_raw is not None:

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -63,7 +63,10 @@ def anyio_backend() -> str:
 
 
 @pytest.mark.anyio("asyncio")
-async def test_process_mulenpay_callback_success(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("status_field", ["payment_status", "status", "paymentStatus"])
+async def test_process_mulenpay_callback_success(
+    monkeypatch: pytest.MonkeyPatch, status_field: str
+) -> None:
     bot = DummyBot()
     service = _make_service(bot)
     fake_session = FakeSession()
@@ -142,10 +145,10 @@ async def test_process_mulenpay_callback_success(monkeypatch: pytest.MonkeyPatch
 
     payload = {
         "uuid": "mulen_uuid",
-        "payment_status": "success",
         "id": 123,
         "amount": "50.00",
     }
+    payload[status_field] = "success"
 
     result = await service.process_mulenpay_callback(fake_session, payload)
 


### PR DESCRIPTION
## Summary
- ensure MulenPay webhook processing reads the HTML display name before sending notifications
- accept multiple field names for the MulenPay payment status so successful callbacks are processed automatically
- extend the webhook unit test to cover the supported status field variations