### PR TITLE
fix: restore YooKassa signature checks in FastAPI webhook

### DIFF
--- a/tests/external/test_yookassa_webhook.py
+++ b/tests/external/test_yookassa_webhook.py
@@ -1,0 +1,150 @@
+import base64
+import hashlib
+import hmac
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from app.config import settings
+from app.external.yookassa_webhook import (
+    create_yookassa_webhook_app,
+    resolve_yookassa_ip,
+)
+
+
+ALLOWED_IP = "185.71.76.10"
+
+
+class DummyDB:
+    async def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def _generate_signature(body: str, secret: str) -> str:
+    payment_id = "test-payment"
+    timestamp = "2024-01-01T00:00:00.000Z"
+    payload = f"{payment_id}.{timestamp}.{body}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).digest()
+    return f"v1 {payment_id} {timestamp} {base64.b64encode(digest).decode('utf-8')}"
+
+
+@pytest.fixture(autouse=True)
+def configure_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_SHOP_ID", "shop", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_SECRET_KEY", "key", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_PATH", "/yookassa-webhook", raising=False)
+
+
+def _build_headers(**overrides: str) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "X-Forwarded-For": ALLOWED_IP,
+    }
+    headers.update(overrides)
+    return headers
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    (
+        ("185.71.76.10", "185.71.76.10"),
+        ("8.8.8.8", "8.8.8.8"),
+        ("10.0.0.5", "185.71.76.10"),
+        (None, "185.71.76.10"),
+    ),
+)
+def test_resolve_yookassa_ip_trust_rules(remote: str | None, expected: str) -> None:
+    candidates = [ALLOWED_IP]
+    ip_object = resolve_yookassa_ip(candidates, remote=remote)
+
+    assert ip_object is not None
+    assert str(ip_object) == expected
+
+
+def test_resolve_yookassa_ip_returns_none_when_no_candidates() -> None:
+    assert resolve_yookassa_ip([], remote=None) is None
+
+
+async def _post_webhook(client: TestClient, payload: dict, **headers: str) -> web.Response:
+    body = json.dumps(payload, ensure_ascii=False)
+    return await client.post(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        data=body.encode("utf-8"),
+        headers=_build_headers(**headers),
+    )
+
+
+def _patch_get_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_db():
+        yield DummyDB()
+
+    monkeypatch.setattr("app.external.yookassa_webhook.get_db", fake_get_db)
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await _post_webhook(client, {"event": "payment.succeeded"})
+        status = response.status
+        body = await response.text()
+
+    assert status == 401
+    assert body == "Missing signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await _post_webhook(
+            client,
+            {"event": "payment.succeeded"},
+            Signature="v1 test-payment 2024-01-01T00:00:00.000Z invalid",
+        )
+        status = response.status
+        body = await response.text()
+
+    assert status == 401
+    assert body == "Invalid signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_valid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        payload = {"event": "payment.succeeded"}
+        body = json.dumps(payload, ensure_ascii=False)
+        signature = _generate_signature(body, settings.YOOKASSA_WEBHOOK_SECRET)
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=body.encode("utf-8"),
+            headers=_build_headers(Signature=signature),
+        )
+        status = response.status
+        text = await response.text()
+
+    assert status == 200
+    assert text == "OK"
+    process_mock.assert_awaited_once()

--- a/tests/webserver/test_payments.py
+++ b/tests/webserver/test_payments.py
@@ -1,3 +1,6 @@
+import base64
+import hashlib
+import hmac
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -11,6 +14,14 @@ from app.webserver.payments import create_payment_router
 
 class DummyBot:
     pass
+
+
+def _generate_yookassa_signature(body: str, secret: str) -> str:
+    payment_id = "test-payment"
+    timestamp = "2024-01-01T00:00:00.000Z"
+    payload = f"{payment_id}.{timestamp}.{body}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).digest()
+    return f"v1 {payment_id} {timestamp} {base64.b64encode(digest).decode('utf-8')}"
 
 
 @pytest.fixture(autouse=True)
