### PR TITLE
Allow replacing subscriptions via API

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -129,7 +129,7 @@ async def create_paid_subscription(
     connected_squads: List[str] = None,
     update_server_counters: bool = False,
 ) -> Subscription:
-    
+
     end_date = datetime.utcnow() + timedelta(days=duration_days)
     
     if device_limit is None:
@@ -180,6 +180,78 @@ async def create_paid_subscription(
             logger.error(
                 "⚠️ Ошибка обновления счетчика пользователей серверов для платной подписки пользователя %s: %s",
                 user_id,
+                error,
+            )
+
+    return subscription
+
+
+async def replace_subscription(
+    db: AsyncSession,
+    subscription: Subscription,
+    *,
+    duration_days: int,
+    traffic_limit_gb: int,
+    device_limit: int,
+    connected_squads: List[str],
+    is_trial: bool,
+    update_server_counters: bool = False,
+) -> Subscription:
+    """Перезаписывает параметры существующей подписки пользователя."""
+
+    current_time = datetime.utcnow()
+    old_squads = set(subscription.connected_squads or [])
+    new_squads = set(connected_squads or [])
+
+    subscription.status = SubscriptionStatus.ACTIVE.value
+    subscription.is_trial = is_trial
+    subscription.start_date = current_time
+    subscription.end_date = current_time + timedelta(days=duration_days)
+    subscription.traffic_limit_gb = traffic_limit_gb
+    subscription.traffic_used_gb = 0.0
+    subscription.device_limit = device_limit
+    subscription.connected_squads = list(new_squads)
+    subscription.subscription_url = None
+    subscription.subscription_crypto_link = None
+    subscription.remnawave_short_uuid = None
+    subscription.autopay_enabled = settings.is_autopay_enabled_by_default()
+    subscription.autopay_days_before = settings.DEFAULT_AUTOPAY_DAYS_BEFORE
+    subscription.updated_at = current_time
+
+    await db.commit()
+    await db.refresh(subscription)
+
+    if update_server_counters:
+        try:
+            from app.database.crud.server_squad import (
+                add_user_to_servers,
+                get_server_ids_by_uuids,
+                remove_user_from_servers,
+            )
+
+            squads_to_remove = old_squads - new_squads
+            squads_to_add = new_squads - old_squads
+
+            if squads_to_remove:
+                server_ids = await get_server_ids_by_uuids(db, list(squads_to_remove))
+                if server_ids:
+                    await remove_user_from_servers(db, sorted(server_ids))
+
+            if squads_to_add:
+                server_ids = await get_server_ids_by_uuids(db, list(squads_to_add))
+                if server_ids:
+                    await add_user_to_servers(db, sorted(server_ids))
+
+            logger.info(
+                "♻️ Обновлены параметры подписки %s: удалено сквадов %s, добавлено %s",
+                subscription.id,
+                len(squads_to_remove),
+                len(squads_to_add),
+            )
+        except Exception as error:
+            logger.error(
+                "⚠️ Ошибка обновления счетчиков серверов при замене подписки %s: %s",
+                subscription.id,
                 error,
             )
 

--- a/app/webapi/schemas/subscriptions.py
+++ b/app/webapi/schemas/subscriptions.py
@@ -34,6 +34,7 @@ class SubscriptionCreateRequest(BaseModel):
     device_limit: Optional[int] = None
     squad_uuid: Optional[str] = None
     connected_squads: Optional[List[str]] = None
+    replace_existing: bool = False
 
 
 class SubscriptionExtendRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add an API flag to allow replacing an existing user subscription when creating through the web API
- update subscription creation flow to reuse the new replacement path for both trial and paid subscriptions
- add a helper to rewrite subscription parameters while syncing server user counters
