### PR TITLE
Fix unlimited traffic display in payment methods

### DIFF
--- a/app/handlers/balance/main.py
+++ b/app/handlers/balance/main.py
@@ -284,7 +284,16 @@ async def show_payment_methods(
                 devices_discounted_per_month * months_in_period
             )
             
-            current_tariff_desc = f"📱 Подписка: {len(current_connected_squads)} серверов, {current_traffic} ГБ, {current_device_limit} устр."
+            traffic_value = current_traffic or 0
+            if traffic_value <= 0:
+                traffic_display = texts.t("TRAFFIC_UNLIMITED_SHORT", "Безлимит")
+            else:
+                traffic_display = texts.format_traffic(traffic_value)
+
+            current_tariff_desc = (
+                f"📱 Подписка: {len(current_connected_squads)} серверов, "
+                f"{traffic_display}, {current_device_limit} устр."
+            )
             estimated_price_info = f"💰 Стоимость продления (примерно): {texts.format_price(total_price)} за {duration_days} дней"
             
             tariff_info = f"\n\n📋 <b>Ваш текущий тариф:</b>\n{current_tariff_desc}\n{estimated_price_info}"

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -1409,6 +1409,7 @@
   "TRAFFIC_NO_CHANGE": "ℹ️ Traffic limit was not changed",
   "TRAFFIC_PACKAGES_NOT_CONFIGURED": "⚠️ Traffic packages are not configured",
   "TRAFFIC_UNLIMITED": "📊 Unlimited - {settings.format_price(settings.PRICE_TRAFFIC_UNLIMITED)}",
+  "TRAFFIC_UNLIMITED_SHORT": "Unlimited",
   "TRIAL_ACTIVATED": "🎉 Trial subscription activated!",
   "TRIAL_ACTIVATE_BUTTON": "🎁 Activate",
   "TRIAL_ALREADY_USED": "❌ The trial subscription has already been used",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -1429,6 +1429,7 @@
   "TRAFFIC_NO_CHANGE": "ℹ️ Лимит трафика не изменился",
   "TRAFFIC_PACKAGES_NOT_CONFIGURED": "⚠️ Пакеты трафика не настроены",
   "TRAFFIC_UNLIMITED": "📊 Безлимит - {settings.format_price(settings.PRICE_TRAFFIC_UNLIMITED)}",
+  "TRAFFIC_UNLIMITED_SHORT": "Безлимит",
   "TRIAL_ACTIVATED": "🎉 Тестовая подписка активирована!",
   "TRIAL_ACTIVATE_BUTTON": "🎁 Активировать",
   "TRIAL_ALREADY_USED": "❌ Тестовая подписка уже была использована",


### PR DESCRIPTION
## Summary
- show a localized unlimited label for current tariff traffic in the balance top-up screen
- add short unlimited localization strings for ru and en locales
