### PR TITLE
Fix user search when numeric query exceeds INT32 range

### DIFF
--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -26,6 +26,8 @@ from app.utils.validators import sanitize_telegram_name
 
 logger = logging.getLogger(__name__)
 
+INT32_MAX = 2_147_483_647
+
 
 def generate_referral_code() -> str:
     alphabet = string.ascii_letters + string.digits
@@ -538,8 +540,10 @@ async def get_users_list(
         ]
         
         if search.isdigit():
-            conditions.append(User.telegram_id == int(search))
-            conditions.append(User.id == int(search))  # Add support for searching by internal user ID
+            search_int = int(search)
+            conditions.append(User.telegram_id == search_int)
+            if search_int <= INT32_MAX:
+                conditions.append(User.id == search_int)  # Add support for searching by internal user ID
         
         query = query.where(or_(*conditions))
 
@@ -636,8 +640,10 @@ async def get_users_count(
         ]
         
         if search.isdigit():
-            conditions.append(User.telegram_id == int(search))
-            conditions.append(User.id == int(search))  # Add support for searching by internal user ID
+            search_int = int(search)
+            conditions.append(User.telegram_id == search_int)
+            if search_int <= INT32_MAX:
+                conditions.append(User.id == search_int)  # Add support for searching by internal user ID
         
         query = query.where(or_(*conditions))
     

--- a/app/webapi/routes/users.py
+++ b/app/webapi/routes/users.py
@@ -31,6 +31,8 @@ from ..schemas.users import (
 
 router = APIRouter()
 
+INT32_MAX = 2_147_483_647
+
 
 def _serialize_promo_group(group: Optional[PromoGroup]) -> Optional[PromoGroupSummary]:
     if not group:
@@ -103,8 +105,10 @@ def _apply_search_filter(query, search: str):
     ]
 
     if search.isdigit():
-        conditions.append(User.telegram_id == int(search))
-        conditions.append(User.id == int(search))
+        search_int = int(search)
+        conditions.append(User.telegram_id == search_int)
+        if search_int <= INT32_MAX:
+            conditions.append(User.id == search_int)
 
     return query.where(or_(*conditions))
 


### PR DESCRIPTION
## Summary
- avoid binding oversized numeric search terms to users.id comparisons in both admin and web API queries
- ensure large numeric queries continue to work for telegram_id searches while preventing database errors
