### PR TITLE
Handle simple subscription star purchase flow

### DIFF
--- a/app/handlers/stars_payments.py
+++ b/app/handlers/stars_payments.py
@@ -20,7 +20,7 @@ async def handle_pre_checkout_query(query: types.PreCheckoutQuery):
     try:
         logger.info(f"📋 Pre-checkout query от {query.from_user.id}: {query.total_amount} XTR, payload: {query.invoice_payload}")
 
-        allowed_prefixes = ("balance_", "admin_stars_test_")
+        allowed_prefixes = ("balance_", "admin_stars_test_", "simple_sub_")
 
         if not query.invoice_payload or not query.invoice_payload.startswith(allowed_prefixes):
             logger.warning(f"Невалидный payload: {query.invoice_payload}")

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_UP
 from typing import Optional
@@ -25,6 +26,14 @@ from app.services.subscription_auto_purchase_service import (
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _SimpleSubscriptionPayload:
+    """Данные для простой подписки, извлечённые из payload звёздного платежа."""
+
+    subscription_id: Optional[int]
+    period_days: Optional[int]
 
 
 class TelegramStarsMixin:
@@ -88,7 +97,6 @@ class TelegramStarsMixin:
         telegram_payment_charge_id: str,
     ) -> bool:
         """Финализирует платеж, пришедший из Telegram Stars, и обновляет баланс пользователя."""
-        del payload  # payload пока не используется, но оставляем аргумент для совместимости.
         try:
             rubles_amount = TelegramStarsService.calculate_rubles_from_stars(
                 stars_amount
@@ -99,12 +107,28 @@ class TelegramStarsMixin:
                 )
             )
 
+            simple_payload = self._parse_simple_subscription_payload(
+                payload,
+                user_id,
+            )
+
+            transaction_description = (
+                f"Оплата подписки через Telegram Stars ({stars_amount} ⭐)"
+                if simple_payload
+                else f"Пополнение через Telegram Stars ({stars_amount} ⭐)"
+            )
+            transaction_type = (
+                TransactionType.SUBSCRIPTION_PAYMENT
+                if simple_payload
+                else TransactionType.DEPOSIT
+            )
+
             transaction = await create_transaction(
                 db=db,
                 user_id=user_id,
-                type=TransactionType.DEPOSIT,
+                type=transaction_type,
                 amount_kopeks=amount_kopeks,
-                description=f"Пополнение через Telegram Stars ({stars_amount} ⭐)",
+                description=transaction_description,
                 payment_method=PaymentMethod.TELEGRAM_STARS,
                 external_id=telegram_payment_charge_id,
                 is_completed=True,
@@ -118,197 +142,487 @@ class TelegramStarsMixin:
                 )
                 return False
 
