### PR TITLE
Fix subscription timestamps to use configured timezone

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ import html
 from collections import defaultdict
 from datetime import time
 from typing import List, Optional, Union, Dict
+from zoneinfo import ZoneInfo
 from pydantic_settings import BaseSettings
 from pydantic import field_validator, Field
 from pathlib import Path
@@ -60,6 +61,8 @@ class Settings(BaseSettings):
     
     SQLITE_PATH: str = "./data/bot.db"
     LOCALES_PATH: str = "./locales"
+
+    TIMEZONE: str = Field(default_factory=lambda: os.getenv("TZ", "UTC"))
     
     DATABASE_MODE: str = "auto"
     
@@ -1424,8 +1427,19 @@ class Settings(BaseSettings):
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",
-        "extra": "ignore"  
+        "extra": "ignore"
     }
+
+    @field_validator("TIMEZONE")
+    @classmethod
+    def validate_timezone(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except Exception as exc:  # pragma: no cover - defensive validation
+            raise ValueError(
+                f"Некорректный идентификатор часового пояса: {value}"
+            ) from exc
+        return value
 
 
 settings = Settings()

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -15,6 +15,7 @@ from app.database.models import (
 from app.database.crud.notification import clear_notifications
 from app.utils.pricing_utils import calculate_months_from_days, get_remaining_months
 from app.config import settings
+from app.utils.timezone import format_local_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -1131,7 +1132,13 @@ async def check_and_update_subscription_status(
     
     current_time = datetime.utcnow()
     
-    logger.info(f"🔍 Проверка статуса подписки {subscription.id}, текущий статус: {subscription.status}, дата окончания: {subscription.end_date}, текущее время: {current_time}")
+    logger.info(
+        "🔍 Проверка статуса подписки %s, текущий статус: %s, дата окончания: %s, текущее время: %s",
+        subscription.id,
+        subscription.status,
+        format_local_datetime(subscription.end_date),
+        format_local_datetime(current_time),
+    )
     
     if (subscription.status == SubscriptionStatus.ACTIVE.value and 
         subscription.end_date <= current_time):

--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -38,6 +38,7 @@ from app.utils.promo_offer import (
 from app.services.privacy_policy_service import PrivacyPolicyService
 from app.services.public_offer_service import PublicOfferService
 from app.services.faq_service import FaqService
+from app.utils.timezone import format_local_datetime
 from app.utils.pricing_utils import format_period_description
 
 logger = logging.getLogger(__name__)
@@ -952,7 +953,8 @@ def _get_subscription_status(user: User, texts) -> str:
 
     current_time = datetime.utcnow()
     actual_status = (subscription.actual_status or "").lower()
-    end_date_text = subscription.end_date.strftime("%d.%m.%Y")
+    end_date = getattr(subscription, "end_date", None)
+    end_date_text = format_local_datetime(end_date, "%d.%m.%Y") if end_date else None
     days_left = 0
 
     if subscription.end_date > current_time:
@@ -968,10 +970,10 @@ def _get_subscription_status(user: User, texts) -> str:
         return texts.t(
             "SUB_STATUS_EXPIRED",
             "🔴 Истекла\n📅 {end_date}",
-        ).format(end_date=end_date_text)
+        ).format(end_date=end_date_text or "—")
 
     if actual_status == "trial":
-        if days_left > 1:
+        if days_left > 1 and end_date_text:
             return texts.t(
                 "SUB_STATUS_TRIAL_ACTIVE",
                 "🎁 Тестовая подписка\n📅 до {end_date} ({days} дн.)",
@@ -990,7 +992,7 @@ def _get_subscription_status(user: User, texts) -> str:
         )
 
     if actual_status == "active":
-        if days_left > 7:
+        if days_left > 7 and end_date_text:
             return texts.t(
                 "SUB_STATUS_ACTIVE_LONG",
                 "💎 Активна\n📅 до {end_date} ({days} дн.)",

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -37,6 +37,7 @@ from app.utils.promo_offer import (
     build_promo_offer_hint,
     build_test_access_hint,
 )
+from app.utils.timezone import format_local_datetime
 from app.database.crud.user_message import get_random_active_message
 from app.database.crud.subscription import decrement_subscription_server_counts
 
@@ -1268,6 +1269,7 @@ def _get_subscription_status(user, texts):
     from datetime import datetime
 
     end_date = getattr(subscription, "end_date", None)
+    end_date_display = format_local_datetime(end_date, "%d.%m.%Y") if end_date else None
     current_time = datetime.utcnow()
 
     if actual_status == "disabled":
@@ -1277,11 +1279,11 @@ def _get_subscription_status(user, texts):
         return texts.t("SUB_STATUS_PENDING", "⏳ Ожидает активации")
 
     if actual_status == "expired" or (end_date and end_date <= current_time):
-        if end_date:
+        if end_date_display:
             return texts.t(
                 "SUB_STATUS_EXPIRED",
                 "🔴 Истекла\n📅 {end_date}",
-            ).format(end_date=end_date.strftime('%d.%m.%Y'))
+            ).format(end_date=end_date_display)
         return texts.t("SUBSCRIPTION_STATUS_EXPIRED", "🔴 Истекла")
 
     if not end_date:
@@ -1294,11 +1296,11 @@ def _get_subscription_status(user, texts):
         return texts.t("SUBSCRIPTION_STATUS_UNKNOWN", "❓ Статус неизвестен")
 
     if is_trial:
-        if days_left > 1:
+        if days_left > 1 and end_date_display:
             return texts.t(
                 "SUB_STATUS_TRIAL_ACTIVE",
                 "🎁 Тестовая подписка\n📅 до {end_date} ({days} дн.)",
-            ).format(end_date=end_date.strftime('%d.%m.%Y'), days=days_left)
+            ).format(end_date=end_date_display, days=days_left)
         if days_left == 1:
             return texts.t(
                 "SUB_STATUS_TRIAL_TOMORROW",
@@ -1309,11 +1311,11 @@ def _get_subscription_status(user, texts):
             "🎁 Тестовая подписка\n⚠️ истекает сегодня!",
         )
 
-    if days_left > 7:
+    if days_left > 7 and end_date_display:
         return texts.t(
             "SUB_STATUS_ACTIVE_LONG",
             "💎 Активна\n📅 до {end_date} ({days} дн.)",
-        ).format(end_date=end_date.strftime('%d.%m.%Y'), days=days_left)
+        ).format(end_date=end_date_display, days=days_left)
     if days_left > 1:
         return texts.t(
             "SUB_STATUS_ACTIVE_FEW_DAYS",

--- a/app/handlers/subscription/pricing.py
+++ b/app/handlers/subscription/pricing.py
@@ -77,6 +77,7 @@ from app.utils.promo_offer import (
     build_promo_offer_hint,
     get_user_active_promo_discount_percent,
 )
+from app.utils.timezone import format_local_datetime
 
 from .common import _apply_discount_to_monthly_component, _apply_promo_offer_discount, logger
 from .countries import _get_available_countries, _get_countries_info, get_countries_price_by_uuids_fallback
@@ -491,7 +492,7 @@ async def get_subscription_info_text(subscription, texts, db_user, db: AsyncSess
     info_text = info_template.format(
         status=status_text,
         type=type_text,
-        end_date=subscription.end_date.strftime("%d.%m.%Y %H:%M"),
+        end_date=format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M"),
         days_left=max(0, subscription.days_left),
         traffic_used=texts.format_traffic(subscription.traffic_used_gb),
         traffic_limit=traffic_text,

--- a/app/handlers/subscription/purchase.py
+++ b/app/handlers/subscription/purchase.py
@@ -77,6 +77,7 @@ from app.utils.subscription_utils import (
     get_happ_cryptolink_redirect_link,
     resolve_simple_subscription_device_limit,
 )
+from app.utils.timezone import format_local_datetime
 from app.utils.promo_offer import (
     build_promo_offer_hint,
     get_user_active_promo_discount_percent,
@@ -301,7 +302,7 @@ async def show_subscription_info(
         status_display=status_display,
         warning=warning_text,
         subscription_type=subscription_type,
-        end_date=subscription.end_date.strftime("%d.%m.%Y %H:%M"),
+        end_date=format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M"),
         time_left=time_left_text,
         traffic=traffic_used_display,
         servers=servers_display,
@@ -1333,7 +1334,7 @@ async def confirm_extend_subscription(
         success_message = (
             "✅ Подписка успешно продлена!\n\n"
             f"⏰ Добавлено: {days} дней\n"
-            f"Действует до: {refreshed_end_date.strftime('%d.%m.%Y %H:%M')}\n\n"
+            f"Действует до: {format_local_datetime(refreshed_end_date, '%d.%m.%Y %H:%M')}\n\n"
             f"💰 Списано: {texts.format_price(price)}"
         )
 
@@ -2983,7 +2984,7 @@ async def _extend_existing_subscription(
     success_message = (
         "✅ Подписка успешно продлена!\n\n"
         f"⏰ Добавлено: {period_days} дней\n"
-        f"Действует до: {new_end_date.strftime('%d.%m.%Y %H:%M')}\n\n"
+        f"Действует до: {format_local_datetime(new_end_date, '%d.%m.%Y %H:%M')}\n\n"
         f"💰 Списано: {texts.format_price(price_kopeks)}"
     )
     

--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -19,6 +19,7 @@ from app.database.models import (
     TransactionType,
     User,
 )
+from app.utils.timezone import format_local_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -224,10 +225,10 @@ class AdminNotificationService:
 📱 Устройства: {trial_device_limit}
 🌐 Сервер: {subscription.connected_squads[0] if subscription.connected_squads else 'По умолчанию'}
 
-📆 <b>Действует до:</b> {subscription.end_date.strftime('%d.%m.%Y %H:%M')}
+📆 <b>Действует до:</b> {format_local_datetime(subscription.end_date, '%d.%m.%Y %H:%M')}
 🔗 <b>Реферер:</b> {referrer_info}
 
-⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"""
+⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"""
             
             return await self._send_message(message)
             
@@ -288,11 +289,11 @@ class AdminNotificationService:
 📱 Устройства: {subscription.device_limit}
 🌐 Серверы: {servers_info}
 
-📆 <b>Действует до:</b> {subscription.end_date.strftime('%d.%m.%Y %H:%M')}
+📆 <b>Действует до:</b> {format_local_datetime(subscription.end_date, '%d.%m.%Y %H:%M')}
 💰 <b>Баланс после покупки:</b> {settings.format_price(user.balance_kopeks)}
 🔗 <b>Реферер:</b> {referrer_info}
 
-⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"""
+⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"""
             
             return await self._send_message(message)
             
@@ -339,7 +340,7 @@ class AdminNotificationService:
     
     ℹ️ Для обновления перезапустите контейнер с новым тегом или обновите код из репозитория.
     
-    ⚙️ <i>Автоматическая проверка обновлений • {datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"""
+    ⚙️ <i>Автоматическая проверка обновлений • {format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"""
             
             return await self._send_message(message)
             
@@ -364,7 +365,7 @@ class AdminNotificationService:
     🔄 Следующая попытка через час.
     ⚙️ Проверьте доступность GitHub API и настройки сети.
     
-    ⚙️ <i>Система автоматических обновлений • {datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"""
+    ⚙️ <i>Система автоматических обновлений • {format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"""
             
             return await self._send_message(message)
             
@@ -387,7 +388,7 @@ class AdminNotificationService:
         balance_change = user.balance_kopeks - old_balance
         subscription_status = self._get_subscription_status(subscription)
         promo_block = self._format_promo_group_block(promo_group)
-        timestamp = datetime.now().strftime('%d.%m.%Y %H:%M:%S')
+        timestamp = format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')
         user_display = self._get_user_display(user)
 
         return f"""💰 <b>ПОПОЛНЕНИЕ БАЛАНСА</b>
@@ -585,8 +586,8 @@ class AdminNotificationService:
 
 📅 <b>Продление:</b>
 ➕ Добавлено дней: {extended_days}
-📆 Было до: {old_end_date.strftime('%d.%m.%Y %H:%M')}
-📆 Стало до: {current_end_date.strftime('%d.%m.%Y %H:%M')}
+📆 Было до: {format_local_datetime(old_end_date, '%d.%m.%Y %H:%M')}
+📆 Стало до: {format_local_datetime(current_end_date, '%d.%m.%Y %H:%M')}
 
 📱 <b>Текущие параметры:</b>
 📊 Трафик: {self._format_traffic(subscription.traffic_limit_gb)}
@@ -595,7 +596,7 @@ class AdminNotificationService:
 
 💰 <b>Баланс после операции:</b> {settings.format_price(current_balance)}
 
-⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"""
+⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"""
 
             return await self._send_message(message)
 
@@ -648,7 +649,7 @@ class AdminNotificationService:
             valid_until = promocode_data.get("valid_until")
             if valid_until:
                 message_lines.append(
-                    f"⏳ Действует до: {valid_until.strftime('%d.%m.%Y %H:%M')}"
+                    f"⏳ Действует до: {format_local_datetime(valid_until, '%d.%m.%Y %H:%M')}"
                     if isinstance(valid_until, datetime)
                     else f"⏳ Действует до: {valid_until}"
                 )
@@ -659,7 +660,7 @@ class AdminNotificationService:
                     "📝 <b>Эффект:</b>",
                     effect_description.strip() or "✅ Промокод активирован",
                     "",
-                    f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>",
+                    f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>",
                 ]
             )
 
@@ -713,7 +714,7 @@ class AdminNotificationService:
             message_lines.extend(
                 [
                     "",
-                    f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>",
+                    f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>",
                 ]
             )
 
@@ -778,7 +779,7 @@ class AdminNotificationService:
                 [
                     "",
                     f"💰 Баланс пользователя: {settings.format_price(user.balance_kopeks)}",
-                    f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>",
+                    f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>",
                 ]
             )
 
@@ -856,9 +857,9 @@ class AdminNotificationService:
             return "❌ Нет подписки"
 
         if subscription.is_trial:
-            return f"🎯 Триал (до {subscription.end_date.strftime('%d.%m')})"
+            return f"🎯 Триал (до {format_local_datetime(subscription.end_date, '%d.%m')})"
         elif subscription.is_active:
-            return f"✅ Активна (до {subscription.end_date.strftime('%d.%m')})"
+            return f"✅ Активна (до {format_local_datetime(subscription.end_date, '%d.%m')})"
         else:
             return "❌ Неактивна"
     
@@ -929,7 +930,9 @@ class AdminNotificationService:
                     if isinstance(enabled_at, str):
                         from datetime import datetime
                         enabled_at = datetime.fromisoformat(enabled_at)
-                    message_parts.append(f"🕐 <b>Время включения:</b> {enabled_at.strftime('%d.%m.%Y %H:%M:%S')}")
+                    message_parts.append(
+                        f"🕐 <b>Время включения:</b> {format_local_datetime(enabled_at, '%d.%m.%Y %H:%M:%S')}"
+                    )
                 
                 message_parts.append(f"🤖 <b>Автоматически:</b> {'Да' if details.get('auto_enabled', False) else 'Нет'}")
                 message_parts.append("")
@@ -941,7 +944,9 @@ class AdminNotificationService:
                     if isinstance(disabled_at, str):
                         from datetime import datetime
                         disabled_at = datetime.fromisoformat(disabled_at)
-                    message_parts.append(f"🕐 <b>Время отключения:</b> {disabled_at.strftime('%d.%m.%Y %H:%M:%S')}")
+                    message_parts.append(
+                        f"🕐 <b>Время отключения:</b> {format_local_datetime(disabled_at, '%d.%m.%Y %H:%M:%S')}"
+                    )
                 
                 if details.get("duration"):
                     duration = details["duration"]
@@ -1000,9 +1005,10 @@ class AdminNotificationService:
                 else:  
                     message_parts.append("Автоматический мониторинг API остановлен.")
             
-            from datetime import datetime
             message_parts.append("")
-            message_parts.append(f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>")
+            message_parts.append(
+                f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"
+            )
             
             message = "\n".join(message_parts)
             
@@ -1048,7 +1054,9 @@ class AdminNotificationService:
                 if isinstance(last_check, str):
                     from datetime import datetime
                     last_check = datetime.fromisoformat(last_check)
-                message_parts.append(f"🕐 <b>Последняя проверка:</b> {last_check.strftime('%H:%M:%S')}")
+                message_parts.append(
+                    f"🕐 <b>Последняя проверка:</b> {format_local_datetime(last_check, '%H:%M:%S')}"
+                )
                 
             if status == "online":
                 if details.get("uptime"):
@@ -1094,9 +1102,10 @@ class AdminNotificationService:
                 message_parts.append("")
                 message_parts.append("Панель временно недоступна для обслуживания.")
             
-            from datetime import datetime
             message_parts.append("")
-            message_parts.append(f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>")
+            message_parts.append(
+                f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>"
+            )
             
             message = "\n".join(message_parts)
             
@@ -1171,11 +1180,11 @@ class AdminNotificationService:
             message_lines.extend(
                 [
                     "",
-                    f"📅 <b>Подписка действует до:</b> {subscription.end_date.strftime('%d.%m.%Y %H:%M')}",
+                    f"📅 <b>Подписка действует до:</b> {format_local_datetime(subscription.end_date, '%d.%m.%Y %H:%M')}",
                     f"💰 <b>Баланс после операции:</b> {settings.format_price(user.balance_kopeks)}",
                     f"🔗 <b>Рефер:</b> {referrer_info}",
                     "",
-                    f"⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>",
+                    f"⏰ <i>{format_local_datetime(datetime.utcnow(), '%d.%m.%Y %H:%M:%S')}</i>",
                 ]
             )
 

--- a/app/services/maintenance_service.py
+++ b/app/services/maintenance_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from app.config import settings
 from app.external.remnawave_api import RemnaWaveAPI, test_api_connection
 from app.utils.cache import cache
+from app.utils.timezone import format_local_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ class MaintenanceService:
     
     def get_maintenance_message(self) -> str:
         if self._status.auto_enabled:
+            last_check_display = format_local_datetime(
+                self._status.last_check, "%H:%M:%S", "неизвестно"
+            )
             return f"""
 🔧 Технические работы!
 
@@ -52,7 +56,7 @@ class MaintenanceService:
 
 ⏰ Мы работаем над восстановлением. Попробуйте через несколько минут.
 
-🔄 Последняя проверка: {self._status.last_check.strftime('%H:%M:%S') if self._status.last_check else 'неизвестно'}
+🔄 Последняя проверка: {last_check_display}
 """
         else:
             return settings.get_maintenance_message()
@@ -79,7 +83,12 @@ class MaintenanceService:
             }
             emoji = emoji_map.get(alert_type, "ℹ️")
             
-            formatted_message = f"{emoji} <b>ТЕХНИЧЕСКИЕ РАБОТЫ</b>\n\n{message}\n\n⏰ <i>{datetime.now().strftime('%d.%m.%Y %H:%M:%S')}</i>"
+            timestamp = format_local_datetime(
+                datetime.utcnow(), "%d.%m.%Y %H:%M:%S %Z"
+            )
+            formatted_message = (
+                f"{emoji} <b>ТЕХНИЧЕСКИЕ РАБОТЫ</b>\n\n{message}\n\n⏰ <i>{timestamp}</i>"
+            )
             
             return await notification_service._send_message(formatted_message)
             
@@ -152,11 +161,14 @@ class MaintenanceService:
             
             await self._save_status_to_cache()
             
+            enabled_time = format_local_datetime(
+                self._status.enabled_at, "%d.%m.%Y %H:%M:%S %Z"
+            )
             notification_msg = f"""Режим технических работ ВКЛЮЧЕН
 
 📋 <b>Причина:</b> {self._status.reason}
 🤖 <b>Автоматически:</b> {'Да' if auto else 'Нет'}
-🕐 <b>Время:</b> {self._status.enabled_at.strftime('%d.%m.%Y %H:%M:%S')}
+🕐 <b>Время:</b> {enabled_time}
 
 Обычные пользователи временно не смогут использовать бота."""
             
@@ -197,10 +209,13 @@ class MaintenanceService:
                 else:
                     duration_str = f"\n⏱️ <b>Длительность:</b> {minutes}мин"
             
+            notification_time = format_local_datetime(
+                datetime.utcnow(), "%d.%m.%Y %H:%M:%S %Z"
+            )
             notification_msg = f"""Режим технических работ ВЫКЛЮЧЕН
 
 🤖 <b>Автоматически:</b> {'Да' if was_auto else 'Нет'}
-🕐 <b>Время:</b> {datetime.utcnow().strftime('%d.%m.%Y %H:%M:%S')}
+🕐 <b>Время:</b> {notification_time}
 {duration_str}
 
 Сервис снова доступен для пользователей."""
@@ -229,14 +244,17 @@ class MaintenanceService:
                 settings.get_maintenance_retry_attempts(),
             )
 
-            await self._notify_admins(f"""Мониторинг технических работ запущен
+            await self._notify_admins(
+                f"""Мониторинг технических работ запущен
 
 🔄 <b>Интервал проверки:</b> {settings.get_maintenance_check_interval()} секунд
 🤖 <b>Автовключение:</b> {'Включено' if settings.is_maintenance_auto_enable() else 'Отключено'}
 🎯 <b>Порог ошибок:</b> {self._max_consecutive_failures}
 🔁 <b>Повторных попыток:</b> {settings.get_maintenance_retry_attempts()}
 
-Система будет следить за доступностью API.""", "info")
+Система будет следить за доступностью API.""",
+                "info",
+            )
             
             return True
             
@@ -291,13 +309,19 @@ class MaintenanceService:
                             )
 
                         if not self._status.api_status:
-                            await self._notify_admins(f"""API Remnawave восстановлено!
+                            recovery_time = format_local_datetime(
+                                self._status.last_check, "%H:%M:%S %Z"
+                            )
+                            await self._notify_admins(
+                                f"""API Remnawave восстановлено!
 
 ✅ <b>Статус:</b> Доступно
-🕐 <b>Время восстановления:</b> {self._status.last_check.strftime('%H:%M:%S')}
+🕐 <b>Время восстановления:</b> {recovery_time}
 🔄 <b>Неудачных попыток было:</b> {self._status.consecutive_failures}
 
-API снова отвечает на запросы.""", "success")
+API снова отвечает на запросы.""",
+                                "success",
+                            )
 
                         self._status.api_status = True
                         self._status.consecutive_failures = 0
@@ -321,13 +345,19 @@ API снова отвечает на запросы.""", "success")
                 self._status.consecutive_failures += 1
 
                 if was_available:
-                    await self._notify_admins(f"""API Remnawave недоступно!
+                    detection_time = format_local_datetime(
+                        self._status.last_check, "%H:%M:%S %Z"
+                    )
+                    await self._notify_admins(
+                        f"""API Remnawave недоступно!
 
 ❌ <b>Статус:</b> Недоступно
-🕐 <b>Время обнаружения:</b> {self._status.last_check.strftime('%H:%M:%S')}
+🕐 <b>Время обнаружения:</b> {detection_time}
 🔄 <b>Попытка:</b> {self._status.consecutive_failures}
 
-Началась серия неудачных проверок API.""", "error")
+Началась серия неудачных проверок API.""",
+                        "error",
+                    )
 
                 if (
                     self._status.consecutive_failures >= self._max_consecutive_failures
@@ -349,12 +379,16 @@ API снова отвечает на запросы.""", "success")
             logger.error(f"Ошибка проверки API: {e}")
             
             if self._status.api_status:
-                await self._notify_admins(f"""Ошибка при проверке API Remnawave
+                error_time = format_local_datetime(datetime.utcnow(), "%H:%M:%S %Z")
+                await self._notify_admins(
+                    f"""Ошибка при проверке API Remnawave
 
 ❌ <b>Ошибка:</b> {str(e)}
-🕐 <b>Время:</b> {datetime.utcnow().strftime('%H:%M:%S')}
+🕐 <b>Время:</b> {error_time}
 
-Не удалось выполнить проверку доступности API.""", "error")
+Не удалось выполнить проверку доступности API.""",
+                    "error",
+                )
             
             self._status.api_status = False
             self._status.consecutive_failures += 1

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -38,6 +38,7 @@ from app.database.crud.user import (
     subtract_user_balance,
     cleanup_expired_promo_offer_discounts,
 )
+from app.utils.timezone import format_local_datetime
 from app.utils.subscription_utils import (
     resolve_hwid_device_limit_for_payload,
 )
@@ -1035,7 +1036,7 @@ class MonitoringService:
             message = f"""
 ⚠️ <b>Подписка истекает через {days_text}!</b>
 
-Ваша платная подписка истекает {subscription.end_date.strftime("%d.%m.%Y %H:%M")}.
+Ваша платная подписка истекает {format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M")}.
 
 💳 <b>Автоплатеж:</b> {autopay_status}
 
@@ -1151,7 +1152,7 @@ class MonitoringService:
 
             message = template.format(
                 price=settings.format_price(settings.PRICE_30_DAYS),
-                end_date=subscription.end_date.strftime("%d.%m.%Y %H:%M"),
+                end_date=format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M"),
             )
 
             from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
@@ -1267,7 +1268,7 @@ class MonitoringService:
                 ),
             )
             message = template.format(
-                end_date=subscription.end_date.strftime("%d.%m.%Y %H:%M"),
+                end_date=format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M"),
                 price=settings.format_price(settings.PRICE_30_DAYS),
             )
 
@@ -1344,7 +1345,7 @@ class MonitoringService:
 
             message = template.format(
                 percent=percent,
-                expires_at=expires_at.strftime("%d.%m.%Y %H:%M"),
+                expires_at=format_local_datetime(expires_at, "%d.%m.%Y %H:%M"),
                 trigger_days=trigger_days or "",
             )
 

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import re
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timedelta
@@ -42,6 +41,7 @@ from app.database.models import (
 from app.utils.subscription_utils import (
     resolve_hwid_device_limit_for_payload,
 )
+from app.utils.timezone import get_local_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -59,15 +59,7 @@ class RemnaWaveService:
 
         self._config_error: Optional[str] = None
 
-        tz_name = os.getenv("TZ", "UTC")
-        try:
-            self._panel_timezone = ZoneInfo(tz_name)
-        except Exception:
-            logger.warning(
-                "⚠️ Не удалось загрузить временную зону '%s'. Используется UTC.",
-                tz_name,
-            )
-            self._panel_timezone = ZoneInfo("UTC")
+        self._panel_timezone = get_local_timezone()
 
         if not base_url:
             self._config_error = "REMNAWAVE_API_URL не настроен"

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -29,6 +29,7 @@ from app.services.subscription_purchase_service import (
 from app.services.subscription_service import SubscriptionService
 from app.services.user_cart_service import user_cart_service
 from app.utils.pricing_utils import format_period_description
+from app.utils.timezone import format_local_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +334,7 @@ async def _auto_extend_subscription(
         getattr(user, "language", "ru"),
     )
     new_end_date = updated_subscription.end_date
-    end_date_label = new_end_date.strftime("%d.%m.%Y %H:%M")
+    end_date_label = format_local_datetime(new_end_date, "%d.%m.%Y %H:%M")
 
     if bot:
         try:

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -1,0 +1,82 @@
+"""Timezone utilities for consistent local time handling."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone as dt_timezone
+from functools import lru_cache
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def get_local_timezone() -> ZoneInfo:
+    """Return the configured local timezone.
+
+    Falls back to UTC if the configured timezone cannot be loaded. The
+    fallback is logged once and cached for subsequent calls.
+    """
+
+    tz_name = settings.TIMEZONE
+
+    try:
+        return ZoneInfo(tz_name)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        logger.warning(
+            "⚠️ Не удалось загрузить временную зону '%s': %s. Используем UTC.",
+            tz_name,
+            exc,
+        )
+        return ZoneInfo("UTC")
+
+
+def to_local_datetime(dt: Optional[datetime]) -> Optional[datetime]:
+    """Convert a datetime value to the configured local timezone."""
+
+    if dt is None:
+        return None
+
+    aware_dt = dt if dt.tzinfo is not None else dt.replace(tzinfo=dt_timezone.utc)
+    return aware_dt.astimezone(get_local_timezone())
+
+
+def format_local_datetime(
+    dt: Optional[datetime],
+    fmt: str = "%Y-%m-%d %H:%M:%S %Z",
+    na_placeholder: str = "N/A",
+) -> str:
+    """Format a datetime value in the configured local timezone."""
+
+    localized = to_local_datetime(dt)
+    if localized is None:
+        return na_placeholder
+    return localized.strftime(fmt)
+
+
+class TimezoneAwareFormatter(logging.Formatter):
+    """Logging formatter that renders timestamps in the configured timezone."""
+
+    def __init__(self, *args, timezone_name: Optional[str] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if timezone_name:
+            try:
+                self._timezone = ZoneInfo(timezone_name)
+            except Exception as exc:  # pragma: no cover - defensive branch
+                logger.warning(
+                    "⚠️ Не удалось загрузить временную зону '%s': %s. Используем UTC.",
+                    timezone_name,
+                    exc,
+                )
+                self._timezone = ZoneInfo("UTC")
+        else:
+            self._timezone = get_local_timezone()
+
+    def formatTime(self, record, datefmt=None):  # noqa: N802 - inherited method name
+        dt = datetime.fromtimestamp(record.created, tz=self._timezone)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -58,6 +58,7 @@ from app.services.admin_notification_service import AdminNotificationService
 from app.services.faq_service import FaqService
 from app.services.privacy_policy_service import PrivacyPolicyService
 from app.services.public_offer_service import PublicOfferService
+from app.utils.timezone import format_local_datetime
 from app.services.remnawave_service import (
     RemnaWaveConfigurationError,
     RemnaWaveService,
@@ -4428,7 +4429,7 @@ async def submit_subscription_renewal_endpoint(
     language_code = _normalize_language_code(user)
     amount_label = settings.format_price(final_total)
     date_label = (
-        subscription.end_date.strftime("%d.%m.%Y %H:%M")
+        format_local_datetime(subscription.end_date, "%d.%m.%Y %H:%M")
         if subscription.end_date
         else ""
     )

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from app.services.system_settings_service import bot_configuration_service
 from app.services.external_admin_service import ensure_external_admin_token
 from app.services.broadcast_service import broadcast_service
 from app.utils.startup_timeline import StartupTimeline
+from app.utils.timezone import TimezoneAwareFormatter
 
 
 class GracefulExit:
@@ -49,13 +50,20 @@ class GracefulExit:
 
 
 async def main():
+    formatter = TimezoneAwareFormatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        timezone_name=settings.TIMEZONE,
+    )
+
+    file_handler = logging.FileHandler(settings.LOG_FILE, encoding='utf-8')
+    file_handler.setFormatter(formatter)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+
     logging.basicConfig(
         level=getattr(logging, settings.LOG_LEVEL),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.FileHandler(settings.LOG_FILE, encoding='utf-8'),
-            logging.StreamHandler(sys.stdout)
-        ]
+        handlers=[file_handler, stream_handler],
     )
     
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- use the shared timezone formatter for subscription overview messages and renewal confirmations
- update admin and monitoring notifications to display timestamps in the configured timezone
- apply the timezone helper across menu, start, auto-purchase, and miniapp flows for consistent expiry messaging
