### PR TITLE
Fix promo group deletion to maintain user_promo_groups

### DIFF
--- a/app/database/crud/promo_group.py
+++ b/app/database/crud/promo_group.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.database.models import PromoGroup, User
+from app.database.models import PromoGroup, User, UserPromoGroup
 
 
 def _normalize_period_discounts(period_discounts: Optional[Dict[int, int]]) -> Dict[int, int]:
@@ -233,11 +233,42 @@ async def delete_promo_group(db: AsyncSession, group: PromoGroup) -> bool:
         return False
 
 
+    # Получаем список пользователей, связанных с удаляемой промогруппой
+    affected_user_ids: Set[int] = set()
+
+    user_ids_result = await db.execute(
+        select(User.id).where(User.promo_group_id == group.id)
+    )
+    affected_user_ids.update(user_ids_result.scalars().all())
+
+    promo_group_links_result = await db.execute(
+        select(UserPromoGroup.user_id).where(UserPromoGroup.promo_group_id == group.id)
+    )
+    affected_user_ids.update(promo_group_links_result.scalars().all())
+
     await db.execute(
         update(User)
         .where(User.promo_group_id == group.id)
         .values(promo_group_id=default_group.id)
     )
+
+    if affected_user_ids:
+        existing_defaults_result = await db.execute(
+            select(UserPromoGroup.user_id)
+            .where(UserPromoGroup.promo_group_id == default_group.id)
+            .where(UserPromoGroup.user_id.in_(affected_user_ids))
+        )
+        existing_default_user_ids = set(existing_defaults_result.scalars().all())
+
+        for user_id in affected_user_ids - existing_default_user_ids:
+            db.add(
+                UserPromoGroup(
+                    user_id=user_id,
+                    promo_group_id=default_group.id,
+                    assigned_by="system",
+                )
+            )
+
     await db.delete(group)
     await db.commit()
 


### PR DESCRIPTION
## Summary
- collect users tied to a promo group before deletion
- reassign affected users to the default group in user_promo_groups when removing a promo group