@@ -38,7 +49,12 @@ def _get_route(router, path: str, method: str = "POST"):
     raise AssertionError(f"Route {path} with method {method} not found")
 
 
-def _build_request(path: str, body: bytes, headers: dict[str, str]) -> Request:
+def _build_request(
+    path: str,
+    body: bytes,
+    headers: dict[str, str],
+    client_ip: str | None = "185.71.76.1",
+) -> Request:
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -46,6 +62,9 @@ def _build_request(path: str, body: bytes, headers: dict[str, str]) -> Request:
         "path": path,
         "headers": [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()],
     }
+
+    if client_ip is not None:
+        scope["client"] = (client_ip, 12345)
 
     async def receive() -> dict:
         return {"type": "http.request", "body": body, "more_body": False}
@@ -92,38 +111,152 @@ async def test_tribute_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.anyio
-async def test_yookassa_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_yookassa_unknown_ip(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
 
-    class StubHandler:
-        @staticmethod
-        def verify_webhook_signature(body: str, signature: str, secret: str) -> bool:  # noqa: D401
-            return False
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
 
-    monkeypatch.setattr("app.webserver.payments.YooKassaWebhookHandler", StubHandler)
-
-    router = create_payment_router(DummyBot(), SimpleNamespace())
+    router = create_payment_router(DummyBot(), service)
     assert router is not None
 
     route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
     request = _build_request(
         settings.YOOKASSA_WEBHOOK_PATH,
         body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"Signature": "bad"},
+        headers={},
+        client_ip=None,
     )
 
     response = await route.endpoint(request)
 
-    assert response.status_code == 401
+    assert response.status_code == 403
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["reason"] == "unknown_ip"
+    service.process_yookassa_webhook.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_yookassa_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_yookassa_forbidden_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={},
+        client_ip="8.8.8.8",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 403
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["reason"] == "forbidden_ip"
+    assert payload["ip"] == "8.8.8.8"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_forbidden_ip_ignores_spoofed_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={"X-Forwarded-For": "185.71.76.10"},
+        client_ip="8.8.8.8",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 403
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["reason"] == "forbidden_ip"
+    assert payload["ip"] == "8.8.8.8"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_allowed_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    async def fake_get_db():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={},
+        client_ip="185.71.76.10",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["status"] == "ok"
+    process_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_yookassa_allowed_via_forwarded_header_when_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+
+    async def fake_get_db():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={"X-Forwarded-For": "185.71.76.10"},
+        client_ip="10.0.0.5",
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["status"] == "ok"
+    process_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_yookassa_missing_signature_when_secret_configured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
     monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
 
-    router = create_payment_router(DummyBot(), SimpleNamespace())
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    router = create_payment_router(DummyBot(), service)
     assert router is not None
 
     route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
@@ -138,6 +271,66 @@ async def test_yookassa_missing_signature(monkeypatch: pytest.MonkeyPatch) -> No
     assert response.status_code == 401
     payload = json.loads(response.body.decode("utf-8"))
     assert payload["reason"] == "missing_signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
+
+    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
+        headers={"Signature": "v1 test invalid"},
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 401
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["reason"] == "invalid_signature"
+    service.process_yookassa_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_yookassa_valid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_SECRET", "secret", raising=False)
+
+    async def fake_get_db():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
+    payload = {"event": "payment.succeeded"}
+    body = json.dumps(payload).encode("utf-8")
+    signature = _generate_yookassa_signature(body.decode("utf-8"), settings.YOOKASSA_WEBHOOK_SECRET)
+    request = _build_request(
+        settings.YOOKASSA_WEBHOOK_PATH,
+        body=body,
+        headers={"Signature": signature},
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["status"] == "ok"
+    process_mock.assert_awaited_once()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- require YooKassa webhooks handled by the FastAPI router to present a valid signature when a secret is configured, alongside the IP checks
- add regression tests that cover missing, invalid, and valid YooKassa signatures and a helper for generating signed payloads
