### PR TITLE
Fix YooKassa webhook paid flag persistence

### DIFF
--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -550,13 +550,13 @@ class YooKassaPaymentMixin:
         payment.status = event_object.get("status", payment.status)
         payment.confirmation_url = event_object.get("confirmation_url")
 
-        current_paid = getattr(payment, "paid", False)
-        payment.paid = event_object.get("paid", current_paid)
+        current_paid = bool(getattr(payment, "is_paid", getattr(payment, "paid", False)))
+        payment.is_paid = bool(event_object.get("paid", current_paid))
 
         await db.commit()
         await db.refresh(payment)
 
-        if payment.status == "succeeded" and payment.paid:
+        if payment.status == "succeeded" and payment.is_paid:
             return await self._process_successful_yookassa_payment(db, payment)
 
         logger.info(

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -490,6 +490,7 @@ async def test_process_yookassa_webhook_success(monkeypatch: pytest.MonkeyPatch)
     assert result is True
     assert transactions and transactions[0]["amount_kopeks"] == 10000
     assert payment.transaction_id == 999
+    assert payment.is_paid is True
     assert user.balance_kopeks == 10000
     assert bot.sent_messages
     assert admin_calls


### PR DESCRIPTION
## Summary
- ensure YooKassa webhook processing updates the persisted `is_paid` flag instead of an in-memory field
- add a regression assertion so the webhook test verifies the payment becomes paid