### PR TITLE
Fix automatic subscription purchase after balance top-up

### DIFF
--- a/app/services/subscription_purchase_service.py
+++ b/app/services/subscription_purchase_service.py
@@ -1175,8 +1175,19 @@ class MiniAppSubscriptionPurchaseService:
         }
 
 
-class SubscriptionPurchaseService:
-    """Service for handling simple subscription purchases with predefined parameters."""
+class SubscriptionPurchaseService(MiniAppSubscriptionPurchaseService):
+    """High-level purchase service used across bot flows.
+
+    Historically this class only exposed :meth:`create_subscription_order` for
+    simple YooKassa purchases.  Automatic post-top-up purchases (and other
+    flows) expect it to provide the full mini-app purchase workflow, including
+    :meth:`submit_purchase`.  After refactoring the mini-app service this class
+    lost these methods which resulted in an ``AttributeError`` during the
+    automatic checkout pipeline.  Inheriting from
+    :class:`MiniAppSubscriptionPurchaseService` keeps a single implementation of
+    the purchase logic and guarantees that all consumers have access to the same
+    API surface.
+    """
     
     async def create_subscription_order(
         self,


### PR DESCRIPTION
## Summary
- make SubscriptionPurchaseService inherit from MiniAppSubscriptionPurchaseService so it exposes submit_purchase
- keep existing order creation helper while sharing the full purchase workflow logic for auto-purchase flows
