### PR TITLE
Add configurable template for RemnaWave panel usernames

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,14 @@ REMNAWAVE_SECRET_KEY=
 #   {telegram_id}       — ID Telegram
 REMNAWAVE_USER_DESCRIPTION_TEMPLATE="Bot user: {full_name} {username}"
 
+# Шаблон имени пользователя в панели Remnawave
+# Доступные плейсхолдеры аналогичны описанию выше
+#   {full_name}         — Имя, Фамилия из Telegram
+#   {username}          — @логин из Telegram (c @)
+#   {username_clean}    — логин из Telegram (без @)
+#   {telegram_id}       — ID Telegram
+REMNAWAVE_USER_USERNAME_TEMPLATE="user_{telegram_id}"
+
 # Режим удаления пользователей из панели RemnaWave
 # delete - полностью удалить пользователя из панели
 # disable - только деактивировать пользователя

--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ REMNAWAVE_AUTO_SYNC_TIMES=03:00,15:00
 
 # Шаблон описания пользователя
 REMNAWAVE_USER_DESCRIPTION_TEMPLATE="Bot user: {full_name} {username}"
+# Шаблон имени пользователя в панели
+REMNAWAVE_USER_USERNAME_TEMPLATE="user_{telegram_id}"
 REMNAWAVE_USER_DELETE_MODE=delete
 
 # ===== ПОДПИСКИ =====

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -3878,7 +3878,11 @@ async def admin_buy_subscription_execute(
 
                         remnawave_user = await api.update_user(**update_kwargs)
                 else:
-                    username = f"user_{target_user.telegram_id}"
+                    username = settings.format_remnawave_username(
+                        full_name=target_user.full_name,
+                        username=target_user.username,
+                        telegram_id=target_user.telegram_id,
+                    )
                     async with remnawave_service.get_api_client() as api:
                         create_kwargs = dict(
                             username=username,

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -1245,7 +1245,11 @@ class RemnaWaveService:
                             await api.update_user(**update_kwargs)
                             stats["updated"] += 1
                         else:
-                            username = f"user_{user.telegram_id}"
+                            username = settings.format_remnawave_username(
+                                full_name=user.full_name,
+                                username=user.username,
+                                telegram_id=user.telegram_id,
+                            )
 
                             create_kwargs = dict(
                                 username=username,

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -216,7 +216,11 @@ class SubscriptionService:
 
                 else:
                     logger.info(f"🆕 Создаем нового пользователя в панели для {user.telegram_id}")
-                    username = f"user_{user.telegram_id}"
+                    username = settings.format_remnawave_username(
+                        full_name=user.full_name,
+                        username=user.username,
+                        telegram_id=user.telegram_id,
+                    )
                     create_kwargs = dict(
                         username=username,
                         expire_at=subscription.end_date,

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -269,6 +269,7 @@ class BotConfigurationService:
         "VERSION_CHECK_INTERVAL_HOURS": "VERSION",
         "TELEGRAM_STARS_RATE_RUB": "TELEGRAM",
         "REMNAWAVE_USER_DESCRIPTION_TEMPLATE": "REMNAWAVE",
+        "REMNAWAVE_USER_USERNAME_TEMPLATE": "REMNAWAVE",
         "REMNAWAVE_AUTO_SYNC_ENABLED": "REMNAWAVE",
         "REMNAWAVE_AUTO_SYNC_TIMES": "REMNAWAVE",
     }
@@ -551,6 +552,31 @@ class BotConfigurationService:
                 "синхронизации нагружают панель."
             ),
             "dependencies": "REMNAWAVE_AUTO_SYNC_ENABLED",
+        },
+        "REMNAWAVE_USER_DESCRIPTION_TEMPLATE": {
+            "description": (
+                "Шаблон текста, который бот передает в поле Description при создании "
+                "или обновлении пользователя в панели RemnaWave."
+            ),
+            "format": (
+                "Доступные плейсхолдеры: {full_name}, {username}, {username_clean}, {telegram_id}."
+            ),
+            "example": "Bot user: {full_name} {username}",
+            "warning": "Плейсхолдер {username} автоматически очищается, если у пользователя нет @username.",
+        },
+        "REMNAWAVE_USER_USERNAME_TEMPLATE": {
+            "description": (
+                "Шаблон имени пользователя, которое создаётся в панели RemnaWave для "
+                "телеграм-пользователя."
+            ),
+            "format": (
+                "Доступные плейсхолдеры: {full_name}, {username}, {username_clean}, {telegram_id}."
+            ),
+            "example": "vpn_{username_clean}_{telegram_id}",
+            "warning": (
+                "Недопустимые символы автоматически заменяются на подчёркивания. "
+                "Если результат пустой, используется user_{telegram_id}."
+            ),
         },
         "EXTERNAL_ADMIN_TOKEN": {
             "description": "Приватный токен, который использует внешняя админка для проверки запросов.",


### PR DESCRIPTION
## Summary
- add the REMNAWAVE_USER_USERNAME_TEMPLATE option with formatting helper for panel usernames
- apply the new template when provisioning RemnaWave users from subscriptions, sync jobs, and admin actions
- document the username template in environment examples and system settings hints