-            # Запоминаем старые значения, чтобы корректно построить уведомления.
-            old_balance = user.balance_kopeks
-            was_first_topup = not user.has_made_first_topup
-
-            # Обновляем баланс в БД.
-            user.balance_kopeks += amount_kopeks
-            user.updated_at = datetime.utcnow()
-
-            promo_group = getattr(user, "promo_group", None)
-            subscription = getattr(user, "subscription", None)
-            referrer_info = format_referrer_info(user)
-            topup_status = (
-                "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
-            )
-
-            await db.commit()
-
-            description_for_referral = (
-                f"Пополнение Stars: {settings.format_price(amount_kopeks)} ({stars_amount} ⭐)"
-            )
-            logger.info(
-                "🔍 Проверка реферальной логики для описания: '%s'",
-                description_for_referral,
-            )
-
-            lower_description = description_for_referral.lower()
-            contains_allowed_keywords = any(
-                word in lower_description
-                for word in ["пополнение", "stars", "yookassa", "topup"]
-            )
-            contains_forbidden_keywords = any(
-                word in lower_description for word in ["комиссия", "бонус"]
-            )
-            allow_referral = contains_allowed_keywords and not contains_forbidden_keywords
-
-            if allow_referral:
-                logger.info(
-                    "🔞 Вызов process_referral_topup для пользователя %s",
-                    user_id,
-                )
-                try:
-                    from app.services.referral_service import process_referral_topup
-
-                    await process_referral_topup(
-                        db, user_id, amount_kopeks, getattr(self, "bot", None)
-                    )
-                except Exception as error:
-                    logger.error(
-                        "Ошибка обработки реферального пополнения: %s", error
-                    )
-            else:
-                logger.info(
-                    "❌ Описание '%s' не подходит для реферальной логики",
-                    description_for_referral,
+            if simple_payload:
+                return await self._finalize_simple_subscription_stars_payment(
+                    db=db,
+                    user=user,
+                    transaction=transaction,
+                    amount_kopeks=amount_kopeks,
+                    stars_amount=stars_amount,
+                    payload_data=simple_payload,
+                    telegram_payment_charge_id=telegram_payment_charge_id,
                 )
 
-            if was_first_topup and not user.has_made_first_topup:
-                user.has_made_first_topup = True
-                await db.commit()
-
-            await db.refresh(user)
-
-            logger.info(
-                "💰 Баланс пользователя %s изменен: %s → %s (Δ +%s)",
-                user.telegram_id,
-                old_balance,
-                user.balance_kopeks,
-                amount_kopeks,
+            return await self._finalize_stars_balance_topup(
+                db=db,
+                user=user,
+                transaction=transaction,
+                amount_kopeks=amount_kopeks,
+                stars_amount=stars_amount,
+                telegram_payment_charge_id=telegram_payment_charge_id,
             )
-
-            if getattr(self, "bot", None):
-                try:
-                    from app.services.admin_notification_service import (
-                        AdminNotificationService,
-                    )
-
-                    notification_service = AdminNotificationService(self.bot)
-                    await notification_service.send_balance_topup_notification(
-                        user,
-                        transaction,
-                        old_balance,
-                        topup_status=topup_status,
-                        referrer_info=referrer_info,
-                        subscription=subscription,
-                        promo_group=promo_group,
-                        db=db,
-                    )
-                except Exception as error:
-                    logger.error(
-                        "Ошибка отправки уведомления о пополнении Stars: %s",
-                        error,
-                        exc_info=True
-                    )
-
-            if getattr(self, "bot", None):
-                try:
-                    keyboard = await self.build_topup_success_keyboard(user)
-
-                    await self.bot.send_message(
-                        user.telegram_id,
-                        (
-                            "✅ <b>Пополнение успешно!</b>\n\n"
-                            f"⭐ Звезд: {stars_amount}\n"
-                            f"💰 Сумма: {settings.format_price(amount_kopeks)}\n"
-                            "🦊 Способ: Telegram Stars\n"
-                            f"🆔 Транзакция: {telegram_payment_charge_id[:8]}...\n\n"
-                            "Баланс пополнен автоматически!"
-                        ),
-                        parse_mode="HTML",
-                        reply_markup=keyboard,
-                    )
-                    logger.info(
-                        "✅ Отправлено уведомление пользователю %s о пополнении на %s",
-                        user.telegram_id,
-                        settings.format_price(amount_kopeks),
-                    )
-                except Exception as error:
-                    logger.error(
-                        "Ошибка отправки уведомления о пополнении Stars: %s",
-                        error,
-                    )
-
-            # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-            try:
-                from app.services.user_cart_service import user_cart_service
-                from aiogram import types
-                has_saved_cart = await user_cart_service.has_user_cart(user.id)
-                auto_purchase_success = False
-                if has_saved_cart:
-                    try:
-                        auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                            db,
-                            user,
-                            bot=getattr(self, "bot", None),
-                        )
-                    except Exception as auto_error:
-                        logger.error(
-                            "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                            user.id,
-                            auto_error,
-                            exc_info=True,
-                        )
-
-                    if auto_purchase_success:
-                        has_saved_cart = False
-
-                if has_saved_cart and getattr(self, "bot", None):
-                    # Если у пользователя есть сохраненная корзина,
-                    # отправляем ему уведомление с кнопкой вернуться к оформлению
-                    from app.localization.texts import get_texts
-                    
-                    texts = get_texts(user.language)
-                    cart_message = texts.t(
-                        "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                        "🛒 У вас есть неоформленный заказ.\n\n"
-                        "Вы можете продолжить оформление с теми же параметрами."
-                    )
-                    
-                    # Создаем клавиатуру с кнопками
-                    keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                        [types.InlineKeyboardButton(
-                            text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                            callback_data="subscription_resume_checkout"
-                        )],
-                        [types.InlineKeyboardButton(
-                            text="💰 Мой баланс",
-                            callback_data="menu_balance"
-                        )],
-                        [types.InlineKeyboardButton(
-                            text="🏠 Главное меню",
-                            callback_data="back_to_menu"
-                        )]
-                    ])
-                    
-                    await self.bot.send_message(
-                        chat_id=user.telegram_id,
-                        text=f"✅ Баланс пополнен на {settings.format_price(amount_kopeks)}!\n\n{cart_message}",
-                        reply_markup=keyboard
-                    )
-                    logger.info(f"Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю {user.id}")
-            except Exception as e:
-                logger.error(f"Ошибка при работе с сохраненной корзиной для пользователя {user.id}: {e}", exc_info=True)
-
-            logger.info(
-                "✅ Обработан Stars платеж: пользователь %s, %s звезд → %s",
-                user_id,
-                stars_amount,
-                settings.format_price(amount_kopeks),
-            )
-            return True
 
         except Exception as error:
             logger.error("Ошибка обработки Stars платежа: %s", error, exc_info=True)
             return False
