### PR TITLE
Fix automatic subscription purchase after balance top-up

### DIFF
--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -13,6 +13,7 @@ from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
 from app.services.subscription_auto_purchase_service import (
     auto_purchase_saved_cart_after_topup,
+    get_saved_cart_total_kopeks,
 )
 from app.utils.user_utils import format_referrer_info
 
@@ -353,13 +354,24 @@ class MulenPayPaymentMixin:
                         # Если у пользователя есть сохраненная корзина,
                         # отправляем ему уведомление с кнопкой вернуться к оформлению
                         from app.localization.texts import get_texts
-                        
+
                         texts = get_texts(user.language)
+                        cart_data = await user_cart_service.get_user_cart(user.id)
+                        cart_total = get_saved_cart_total_kopeks(
+                            cart_data, getattr(user, "balance_kopeks", None)
+                        )
+
+                        total_amount_label = (
+                            texts.format_price(cart_total)
+                            if cart_total
+                            else settings.format_price(payment.amount_kopeks)
+                        )
+
                         cart_message = texts.t(
                             "BALANCE_TOPUP_CART_REMINDER_DETAILED",
                             "🛒 У вас есть неоформленный заказ.\n\n"
                             "Вы можете продолжить оформление с теми же параметрами."
-                        )
+                        ).format(total_amount=total_amount_label)
                         
                         # Создаем клавиатуру с кнопками
                         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -21,6 +21,7 @@ from app.database.models import PaymentMethod, TransactionType
 from app.external.telegram_stars import TelegramStarsService
 from app.services.subscription_auto_purchase_service import (
     auto_purchase_saved_cart_after_topup,
+    get_saved_cart_total_kopeks,
 )
 from app.utils.user_utils import format_referrer_info
 
@@ -268,14 +269,25 @@ class TelegramStarsMixin:
                     # Если у пользователя есть сохраненная корзина,
                     # отправляем ему уведомление с кнопкой вернуться к оформлению
                     from app.localization.texts import get_texts
-                    
+
                     texts = get_texts(user.language)
+                    cart_data = await user_cart_service.get_user_cart(user.id)
+                    cart_total = get_saved_cart_total_kopeks(
+                        cart_data, getattr(user, "balance_kopeks", None)
+                    )
+
+                    total_amount_label = (
+                        texts.format_price(cart_total)
+                        if cart_total
+                        else settings.format_price(amount_kopeks)
+                    )
+
                     cart_message = texts.t(
                         "BALANCE_TOPUP_CART_REMINDER_DETAILED",
                         "🛒 У вас есть неоформленный заказ.\n\n"
                         "Вы можете продолжить оформление с теми же параметрами."
-                    )
-                    
+                    ).format(total_amount=total_amount_label)
+
                     # Создаем клавиатуру с кнопками
                     keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
                         [types.InlineKeyboardButton(

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -18,6 +18,7 @@ from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
 from app.services.subscription_auto_purchase_service import (
     auto_purchase_saved_cart_after_topup,
+    get_saved_cart_total_kopeks,
 )
 from app.utils.user_utils import format_referrer_info
 
@@ -500,8 +501,19 @@ class YooKassaPaymentMixin:
                             from aiogram import types
 
                             texts = get_texts(user.language)
+                            cart_data = await user_cart_service.get_user_cart(user.id)
+                            cart_total = get_saved_cart_total_kopeks(
+                                cart_data, getattr(user, "balance_kopeks", None)
+                            )
+
+                            total_amount_label = (
+                                texts.format_price(cart_total)
+                                if cart_total
+                                else settings.format_price(payment.amount_kopeks)
+                            )
+
                             cart_message = texts.BALANCE_TOPUP_CART_REMINDER_DETAILED.format(
-                                total_amount=settings.format_price(payment.amount_kopeks)
+                                total_amount=total_amount_label
                             )
 
                             # Создаем клавиатуру с кнопками

--- a/app/services/subscription_purchase_service.py
+++ b/app/services/subscription_purchase_service.py
@@ -1177,7 +1177,28 @@ class MiniAppSubscriptionPurchaseService:
 
 class SubscriptionPurchaseService:
     """Service for handling simple subscription purchases with predefined parameters."""
-    
+
+    async def submit_purchase(
+        self,
+        db: AsyncSession,
+        context: PurchaseOptionsContext,
+        pricing: PurchasePricingResult,
+    ) -> Dict[str, Any]:
+        """Proxy purchase submission to the mini-app purchase flow.
+
+        The automatic purchase flow reuses the mini-app pricing logic to ensure that
+        the saved cart is processed with the same validations and side effects as a
+        manual checkout. Historically this method was available on
+        :class:`MiniAppSubscriptionPurchaseService` only, which caused attribute
+        errors when the auto-purchase routine attempted to delegate to this class.
+
+        By exposing the method here we keep backwards compatibility for the simpler
+        subscription flows while letting them reuse the battle-tested implementation.
+        """
+
+        delegate = MiniAppSubscriptionPurchaseService()
+        return await delegate.submit_purchase(db, context, pricing)
+
     async def create_subscription_order(
         self,
         db: AsyncSession,

--- a/app/services/tribute_service.py
+++ b/app/services/tribute_service.py
@@ -16,6 +16,7 @@ from app.external.tribute import TributeService as TributeAPI
 from app.services.payment_service import PaymentService
 from app.services.subscription_auto_purchase_service import (
     auto_purchase_saved_cart_after_topup,
+    get_saved_cart_total_kopeks,
 )
 from app.utils.user_utils import format_referrer_info
 
@@ -296,8 +297,19 @@ class TributeService:
                 from aiogram import types
 
                 texts = get_texts(user.language)
+                cart_data = await user_cart_service.get_user_cart(user.id)
+                cart_total = get_saved_cart_total_kopeks(
+                    cart_data, getattr(user, "balance_kopeks", None)
+                )
+
+                total_amount_label = (
+                    texts.format_price(cart_total)
+                    if cart_total
+                    else settings.format_price(amount_kopeks)
+                )
+
                 cart_message = texts.BALANCE_TOPUP_CART_REMINDER_DETAILED.format(
-                    total_amount=settings.format_price(amount_kopeks)
+                    total_amount=total_amount_label
                 )
 
                 # Создаем клавиатуру с кнопками


### PR DESCRIPTION
## Summary
- add a submit_purchase proxy to SubscriptionPurchaseService so auto-purchase can reuse the mini-app flow
- expose a helper to determine saved cart totals and update payment handlers to use it when composing reminders
- ensure saved cart reminders interpolate the total amount after balance top-ups
