### PR TITLE
Fix category pricing to ignore full squads

### DIFF
--- a/app/database/crud/server_category.py
+++ b/app/database/crud/server_category.py
@@ -1,0 +1,57 @@
+from typing import List, Optional
+
+from sqlalchemy import select, update, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import ServerCategory
+
+
+async def get_all_server_categories(db: AsyncSession, include_inactive: bool = False) -> List[ServerCategory]:
+    query = select(ServerCategory).order_by(ServerCategory.sort_order, ServerCategory.name)
+    if not include_inactive:
+        query = query.where(ServerCategory.is_active.is_(True))
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+async def get_server_category_by_id(db: AsyncSession, category_id: int) -> Optional[ServerCategory]:
+    result = await db.execute(
+        select(ServerCategory).where(ServerCategory.id == category_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_server_category(
+    db: AsyncSession,
+    name: str,
+    sort_order: int = 0,
+    is_active: bool = True,
+) -> ServerCategory:
+    category = ServerCategory(name=name, sort_order=sort_order, is_active=is_active)
+    db.add(category)
+    await db.commit()
+    await db.refresh(category)
+    return category
+
+
+async def update_server_category(
+    db: AsyncSession,
+    category_id: int,
+    **updates,
+) -> Optional[ServerCategory]:
+    valid_fields = {"name", "sort_order", "is_active"}
+    filtered_updates = {k: v for k, v in updates.items() if k in valid_fields}
+    if not filtered_updates:
+        return await get_server_category_by_id(db, category_id)
+
+    await db.execute(
+        update(ServerCategory).where(ServerCategory.id == category_id).values(**filtered_updates)
+    )
+    await db.commit()
+    return await get_server_category_by_id(db, category_id)
+
+
+async def delete_server_category(db: AsyncSession, category_id: int) -> bool:
+    await db.execute(delete(ServerCategory).where(ServerCategory.id == category_id))
+    await db.commit()
+    return True

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1281,6 +1281,22 @@ class PollAnswer(Base):
     )
 
 
+class ServerCategory(Base):
+    __tablename__ = "server_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True)
+    sort_order = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now(), nullable=False)
+
+    servers = relationship("ServerSquad", back_populates="category")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<ServerCategory(id={self.id}, name={self.name!r})>"
+
+
 class ServerSquad(Base):
     __tablename__ = "server_squads"
 
@@ -1302,8 +1318,10 @@ class ServerSquad(Base):
     description = Column(Text, nullable=True)
     
     sort_order = Column(Integer, default=0)
-    
-    max_users = Column(Integer, nullable=True) 
+
+    category_id = Column(Integer, ForeignKey("server_categories.id", ondelete="SET NULL"), nullable=True)
+
+    max_users = Column(Integer, nullable=True)
     current_users = Column(Integer, default=0)
 
     created_at = Column(DateTime, default=func.now())
@@ -1315,6 +1333,8 @@ class ServerSquad(Base):
         back_populates="server_squads",
         lazy="selectin",
     )
+
+    category = relationship("ServerCategory", back_populates="servers")
     
     @property
     def price_rubles(self) -> float:

--- a/app/handlers/admin/servers.py
+++ b/app/handlers/admin/servers.py
@@ -1,5 +1,7 @@
 import html
 import logging
+from typing import List
+
 from aiogram import Dispatcher, types, F
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +19,10 @@ from app.database.crud.server_squad import (
     get_available_server_squads,
     update_server_squad_promo_groups,
     get_server_connected_users,
+)
+from app.database.crud.server_category import (
+    get_all_server_categories,
+    create_server_category,
 )
 from app.database.crud.promo_group import get_promo_groups_with_counts
 from app.services.remnawave_service import RemnaWaveService
@@ -36,6 +42,7 @@ def _build_server_edit_view(server):
     )
 
     trial_status = "✅ Да" if server.is_trial_eligible else "⚪️ Нет"