+
+    @staticmethod
+    def _parse_simple_subscription_payload(
+        payload: str,
+        expected_user_id: int,
+    ) -> Optional[_SimpleSubscriptionPayload]:
+        """Пытается извлечь параметры простой подписки из payload звёздного платежа."""
+
+        prefix = "simple_sub_"
+        if not payload or not payload.startswith(prefix):
+            return None
+
+        tail = payload[len(prefix) :]
+        parts = tail.split("_", 2)
+        if len(parts) < 3:
+            logger.warning(
+                "Payload Stars simple subscription имеет некорректный формат: %s",
+                payload,
+            )
+            return None
+
+        user_part, subscription_part, period_part = parts
+
+        try:
+            payload_user_id = int(user_part)
+        except ValueError:
+            logger.warning(
+                "Не удалось разобрать user_id в payload Stars simple subscription: %s",
+                payload,
+            )
+            return None
+
+        if payload_user_id != expected_user_id:
+            logger.warning(
+                "Получен payload Stars simple subscription с чужим user_id: %s (ожидался %s)",
+                payload_user_id,
+                expected_user_id,
+            )
+            return None
+
+        try:
+            subscription_id = int(subscription_part)
+        except ValueError:
+            logger.warning(
+                "Не удалось разобрать subscription_id в payload Stars simple subscription: %s",
+                payload,
+            )
+            return None
+
+        period_days: Optional[int] = None
+        try:
+            period_days = int(period_part)
+        except ValueError:
+            logger.warning(
+                "Не удалось разобрать период в payload Stars simple subscription: %s",
+                payload,
+            )
+
+        return _SimpleSubscriptionPayload(
+            subscription_id=subscription_id,
+            period_days=period_days,
+        )
+
+    async def _finalize_simple_subscription_stars_payment(
+        self,
+        db: AsyncSession,
+        user,
+        transaction,
+        amount_kopeks: int,
+        stars_amount: int,
+        payload_data: _SimpleSubscriptionPayload,
+        telegram_payment_charge_id: str,
+    ) -> bool:
+        """Активация простой подписки, оплаченной через Telegram Stars."""
+
+        period_days = payload_data.period_days or settings.SIMPLE_SUBSCRIPTION_PERIOD_DAYS
+        pending_subscription = None
+
+        if payload_data.subscription_id is not None:
+            try:
+                from sqlalchemy import select
+                from app.database.models import Subscription
+
+                result = await db.execute(
+                    select(Subscription).where(
+                        Subscription.id == payload_data.subscription_id,
+                        Subscription.user_id == user.id,
+                    )
+                )
+                pending_subscription = result.scalar_one_or_none()
+            except Exception as lookup_error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка поиска pending подписки %s для пользователя %s: %s",
+                    payload_data.subscription_id,
+                    user.id,
+                    lookup_error,
+                    exc_info=True,
+                )
+                pending_subscription = None
+
+            if not pending_subscription:
+                logger.error(
+                    "Не найдена pending подписка %s для пользователя %s",
+                    payload_data.subscription_id,
+                    user.id,
+                )
+                return False
+
+            if payload_data.period_days is None:
+                start_point = pending_subscription.start_date or datetime.utcnow()
+                end_point = pending_subscription.end_date or start_point
+                computed_days = max(1, (end_point - start_point).days or 0)
+                period_days = max(period_days, computed_days)
+
+        try:
+            from app.database.crud.subscription import activate_pending_subscription
+
+            subscription = await activate_pending_subscription(
+                db=db,
+                user_id=user.id,
+                period_days=period_days,
+            )
+        except Exception as error:
+            logger.error(
+                "Ошибка активации pending подписки для пользователя %s: %s",
+                user.id,
+                error,
+                exc_info=True,
+            )
+            return False
+
+        if not subscription:
+            logger.error(
+                "Не удалось активировать pending подписку пользователя %s",
+                user.id,
+            )
+            return False
+
+        try:
+            from app.services.subscription_service import SubscriptionService
+
+            subscription_service = SubscriptionService()
+            remnawave_user = await subscription_service.create_remnawave_user(
+                db,
+                subscription,
+            )
+            if remnawave_user:
+                await db.refresh(subscription)
+        except Exception as sync_error:  # pragma: no cover - диагностический лог
+            logger.error(
+                "Ошибка синхронизации подписки с RemnaWave для пользователя %s: %s",
+                user.id,
+                sync_error,
+                exc_info=True,
+            )
+
+        period_display = period_days
+        if not period_display and getattr(subscription, "start_date", None) and getattr(
+            subscription, "end_date", None
+        ):
+            period_display = max(1, (subscription.end_date - subscription.start_date).days or 0)
+        if not period_display:
+            period_display = settings.SIMPLE_SUBSCRIPTION_PERIOD_DAYS
+
+        if getattr(self, "bot", None):
+            try:
+                from aiogram import types
+                from app.localization.texts import get_texts
+
+                texts = get_texts(user.language)
+                traffic_limit = getattr(subscription, "traffic_limit_gb", 0) or 0
+                traffic_label = (
+                    "Безлимит" if traffic_limit == 0 else f"{int(traffic_limit)} ГБ"
+                )
+
+                success_message = (
+                    "✅ <b>Подписка успешно активирована!</b>\n\n"
+                    f"📅 Период: {period_display} дней\n"
+                    f"📱 Устройства: {getattr(subscription, 'device_limit', 1)}\n"
+                    f"📊 Трафик: {traffic_label}\n"
+                    f"⭐ Оплата: {stars_amount} ⭐ ({settings.format_price(amount_kopeks)})\n\n"
+                    "🔗 Для подключения перейдите в раздел 'Моя подписка'"
+                )
+
+                keyboard = types.InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            types.InlineKeyboardButton(
+                                text="📱 Моя подписка",
+                                callback_data="menu_subscription",
+                            )
+                        ],
+                        [
+                            types.InlineKeyboardButton(
+                                text="🏠 Главное меню",
+                                callback_data="back_to_menu",
+                            )
+                        ],
+                    ]
+                )
+
+                await self.bot.send_message(
+                    chat_id=user.telegram_id,
+                    text=success_message,
+                    reply_markup=keyboard,
+                    parse_mode="HTML",
+                )
+                logger.info(
+                    "✅ Пользователь %s получил уведомление об оплате подписки через Stars",
+                    user.telegram_id,
+                )
+            except Exception as error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка отправки уведомления о подписке через Stars: %s",
+                    error,
+                    exc_info=True,
+                )
+
+        if getattr(self, "bot", None):
+            try:
+                from app.services.admin_notification_service import AdminNotificationService
+
+                notification_service = AdminNotificationService(self.bot)
+                await notification_service.send_subscription_purchase_notification(
+                    db,
+                    user,
+                    subscription,
+                    transaction,
+                    period_display,
+                    was_trial_conversion=False,
+                )
+            except Exception as admin_error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка уведомления администраторов о подписке через Stars: %s",
+                    admin_error,
+                    exc_info=True,
+                )
+
+        logger.info(
+            "✅ Обработан Stars платеж как покупка подписки: пользователь %s, %s звезд → %s",
+            user.id,
+            stars_amount,
+            settings.format_price(amount_kopeks),
+        )
+        return True
+
+    async def _finalize_stars_balance_topup(
+        self,
+        db: AsyncSession,
+        user,
+        transaction,
+        amount_kopeks: int,
+        stars_amount: int,
+        telegram_payment_charge_id: str,
+    ) -> bool:
+        """Начисляет баланс пользователю после оплаты Stars и запускает автопокупку."""
+
+        # Запоминаем старые значения, чтобы корректно построить уведомления.
+        old_balance = user.balance_kopeks
+        was_first_topup = not user.has_made_first_topup
+
+        # Обновляем баланс в БД.
+        user.balance_kopeks += amount_kopeks
+        user.updated_at = datetime.utcnow()
+
+        promo_group = getattr(user, "promo_group", None)
+        subscription = getattr(user, "subscription", None)
+        referrer_info = format_referrer_info(user)
+        topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
+
+        await db.commit()
+
+        description_for_referral = (
+            f"Пополнение Stars: {settings.format_price(amount_kopeks)} ({stars_amount} ⭐)"
+        )
+        logger.info(
+            "🔍 Проверка реферальной логики для описания: '%s'",
+            description_for_referral,
+        )
+
+        lower_description = description_for_referral.lower()
+        contains_allowed_keywords = any(
+            word in lower_description for word in ["пополнение", "stars", "yookassa", "topup"]
+        )
+        contains_forbidden_keywords = any(
+            word in lower_description for word in ["комиссия", "бонус"]
+        )
+        allow_referral = contains_allowed_keywords and not contains_forbidden_keywords
+
+        if allow_referral:
+            logger.info(
+                "🔞 Вызов process_referral_topup для пользователя %s",
+                user.id,
+            )
+            try:
+                from app.services.referral_service import process_referral_topup
+
+                await process_referral_topup(
+                    db,
+                    user.id,
+                    amount_kopeks,
+                    getattr(self, "bot", None),
+                )
+            except Exception as error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка обработки реферального пополнения: %s",
+                    error,
+                )
+        else:
+            logger.info(
+                "❌ Описание '%s' не подходит для реферальной логики",
+                description_for_referral,
+            )
+
+        if was_first_topup and not user.has_made_first_topup:
+            user.has_made_first_topup = True
+            await db.commit()
+
+        await db.refresh(user)
+
+        logger.info(
+            "💰 Баланс пользователя %s изменен: %s → %s (Δ +%s)",
+            user.telegram_id,
+            old_balance,
+            user.balance_kopeks,
+            amount_kopeks,
+        )
+
+        if getattr(self, "bot", None):
+            try:
+                from app.services.admin_notification_service import AdminNotificationService
+
+                notification_service = AdminNotificationService(self.bot)
+                await notification_service.send_balance_topup_notification(
+                    user,
+                    transaction,
+                    old_balance,
+                    topup_status=topup_status,
+                    referrer_info=referrer_info,
+                    subscription=subscription,
+                    promo_group=promo_group,
+                    db=db,
+                )
+            except Exception as error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка отправки уведомления о пополнении Stars: %s",
+                    error,
+                    exc_info=True,
+                )
+
+        if getattr(self, "bot", None):
+            try:
+                keyboard = await self.build_topup_success_keyboard(user)
+
+                charge_id_short = (telegram_payment_charge_id or getattr(transaction, "external_id", ""))[:8]
+
+                await self.bot.send_message(
+                    user.telegram_id,
+                    (
+                        "✅ <b>Пополнение успешно!</b>\n\n"
+                        f"⭐ Звезд: {stars_amount}\n"
+                        f"💰 Сумма: {settings.format_price(amount_kopeks)}\n"
+                        "🦊 Способ: Telegram Stars\n"
+                        f"🆔 Транзакция: {charge_id_short}...\n\n"
+                        "Баланс пополнен автоматически!"
+                    ),
+                    parse_mode="HTML",
+                    reply_markup=keyboard,
+                )
+                logger.info(
+                    "✅ Отправлено уведомление пользователю %s о пополнении на %s",
+                    user.telegram_id,
+                    settings.format_price(amount_kopeks),
+                )
+            except Exception as error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка отправки уведомления о пополнении Stars: %s",
+                    error,
+                )
+
+        # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
+        try:
+            from aiogram import types
+            from app.localization.texts import get_texts
+            from app.services.user_cart_service import user_cart_service
+
+            has_saved_cart = await user_cart_service.has_user_cart(user.id)
+            auto_purchase_success = False
+            if has_saved_cart:
+                try:
+                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
+                        db,
+                        user,
+                        bot=getattr(self, "bot", None),
+                    )
+                except Exception as auto_error:  # pragma: no cover - диагностический лог
+                    logger.error(
+                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
+                        user.id,
+                        auto_error,
+                        exc_info=True,
+                    )
+
+                if auto_purchase_success:
+                    has_saved_cart = False
+
+            if has_saved_cart and getattr(self, "bot", None):
+                texts = get_texts(user.language)
+                cart_message = texts.t(
+                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
+                    "🛒 У вас есть неоформленный заказ.\n\n"
+                    "Вы можете продолжить оформление с теми же параметрами.",
+                )
+
+                keyboard = types.InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            types.InlineKeyboardButton(
+                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
+                                callback_data="subscription_resume_checkout",
+                            )
+                        ],
+                        [
+                            types.InlineKeyboardButton(
+                                text="💰 Мой баланс",
+                                callback_data="menu_balance",
+                            )
+                        ],
+                        [
+                            types.InlineKeyboardButton(
+                                text="🏠 Главное меню",
+                                callback_data="back_to_menu",
+                            )
+                        ],
+                    ]
+                )
+
+                await self.bot.send_message(
+                    chat_id=user.telegram_id,
+                    text=f"✅ Баланс пополнен на {settings.format_price(amount_kopeks)}!\n\n{cart_message}",
+                    reply_markup=keyboard,
+                )
+                logger.info(
+                    "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
+                    user.id,
+                )
+        except Exception as error:  # pragma: no cover - диагностический лог
+            logger.error(
+                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
+                user.id,
+                error,
+                exc_info=True,
+            )
+
+        logger.info(
+            "✅ Обработан Stars платеж: пользователь %s, %s звезд → %s",
+            user.id,
+            stars_amount,
+            settings.format_price(amount_kopeks),
+        )
+        return True

