### PR TITLE
Remove YooKassa IP filtering from webhooks

### DIFF
--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -786,31 +786,52 @@ class YooKassaPaymentMixin:
             logger.warning("Webhook без payment id: %s", event)
             return False
 
-        remote_data: Optional[Dict[str, Any]] = None
-        if getattr(self, "yookassa_service", None):
-            try:
-                remote_data = await self.yookassa_service.get_payment_info(  # type: ignore[union-attr]
-                    yookassa_payment_id
-                )
-            except Exception as error:  # pragma: no cover - диагностический лог
-                logger.warning(
-                    "Не удалось запросить актуальный статус платежа YooKassa %s: %s",
-                    yookassa_payment_id,
-                    error,
-                    exc_info=True,
-                )
+        if not getattr(self, "yookassa_service", None):
+            logger.error(
+                "Не настроена служба YooKassa для верификации платежей, webhook %s отклонён",
+                yookassa_payment_id,
+            )
+            return False
 
-        if remote_data:
-            previous_status = event_object.get("status")
-            event_object = self._merge_remote_yookassa_payload(event_object, remote_data)
-            if previous_status and event_object.get("status") != previous_status:
-                logger.info(
-                    "Статус платежа YooKassa %s скорректирован по данным API: %s → %s",
-                    yookassa_payment_id,
-                    previous_status,
-                    event_object.get("status"),
-                )
-            event["object"] = event_object
+        try:
+            remote_data = await self.yookassa_service.get_payment_info(  # type: ignore[union-attr]
+                yookassa_payment_id
+            )
+        except Exception as error:  # pragma: no cover - диагностический лог
+            logger.warning(
+                "Не удалось запросить актуальный статус платежа YooKassa %s: %s",
+                yookassa_payment_id,
+                error,
+                exc_info=True,
+            )
+            return False
+
+        if not remote_data:
+            logger.error(
+                "YooKassa API вернул пустой ответ при проверке платежа %s",
+                yookassa_payment_id,
+            )
+            return False
+
+        remote_payment_id = remote_data.get("id")
+        if remote_payment_id and remote_payment_id != yookassa_payment_id:
+            logger.error(
+                "Несовпадение идентификаторов платежа при проверке YooKassa: webhook=%s, api=%s",
+                yookassa_payment_id,
+                remote_payment_id,
+            )
+            return False
+
+        previous_status = event_object.get("status")
+        event_object = self._merge_remote_yookassa_payload(event_object, remote_data)
+        if previous_status and event_object.get("status") != previous_status:
+            logger.info(
+                "Статус платежа YooKassa %s скорректирован по данным API: %s → %s",
+                yookassa_payment_id,
+                previous_status,
+                event_object.get("status"),
+            )
+        event["object"] = event_object
 
         payment_module = import_module("app.services.payment_service")
 

--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -346,36 +346,6 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
 
         @router.post(settings.YOOKASSA_WEBHOOK_PATH)
         async def yookassa_webhook(request: Request) -> JSONResponse:
-            header_ip_candidates = yookassa_webhook_module.collect_yookassa_ip_candidates(
-                request.headers.get("X-Forwarded-For"),
-                request.headers.get("X-Real-IP"),
-            )
-            remote_ip = request.client.host if request.client else None
-            client_ip = yookassa_webhook_module.resolve_yookassa_ip(
-                header_ip_candidates,
-                remote=remote_ip,
-            )
-
-            if client_ip is None:
-                return JSONResponse(
-                    {
-                        "status": "error",
-                        "reason": "unknown_ip",
-                        "candidates": header_ip_candidates + ([remote_ip] if remote_ip else []),
-                    },
-                    status_code=status.HTTP_403_FORBIDDEN,
-                )
-
-            if not yookassa_webhook_module.is_yookassa_ip_allowed(client_ip):
-                return JSONResponse(
-                    {
-                        "status": "error",
-                        "reason": "forbidden_ip",
-                        "ip": str(client_ip),
-                    },
-                    status_code=status.HTTP_403_FORBIDDEN,
-                )
-
             body_bytes = await request.body()
             if not body_bytes:
                 return JSONResponse({"status": "error", "reason": "empty_body"}, status_code=status.HTTP_400_BAD_REQUEST)

--- a/tests/external/test_yookassa_webhook.py
+++ b/tests/external/test_yookassa_webhook.py
@@ -7,13 +7,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from app.config import settings
-from app.external.yookassa_webhook import (
-    create_yookassa_webhook_app,
-    resolve_yookassa_ip,
-)
-
-
-ALLOWED_IP = "185.71.76.10"
+from app.external.yookassa_webhook import create_yookassa_webhook_app
 
 
 class DummyDB:
