### PR TITLE
Handle Cloudflare proxied YooKassa webhooks

### DIFF
--- a/app/external/yookassa_webhook.py
+++ b/app/external/yookassa_webhook.py
@@ -33,6 +33,32 @@ YOOKASSA_ALLOWED_IP_NETWORKS: tuple[IPNetwork, ...] = (
 )
 
 
+CLOUDFLARE_TRUSTED_NETWORKS: tuple[IPNetwork, ...] = (
+    ip_network("173.245.48.0/20"),
+    ip_network("103.21.244.0/22"),
+    ip_network("103.22.200.0/22"),
+    ip_network("103.31.4.0/22"),
+    ip_network("141.101.64.0/18"),
+    ip_network("108.162.192.0/18"),
+    ip_network("190.93.240.0/20"),
+    ip_network("188.114.96.0/20"),
+    ip_network("197.234.240.0/22"),
+    ip_network("198.41.128.0/17"),
+    ip_network("162.158.0.0/15"),
+    ip_network("104.16.0.0/13"),
+    ip_network("104.24.0.0/14"),
+    ip_network("172.64.0.0/13"),
+    ip_network("131.0.72.0/22"),
+    ip_network("2400:cb00::/32"),
+    ip_network("2606:4700::/32"),
+    ip_network("2803:f800::/32"),
+    ip_network("2405:b500::/32"),
+    ip_network("2405:8100::/32"),
+    ip_network("2a06:98c0::/29"),
+    ip_network("2c0f:f248::/32"),
+)
+
+
 YOOKASSA_ALLOWED_EVENTS: tuple[str, ...] = (
     "payment.succeeded",
     "payment.waiting_for_capture",
@@ -122,6 +148,9 @@ def _is_trusted_proxy_ip(ip_object: IPAddress) -> bool:
     ):
         return True
 
+    if any(ip_object in network for network in CLOUDFLARE_TRUSTED_NETWORKS):
+        return True
+
     return any(ip_object in network for network in _get_trusted_proxy_networks())
 
 
@@ -180,6 +209,7 @@ class YooKassaWebhookHandler:
             header_ip_candidates = collect_yookassa_ip_candidates(
                 request.headers.get("X-Forwarded-For"),
                 request.headers.get("X-Real-IP"),
+                request.headers.get("Cf-Connecting-Ip"),
             )
             client_ip = resolve_yookassa_ip(
                 header_ip_candidates,

--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -349,6 +349,7 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
             header_ip_candidates = yookassa_webhook_module.collect_yookassa_ip_candidates(
                 request.headers.get("X-Forwarded-For"),
                 request.headers.get("X-Real-IP"),
+                request.headers.get("Cf-Connecting-Ip"),
             )
             remote_ip = request.client.host if request.client else None
             client_ip = yookassa_webhook_module.resolve_yookassa_ip(


### PR DESCRIPTION
## Summary
- treat Cloudflare edge networks as trusted proxies when resolving YooKassa webhook IPs
- accept the Cf-Connecting-Ip header in both FastAPI and aiohttp webhook handlers
- extend the YooKassa webhook tests to cover Cloudflare scenarios