### PR TITLE
Fix Pal24 SBP link handling after status checks

### DIFF
--- a/app/handlers/simple_subscription.py
+++ b/app/handlers/simple_subscription.py
@@ -1655,8 +1655,18 @@ async def check_simple_pal24_payment_status(
         if not isinstance(links_meta, dict):
             links_meta = {}
 
-        sbp_link = links_meta.get("sbp") or payment.link_url
-        card_link = links_meta.get("card")
+        links_info = status_info.get("links") or {}
+        sbp_link = (
+            links_info.get("sbp")
+            or links_meta.get("sbp")
+            or status_info.get("sbp_url")
+            or payment.link_url
+        )
+        card_link = (
+            links_info.get("card")
+            or links_meta.get("card")
+            or status_info.get("card_url")
+        )
         if not card_link and payment.link_page_url and payment.link_page_url != sbp_link:
             card_link = payment.link_page_url
 
@@ -1689,8 +1699,45 @@ async def check_simple_pal24_payment_status(
                 f"❌ Платеж не завершен корректно. Обратитесь в {settings.get_support_contact_display()}",
             ]
 
+        pay_rows: list[list[types.InlineKeyboardButton]] = []
+
+        if not payment.is_paid and payment.status in {"NEW", "PROCESS"}:
+            default_sbp_text = texts.t(
+                "PAL24_SBP_PAY_BUTTON",
+                "🏦 Оплатить через PayPalych (СБП)",
+            )
+            sbp_button_text = settings.get_pal24_sbp_button_text(default_sbp_text)
+
+            if sbp_link and settings.is_pal24_sbp_button_visible():
+                pay_rows.append(
+                    [
+                        types.InlineKeyboardButton(
+                            text=sbp_button_text,
+                            url=sbp_link,
+                        )
+                    ]
+                )
+
+            default_card_text = texts.t(
+                "PAL24_CARD_PAY_BUTTON",
+                "💳 Оплатить банковской картой (PayPalych)",
+            )
+            card_button_text = settings.get_pal24_card_button_text(default_card_text)
+
+            if card_link and settings.is_pal24_card_button_visible():
+                if not pay_rows or pay_rows[-1][0].url != card_link:
+                    pay_rows.append(
+                        [
+                            types.InlineKeyboardButton(
+                                text=card_button_text,
+                                url=card_link,
+                            )
+                        ]
+                    )
+
         keyboard = types.InlineKeyboardMarkup(
-            inline_keyboard=[
+            inline_keyboard=pay_rows
+            + [
                 [
                     types.InlineKeyboardButton(
                         text=texts.t("CHECK_STATUS_BUTTON", "📊 Проверить статус"),

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -1537,6 +1537,8 @@ async def _resolve_pal24_payment_status(
         if remote_status:
             message = f"Status: {remote_status}"
 
+    links_info = status_info.get("links") if status_info else {}
+
     return MiniAppPaymentStatusResult(
         method="pal24",
         status=status,
@@ -1556,6 +1558,14 @@ async def _resolve_pal24_payment_status(
             "payment_method": getattr(payment, "payment_method", None),
             "payload": query.payload,
             "started_at": query.started_at,
+            "links": links_info or None,
+            "sbp_url": status_info.get("sbp_url") if status_info else None,
+            "card_url": status_info.get("card_url") if status_info else None,
+            "link_url": status_info.get("link_url") if status_info else None,
+            "link_page_url": status_info.get("link_page_url") if status_info else None,
+            "primary_url": status_info.get("primary_url") if status_info else None,
+            "secondary_url": status_info.get("secondary_url") if status_info else None,
+            "selected_method": status_info.get("selected_method") if status_info else None,
         },
     )
 


### PR DESCRIPTION
## Summary
- preserve PayPalych SBP links when polling Pal24 payment status and expose them with metadata
- restore SBP/card payment buttons after status checks in balance and subscription flows
- surface Pal24 link details in the mini-app status endpoint for clients
