### PR TITLE
Adjust Platega top-up prompt to show configured limits

### DIFF
--- a/app/handlers/balance/platega.py
+++ b/app/handlers/balance/platega.py
@@ -32,11 +32,25 @@ async def _prompt_amount(
     texts = get_texts(db_user.language)
     method_name = settings.get_platega_method_display_title(method_code)
 
+    min_amount_label = settings.format_price(settings.PLATEGA_MIN_AMOUNT_KOPEKS)
+    max_amount_kopeks = settings.PLATEGA_MAX_AMOUNT_KOPEKS
+    max_amount_label = (
+        settings.format_price(max_amount_kopeks)
+        if max_amount_kopeks and max_amount_kopeks > 0
+        else ""
+    )
+
+    default_prompt_body = (
+        "Введите сумму для пополнения от {min_amount} до {max_amount}.\n"
+        if max_amount_kopeks and max_amount_kopeks > 0
+        else "Введите сумму для пополнения от {min_amount}.\n"
+    )
+
     prompt_template = texts.t(
         "PLATEGA_TOPUP_PROMPT",
         (
             "💳 <b>Оплата через Platega ({method_name})</b>\n\n"
-            "Введите сумму для пополнения от 100 до 1 000 000 ₽.\n"
+            f"{default_prompt_body}"
             "Оплата происходит через Platega."
         ),
     )
@@ -51,7 +65,11 @@ async def _prompt_amount(
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
 
     await message.edit_text(
-        prompt_template.format(method_name=method_name),
+        prompt_template.format(
+            method_name=method_name,
+            min_amount=min_amount_label,
+            max_amount=max_amount_label,
+        ),
         reply_markup=keyboard,
         parse_mode="HTML",
     )

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -1081,7 +1081,7 @@
   "PAYMENT_SBP_YOOKASSA": "🏦 Pay via SBP (YooKassa)",
   "PAYMENT_TELEGRAM_STARS": "⭐ Telegram Stars",
   "PAYMENT_VIA_SUPPORT": "🛠️ Via support",
-  "PLATEGA_TOPUP_PROMPT": "💳 <b>Payment via Platega ({method_name})</b>\n\nEnter the amount from 100 to 1,000,000 ₽.\nPayment is processed by Platega.",
+  "PLATEGA_TOPUP_PROMPT": "💳 <b>Payment via Platega ({method_name})</b>\n\nEnter an amount from {min_amount} to {max_amount}.\nPayment is processed by Platega.",
   "PLATEGA_SELECT_PAYMENT_METHOD": "Choose a Platega payment method:",
   "PLATEGA_TEMPORARILY_UNAVAILABLE": "❌ Platega payments are temporarily unavailable",
   "PLATEGA_METHODS_NOT_CONFIGURED": "⚠️ No active Platega methods configured",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -1101,7 +1101,7 @@
   "PAYMENT_SBP_YOOKASSA": "🏬 Оплатить по СБП (YooKassa)",
   "PAYMENT_TELEGRAM_STARS": "⭐ Telegram Stars",
   "PAYMENT_VIA_SUPPORT": "🛠️ Через поддержку",
-  "PLATEGA_TOPUP_PROMPT": "💳 <b>Оплата через Platega ({method_name})</b>\n\nВведите сумму для пополнения от 100 до 1 000 000 ₽.\nОплата происходит через Platega.",
+  "PLATEGA_TOPUP_PROMPT": "💳 <b>Оплата через Platega ({method_name})</b>\n\nВведите сумму для пополнения от {min_amount} до {max_amount}.\nОплата происходит через Platega.",
   "PLATEGA_SELECT_PAYMENT_METHOD": "Выберите способ оплаты Platega:",
   "PLATEGA_TEMPORARILY_UNAVAILABLE": "❌ Оплата через Platega временно недоступна",
   "PLATEGA_METHODS_NOT_CONFIGURED": "⚠️ На стороне Platega нет доступных методов оплаты",


### PR DESCRIPTION
## Summary
- show the configured Platega minimum and maximum amounts instead of hardcoded values when prompting for a top-up
- allow the Platega localization strings to accept dynamic min/max placeholders
