### PR TITLE
Fix Pal24 payment status retrieval crash

### DIFF
--- a/app/services/pal24_service.py
+++ b/app/services/pal24_service.py
@@ -83,6 +83,12 @@ class Pal24Service:
         logger.debug("Запрашиваем статус Pal24 платежа %s", payment_id)
         return await self.client.get_payment_status(payment_id)
 
+    async def get_bill_payments(self, bill_id: str) -> Dict[str, Any]:
+        """Возвращает список платежей, связанных со счетом."""
+
+        logger.debug("Запрашиваем платежи Pal24 счёта %s", bill_id)
+        return await self.client.get_bill_payments(bill_id)
+
     @staticmethod
     def parse_postback(payload: Dict[str, Any]) -> Dict[str, Any]:
         required_fields = ["InvId", "OutSum", "Status", "SignatureValue"]

--- a/tests/services/test_pal24_service_adapter.py
+++ b/tests/services/test_pal24_service_adapter.py
@@ -42,6 +42,9 @@ class StubPal24Client:
     async def get_payment_status(self, payment_id: str) -> Dict[str, Any]:
         return {"id": payment_id, "status": "SUCCESS"}
 
+    async def get_bill_payments(self, bill_id: str) -> Dict[str, Any]:
+        return {"id": bill_id, "payments": [{"id": "PAY-1"}]}
+
 
 def _enable_pal24(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(type(settings), "is_pal24_enabled", lambda self: True, raising=False)
@@ -94,6 +97,17 @@ async def test_create_bill_requires_configuration(monkeypatch: pytest.MonkeyPatc
             order_id="order",
             description="desc",
         )
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_bill_payments(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_pal24(monkeypatch)
+    client = StubPal24Client()
+    service = Pal24Service(client)
+
+    result = await service.get_bill_payments("BILL42")
+
+    assert result == {"id": "BILL42", "payments": [{"id": "PAY-1"}]}
 
 
 def test_parse_postback_success(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a get_bill_payments helper to Pal24Service so payment status checks can call it safely
- cover the new helper with a unit test to prevent regressions
