### PR TITLE
Add database health and pool metrics endpoints

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -1,0 +1,23 @@
+"""Database package exports."""
+
+from .database import (
+    DatabaseManager,
+    batch_ops,
+    close_db,
+    db_manager,
+    get_db,
+    get_db_read_only,
+    get_pool_metrics,
+    init_db,
+)
+
+__all__ = [
+    "DatabaseManager",
+    "batch_ops",
+    "close_db",
+    "db_manager",
+    "get_db",
+    "get_db_read_only",
+    "get_pool_metrics",
+    "init_db",
+]

--- a/app/webapi/routes/health.py
+++ b/app/webapi/routes/health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Security
 
 from app.config import settings
+from app.database import db_manager, get_pool_metrics
 from app.services.version_service import version_service
 
 from ..dependencies import require_api_token
@@ -24,3 +25,17 @@ async def health_check(_: object = Security(require_api_token)) -> HealthCheckRe
             webhooks=bool(settings.WEBHOOK_URL),
         ),
     )
+
+
+@router.get("/health/database", tags=["health"])
+async def database_health(_: object = Security(require_api_token)) -> dict:
+    """Детальная информация о состоянии базы данных."""
+
+    return await db_manager.health_check()
+
+
+@router.get("/metrics/pool", tags=["health"])
+async def pool_metrics(_: object = Security(require_api_token)) -> dict:
+    """Метрики пула подключений к базе данных."""
+
+    return await get_pool_metrics()


### PR DESCRIPTION
## Summary
- expose database health and pool metrics endpoints on the health router
- export database helpers from the package for straightforward imports
