### PR TITLE
Fix monitoring to only deactivate trial subscriptions after channel unsubscribe

### DIFF
--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -564,7 +564,11 @@ class MonitoringService:
                     )
                     continue
 
-                if subscription.status == SubscriptionStatus.ACTIVE.value and not is_member:
+                if (
+                    subscription.status == SubscriptionStatus.ACTIVE.value
+                    and subscription.is_trial
+                    and not is_member
+                ):
                     subscription = await deactivate_subscription(db, subscription)
                     disabled_count += 1
                     logger.info(
@@ -598,7 +602,11 @@ class MonitoringService:
                                     subscription.id,
                                     "trial_channel_unsubscribed",
                                 )
-                elif subscription.status == SubscriptionStatus.DISABLED.value and is_member:
+                elif (
+                    subscription.status == SubscriptionStatus.DISABLED.value
+                    and subscription.is_trial
+                    and is_member
+                ):
                     subscription.status = SubscriptionStatus.ACTIVE.value
                     subscription.updated_at = datetime.utcnow()
                     await db.commit()


### PR DESCRIPTION
## Summary
- ensure the monitoring job only deactivates subscriptions that are still in trial when a user unsubscribes from the news channel
- allow trial subscriptions to be reactivated only when they were previously disabled by the monitoring job
