### PR TITLE
Handle optional Pal24 attributes for queue pool update

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -2,16 +2,19 @@ import logging
 from typing import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlalchemy.pool import NullPool
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from app.config import settings
 from app.database.models import Base
 
 logger = logging.getLogger(__name__)
 
+QueuePool = AsyncAdaptedQueuePool
+
+
 engine = create_async_engine(
     settings.get_database_url(),
-    poolclass=NullPool,
+    poolclass=QueuePool,
     echo=settings.DEBUG,
     future=True
 )

--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -700,8 +700,8 @@ class Pal24PaymentMixin:
 
             return {
                 "payment": payment,
-                "status": payment.status,
-                "is_paid": payment.is_paid,
+                "status": getattr(payment, "status", None),
+                "is_paid": getattr(payment, "is_paid", None),
                 "remote_status": remote_status_for_return,
                 "remote_data": remote_data,
                 "links": links_map or None,
@@ -709,8 +709,9 @@ class Pal24PaymentMixin:
                 "secondary_url": secondary_url,
                 "sbp_url": links_map.get("sbp"),
                 "card_url": links_map.get("card"),
-                "link_page_url": links_map.get("page") or payment.link_page_url,
-                "link_url": payment.link_url,
+                "link_page_url": links_map.get("page")
+                or getattr(payment, "link_page_url", None),
+                "link_url": getattr(payment, "link_url", None),
                 "selected_method": selected_method,
             }
 
@@ -878,7 +879,8 @@ class Pal24PaymentMixin:
     ) -> tuple[Dict[str, str], str]:
         links: Dict[str, str] = {}
 
-        metadata = payment.metadata_json if isinstance(payment.metadata_json, dict) else {}
+        metadata_raw = getattr(payment, "metadata_json", None)
+        metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
         if metadata:
             links_meta = metadata.get("links")
             if isinstance(links_meta, dict):


### PR DESCRIPTION
## Summary
- guard Pal24 status response assembly against missing optional attributes
- avoid attribute errors in link map construction when metadata is absent
