### PR TITLE
Deduplicate RemnaWave sync users with freshest subscriptions

### DIFF
--- a/tests/services/test_remnawave_service_sync.py
+++ b/tests/services/test_remnawave_service_sync.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+from zoneinfo import ZoneInfo
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.services.remnawave_service import RemnaWaveService
+
+
+def _create_service() -> RemnaWaveService:
+    service = RemnaWaveService.__new__(RemnaWaveService)
+    service._panel_timezone = ZoneInfo("UTC")
+    return service
+
+
+def _make_panel_user(telegram_id: int, expire_at: str, status: str = "ACTIVE") -> dict:
+    return {
+        "telegramId": telegram_id,
+        "expireAt": expire_at,
+        "status": status,
+    }
+
+
+def test_deduplicate_prefers_latest_expire_date():
+    service = _create_service()
+
+    telegram_id = 100
+    older = _make_panel_user(telegram_id, datetime(2025, 1, 1, 0, 0, 0).isoformat())
+    newer = _make_panel_user(telegram_id, datetime(2025, 2, 1, 0, 0, 0).isoformat())
+
+    deduplicated = service._deduplicate_panel_users_by_telegram_id([older, newer])
+
+    assert deduplicated[telegram_id] is newer
+
+
+def test_deduplicate_prefers_active_status_on_same_expire():
+    service = _create_service()
+
+    telegram_id = 200
+    expire = datetime(2025, 1, 1, 0, 0, 0).isoformat()
+    disabled = _make_panel_user(telegram_id, expire, status="DISABLED")
+    active = _make_panel_user(telegram_id, expire, status="ACTIVE")
+
+    deduplicated = service._deduplicate_panel_users_by_telegram_id([disabled, active])
+
+    assert deduplicated[telegram_id] is active
+
+
+def test_deduplicate_ignores_records_without_expire_date():
+    service = _create_service()
+
+    telegram_id = 300
+    missing_expire = _make_panel_user(telegram_id, "")
+    valid = _make_panel_user(telegram_id, datetime(2025, 3, 1, 0, 0, 0).isoformat())
+
+    deduplicated = service._deduplicate_panel_users_by_telegram_id([missing_expire, valid])
+
+    assert deduplicated[telegram_id] is valid


### PR DESCRIPTION
## Summary
- deduplicate panel users by telegram id during RemnaWave sync so only the freshest record is processed
- add tests covering the deduplication priority logic
