### PR TITLE
Fix saved subscription cart resume button when returning from balance top-up

### DIFF
--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -356,10 +356,13 @@ def get_main_menu_keyboard(
         paired_buttons.append(simple_purchase_button)
 
     if show_resume_checkout or has_saved_cart:
+        resume_callback = (
+            "return_to_saved_cart" if has_saved_cart else "subscription_resume_checkout"
+        )
         paired_buttons.append(
             InlineKeyboardButton(
                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                callback_data="subscription_resume_checkout",
+                callback_data=resume_callback,
             )
         )
 
@@ -671,7 +674,7 @@ def get_insufficient_balance_keyboard(
         return_row = [
             InlineKeyboardButton(
                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                callback_data="subscription_resume_checkout",
+                callback_data="return_to_saved_cart",
             )
         ]
         insert_index = back_row_index if back_row_index is not None else len(keyboard.inline_keyboard)
@@ -803,7 +806,7 @@ def get_payment_methods_keyboard_with_cart(
     keyboard.inline_keyboard.insert(-1, [  # Вставляем перед кнопкой "назад"
         InlineKeyboardButton(
             text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-            callback_data="subscription_resume_checkout"
+            callback_data="return_to_saved_cart"
         )
     ])
     

--- a/app/services/payment/common.py
+++ b/app/services/payment/common.py
@@ -23,6 +23,7 @@ from app.services.subscription_checkout_service import (
     has_subscription_checkout_draft,
     should_offer_checkout_resume,
 )
+from app.services.user_cart_service import user_cart_service
 from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 
 logger = logging.getLogger(__name__)
@@ -56,14 +57,32 @@ class PaymentCommonMixin:
 
         # Если для пользователя есть незавершённый checkout, предлагаем вернуться к нему.
         if user:
-            draft_exists = await has_subscription_checkout_draft(user.id)
-            if should_offer_checkout_resume(user, draft_exists):
+            try:
+                has_saved_cart = await user_cart_service.has_user_cart(user.id)
+            except Exception as cart_error:
+                logger.warning(
+                    "Не удалось проверить наличие сохраненной корзины у пользователя %s: %s",
+                    user.id,
+                    cart_error,
+                )
+                has_saved_cart = False
+
+            if has_saved_cart:
                 keyboard_rows.append([
                     build_miniapp_or_callback_button(
                         text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                        callback_data="subscription_resume_checkout",
+                        callback_data="return_to_saved_cart",
                     )
                 ])
+            else:
+                draft_exists = await has_subscription_checkout_draft(user.id)
+                if should_offer_checkout_resume(user, draft_exists):
+                    keyboard_rows.append([
+                        build_miniapp_or_callback_button(
+                            text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
+                            callback_data="subscription_resume_checkout",
+                        )
+                    ])
 
         # Стандартные кнопки быстрого доступа к балансу и главному меню.
         keyboard_rows.append([

--- a/app/services/payment/cryptobot.py
+++ b/app/services/payment/cryptobot.py
@@ -332,7 +332,7 @@ class CryptoBotPaymentMixin:
                         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
                             [types.InlineKeyboardButton(
                                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="subscription_resume_checkout"
+                                callback_data="return_to_saved_cart"
                             )],
                             [types.InlineKeyboardButton(
                                 text="💰 Мой баланс",

--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -366,7 +366,7 @@ class MulenPayPaymentMixin:
                         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
                             [types.InlineKeyboardButton(
                                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="subscription_resume_checkout"
+                                callback_data="return_to_saved_cart"
                             )],
                             [types.InlineKeyboardButton(
                                 text="💰 Мой баланс",

--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -473,7 +473,7 @@ class Pal24PaymentMixin:
                                     "BALANCE_TOPUP_CART_BUTTON",
                                     "🛒 Продолжить оформление",
                                 ),
-                                callback_data="subscription_resume_checkout",
+                                callback_data="return_to_saved_cart",
                             )
                         ],
                         [

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -584,7 +584,7 @@ class TelegramStarsMixin:
                         [
                             types.InlineKeyboardButton(
                                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="subscription_resume_checkout",
+                                callback_data="return_to_saved_cart",
                             )
                         ],
                         [

--- a/app/services/payment/wata.py
+++ b/app/services/payment/wata.py
@@ -561,7 +561,7 @@ class WataPaymentMixin:
                         [
                             types.InlineKeyboardButton(
                                 text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="subscription_resume_checkout",
+                                callback_data="return_to_saved_cart",
                             )
                         ],
                         [

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -534,7 +534,7 @@ class YooKassaPaymentMixin:
                                     [
                                         types.InlineKeyboardButton(
                                             text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                            callback_data="subscription_resume_checkout",
+                                            callback_data="return_to_saved_cart",
                                         )
                                     ],
                                     [

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -882,7 +882,7 @@ async def test_process_pal24_postback_success(monkeypatch: pytest.MonkeyPatch) -
     saved_cart_message = bot.sent_messages[-1]
     reply_markup = saved_cart_message["kwargs"].get("reply_markup")
     assert reply_markup is not None
-    assert reply_markup.inline_keyboard[0][0].kwargs["callback_data"] == "subscription_resume_checkout"
+    assert reply_markup.inline_keyboard[0][0].kwargs["callback_data"] == "return_to_saved_cart"
     assert admin_calls
 
 


### PR DESCRIPTION
## Summary
- ensure buttons shown for saved subscription carts point to the return-to-cart flow
- update payment success keyboards to prefer restored carts over checkout drafts
- adjust tests to reflect the new callback when a cart is available
