### PR TITLE
Add Docker mounting guidance for miniapp

### DIFF
--- a/docs/miniapp-setup.md
+++ b/docs/miniapp-setup.md
@@ -36,13 +36,51 @@ curl -H "X-API-Key: super-secret-token" http://127.0.0.1:8080/health
 1. При необходимости отредактируйте `miniapp/app-config.json`, чтобы настроить инструкции и ссылки на нужные клиенты.
 2. Убедитесь, что файлы доступны для чтения пользователем веб-сервера.
 
-## 5. Настройка кнопки в Telegram
+## 5. Размещение статических файлов в Docker
+
+Если reverse-proxy (nginx или Caddy) работает внутри контейнера, смонтируйте каталог `miniapp` внутрь него по пути `/miniapp`. Та
+ким образом файлы `index.html` и `app-config.json` будут доступны серверу без копирования образа каждый раз при обновлении.
+
+### Пример для docker-compose с Caddy
+
+```yaml
+services:
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    volumes:
+      - ./miniapp:/miniapp:ro          # монтируем локальную папку внутрь контейнера
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+    ports:
+      - "80:80"
+      - "443:443"
+```
+
+### Пример для docker-compose с nginx
+
+```yaml
+services:
+  nginx:
+    image: nginx:1.25-alpine
+    restart: unless-stopped
+    volumes:
+      - ./miniapp:/miniapp:ro          # общий каталог статических файлов
+      - ./deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+      - "443:443"
+```
+
+Внутри конфигурации прокси укажите путь `/miniapp` как корневой для статических файлов или используйте директиву `alias`.
+При пересборке проекта структура останется той же, достаточно обновить файлы в локальной папке.
+
+## 6. Настройка кнопки в Telegram
 
 1. В дминке бота настраиваем параметры - Конфигурации бота - Прочее - Miniapp
 2. Перезапустите бота. 
 3. При необходимости задайте кастомную кнопку на миниапп через `@BotFather` (команда `/setmenu` -> Web App URL).
 
-## 6. Конфигурация nginx
+## 7. Конфигурация nginx
 
 ```nginx
 server {
@@ -54,7 +92,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/miniapp.example.com/privkey.pem;
 
     # Статические файлы мини-приложения
-    root /var/www/remnawave-miniapp;
+    root /miniapp;
     index index.html;
 
     location = /miniapp/app-config.json {
@@ -79,12 +117,12 @@ server {
 }
 ```
 
-## 7. Конфигурация Caddy
+## 8. Конфигурация Caddy
 
 ```caddy
 miniapp.example.com {
     encode gzip zstd
-    root * /var/www/remnawave-miniapp
+    root * /miniapp
     file_server
 
     @config path /app-config.json
@@ -98,13 +136,13 @@ miniapp.example.com {
 ```
 Caddy автоматически выпустит сертификаты через ACME. Убедитесь, что порт 443 проброшен и домен указывает на сервер.
 
-## 8. Проверка работы
+## 9. Проверка работы
 
 1. Откройте мини-приложение прямо в Telegram или через браузер: `https://miniapp.example.com`.
 2. В консоли разработчика убедитесь, что запрос к `https://miniapp.example.com/miniapp/subscription` возвращает JSON с данными подписки.
 3. Проверьте, что ссылки из блока «Подключить подписку» открываются и копируются без ошибок.
 
-## 9. Диагностика
+## 10. Диагностика
 
 | Симптом | Возможная причина | Проверка |
 |---------|------------------|----------|


### PR DESCRIPTION
## Summary
- describe how to mount the miniapp folder into nginx or Caddy containers
- include docker-compose snippets and update proxy configs to use /miniapp as the document root

