### PR TITLE
Expand admin API for polls, logs, and tickets

### DIFF
--- a/app/webapi/schemas/logs.py
+++ b/app/webapi/schemas/logs.py
@@ -88,3 +88,14 @@ class SystemLogPreviewResponse(BaseModel):
         default=None,
         description="Относительный путь до endpoint для скачивания лог-файла",
     )
+
+
+class SystemLogFullResponse(BaseModel):
+    """Полное содержимое системного лог-файла."""
+
+    path: str
+    exists: bool
+    updated_at: Optional[datetime] = None
+    size_bytes: int
+    size_chars: int
+    content: str

--- a/app/webapi/schemas/polls.py
+++ b/app/webapi/schemas/polls.py
@@ -169,3 +169,23 @@ class PollResponsesListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class PollSendRequest(BaseModel):
+    target: str = Field(
+        ...,
+        description=(
+            "Аудитория для отправки опроса (например: all, active, trial, "
+            "custom_today и т.д.)"
+        ),
+        max_length=100,
+    )
+
+
+class PollSendResponse(BaseModel):
+    poll_id: int
+    target: str
+    sent: int
+    failed: int
+    skipped: int
+    total: int

--- a/app/webapi/schemas/tickets.py
+++ b/app/webapi/schemas/tickets.py
@@ -13,6 +13,7 @@ class TicketMessageResponse(BaseModel):
     is_from_admin: bool
     has_media: bool
     media_type: Optional[str] = None
+    media_file_id: Optional[str] = None
     media_caption: Optional[str] = None
     created_at: datetime
 
@@ -42,3 +43,27 @@ class TicketPriorityUpdateRequest(BaseModel):
 class TicketReplyBlockRequest(BaseModel):
     permanent: bool = False
     until: Optional[datetime] = None
+
+
+class TicketReplyRequest(BaseModel):
+    message_text: Optional[str] = Field(default=None, max_length=4000)
+    media_type: Optional[str] = Field(
+        default=None,
+        description="Тип медиа (photo, video, document, voice и т.д.)",
+        max_length=32,
+    )
+    media_file_id: Optional[str] = Field(default=None, max_length=255)
+    media_caption: Optional[str] = Field(default=None, max_length=4000)
+
+
+class TicketReplyResponse(BaseModel):
+    ticket: TicketResponse
+    message: TicketMessageResponse
+
+
+class TicketMediaResponse(BaseModel):
+    id: int
+    ticket_id: int
+    media_type: str
+    media_file_id: str
+    media_caption: Optional[str] = None


### PR DESCRIPTION
## Summary
- add endpoint to send polls to targeted audiences via API
- expose full system log download via JSON response
- allow replying to tickets and retrieving ticket message media through the API
