### PR TITLE
Fix trial subscription status display in menu

### DIFF
--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -972,7 +972,13 @@ def _get_subscription_status(user: User, texts) -> str:
             "🔴 Истекла\n📅 {end_date}",
         ).format(end_date=end_date_text or "—")
 
-    if actual_status == "trial":
+    is_trial_subscription = getattr(subscription, "is_trial", False)
+
+    is_trial_like_status = actual_status == "trial" or (
+        is_trial_subscription and actual_status in {"active", "trial"}
+    )
+
+    if is_trial_like_status:
         if days_left > 1 and end_date_text:
             return texts.t(
                 "SUB_STATUS_TRIAL_ACTIVE",

--- a/tests/test_menu_subscription_status.py
+++ b/tests/test_menu_subscription_status.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from app.handlers.menu import _get_subscription_status
+
+
+class DummyTexts:
+    def t(self, key: str, default: str):  # pragma: no cover - simple stub
+        return default
+
+
+def _build_user_with_subscription(actual_status: str, is_trial: bool, days_left: int):
+    subscription = MagicMock()
+    subscription.actual_status = actual_status
+    subscription.is_trial = is_trial
+    subscription.end_date = datetime.utcnow() + timedelta(days=days_left, hours=1)
+
+    user = MagicMock()
+    user.subscription = subscription
+    return user
+
+
+def test_get_subscription_status_marks_trial_as_trial():
+    texts = DummyTexts()
+    user = _build_user_with_subscription(actual_status="active", is_trial=True, days_left=5)
+
+    status_text = _get_subscription_status(user, texts)
+
+    assert "Тестовая подписка" in status_text
+    assert "Активна" not in status_text


### PR DESCRIPTION
## Summary
- ensure trial subscriptions are labeled as trial in the main menu status helper
- add regression coverage for the trial status display
