### PR TITLE
Add automatic subscription purchase after balance top-up

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -187,6 +187,8 @@ class Settings(BaseSettings):
     DISABLE_TOPUP_BUTTONS: bool = False
     PAYMENT_VERIFICATION_AUTO_CHECK_ENABLED: bool = False
     PAYMENT_VERIFICATION_AUTO_CHECK_INTERVAL_MINUTES: int = 10
+
+    AUTOBUY_AFTER_TOPUP_ENABLED: bool = False
     
     # Настройки простой покупки
     SIMPLE_SUBSCRIPTION_ENABLED: bool = False
@@ -786,9 +788,12 @@ class Settings(BaseSettings):
     
     def is_traffic_fixed(self) -> bool:
         return self.TRAFFIC_SELECTION_MODE.lower() == "fixed"
-    
+
     def get_fixed_traffic_limit(self) -> int:
         return self.FIXED_TRAFFIC_LIMIT_GB
+
+    def is_autobuy_after_topup_enabled(self) -> bool:
+        return bool(self.AUTOBUY_AFTER_TOPUP_ENABLED)
     
     def is_yookassa_enabled(self) -> bool:
         return (self.YOOKASSA_ENABLED and 

--- a/app/services/payment/common.py
+++ b/app/services/payment/common.py
@@ -101,6 +101,58 @@ class PaymentCommonMixin:
             db=db,
         )
 
+        if settings.is_autobuy_after_topup_enabled():
+            full_user = user
+            session_for_purchase: AsyncSession | None = db
+
+            if full_user is None and db is not None:
+                try:
+                    full_user = await get_user_by_telegram_id(db, telegram_id)
+                except Exception as fetch_error:
+                    logger.warning(
+                        "Не удалось получить пользователя %s из переданной сессии для автопокупки: %s",
+                        telegram_id,
+                        fetch_error,
+                    )
+
+            if full_user is None:
+                try:
+                    async for db_session in get_db():
+                        try:
+                            full_user = await get_user_by_telegram_id(db_session, telegram_id)
+                            session_for_purchase = db_session
+                        except Exception as fetch_error:
+                            logger.warning(
+                                "Не удалось получить пользователя %s из новой сессии: %s",
+                                telegram_id,
+                                fetch_error,
+                            )
+                            full_user = None
+                        else:
+                            break
+                except Exception as fetch_error:
+                    logger.warning(
+                        "Ошибка открытия сессии для автопокупки пользователя %s: %s",
+                        telegram_id,
+                        fetch_error,
+                    )
+
+            if full_user is not None and session_for_purchase is not None:
+                try:
+                    from app.handlers.subscription.purchase import attempt_auto_purchase_after_topup
+
+                    await attempt_auto_purchase_after_topup(
+                        session_for_purchase,
+                        full_user,
+                        getattr(self, "bot", None),
+                    )
+                except Exception as auto_error:
+                    logger.error(
+                        "Ошибка автопокупки подписки после пополнения для пользователя %s: %s",
+                        telegram_id,
+                        auto_error,
+                    )
+
         try:
             keyboard = await self.build_topup_success_keyboard(user_snapshot)
 

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -198,6 +198,7 @@ class BotConfigurationService:
         "BASE_SUBSCRIPTION_PRICE": "SUBSCRIPTIONS_CORE",
         "DEFAULT_TRAFFIC_RESET_STRATEGY": "TRAFFIC",
         "RESET_TRAFFIC_ON_PAYMENT": "TRAFFIC",
+        "AUTOBUY_AFTER_TOPUP_ENABLED": "PAYMENT",
         "TRAFFIC_SELECTION_MODE": "TRAFFIC",
         "FIXED_TRAFFIC_LIMIT_GB": "TRAFFIC",
         "AVAILABLE_SUBSCRIPTION_PERIODS": "PERIODS",
@@ -473,6 +474,15 @@ class BotConfigurationService:
             "example": "10",
             "warning": "Слишком малый интервал может привести к частым обращениям к платёжным API.",
             "dependencies": "PAYMENT_VERIFICATION_AUTO_CHECK_ENABLED",
