### PR TITLE
Fix auto-purchase after top-up to use miniapp purchase service

### DIFF
--- a/tests/services/test_subscription_auto_purchase_service.py
+++ b/tests/services/test_subscription_auto_purchase_service.py
@@ -130,7 +130,6 @@ async def test_auto_purchase_saved_cart_after_topup_success(monkeypatch):
                 details=base_pricing.details,
             )
 
-    class DummyPurchaseService:
         async def submit_purchase(self, db, prepared_context, pricing):
             return {
                 "subscription": MagicMock(),
@@ -142,10 +141,6 @@ async def test_auto_purchase_saved_cart_after_topup_success(monkeypatch):
     monkeypatch.setattr(
         "app.services.subscription_auto_purchase_service.MiniAppSubscriptionPurchaseService",
         lambda: DummyMiniAppService(),
-    )
-    monkeypatch.setattr(
-        "app.services.subscription_auto_purchase_service.SubscriptionPurchaseService",
-        lambda: DummyPurchaseService(),
     )
     monkeypatch.setattr(
         "app.services.subscription_auto_purchase_service.user_cart_service.get_user_cart",


### PR DESCRIPTION
## Summary
- reuse the mini app subscription purchase service instance during automatic checkout
- store the purchase service in the prepared auto-purchase context so submit_purchase can be called
- adjust the auto-purchase unit test to match the new flow