--- a/tests/services/test_payment_service_stars.py
+++ b/tests/services/test_payment_service_stars.py
@@ -1,5 +1,7 @@
 """Тесты для Telegram Stars-сценариев внутри PaymentService."""
 
+from datetime import datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, Optional
 import sys
@@ -25,11 +27,16 @@ class DummyBot:
 
     def __init__(self) -> None:
         self.calls: list[Dict[str, Any]] = []
+        self.sent_messages: list[Dict[str, Any]] = []
 
     async def create_invoice_link(self, **kwargs: Any) -> str:
         """Эмулируем создание платежной ссылки и сохраняем параметры вызова."""
         self.calls.append(kwargs)
         return "https://t.me/invoice/stars"
+
+    async def send_message(self, **kwargs: Any) -> None:
+        """Фиксируем отправленные сообщения пользователю."""
+        self.sent_messages.append(kwargs)
 
 
 def _make_service(bot: Optional[DummyBot]) -> PaymentService:
@@ -40,6 +47,80 @@ def _make_service(bot: Optional[DummyBot]) -> PaymentService:
     service.stars_service = object() if bot else None
     return service
 
+
+class DummySession:
+    """Минимальная заглушка AsyncSession для проверки сценариев Stars."""
+
+    def __init__(self, pending_subscription: "DummySubscription") -> None:
+        self.pending_subscription = pending_subscription
+        self.commits: int = 0
+        self.refreshed: list[Any] = []
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        class _Result:
+            def __init__(self, subscription: "DummySubscription") -> None:
+                self._subscription = subscription
+
+            def scalar_one_or_none(self) -> "DummySubscription":
+                return self._subscription
+
+        return _Result(self.pending_subscription)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def refresh(self, obj: Any) -> None:
+        self.refreshed.append(obj)
+
+
+class DummySubscription:
+    """Упрощённая модель подписки для тестов."""
+
+    def __init__(
+        self,
+        subscription_id: int,
+        *,
+        traffic_limit_gb: int = 0,
+        device_limit: int = 1,
+        period_days: int = 30,
+    ) -> None:
+        self.id = subscription_id
+        self.traffic_limit_gb = traffic_limit_gb
+        self.device_limit = device_limit
+        self.status = "pending"
+        self.start_date = datetime(2024, 1, 1)
+        self.end_date = self.start_date + timedelta(days=period_days)
+
+
+class DummyUser:
+    """Минимальные данные пользователя для тестов Stars-покупки."""
+
+    def __init__(self, user_id: int = 501, telegram_id: int = 777) -> None:
+        self.id = user_id
+        self.telegram_id = telegram_id
+        self.language = "ru"
+        self.balance_kopeks = 0
+        self.has_made_first_topup = False
+        self.promo_group = None
+        self.subscription = None
+
+
+class DummyTransaction:
+    """Локальная транзакция, созданная в тестах."""
+
+    def __init__(self, external_id: str) -> None:
+        self.external_id = external_id
+
+
+class DummySubscriptionService:
+    """Заглушка SubscriptionService, запоминающая вызовы."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, Any]] = []
+
+    async def create_remnawave_user(self, db: Any, subscription: Any) -> object:
+        self.calls.append((db, subscription))
+        return object()
 
 @pytest.mark.anyio("asyncio")
 async def test_create_stars_invoice_calculates_stars(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -140,3 +221,127 @@ async def test_create_stars_invoice_requires_bot() -> None:
             amount_kopeks=1000,
             description="Пополнение",
         )
+
+
+@pytest.mark.anyio("asyncio")
+async def test_process_stars_payment_simple_subscription_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Оплата простой подписки через Stars активирует pending подписку и уведомляет пользователя."""
+
+    bot = DummyBot()
+    service = _make_service(bot)
+
+    pending_subscription = DummySubscription(subscription_id=321, device_limit=2)
+    db = DummySession(pending_subscription)
+    user = DummyUser(user_id=900, telegram_id=123456)
+    activated_subscription = DummySubscription(subscription_id=321, device_limit=2)
+
+    transaction_holder: Dict[str, DummyTransaction] = {}
+
+    async def fake_create_transaction(**kwargs: Any) -> DummyTransaction:
+        transaction = DummyTransaction(external_id=kwargs.get("external_id", ""))
+        transaction_holder["value"] = transaction
+        return transaction
+
+    async def fake_get_user_by_id(_db: Any, _user_id: int) -> DummyUser:
+        return user
+
+    async def fake_activate_pending_subscription(
+        db: Any,
+        user_id: int,
+        period_days: Optional[int] = None,
+    ) -> DummySubscription:
+        activated_subscription.start_date = pending_subscription.start_date
+        activated_subscription.end_date = activated_subscription.start_date + timedelta(
+            days=period_days or 30
+        )
+        return activated_subscription
+
+    subscription_service_stub = DummySubscriptionService()
+    admin_calls: list[Dict[str, Any]] = []
+
+    class AdminNotificationStub:
+        def __init__(self, _bot: Any) -> None:
+            self.bot = _bot
+
+        async def send_subscription_purchase_notification(
+            self,
+            db: Any,
+            user_obj: Any,
+            subscription: Any,
+            transaction: Any,
+            period_days: int,
+            was_trial_conversion: bool,
+        ) -> None:
+            admin_calls.append(
+                {
+                    "user": user_obj,
+                    "subscription": subscription,
+                    "transaction": transaction,
+                    "period": period_days,
+                    "was_trial": was_trial_conversion,
+                }
+            )
+
+    monkeypatch.setattr(
+        "app.services.payment.stars.create_transaction",
+        fake_create_transaction,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.payment.stars.get_user_by_id",
+        fake_get_user_by_id,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.database.crud.subscription.activate_pending_subscription",
+        fake_activate_pending_subscription,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.subscription_service.SubscriptionService",
+        lambda: subscription_service_stub,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.admin_notification_service.AdminNotificationService",
+        AdminNotificationStub,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        type(settings),
+        "format_price",
+        lambda self, amount: f"{amount / 100:.0f}₽",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "SIMPLE_SUBSCRIPTION_PERIOD_DAYS",
+        30,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.payment.stars.TelegramStarsService.calculate_rubles_from_stars",
+        lambda stars: Decimal("100"),
+        raising=False,
+    )
+
+    payload = f"simple_sub_{user.id}_{pending_subscription.id}_30"
+    result = await service.process_stars_payment(
+        db=db,
+        user_id=user.id,
+        stars_amount=5,
+        payload=payload,
+        telegram_payment_charge_id="charge12345",
+    )
+
+    assert result is True
+    assert user.balance_kopeks == 0, "Баланс не должен меняться при оплате подписки"
+    assert subscription_service_stub.calls == [(db, activated_subscription)]
+    assert len(admin_calls) == 1
+    assert admin_calls[0]["subscription"] is activated_subscription
+    assert admin_calls[0]["period"] == 30
+    assert bot.sent_messages, "Пользователь должен получить уведомление"
+    assert "Подписка успешно активирована" in bot.sent_messages[0]["text"]
+    assert transaction_holder["value"].external_id == "charge12345"

