### PR TITLE
fix: harden YooKassa webhook IP trust rules

### DIFF
--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -15,7 +15,7 @@ from aiogram import Bot
 from app.config import settings
 from app.database.database import get_db
 from app.external.tribute import TributeService as TributeAPI
-from app.external.yookassa_webhook import YooKassaWebhookHandler
+from app.external import yookassa_webhook as yookassa_webhook_module
 from app.external.wata_webhook import WataWebhookHandler
 from app.external.heleket_webhook import HeleketWebhookHandler
 from app.external.pal24_client import Pal24APIError
@@ -322,7 +322,6 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
         routes_registered = True
 
     if settings.is_yookassa_enabled():
-        yookassa_secret = settings.YOOKASSA_WEBHOOK_SECRET or ""
 
         @router.options(settings.YOOKASSA_WEBHOOK_PATH)
         async def yookassa_options() -> Response:
@@ -347,25 +346,41 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
 
         @router.post(settings.YOOKASSA_WEBHOOK_PATH)
         async def yookassa_webhook(request: Request) -> JSONResponse:
+            header_ip_candidates = yookassa_webhook_module.collect_yookassa_ip_candidates(
+                request.headers.get("X-Forwarded-For"),
+                request.headers.get("X-Real-IP"),
+            )
+            remote_ip = request.client.host if request.client else None
+            client_ip = yookassa_webhook_module.resolve_yookassa_ip(
+                header_ip_candidates,
+                remote=remote_ip,
+            )
+
+            if client_ip is None:
+                return JSONResponse(
+                    {
+                        "status": "error",
+                        "reason": "unknown_ip",
+                        "candidates": header_ip_candidates + ([remote_ip] if remote_ip else []),
+                    },
+                    status_code=status.HTTP_403_FORBIDDEN,
+                )
+
+            if not yookassa_webhook_module.is_yookassa_ip_allowed(client_ip):
+                return JSONResponse(
+                    {
+                        "status": "error",
+                        "reason": "forbidden_ip",
+                        "ip": str(client_ip),
+                    },
+                    status_code=status.HTTP_403_FORBIDDEN,
+                )
+
             body_bytes = await request.body()
             if not body_bytes:
                 return JSONResponse({"status": "error", "reason": "empty_body"}, status_code=status.HTTP_400_BAD_REQUEST)
 
             body = body_bytes.decode("utf-8")
-
-            signature = request.headers.get("Signature") or request.headers.get("X-YooKassa-Signature")
-            if yookassa_secret:
-                if not signature:
-                    return JSONResponse(
-                        {"status": "error", "reason": "missing_signature"},
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                    )
-
-                if not YooKassaWebhookHandler.verify_webhook_signature(body, signature, yookassa_secret):
-                    return JSONResponse(
-                        {"status": "error", "reason": "invalid_signature"},
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                    )
 
             try:
                 webhook_data = json.loads(body)

--- a/tests/external/test_yookassa_webhook.py
+++ b/tests/external/test_yookassa_webhook.py
@@ -1,0 +1,150 @@
+import base64
+import hashlib
+import hmac
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from app.config import settings
+from app.external.yookassa_webhook import (
+    create_yookassa_webhook_app,
+    resolve_yookassa_ip,
+)
+
+
+ALLOWED_IP = "185.71.76.10"
+
+
+class DummyDB:
+    async def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def _generate_signature(body: str, secret: str) -> str:
+    payment_id = "test-payment"
+    timestamp = "2024-01-01T00:00:00.000Z"
+    payload = f"{payment_id}.{timestamp}.{body}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).digest()
+    return f"v1 {payment_id} {timestamp} {base64.b64encode(digest).decode('utf-8')}"
+
+
+@pytest.fixture(autouse=True)
+def configure_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_SHOP_ID", "shop", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_SECRET_KEY", "key", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_PATH", "/yookassa-webhook", raising=False)
+
+
+def _build_headers(**overrides: str) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "X-Forwarded-For": ALLOWED_IP,
+    }
+    headers.update(overrides)
+    return headers
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    (
+        ("185.71.76.10", "185.71.76.10"),
+        ("8.8.8.8", "8.8.8.8"),
+        ("10.0.0.5", "185.71.76.10"),
+        (None, "185.71.76.10"),
+    ),
+)
+def test_resolve_yookassa_ip_trust_rules(remote: str | None, expected: str) -> None:
+    candidates = [ALLOWED_IP]
+    ip_object = resolve_yookassa_ip(candidates, remote=remote)
+
+    assert ip_object is not None
+    assert str(ip_object) == expected
+
+
+def test_resolve_yookassa_ip_returns_none_when_no_candidates() -> None:
+    assert resolve_yookassa_ip([], remote=None) is None
+
+
+async def _post_webhook(client: TestClient, payload: dict, **headers: str) -> web.Response:
+    body = json.dumps(payload, ensure_ascii=False)
+    return await client.post(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        data=body.encode("utf-8"),
+        headers=_build_headers(**headers),
+    )
+
+
+def _patch_get_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_db():
+        yield DummyDB()
+
+    monkeypatch.setattr("app.external.yookassa_webhook.get_db", fake_get_db)
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await _post_webhook(client, {"event": "payment.succeeded"})
+        status = response.status
+        body = await response.text()
+
+    assert status == 401
+    assert body == "Missing signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await _post_webhook(
+            client,
+            {"event": "payment.succeeded"},
+            Signature="v1 test-payment 2024-01-01T00:00:00.000Z invalid",
+        )
+        status = response.status
+        body = await response.text()
+
+    assert status == 401
+    assert body == "Invalid signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_valid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        payload = {"event": "payment.succeeded"}
+        body = json.dumps(payload, ensure_ascii=False)
+        signature = _generate_signature(body, settings.YOOKASSA_WEBHOOK_SECRET)
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=body.encode("utf-8"),
+            headers=_build_headers(Signature=signature),
+        )
+        status = response.status
+        text = await response.text()
+
+    assert status == 200
+    assert text == "OK"
+    process_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ensure YooKassa webhook handlers only trust forwarded headers when the remote peer is private or loopback before enforcing the allowlist
- add aiohttp helper coverage for the IP selection logic and FastAPI tests for spoofed versus proxy-forwarded YooKassa callbacks
