### PR TITLE
feat: verify YooKassa webhooks by IP

### DIFF
--- a/app/external/yookassa_webhook.py
+++ b/app/external/yookassa_webhook.py
@@ -4,15 +4,82 @@ import json
 import hashlib
 import hmac
 import base64
-from typing import Optional, Dict, Any
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
+from typing import Iterable, Optional, Dict, Any, List, Union
 from aiohttp import web
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.services.payment_service import PaymentService
 from app.database.database import get_db
 
 logger = logging.getLogger(__name__)
+
+
+IPAddress = Union[IPv4Address, IPv6Address]
+IPNetwork = Union[IPv4Network, IPv6Network]
+
+YOOKASSA_ALLOWED_IP_NETWORKS: tuple[IPNetwork, ...] = (
+    ip_network("185.71.76.0/27"),
+    ip_network("185.71.77.0/27"),
+    ip_network("77.75.153.0/25"),
+    ip_network("77.75.154.128/25"),
+    ip_network("77.75.156.11/32"),
+    ip_network("77.75.156.35/32"),
+    ip_network("2a02:5180::/32"),
+)
+
+
+def collect_yookassa_ip_candidates(*values: Optional[str]) -> List[str]:
+    candidates: List[str] = []
+    for value in values:
+        if not value:
+            continue
+        for part in value.split(","):
+            normalized = part.strip()
+            if normalized:
+                candidates.append(normalized)
+    return candidates
+
+
+def _parse_candidate_ip(candidate: str) -> Optional[IPAddress]:
+    value = candidate.strip()
+    if not value:
+        return None
+
+    if value.startswith("[") and "]" in value:
+        value = value[1:value.index("]")]
+
+    if "%" in value:
+        value = value.split("%", 1)[0]
+
+    if value.count(":") == 1 and "." in value:
+        host, _, port = value.rpartition(":")
+        if port.isdigit():
+            value = host
+
+    try:
+        return ip_address(value)
+    except ValueError:
+        return None
+
+
+def resolve_yookassa_ip(candidates: Iterable[str]) -> Optional[IPAddress]:
+    for candidate in candidates:
+        ip_object = _parse_candidate_ip(candidate)
+        if ip_object is not None:
+            return ip_object
+    return None
+
+
+def is_yookassa_ip_allowed(ip_object: IPAddress) -> bool:
+    return any(ip_object in network for network in YOOKASSA_ALLOWED_IP_NETWORKS)
 
 
 class YooKassaWebhookHandler:
@@ -87,38 +154,43 @@ class YooKassaWebhookHandler:
         self.payment_service = payment_service
     
     async def handle_webhook(self, request: web.Request) -> web.Response:
-        
+
         try:
             logger.info(f"📥 Получен YooKassa webhook: {request.method} {request.path}")
             logger.info(f"📋 Headers: {dict(request.headers)}")
-            
+
+            ip_candidates = collect_yookassa_ip_candidates(
+                request.headers.get("X-Forwarded-For"),
+                request.headers.get("X-Real-IP"),
+                request.remote,
+            )
+            client_ip = resolve_yookassa_ip(ip_candidates)
+
+            if client_ip is None:
+                logger.warning(
+                    "🚫 Не удалось определить IP-адрес отправителя YooKassa webhook. Кандидаты: %s",
+                    ip_candidates,
+                )
+                return web.Response(status=403, text="Forbidden")
+
+            if not is_yookassa_ip_allowed(client_ip):
+                logger.warning(
+                    "🚫 YooKassa webhook отклонён: IP %s не входит в доверенные диапазоны (%s)",
+                    client_ip,
+                    ", ".join(str(network) for network in YOOKASSA_ALLOWED_IP_NETWORKS),
+                )
+                return web.Response(status=403, text="Forbidden")
+
+            logger.info("🌐 IP-адрес YooKassa подтверждён: %s", client_ip)
+
             body = await request.text()
-            
+
             if not body:
                 logger.warning("⚠️ Получен пустой webhook от YooKassa")
                 return web.Response(status=400, text="Empty body")
-            
+
             logger.info(f"📄 Body: {body}")
-            
-            signature = request.headers.get('Signature') or request.headers.get('X-YooKassa-Signature')
-            
-            if settings.YOOKASSA_WEBHOOK_SECRET and signature:
-                logger.info(f"🔐 Получена подпись: {signature}")
-                
-                if not YooKassaWebhookHandler.verify_webhook_signature(body, signature, settings.YOOKASSA_WEBHOOK_SECRET):
-                    logger.warning("❌ Подпись не совпала, но продолжаем обработку (режим отладки)")
-                else:
-                    logger.info("✅ Подпись webhook проверена успешно")
-                    
-            elif settings.YOOKASSA_WEBHOOK_SECRET and not signature:
-                logger.warning("⚠️ Webhook без подписи, но секрет настроен")
-                
-            elif signature and not settings.YOOKASSA_WEBHOOK_SECRET:
-                logger.info("ℹ️ Подпись получена, но проверка отключена (YOOKASSA_WEBHOOK_SECRET не настроен)")
-                
-            else:
-                logger.info("ℹ️ Проверка подписи отключена")
-            
+
             try:
                 webhook_data = json.loads(body)
             except json.JSONDecodeError as e:

--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -15,7 +15,7 @@ from aiogram import Bot
 from app.config import settings
 from app.database.database import get_db
 from app.external.tribute import TributeService as TributeAPI
-from app.external.yookassa_webhook import YooKassaWebhookHandler
+from app.external import yookassa_webhook as yookassa_webhook_module
 from app.external.wata_webhook import WataWebhookHandler
 from app.external.heleket_webhook import HeleketWebhookHandler
 from app.external.pal24_client import Pal24APIError
@@ -322,7 +322,6 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
         routes_registered = True
 
     if settings.is_yookassa_enabled():
-        yookassa_secret = settings.YOOKASSA_WEBHOOK_SECRET or ""
 
         @router.options(settings.YOOKASSA_WEBHOOK_PATH)
         async def yookassa_options() -> Response:
@@ -347,25 +346,34 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
 
         @router.post(settings.YOOKASSA_WEBHOOK_PATH)
         async def yookassa_webhook(request: Request) -> JSONResponse:
+            ip_candidates = yookassa_webhook_module.collect_yookassa_ip_candidates(
+                request.headers.get("X-Forwarded-For"),
+                request.headers.get("X-Real-IP"),
+                request.client.host if request.client else None,
+            )
+            client_ip = yookassa_webhook_module.resolve_yookassa_ip(ip_candidates)
+
+            if client_ip is None:
+                return JSONResponse(
+                    {"status": "error", "reason": "unknown_ip", "candidates": ip_candidates},
+                    status_code=status.HTTP_403_FORBIDDEN,
+                )
+
+            if not yookassa_webhook_module.is_yookassa_ip_allowed(client_ip):
+                return JSONResponse(
+                    {
+                        "status": "error",
+                        "reason": "forbidden_ip",
+                        "ip": str(client_ip),
+                    },
+                    status_code=status.HTTP_403_FORBIDDEN,
+                )
+
             body_bytes = await request.body()
             if not body_bytes:
                 return JSONResponse({"status": "error", "reason": "empty_body"}, status_code=status.HTTP_400_BAD_REQUEST)
 
             body = body_bytes.decode("utf-8")
-
-            signature = request.headers.get("Signature") or request.headers.get("X-YooKassa-Signature")
-            if yookassa_secret:
-                if not signature:
-                    return JSONResponse(
-                        {"status": "error", "reason": "missing_signature"},
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                    )
-
-                if not YooKassaWebhookHandler.verify_webhook_signature(body, signature, yookassa_secret):
-                    return JSONResponse(
-                        {"status": "error", "reason": "invalid_signature"},
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                    )
 
             try:
                 webhook_data = json.loads(body)

--- a/tests/webserver/test_payments.py
+++ b/tests/webserver/test_payments.py
@@ -38,7 +38,12 @@ def _get_route(router, path: str, method: str = "POST"):
     raise AssertionError(f"Route {path} with method {method} not found")
 
 
-def _build_request(path: str, body: bytes, headers: dict[str, str]) -> Request:
+def _build_request(
+    path: str,
+    body: bytes,
+    headers: dict[str, str],
+    client_ip: str | None = "185.71.76.1",
+) -> Request:
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -46,6 +51,9 @@ def _build_request(path: str, body: bytes, headers: dict[str, str]) -> Request:
         "path": path,
         "headers": [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()],
     }
+
+    if client_ip is not None:
+        scope["client"] = (client_ip, 12345)
 
     async def receive() -> dict:
         return {"type": "http.request", "body": body, "more_body": False}
@@ -92,38 +100,12 @@ async def test_tribute_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.anyio
-async def test_yookassa_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_yookassa_unknown_ip(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
 
-    class StubHandler:
-        @staticmethod
-        def verify_webhook_signature(body: str, signature: str, secret: str) -> bool:  # noqa: D401
-            return False
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
 
-    monkeypatch.setattr("app.webserver.payments.YooKassaWebhookHandler", StubHandler)
-
-    router = create_payment_router(DummyBot(), SimpleNamespace())
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"Signature": "bad"},
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 401
-
-
-@pytest.mark.anyio
-async def test_yookassa_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
-
-    router = create_payment_router(DummyBot(), SimpleNamespace())
+    router = create_payment_router(DummyBot(), service)
     assert router is not None
 
     route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
@@ -131,13 +113,72 @@ async def test_yookassa_missing_signature(monkeypatch: pytest.MonkeyPatch) -> No
         settings.YOOKASSA_WEBHOOK_PATH,
         body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
         headers={},
+        client_ip=None,
     )
 
     response = await route.endpoint(request)
 
-    assert response.status_code == 401
+    assert response.status_code == 403
     payload = json.loads(response.body.decode("utf-8"))
-    assert payload["reason"] == "missing_signature"
+    assert payload["reason"] == "unknown_ip"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_forbidden_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={},
+        client_ip="203.0.113.10",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 403
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["reason"] == "forbidden_ip"
+    assert payload["ip"] == "203.0.113.10"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_allowed_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    async def fake_get_db():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={},
+        client_ip="185.71.76.10",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["status"] == "ok"
+    process_mock.assert_awaited_once()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add the official YooKassa webhook IP ranges and helper utilities for resolving client addresses
- validate incoming YooKassa callbacks by source IP in both the standalone aiohttp handler and the FastAPI router
- update webserver tests to cover allowed, forbidden, and unknown IP scenarios for YooKassa webhooks