+    category_name = getattr(getattr(server, "category", None), "name", None) or "Не указана"
 
     text = f"""
 🌐 <b>Редактирование сервера</b>
@@ -53,6 +60,7 @@ def _build_server_edit_view(server):
 • Лимит пользователей: {server.max_users or 'Без лимита'}
 • Текущих пользователей: {server.current_users}
 • Промогруппы: {promo_groups_text}
+• Категория: {category_name}
 • Выдача триала: {trial_status}
 
 <b>Описание:</b>
@@ -95,6 +103,11 @@ def _build_server_edit_view(server):
             ),
             types.InlineKeyboardButton(
                 text="📝 Описание", callback_data=f"admin_server_edit_desc_{server.id}"
+            ),
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="🏷 Категория", callback_data=f"admin_server_edit_category_{server.id}"
             ),
         ],
         [
@@ -1076,6 +1089,225 @@ async def process_server_description_edit(
 
 @admin_required
 @error_handler
+async def show_server_category_menu(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+):
+    server_id = int(callback.data.split("_")[-1])
+    server = await get_server_squad_by_id(db, server_id)
+
+    if not server:
+        await callback.answer("❌ Сервер не найден!", show_alert=True)
+        return
+
+    categories = await get_all_server_categories(db)
+
+    current_category = getattr(getattr(server, "category", None), "name", None)
+    safe_current = html.escape(current_category or "Не выбрана")
+
+    text_lines = [
+        "🏷 <b>Категория сервера</b>",
+        "",
+        f"Текущая категория: <b>{safe_current}</b>",
+        "",
+        "Выберите категорию из списка или создайте новую:",
+    ]
+
+    keyboard_rows: List[List[types.InlineKeyboardButton]] = []
+
+    for category in categories:
+        emoji = "✅" if server.category_id == category.id else "⚪️"
+        keyboard_rows.append(
+            [
+                types.InlineKeyboardButton(
+                    text=f"{emoji} {category.name}",
+                    callback_data=f"admin_server_category_set_{server.id}_{category.id}",
+                )
+            ]
+        )
+
+    keyboard_rows.append(
+        [
+            types.InlineKeyboardButton(
+                text="➕ Создать категорию",
+                callback_data=f"admin_server_category_create_{server.id}",
+            )
+        ]
+    )
+
+    if server.category_id:
+        keyboard_rows.append(
+            [
+                types.InlineKeyboardButton(
+                    text="🗑 Удалить категорию",
+                    callback_data=f"admin_server_category_clear_{server.id}",
+                )
+            ]
+        )
+
+    keyboard_rows.append(
+        [
+            types.InlineKeyboardButton(
+                text="⬅️ Назад",
+                callback_data=f"admin_server_edit_{server.id}",
+            )
+        ]
+    )
+
+    await callback.message.edit_text(
+        "\n".join(text_lines),
+        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard_rows),
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def set_server_category(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+):
+    parts = callback.data.split("_")
+    server_id = int(parts[-2])
+    category_id = int(parts[-1])
+
+    server = await update_server_squad(db, server_id, category_id=category_id)
+
+    if not server:
+        await callback.answer("❌ Не удалось обновить категорию", show_alert=True)
+        return
+
+    await cache.delete_pattern("available_countries*")
+
+    text, keyboard = _build_server_edit_view(server)
+    await callback.message.edit_text(
+        text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+    )
+    await callback.answer("✅ Категория обновлена")
+
+
+@admin_required
+@error_handler
+async def clear_server_category(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+):
+    server_id = int(callback.data.split("_")[-1])
+
+    server = await update_server_squad(db, server_id, category_id=None)
+
+    if not server:
+        await callback.answer("❌ Не удалось обновить категорию", show_alert=True)
+        return
+
+    await cache.delete_pattern("available_countries*")
+
+    text, keyboard = _build_server_edit_view(server)
+    await callback.message.edit_text(
+        text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+    )
+    await callback.answer("✅ Категория удалена")
+
+
+@admin_required
+@error_handler
+async def start_server_category_creation(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    db_user: User,
+    db: AsyncSession,
+):
+    server_id = int(callback.data.split("_")[-1])
+    server = await get_server_squad_by_id(db, server_id)
+
+    if not server:
+        await callback.answer("❌ Сервер не найден!", show_alert=True)
+        return
+
+    await state.set_data({"server_id": server_id})
+    await state.set_state(AdminStates.creating_server_category)
+
+    await callback.message.edit_text(
+        "🏷 <b>Новая категория</b>\n\n"
+        "Отправьте название новой категории для сервера:",
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text="⬅️ Назад", callback_data=f"admin_server_edit_category_{server_id}"
+                    )
+                ]
+            ]
+        ),
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def process_server_category_creation(
+    message: types.Message,
+    state: FSMContext,
+    db_user: User,
+    db: AsyncSession,
+):
+    data = await state.get_data()
+    server_id = data.get("server_id")
+
+    if not server_id:
+        await message.answer("❌ Сервер не найден")
+        return
+
+    category_name = (message.text or "").strip()
+
+    if not (2 <= len(category_name) <= 255):
+        await message.answer("❌ Название категории должно содержать от 2 до 255 символов")
+        return
+
+    try:
+        category = await create_server_category(db, name=category_name)
+    except Exception as error:
+        logger.error("Не удалось создать категорию %s: %s", category_name, error)
+        await message.answer("❌ Не удалось создать категорию. Попробуйте другое название")
+        return
+
+    server = await update_server_squad(db, server_id, category_id=category.id)
+
+    await state.clear()
+
+    await cache.delete_pattern("available_countries*")
+
+    if not server:
+        await message.answer("❌ Категория создана, но не удалось обновить сервер")
+        return
+
+    safe_name = html.escape(category.name)
+    await message.answer(
+        f"✅ Категория <b>{safe_name}</b> создана и назначена серверу",
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text="🔙 К серверу", callback_data=f"admin_server_edit_{server_id}"
+                    )
+                ]
+            ]
+        ),
+        parse_mode="HTML",
+    )
+
+
+@admin_required
+@error_handler
 async def start_server_edit_promo_groups(
     callback: types.CallbackQuery,
     state: FSMContext,
@@ -1304,14 +1536,19 @@ def register_handlers(dp: Dispatcher):
     dp.callback_query.register(start_server_edit_price, F.data.startswith("admin_server_edit_price_"))
     dp.callback_query.register(start_server_edit_country, F.data.startswith("admin_server_edit_country_"))
     dp.callback_query.register(start_server_edit_promo_groups, F.data.startswith("admin_server_edit_promo_"))
-    dp.callback_query.register(start_server_edit_limit, F.data.startswith("admin_server_edit_limit_"))         
-    dp.callback_query.register(start_server_edit_description, F.data.startswith("admin_server_edit_desc_"))     
-    
+    dp.callback_query.register(start_server_edit_limit, F.data.startswith("admin_server_edit_limit_"))
+    dp.callback_query.register(start_server_edit_description, F.data.startswith("admin_server_edit_desc_"))
+    dp.callback_query.register(show_server_category_menu, F.data.startswith("admin_server_edit_category_"))
+    dp.callback_query.register(set_server_category, F.data.startswith("admin_server_category_set_"))
+    dp.callback_query.register(clear_server_category, F.data.startswith("admin_server_category_clear_"))
+    dp.callback_query.register(start_server_category_creation, F.data.startswith("admin_server_category_create_"))
+
     dp.message.register(process_server_name_edit, AdminStates.editing_server_name)
     dp.message.register(process_server_price_edit, AdminStates.editing_server_price)
-    dp.message.register(process_server_country_edit, AdminStates.editing_server_country)            
-    dp.message.register(process_server_limit_edit, AdminStates.editing_server_limit)                
+    dp.message.register(process_server_country_edit, AdminStates.editing_server_country)
+    dp.message.register(process_server_limit_edit, AdminStates.editing_server_limit)
     dp.message.register(process_server_description_edit, AdminStates.editing_server_description)
+    dp.message.register(process_server_category_creation, AdminStates.creating_server_category)
     dp.callback_query.register(toggle_server_promo_group, F.data.startswith("admin_server_promo_toggle_"))
     dp.callback_query.register(save_server_promo_groups, F.data.startswith("admin_server_promo_save_"))
     

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -21,7 +21,7 @@ from app.database.models import (
     User, Subscription, Transaction, PromoCode, PromoCodeUse,
     ReferralEarning, Squad, ServiceRule, SystemSetting, MonitoringLog,
     SubscriptionConversion, SentNotification, BroadcastHistory,
-    ServerSquad, SubscriptionServer, UserMessage, YooKassaPayment,
+    ServerCategory, ServerSquad, SubscriptionServer, UserMessage, YooKassaPayment,
     CryptoBotPayment, WelcomeText, Base, PromoGroup, AdvertisingCampaign,
     AdvertisingCampaignRegistration, SupportAuditLog, Ticket, TicketMessage,
     MulenPayPayment, Pal24Payment, DiscountOffer, WebApiToken,
@@ -68,6 +68,7 @@ class BackupService:
             SystemSetting,
             ServiceRule,
             Squad,
+            ServerCategory,
             ServerSquad,
             PromoGroup,
             User,
@@ -726,7 +727,7 @@ class BackupService:
             "mulenpay_payments", "pal24_payments",
             "transactions", "welcome_texts", "subscriptions",
             "promocodes", "users", "promo_groups",
-            "server_squads", "squads", "service_rules",
+            "server_squads", "server_categories", "squads", "service_rules",
             "system_settings", "web_api_tokens", "monitoring_logs"
         ]
         

--- a/app/states.py
+++ b/app/states.py
@@ -113,6 +113,7 @@ class AdminStates(StatesGroup):
     editing_server_limit = State()
     editing_server_description = State()
     editing_server_promo_groups = State()
+    creating_server_category = State()
 
     creating_server_uuid = State()
     creating_server_name = State()


### PR DESCRIPTION
## Summary
- track both overall and selectable prices while aggregating category server data
- use the cheapest selectable server price for category options so full squads do not set the display value
- cover the category pricing path with a regression test to prevent regressions