@@ -25,77 +19,12 @@ def configure_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "YOOKASSA_SHOP_ID", "shop", raising=False)
     monkeypatch.setattr(settings, "YOOKASSA_SECRET_KEY", "key", raising=False)
     monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_PATH", "/yookassa-webhook", raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "", raising=False)
 
 
 def _build_headers(**overrides: str) -> dict[str, str]:
-    headers = {
-        "Content-Type": "application/json",
-        "X-Forwarded-For": ALLOWED_IP,
-    }
+    headers = {"Content-Type": "application/json"}
     headers.update(overrides)
     return headers
-
-
-@pytest.mark.parametrize(
-    ("remote", "expected"),
-    (
-        ("185.71.76.10", "185.71.76.10"),
-        ("8.8.8.8", "8.8.8.8"),
-        ("10.0.0.5", "185.71.76.10"),
-        (None, "185.71.76.10"),
-    ),
-)
-def test_resolve_yookassa_ip_trust_rules(remote: str | None, expected: str) -> None:
-    candidates = [ALLOWED_IP]
-    ip_object = resolve_yookassa_ip(candidates, remote=remote)
-
-    assert ip_object is not None
-    assert str(ip_object) == expected
-
-
-def test_resolve_yookassa_ip_prefers_last_forwarded_candidate() -> None:
-    candidates = ["185.71.76.10", "8.8.8.8"]
-
-    ip_object = resolve_yookassa_ip(candidates, remote="10.0.0.5")
-
-    assert ip_object is not None
-    assert str(ip_object) == "8.8.8.8"
-
-
-def test_resolve_yookassa_ip_accepts_allowed_last_forwarded_candidate() -> None:
-    candidates = ["8.8.8.8", ALLOWED_IP]
-
-    ip_object = resolve_yookassa_ip(candidates, remote="10.0.0.5")
-
-    assert ip_object is not None
-    assert str(ip_object) == ALLOWED_IP
-
-
-def test_resolve_yookassa_ip_skips_trusted_proxy_hops(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "203.0.113.0/24", raising=False)
-
-    candidates = [ALLOWED_IP, "203.0.113.10"]
-
-    ip_object = resolve_yookassa_ip(candidates, remote="10.0.0.5")
-
-    assert ip_object is not None
-    assert str(ip_object) == ALLOWED_IP
-
-
-def test_resolve_yookassa_ip_trusted_public_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "198.51.100.0/24", raising=False)
-
-    candidates = [ALLOWED_IP, "198.51.100.10"]
-
-    ip_object = resolve_yookassa_ip(candidates, remote="198.51.100.20")
-
-    assert ip_object is not None
-    assert str(ip_object) == ALLOWED_IP
-
-
-def test_resolve_yookassa_ip_returns_none_when_no_candidates() -> None:
-    assert resolve_yookassa_ip([], remote=None) is None
 
 
 async def _post_webhook(client: TestClient, payload: dict, **headers: str) -> web.Response:
