### PR TITLE
Normalize RemnaWave sync times to UTC

### DIFF
--- a/tests/services/test_remnawave_service_sync.py
+++ b/tests/services/test_remnawave_service_sync.py
@@ -17,6 +17,7 @@ from app.services.remnawave_service import RemnaWaveService
 def _create_service() -> RemnaWaveService:
     service = RemnaWaveService.__new__(RemnaWaveService)
     service._panel_timezone = ZoneInfo("UTC")
+    service._utc_timezone = ZoneInfo("UTC")
     return service
 
 


### PR DESCRIPTION
## Summary
- normalize RemnaWave subscription timestamp parsing and comparisons to UTC to avoid timezone drift during sync
- ensure RemnaWave service sync tests initialize the UTC timezone when constructing the service without __init__