### PR TITLE
Fix back navigation during subscription confirmation

### DIFF
--- a/app/handlers/subscription/autopay.py
+++ b/app/handlers/subscription/autopay.py
@@ -231,6 +231,16 @@ async def handle_subscription_config_back(
             )
             await state.set_state(SubscriptionStates.selecting_period)
 
+    elif current_state == SubscriptionStates.confirming_purchase.state:
+        data = await state.get_data()
+        selected_devices = data.get('devices', settings.DEFAULT_DEVICE_LIMIT)
+
+        await callback.message.edit_text(
+            texts.SELECT_DEVICES,
+            reply_markup=get_devices_keyboard(selected_devices, db_user.language)
+        )
+        await state.set_state(SubscriptionStates.selecting_devices)
+
     else:
         from app.handlers.menu import show_main_menu
         await show_main_menu(callback, db_user, db)


### PR DESCRIPTION
## Summary
- update `handle_subscription_config_back` to handle the confirming purchase state
- return customers to device selection instead of the main menu when backing out of confirmation
