### PR TITLE
Fix promo group timestamp serialization issues

### DIFF
--- a/app/webapi/routes/promo_groups.py
+++ b/app/webapi/routes/promo_groups.py
@@ -52,12 +52,12 @@ def _serialize(group: PromoGroup, members_count: int = 0) -> PromoGroupResponse:
         apply_discounts_to_addons=group.apply_discounts_to_addons,
         is_default=group.is_default,
         members_count=members_count,
-        created_at=group.created_at,
-        updated_at=group.updated_at,
+        created_at=getattr(group, "created_at", None),
+        updated_at=getattr(group, "updated_at", None),
     )
 
 
-@router.get("", response_model=PromoGroupListResponse)
+@router.get("", response_model=PromoGroupListResponse, response_model_exclude_none=True)
 async def list_promo_groups(
     _: Any = Security(require_api_token),
     db: AsyncSession = Depends(get_db_session),
@@ -79,7 +79,7 @@ async def list_promo_groups(
     )
 
 
-@router.get("/{group_id}", response_model=PromoGroupResponse)
+@router.get("/{group_id}", response_model=PromoGroupResponse, response_model_exclude_none=True)
 async def get_promo_group(
     group_id: int,
     _: Any = Security(require_api_token),
@@ -93,7 +93,12 @@ async def get_promo_group(
     return _serialize(group, members_count=members_count)
 
 
-@router.post("", response_model=PromoGroupResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=PromoGroupResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_promo_group_endpoint(
     payload: PromoGroupCreateRequest,
     _: Any = Security(require_api_token),
@@ -120,7 +125,11 @@ async def create_promo_group_endpoint(
     return _serialize(group, members_count=0)
 
 
-@router.patch("/{group_id}", response_model=PromoGroupResponse)
+@router.patch(
+    "/{group_id}",
+    response_model=PromoGroupResponse,
+    response_model_exclude_none=True,
+)
 async def update_promo_group_endpoint(
     group_id: int,
     payload: PromoGroupUpdateRequest,

--- a/app/webapi/schemas/promo_groups.py
+++ b/app/webapi/schemas/promo_groups.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 
 def _normalize_period_discounts(value: Optional[Dict[object, object]]) -> Optional[Dict[int, int]]:
@@ -23,6 +23,8 @@ def _normalize_period_discounts(value: Optional[Dict[object, object]]) -> Option
 
 
 class PromoGroupResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     server_discount_percent: int
@@ -33,8 +35,8 @@ class PromoGroupResponse(BaseModel):
     apply_discounts_to_addons: bool
     is_default: bool
     members_count: int = 0
-    created_at: datetime
-    updated_at: datetime
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 class _PromoGroupBase(BaseModel):


### PR DESCRIPTION
## Summary
- allow promo group API response models to accept missing timestamps
- exclude null timestamps from promo group API responses and guard serialization
- add a reusable helper for admin user display text and resolve nested f-string syntax errors in notifications