--- a/tests/services/test_subscription_auto_purchase_service.py
+++ b/tests/services/test_subscription_auto_purchase_service.py
@@ -130,7 +130,6 @@ async def test_auto_purchase_saved_cart_after_topup_success(monkeypatch):
                 details=base_pricing.details,
             )
 
-    class DummyPurchaseService:
         async def submit_purchase(self, db, prepared_context, pricing):
             return {
                 "subscription": MagicMock(),
@@ -142,10 +141,6 @@ async def test_auto_purchase_saved_cart_after_topup_success(monkeypatch):
     monkeypatch.setattr(
         "app.services.subscription_auto_purchase_service.MiniAppSubscriptionPurchaseService",
         lambda: DummyMiniAppService(),
-    )
-    monkeypatch.setattr(
-        "app.services.subscription_auto_purchase_service.SubscriptionPurchaseService",
-        lambda: DummyPurchaseService(),
     )
     monkeypatch.setattr(
         "app.services.subscription_auto_purchase_service.user_cart_service.get_user_cart",


### PR DESCRIPTION
## Summary
- ensure the simple subscription stars checkout creates a pending order and stores the order id in the invoice payload before redirecting the user
- extend the Telegram Stars payment handler to detect simple subscription payloads, activate the pending subscription, notify the user/admins, and keep the balance unchanged
- allow simple_sub payloads during pre-check validation and cover the flow with dedicated unit tests