### PR TITLE
Add localization defaults and language flags for new locales

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -328,7 +328,7 @@ class Settings(BaseSettings):
     SKIP_REFERRAL_CODE: bool = False
 
     DEFAULT_LANGUAGE: str = "ru"
-    AVAILABLE_LANGUAGES: str = "ru,en"
+    AVAILABLE_LANGUAGES: str = "ru,en,ua,zh"
     LANGUAGE_SELECTION_ENABLED: bool = True
     
     LOG_LEVEL: str = "INFO"
@@ -703,11 +703,11 @@ class Settings(BaseSettings):
             langs = self.AVAILABLE_LANGUAGES
             if isinstance(langs, str):
                 if not langs.strip():
-                    return ["ru", "en"]
+                    return ["ru", "en", "ua", "zh"]
                 return [x.strip() for x in langs.split(',') if x.strip()]
-            return ["ru", "en"]
+            return ["ru", "en", "ua", "zh"]
         except AttributeError:
-            return ["ru", "en"]
+            return ["ru", "en", "ua", "zh"]
 
     def is_language_selection_enabled(self) -> bool:
         return bool(getattr(self, "LANGUAGE_SELECTION_ENABLED", True))

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -83,6 +83,20 @@ def _build_additional_buttons(additional_section, language: str) -> List[InlineK
 _LANGUAGE_DISPLAY_NAMES = {
     "ru": "🇷🇺 Русский",
     "en": "🇬🇧 English",
+    "ua": "🇺🇦 Українська",
+    "uk": "🇺🇦 Українська",
+    "zh": "🇨🇳 中文",
+    "es": "🇪🇸 Español",
+    "de": "🇩🇪 Deutsch",
+    "fr": "🇫🇷 Français",
+    "it": "🇮🇹 Italiano",
+    "pl": "🇵🇱 Polski",
+    "tr": "🇹🇷 Türkçe",
+    "kk": "🇰🇿 Қазақ тілі",
+    "uz": "🇺🇿 Oʻzbekcha",
+    "az": "🇦🇿 Azərbaycan",
+    "ka": "🇬🇪 ქართული",
+    "hy": "🇦🇲 Հայերեն",
 }
 
 def get_rules_keyboard(language: str = DEFAULT_LANGUAGE) -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- include Ukrainian and Chinese in the default AVAILABLE_LANGUAGES configuration and fallbacks
- extend language display names with flag-prefixed labels for Ukrainian, Chinese, and other common locales

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912cc1b0b8083208550748e6745fea1)