### PR TITLE
Enable trial subscriptions to renew via miniapp

### DIFF
--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -4862,7 +4862,10 @@ async def get_subscription_settings_endpoint(
     db: AsyncSession = Depends(get_db_session),
 ) -> MiniAppSubscriptionSettingsResponse:
     user = await _authorize_miniapp_user(payload.init_data, db)
-    subscription = _ensure_paid_subscription(user)
+    subscription = _ensure_paid_subscription(
+        user,
+        allowed_statuses={"active", "trial"},
+    )
     _validate_subscription_id(payload.subscription_id, subscription)
 
     settings_payload = await _build_subscription_settings(db, user, subscription)
@@ -4879,7 +4882,10 @@ async def update_subscription_servers_endpoint(
     db: AsyncSession = Depends(get_db_session),
 ) -> MiniAppSubscriptionUpdateResponse:
     user = await _authorize_miniapp_user(payload.init_data, db)
-    subscription = _ensure_paid_subscription(user)
+    subscription = _ensure_paid_subscription(
+        user,
+        allowed_statuses={"active", "trial"},
+    )
     _validate_subscription_id(payload.subscription_id, subscription)
     old_servers = list(getattr(subscription, "connected_squads", []) or [])
 
@@ -5085,7 +5091,10 @@ async def update_subscription_traffic_endpoint(
     db: AsyncSession = Depends(get_db_session),
 ) -> MiniAppSubscriptionUpdateResponse:
     user = await _authorize_miniapp_user(payload.init_data, db)
-    subscription = _ensure_paid_subscription(user)
+    subscription = _ensure_paid_subscription(
+        user,
+        allowed_statuses={"active", "trial"},
+    )
     _validate_subscription_id(payload.subscription_id, subscription)
     old_traffic = subscription.traffic_limit_gb
 
@@ -5249,7 +5258,10 @@ async def update_subscription_devices_endpoint(
     db: AsyncSession = Depends(get_db_session),
 ) -> MiniAppSubscriptionUpdateResponse:
     user = await _authorize_miniapp_user(payload.init_data, db)
-    subscription = _ensure_paid_subscription(user)
+    subscription = _ensure_paid_subscription(
+        user,
+        allowed_statuses={"active", "trial"},
+    )
     _validate_subscription_id(payload.subscription_id, subscription)
 
     raw_value = payload.devices if payload.devices is not None else payload.device_limit

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -13955,7 +13955,7 @@
         function ensureSubscriptionRenewalData(options = {}) {
             const { force = false } = options;
 
-            if (!hasPaidSubscription()) {
+            if (!hasActiveSubscription()) {
                 resetSubscriptionRenewalState(null);
                 renderSubscriptionRenewalCard();
                 return Promise.resolve(null);
@@ -14484,7 +14484,7 @@
                 return;
             }
 
-            const shouldShow = hasPaidSubscription();
+            const shouldShow = hasActiveSubscription();
             card.classList.toggle('hidden', !shouldShow);
             if (!shouldShow) {
                 return;
@@ -14601,7 +14601,7 @@
                 return;
             }
 
-            if (!hasPaidSubscription()) {
+            if (!hasActiveSubscription()) {
                 handleSubscriptionRenewalError(createError('Subscription renewal', t('subscription_renewal.error.validation')));
                 return;
             }
@@ -14784,7 +14784,7 @@
 
         function ensureSubscriptionSettingsLoaded(options = {}) {
             const { force = false } = options;
-            if (!hasPaidSubscription()) {
+            if (!hasActiveSubscription()) {
                 subscriptionSettingsData = null;
                 subscriptionSettingsPromise = null;
                 subscriptionSettingsError = null;
@@ -14912,7 +14912,7 @@
                 return;
             }
 
-            const shouldShow = hasPaidSubscription();
+            const shouldShow = hasActiveSubscription();
             card.classList.toggle('hidden', !shouldShow);
             if (!shouldShow) {
                 return;


### PR DESCRIPTION
## Summary
- allow trial subscriptions to access subscription settings and related update endpoints through the mini app API
- treat active trial subscriptions as eligible for renewal/settings flows in the mini app UI so users can extend their plan without errors