@@ -182,3 +111,82 @@ async def test_handle_webhook_accepts_canceled_event(monkeypatch: pytest.MonkeyP
 
     assert status == 200
     process_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_rejects_empty_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=b"",
+            headers=_build_headers(),
+        )
+
+    assert response.status == 400
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_rejects_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=b"{not-json}",
+            headers=_build_headers(),
+        )
+
+    assert response.status == 400
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_requires_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=json.dumps({}).encode("utf-8"),
+            headers=_build_headers(),
+        )
+
+    assert response.status == 400
+    process_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_ignores_unhandled_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            settings.YOOKASSA_WEBHOOK_PATH,
+            data=json.dumps({"event": "unknown.event"}).encode("utf-8"),
+            headers=_build_headers(),
+        )
+        status = response.status
+        text = await response.text()
+
+    assert status == 200
+    assert text == "OK"
+    process_mock.assert_not_called()

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -564,6 +564,17 @@ async def test_process_yookassa_webhook_success(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setitem(sys.modules, "app.services.admin_notification_service", SimpleNamespace(AdminNotificationService=lambda bot: DummyAdminService(bot)))
     service.build_topup_success_keyboard = AsyncMock(return_value=None)
 
+    remote_payload = {
+        "id": "yk_123",
+        "status": "succeeded",
+        "paid": True,
+        "payment_method": {"type": "bank_card"},
+    }
+
+    service.yookassa_service = SimpleNamespace(
+        get_payment_info=AsyncMock(return_value=remote_payload)
+    )
+
     payload = {
         "object": {
             "id": "yk_123",
@@ -576,6 +587,7 @@ async def test_process_yookassa_webhook_success(monkeypatch: pytest.MonkeyPatch)
     result = await service.process_yookassa_webhook(fake_session, payload)
 
     assert result is True
+    service.yookassa_service.get_payment_info.assert_awaited_once_with("yk_123")
     assert transactions and transactions[0]["amount_kopeks"] == 10000
     assert payment.transaction_id == 999
     assert payment.is_paid is True
@@ -750,6 +762,24 @@ async def test_process_yookassa_webhook_handles_cancellation(monkeypatch: pytest
 
 
 @pytest.mark.anyio("asyncio")
+async def test_process_yookassa_webhook_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(DummyBot())
+    db = FakeSession()
+
+    service.yookassa_service = SimpleNamespace(
+        get_payment_info=AsyncMock(return_value=None)
+    )
+
+    result = await service.process_yookassa_webhook(
+        db,
+        {"object": {"id": "yk_fail", "status": "succeeded", "paid": True}},
+    )
+
+    assert result is False
+    service.yookassa_service.get_payment_info.assert_awaited_once_with("yk_fail")
+
+
+@pytest.mark.anyio("asyncio")
 async def test_process_yookassa_webhook_restores_missing_payment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -858,6 +888,24 @@ async def test_process_yookassa_webhook_restores_missing_payment(
     monkeypatch.setitem(sys.modules, "app.services.admin_notification_service", SimpleNamespace(AdminNotificationService=lambda bot: DummyAdminService(bot)))
     service.build_topup_success_keyboard = AsyncMock(return_value=None)
 
+    remote_payload = {
+        "id": "yk_456",
+        "status": "succeeded",
+        "paid": True,
+        "amount": {"value": "150.00", "currency": "RUB"},
+        "metadata": {"user_id": "21", "payment_purpose": "balance_topup"},
+        "description": "Пополнение",
+        "payment_method": {"type": "bank_card"},
+        "created_at": "2024-01-02T12:00:00Z",
+        "captured_at": "2024-01-02T12:05:00Z",
+        "confirmation": {"confirmation_url": "https://pay.example"},
+        "refundable": False,
+    }
+
+    service.yookassa_service = SimpleNamespace(
+        get_payment_info=AsyncMock(return_value=remote_payload)
+    )
+
     payload = {
         "object": {
             "id": "yk_456",
@@ -884,6 +932,7 @@ async def test_process_yookassa_webhook_restores_missing_payment(
     assert user.balance_kopeks == 15000
     assert bot.sent_messages
     assert admin_calls
+    service.yookassa_service.get_payment_info.assert_awaited_once_with("yk_456")
 
 
 @pytest.mark.anyio("asyncio")
@@ -901,11 +950,22 @@ async def test_process_yookassa_webhook_missing_metadata(monkeypatch: pytest.Mon
     monkeypatch.setattr(payment_service_module, "create_yookassa_payment", create_mock)
     monkeypatch.setattr(payment_service_module, "update_yookassa_payment_status", update_mock)
 
+    service.yookassa_service = SimpleNamespace(
+        get_payment_info=AsyncMock(
+            return_value={
+                "id": "yk_missing",
+                "status": "succeeded",
+                "paid": True,
+            }
+        )
+    )
+
     payload = {"object": {"id": "yk_missing", "status": "succeeded", "paid": True}}
 
     result = await service.process_yookassa_webhook(db, payload)
 
     assert result is False
+    service.yookassa_service.get_payment_info.assert_awaited_once_with("yk_missing")
     create_mock.assert_not_awaited()
     update_mock.assert_not_awaited()
 

--- a/tests/webserver/test_payments.py
+++ b/tests/webserver/test_payments.py
@@ -26,7 +26,6 @@ def reset_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "YOOKASSA_WEBHOOK_PATH", "/yookassa", raising=False)
     monkeypatch.setattr(settings, "YOOKASSA_SHOP_ID", "shop", raising=False)
     monkeypatch.setattr(settings, "YOOKASSA_SECRET_KEY", "key", raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "", raising=False)
     monkeypatch.setattr(settings, "WEBHOOK_URL", "http://test", raising=False)
 
 
@@ -41,7 +40,6 @@ def _build_request(
     path: str,
     body: bytes,
     headers: dict[str, str],
-    client_ip: str | None = "185.71.76.1",
 ) -> Request:
     scope = {
         "type": "http",
@@ -50,9 +48,6 @@ def _build_request(
         "path": path,
         "headers": [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()],
     }
-
-    if client_ip is not None:
-        scope["client"] = (client_ip, 12345)
 
     async def receive() -> dict:
         return {"type": "http.request", "body": body, "more_body": False}
@@ -95,235 +90,6 @@ async def test_tribute_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert response.status_code == 200
     assert json.loads(response.body.decode("utf-8"))["status"] == "ok"
-    process_mock.assert_awaited_once()
-
-
-@pytest.mark.anyio
-async def test_yookassa_unknown_ip(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={},
-        client_ip=None,
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 403
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["reason"] == "unknown_ip"
-    service.process_yookassa_webhook.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_yookassa_forbidden_ip(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={},
-        client_ip="8.8.8.8",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 403
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["reason"] == "forbidden_ip"
-    assert payload["ip"] == "8.8.8.8"
-    service.process_yookassa_webhook.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_yookassa_forbidden_ip_ignores_spoofed_header(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"X-Forwarded-For": "185.71.76.10"},
-        client_ip="8.8.8.8",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 403
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["reason"] == "forbidden_ip"
-    assert payload["ip"] == "8.8.8.8"
-    service.process_yookassa_webhook.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_yookassa_forbidden_ip_ignores_spoofed_forwarded_chain(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    service = SimpleNamespace(process_yookassa_webhook=AsyncMock())
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"X-Forwarded-For": "185.71.76.10, 8.8.8.8"},
-        client_ip="10.0.0.5",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 403
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["reason"] == "forbidden_ip"
-    assert payload["ip"] == "8.8.8.8"
-    service.process_yookassa_webhook.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_yookassa_allowed_ip(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    async def fake_get_db():
-        yield SimpleNamespace()
-
-    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
-
-    process_mock = AsyncMock(return_value=True)
-    service = SimpleNamespace(process_yookassa_webhook=process_mock)
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={},
-        client_ip="185.71.76.10",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 200
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["status"] == "ok"
-    process_mock.assert_awaited_once()
-
-
-@pytest.mark.anyio
-async def test_yookassa_allowed_via_forwarded_header_when_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-
-    async def fake_get_db():
-        yield SimpleNamespace()
-
-    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
-
-    process_mock = AsyncMock(return_value=True)
-    service = SimpleNamespace(process_yookassa_webhook=process_mock)
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"X-Forwarded-For": "185.71.76.10"},
-        client_ip="10.0.0.5",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 200
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["status"] == "ok"
-    process_mock.assert_awaited_once()
-
-
-@pytest.mark.anyio
-async def test_yookassa_allowed_via_trusted_forwarded_chain(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "203.0.113.0/24", raising=False)
-
-    async def fake_get_db():
-        yield SimpleNamespace()
-
-    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
-
-    process_mock = AsyncMock(return_value=True)
-    service = SimpleNamespace(process_yookassa_webhook=process_mock)
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"X-Forwarded-For": "185.71.76.10, 203.0.113.10"},
-        client_ip="10.0.0.5",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 200
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["status"] == "ok"
-    process_mock.assert_awaited_once()
-
-
-@pytest.mark.anyio
-async def test_yookassa_allowed_via_trusted_public_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "YOOKASSA_ENABLED", True, raising=False)
-    monkeypatch.setattr(settings, "YOOKASSA_TRUSTED_PROXY_NETWORKS", "198.51.100.0/24", raising=False)
-
-    async def fake_get_db():
-        yield SimpleNamespace()
-
-    monkeypatch.setattr("app.webserver.payments.get_db", fake_get_db)
-
-    process_mock = AsyncMock(return_value=True)
-    service = SimpleNamespace(process_yookassa_webhook=process_mock)
-
-    router = create_payment_router(DummyBot(), service)
-    assert router is not None
-
-    route = _get_route(router, settings.YOOKASSA_WEBHOOK_PATH)
-    request = _build_request(
-        settings.YOOKASSA_WEBHOOK_PATH,
-        body=json.dumps({"event": "payment.succeeded"}).encode("utf-8"),
-        headers={"X-Forwarded-For": "185.71.76.10, 198.51.100.10"},
-        client_ip="198.51.100.20",
-    )
-
-    response = await route.endpoint(request)
-
-    assert response.status_code == 200
-    payload = json.loads(response.body.decode("utf-8"))
-    assert payload["status"] == "ok"
     process_mock.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- drop the YooKassa IP allowlist/proxy handling from the standalone webhook app and FastAPI router so webhooks rely solely on API verification
- tighten YooKassa webhook payload validation and extend tests to cover empty bodies, invalid JSON and ignored events
