### PR TITLE
Fix simple subscription button visibility and random squad assignment

### DIFF
--- a/app/database/crud/server_squad.py
+++ b/app/database/crud/server_squad.py
@@ -167,6 +167,58 @@ async def get_available_server_squads(
     return result.scalars().unique().all()
 
 
+async def get_active_server_squads(db: AsyncSession) -> List[ServerSquad]:
+    """Возвращает список активных серверов, доступных для подключения."""
+
+    squads = await get_available_server_squads(db)
+
+    if not squads:
+        return []
+
+    eligible: List[ServerSquad] = []
+
+    for squad in squads:
+        max_users = squad.max_users
+        current_users = squad.current_users or 0
+
+        if max_users is not None and current_users >= max_users:
+            continue
+
+        eligible.append(squad)
+
+    if eligible:
+        return eligible
+
+    return squads
+
+
+async def choose_random_active_server_squad(
+    db: AsyncSession,
+) -> Optional[ServerSquad]:
+    """Возвращает случайный активный сервер."""
+
+    squads = await get_active_server_squads(db)
+
+    if not squads:
+        return None
+
+    return random.choice(squads)
+
+
+async def get_random_active_squad_uuid(
+    db: AsyncSession,
+    fallback_uuid: Optional[str] = None,
+) -> Optional[str]:
+    """Возвращает UUID случайного активного сервера или запасной UUID."""
+
+    squad = await choose_random_active_server_squad(db)
+
+    if squad:
+        return squad.squad_uuid
+
+    return fallback_uuid
+
+
 async def update_server_squad_promo_groups(
     db: AsyncSession, server_id: int, promo_group_ids: Iterable[int]
 ) -> Optional[ServerSquad]:

--- a/app/handlers/simple_subscription.py
+++ b/app/handlers/simple_subscription.py
@@ -54,6 +54,13 @@ async def start_simple_subscription_purchase(
     user_balance_kopeks = getattr(db_user, "balance_kopeks", 0)
     # Рассчитываем цену подписки
     price_kopeks = _calculate_simple_subscription_price(subscription_params)
+    resolved_squad_uuid = await _ensure_simple_subscription_squad_uuid(
+        db,
+        state,
+        subscription_params,
+        user_id=db_user.id,
+        state_data=data,
+    )
     period_days = subscription_params["period_days"]
     recorded_price = getattr(settings, f"PRICE_{period_days}_DAYS", price_kopeks)
     direct_purchase_min_balance = recorded_price
@@ -102,12 +109,17 @@ async def start_simple_subscription_purchase(
             "ℹ️ У вас уже есть триальная подписка. Она истекает через {days} дн.",
         ).format(days=days_left)
 
+    server_label = _get_simple_subscription_server_label(
+        texts,
+        subscription_params,
+        resolved_squad_uuid,
+    )
     message_text = (
         f"⚡ <b>Простая покупка подписки</b>\n\n"
         f"📅 Период: {subscription_params['period_days']} дней\n"
         f"📱 Устройства: {subscription_params['device_limit']}\n"
         f"📊 Трафик: {'Безлимит' if subscription_params['traffic_limit_gb'] == 0 else f'{subscription_params['traffic_limit_gb']} ГБ'}\n"
-        f"🌍 Сервер: {'Любой доступный' if not subscription_params['squad_uuid'] else 'Выбранный'}\n\n"
+        f"🌍 Сервер: {server_label}\n\n"
         f"💰 Стоимость: {settings.format_price(price_kopeks)}\n"
         f"💳 Ваш баланс: {settings.format_price(user_balance_kopeks)}\n\n"
         + (
@@ -223,8 +235,71 @@ def _get_simple_subscription_payment_keyboard(language: str) -> types.InlineKeyb
         text=texts.BACK,
         callback_data="subscription_purchase"
     )])
-    
+
     return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def _get_simple_subscription_server_label(
+    texts,
+    subscription_params: Dict[str, Any],
+    resolved_squad_uuid: Optional[str] = None,
+) -> str:
+    """Возвращает локализованное описание выбранного сервера."""
+
+    if subscription_params.get("squad_uuid"):
+        return texts.t("SIMPLE_SUBSCRIPTION_SERVER_SELECTED", "Выбранный")
+
+    if resolved_squad_uuid:
+        return texts.t(
+            "SIMPLE_SUBSCRIPTION_SERVER_ASSIGNED",
+            "Назначен автоматически",
+        )
+
+    return texts.t("SIMPLE_SUBSCRIPTION_SERVER_ANY", "Любой доступный")
+
+
+async def _ensure_simple_subscription_squad_uuid(
+    db: AsyncSession,
+    state: FSMContext,
+    subscription_params: Dict[str, Any],
+    *,
+    user_id: Optional[int] = None,
+    state_data: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Определяет UUID сквада для простой подписки."""
+
+    explicit_uuid = subscription_params.get("squad_uuid")
+    if explicit_uuid:
+        return explicit_uuid
+
+    if state_data is None:
+        state_data = await state.get_data()
+
+    resolved_uuid = state_data.get("resolved_squad_uuid")
+    if resolved_uuid:
+        return resolved_uuid
+
+    try:
+        from app.database.crud.server_squad import get_random_active_squad_uuid
+
+        resolved_uuid = await get_random_active_squad_uuid(db)
+    except Exception as error:  # pragma: no cover - defensive logging
+        logger.error(
+            "SIMPLE_SUBSCRIPTION_RANDOM_SQUAD_ERROR | user=%s | error=%s",
+            user_id,
+            error,
+        )
+        return None
+
+    if resolved_uuid:
+        await state.update_data(resolved_squad_uuid=resolved_uuid)
+        logger.info(
+            "SIMPLE_SUBSCRIPTION_RANDOM_SQUAD_ASSIGNED | user=%s | squad=%s",
+            user_id,
+            resolved_uuid,
+        )
+
+    return resolved_uuid
 
 
 @error_handler
@@ -243,7 +318,15 @@ async def handle_simple_subscription_pay_with_balance(
     if not subscription_params:
         await callback.answer("❌ Данные подписки устарели. Пожалуйста, начните сначала.", show_alert=True)
         return
-    
+
+    resolved_squad_uuid = await _ensure_simple_subscription_squad_uuid(
+        db,
+        state,
+        subscription_params,
+        user_id=db_user.id,
+        state_data=data,
+    )
+
     # Рассчитываем цену подписки
     price_kopeks = _calculate_simple_subscription_price(subscription_params)
     recorded_price = getattr(settings, f"PRICE_{subscription_params['period_days']}_DAYS", price_kopeks)
@@ -307,8 +390,8 @@ async def handle_simple_subscription_pay_with_balance(
             # Обновляем параметры подписки
             subscription.traffic_limit_gb = subscription_params["traffic_limit_gb"]
             subscription.device_limit = subscription_params["device_limit"]
-            if subscription_params["squad_uuid"]:
-                subscription.connected_squads = [subscription_params["squad_uuid"]]
+            if resolved_squad_uuid:
+                subscription.connected_squads = [resolved_squad_uuid]
             
             await db.commit()
             await db.refresh(subscription)
@@ -321,7 +404,7 @@ async def handle_simple_subscription_pay_with_balance(
                 duration_days=subscription_params["period_days"],
                 traffic_limit_gb=subscription_params["traffic_limit_gb"],
                 device_limit=subscription_params["device_limit"],
-                connected_squads=[subscription_params["squad_uuid"]] if subscription_params["squad_uuid"] else [],
+                connected_squads=[resolved_squad_uuid] if resolved_squad_uuid else [],
                 update_server_counters=True,
             )
         
@@ -351,12 +434,17 @@ async def handle_simple_subscription_pay_with_balance(
             logger.error(f"Ошибка синхронизации подписки с RemnaWave для пользователя {db_user.id}: {sync_error}", exc_info=True)
         
         # Отправляем уведомление об успешной покупке
+        server_label = _get_simple_subscription_server_label(
+            texts,
+            subscription_params,
+            resolved_squad_uuid,
+        )
         success_message = (
             f"✅ <b>Подписка успешно активирована!</b>\n\n"
             f"📅 Период: {subscription_params['period_days']} дней\n"
             f"📱 Устройства: {subscription_params['device_limit']}\n"
             f"📊 Трафик: {'Безлимит' if subscription_params['traffic_limit_gb'] == 0 else f'{subscription_params['traffic_limit_gb']} ГБ'}\n"
-            f"🌍 Сервер: {'Любой доступный' if not subscription_params['squad_uuid'] else 'Выбранный'}\n\n"
+            f"🌍 Сервер: {server_label}\n\n"
             f"💰 Списано с баланса: {settings.format_price(price_kopeks)}\n"
             f"💳 Ваш баланс: {settings.format_price(db_user.balance_kopeks)}\n\n"
             f"🔗 Для подключения перейдите в раздел 'Подключиться'"
@@ -495,14 +583,14 @@ async def handle_simple_subscription_other_payment_methods(
     
     data = await state.get_data()
     subscription_params = data.get("subscription_params", {})
-    
+
     if not subscription_params:
         await callback.answer("❌ Данные подписки устарели. Пожалуйста, начните сначала.", show_alert=True)
         return
-    
+
     # Рассчитываем цену подписки
     price_kopeks = _calculate_simple_subscription_price(subscription_params)
-    
+
     user_balance_kopeks = getattr(db_user, "balance_kopeks", 0)
     recorded_price = getattr(settings, f"PRICE_{subscription_params['period_days']}_DAYS", price_kopeks)
     total_required = recorded_price
@@ -522,12 +610,18 @@ async def handle_simple_subscription_other_payment_methods(
     )
 
     # Отображаем доступные методы оплаты
+    resolved_squad_uuid = data.get("resolved_squad_uuid")
+    server_label = _get_simple_subscription_server_label(
+        texts,
+        subscription_params,
+        resolved_squad_uuid,
+    )
     message_text = (
         f"💳 <b>Оплата подписки</b>\n\n"
         f"📅 Период: {subscription_params['period_days']} дней\n"
         f"📱 Устройства: {subscription_params['device_limit']}\n"
         f"📊 Трафик: {'Безлимит' if subscription_params['traffic_limit_gb'] == 0 else f'{subscription_params['traffic_limit_gb']} ГБ'}\n"
-        f"🌍 Сервер: {'Любой доступный' if not subscription_params['squad_uuid'] else 'Выбранный'}\n\n"
+        f"🌍 Сервер: {server_label}\n\n"
         f"💰 Стоимость: {settings.format_price(price_kopeks)}\n\n"
         + (
             "Вы можете оплатить подписку с баланса или выбрать другой способ оплаты:"
@@ -625,7 +719,7 @@ async def handle_simple_subscription_payment_method(
                 period_days=subscription_params["period_days"],
                 device_limit=subscription_params["device_limit"],
                 traffic_limit_gb=subscription_params["traffic_limit_gb"],
-                squad_uuid=subscription_params["squad_uuid"],
+                squad_uuid=resolved_squad_uuid,
                 payment_method="yookassa_sbp" if payment_method == "yookassa_sbp" else "yookassa",
                 total_price_kopeks=price_kopeks
             )

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -320,10 +320,16 @@ def get_main_menu_keyboard(
     keyboard.append([InlineKeyboardButton(text=balance_button_text, callback_data="menu_balance")])
     
     show_trial = not has_had_paid_subscription and not has_active_subscription
-    
+
     show_buy = not has_active_subscription or not subscription_is_active
+    current_subscription = subscription
+    has_active_paid_subscription = bool(
+        current_subscription
+        and not getattr(current_subscription, "is_trial", False)
+        and getattr(current_subscription, "is_active", False)
+    )
     simple_purchase_button = None
-    if settings.SIMPLE_SUBSCRIPTION_ENABLED:
+    if settings.SIMPLE_SUBSCRIPTION_ENABLED and not has_active_paid_subscription:
         simple_purchase_button = InlineKeyboardButton(
             text=texts.MENU_SIMPLE_SUBSCRIPTION,
             callback_data="simple_subscription_purchase",

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -1350,5 +1350,8 @@
   "YES": "✅ Yes",
   "SIMPLE_SUBSCRIPTION_TRIAL_NOTICE_ACTIVE": "ℹ️ Your trial subscription is active for another {days} days. Purchasing a new plan will extend the validity.",
   "SIMPLE_SUBSCRIPTION_TRIAL_NOTICE_TRIAL": "ℹ️ Your trial is still running (expires in {days} days). Buying a paid plan will extend it automatically.",
+  "SIMPLE_SUBSCRIPTION_SERVER_ANY": "Any available",
+  "SIMPLE_SUBSCRIPTION_SERVER_SELECTED": "Selected",
+  "SIMPLE_SUBSCRIPTION_SERVER_ASSIGNED": "Assigned automatically",
   "MENU_SIMPLE_SUBSCRIPTION": "⚡ Quick purchase"
 }

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -1350,5 +1350,8 @@
   "YES": "✅ Да",
   "SIMPLE_SUBSCRIPTION_TRIAL_NOTICE_ACTIVE": "ℹ️ У вас уже есть активная триальная подписка. Она будет действовать ещё {days} дн. После покупки к сроку добавится оплаченный период.",
   "SIMPLE_SUBSCRIPTION_TRIAL_NOTICE_TRIAL": "ℹ️ У вас сейчас триальная подписка. Она истекает через {days} дн. Покупка новой продлит срок автоматически.",
+  "SIMPLE_SUBSCRIPTION_SERVER_ANY": "Любой доступный",
+  "SIMPLE_SUBSCRIPTION_SERVER_SELECTED": "Выбранный",
+  "SIMPLE_SUBSCRIPTION_SERVER_ASSIGNED": "Назначен автоматически",
   "MENU_SIMPLE_SUBSCRIPTION": "⚡ Простая покупка"
 }


### PR DESCRIPTION
## Summary
- hide the simple subscription shortcut for users with an active paid plan when the feature is enabled
- add localized labels and helper utilities for resolving the simple subscription server selection
- choose a random available squad for simple subscription orders when no explicit squad is configured
