### PR TITLE
Fix admin ticket DM links to support ID-only users

### DIFF
--- a/app/handlers/admin/tickets.py
+++ b/app/handlers/admin/tickets.py
@@ -22,6 +22,7 @@ from app.services.admin_notification_service import AdminNotificationService
 from app.services.support_settings_service import SupportSettingsService
 from app.config import settings
 from app.utils.cache import RateLimitCache
+from app.utils.telegram_links import build_user_dm_url, build_user_profile_url
 
 logger = logging.getLogger(__name__)
 
@@ -221,17 +222,14 @@ async def view_admin_ticket(
         pass
     # Кнопки ЛС и профиль
     try:
-        if ticket.user and ticket.user.telegram_id:
+        if ticket.user:
             buttons_row = []
-            # DM: при наличии username используем tg://resolve, иначе fallback по ID
-            if ticket.user.username:
-                pm_url = f"tg://resolve?domain={ticket.user.username}"
-            else:
-                pm_url = f"tg://user?id={ticket.user.telegram_id}"
-            buttons_row.append(types.InlineKeyboardButton(text="✉ Написать в ЛС", url=pm_url))
-            # Профиль: по ID
-            profile_url = f"tg://user?id={ticket.user.telegram_id}"
-            buttons_row.append(types.InlineKeyboardButton(text="👤 Профиль", url=profile_url))
+            dm_url = build_user_dm_url(ticket.user.username, ticket.user.telegram_id)
+            profile_url = build_user_profile_url(ticket.user.username, ticket.user.telegram_id)
+            if dm_url:
+                buttons_row.append(types.InlineKeyboardButton(text="✉ Написать в ЛС", url=dm_url))
+            if profile_url:
+                buttons_row.append(types.InlineKeyboardButton(text="👤 Профиль", url=profile_url))
             if buttons_row:
                 keyboard.inline_keyboard.insert(0, buttons_row)
     except Exception:
@@ -778,15 +776,14 @@ async def handle_admin_block_duration_input(
                 pass
             # Кнопки ЛС и профиль при обновлении карточки
             try:
-                if updated.user and updated.user.telegram_id:
+                if updated.user:
                     buttons_row = []
-                    if updated.user.username:
-                        pm_url = f"tg://resolve?domain={updated.user.username}"
-                    else:
-                        pm_url = f"tg://user?id={updated.user.telegram_id}"
-                    buttons_row.append(types.InlineKeyboardButton(text="✉ Написать в ЛС", url=pm_url))
-                    profile_url = f"tg://user?id={updated.user.telegram_id}"
-                    buttons_row.append(types.InlineKeyboardButton(text="👤 Профиль", url=profile_url))
+                    dm_url = build_user_dm_url(updated.user.username, updated.user.telegram_id)
+                    profile_url = build_user_profile_url(updated.user.username, updated.user.telegram_id)
+                    if dm_url:
+                        buttons_row.append(types.InlineKeyboardButton(text="✉ Написать в ЛС", url=dm_url))
+                    if profile_url:
+                        buttons_row.append(types.InlineKeyboardButton(text="👤 Профиль", url=profile_url))
                     if buttons_row:
                         kb.inline_keyboard.insert(0, buttons_row)
             except Exception:

--- a/app/utils/telegram_links.py
+++ b/app/utils/telegram_links.py
@@ -1,0 +1,56 @@
+"""Utilities for constructing Telegram deep links that work with usernames or IDs."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _clean_username(username: str | None) -> str | None:
+    if not username:
+        return None
+    username_clean = username.strip().lstrip("@")
+    return username_clean or None
+
+
+def build_user_dm_url(username: str | None, telegram_id: int | str | None) -> Optional[str]:
+    """Return a deep link for opening a DM with a Telegram user.
+
+    Preference is given to usernames because the ``https://t.me/<username>`` scheme
+    works reliably across platforms. When a username is not available, we fall back
+    to the ``tg://openmessage`` scheme with the numeric Telegram ID so that support
+    agents can still contact the user.
+    """
+
+    username_clean = _clean_username(username)
+    if username_clean:
+        return f"https://t.me/{username_clean}"
+
+    if telegram_id is None:
+        return None
+
+    try:
+        telegram_id_int = int(telegram_id)
+    except (TypeError, ValueError):
+        return None
+
+    return f"tg://openmessage?user_id={telegram_id_int}"
+
+
+def build_user_profile_url(username: str | None, telegram_id: int | str | None) -> Optional[str]:
+    """Return a link that opens a Telegram profile.
+
+    When an ID is available we use the ``tg://user`` scheme to jump directly to the
+    user profile. If the ID cannot be parsed we reuse :func:`build_user_dm_url` as a
+    graceful fallback so that the caller always gets a usable link.
+    """
+
+    if telegram_id is not None:
+        try:
+            telegram_id_int = int(telegram_id)
+        except (TypeError, ValueError):
+            pass
+        else:
+            return f"tg://user?id={telegram_id_int}"
+
+    return build_user_dm_url(username, telegram_id)
+


### PR DESCRIPTION
## Summary
- add reusable helpers to construct Telegram deep links from usernames or numeric IDs
- update admin ticket views to use the new helpers so DM/profile buttons also work for users without usernames