+        },
+        "AUTOBUY_AFTER_TOPUP_ENABLED": {
+            "description": (
+                "Включает автоматическое завершение сохранённой покупки подписки после пополнения"
+                " баланса, если средств стало достаточно."
+            ),
+            "format": "Булево значение.",
+            "example": "true",
+            "warning": "Перед включением убедитесь, что расчёт корзины корректен и пользователи понимают поведение.",
         },
         "SUPPORT_TICKET_SLA_MINUTES": {
             "description": "Лимит времени для ответа модераторов на тикет в минутах.",

--- a/tests/test_autobuy_after_topup.py
+++ b/tests/test_autobuy_after_topup.py
@@ -1,0 +1,106 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.handlers.subscription.purchase import (  # noqa: E402
+    attempt_auto_purchase_after_topup,
+    PurchaseExecutionResult,
+)
+from app.services.payment.common import PaymentCommonMixin  # noqa: E402
+from app.config import settings  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_attempt_auto_purchase_after_topup_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "AUTOBUY_AFTER_TOPUP_ENABLED", False)
+
+    with patch("app.handlers.subscription.purchase.user_cart_service") as cart_service:
+        cart_service.get_user_cart = AsyncMock()
+
+        result = await attempt_auto_purchase_after_topup(
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+        )
+
+        assert result is False
+        cart_service.get_user_cart.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_attempt_auto_purchase_after_topup_success(monkeypatch):
+    monkeypatch.setattr(settings, "AUTOBUY_AFTER_TOPUP_ENABLED", True)
+
+    user = AsyncMock()
+    user.language = "ru"
+    user.telegram_id = 123
+    user.id = 123
+    user.balance_kopeks = 20000
+
+    prepared_data = {
+        "total_price": 10000,
+        "period_days": 30,
+        "months_in_period": 1,
+        "final_traffic_gb": 0,
+        "server_prices_for_period": [],
+    }
+
+    bot = AsyncMock()
+
+    with patch("app.handlers.subscription.purchase.user_cart_service") as cart_service, \
+            patch("app.handlers.subscription.purchase._prepare_subscription_summary") as prepare_summary, \
+            patch("app.handlers.subscription.purchase._complete_purchase_workflow") as complete_purchase, \
+            patch("app.handlers.subscription.purchase.clear_subscription_checkout_draft") as clear_draft:
+
+        cart_service.get_user_cart = AsyncMock(return_value={"period_days": 30, "total_price": 10000})
+        prepare_summary.return_value = (None, prepared_data)
+        complete_purchase.return_value = PurchaseExecutionResult(
+            success=True,
+            message="done",
+            keyboard=None,
+            purchase_completed=True,
+        )
+
+        result = await attempt_auto_purchase_after_topup(
+            AsyncMock(),
+            user,
+            bot,
+        )
+
+        assert result is True
+        bot.send_message.assert_awaited()
+        clear_draft.assert_awaited_with(user.id)
+
+
+class _DummyPayment(PaymentCommonMixin):
+    def __init__(self):
+        self.bot = AsyncMock()
+
+    async def build_topup_success_keyboard(self, user):
+        return AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_send_payment_notification_triggers_autobuy(monkeypatch):
+    monkeypatch.setattr(settings, "AUTOBUY_AFTER_TOPUP_ENABLED", True)
+
+    dummy = _DummyPayment()
+
+    user = AsyncMock()
+    user.telegram_id = 42
+
+    with patch("app.handlers.subscription.purchase.attempt_auto_purchase_after_topup", new=AsyncMock(return_value=True)) as autopurchase:
+
+        await dummy._send_payment_success_notification(
+            telegram_id=user.telegram_id,
+            amount_kopeks=1000,
+            user=user,
+            db=AsyncMock(),
+            payment_method_title="Test",
+        )
+
+        autopurchase.assert_awaited()


### PR DESCRIPTION
## Summary
- add a configuration flag for enabling automatic subscription purchase after a balance top-up
- refactor subscription purchase flow so it can be reused by automatic top-ups and trigger it from payment notifications
- cover the new behaviour with targeted unit tests
