### PR TITLE
Preserve autopay and device limits during subscription replacement

### DIFF
--- a/app/webapi/schemas/subscriptions.py
+++ b/app/webapi/schemas/subscriptions.py
@@ -34,6 +34,7 @@ class SubscriptionCreateRequest(BaseModel):
     device_limit: Optional[int] = None
     squad_uuid: Optional[str] = None
     connected_squads: Optional[List[str]] = None
+    replace_existing: bool = False
 
 
 class SubscriptionExtendRequest(BaseModel):


### PR DESCRIPTION
## Summary
- keep existing autopay preferences when replacing subscriptions unless overrides are provided
- allow callers to optionally supply autopay settings during replacement while defaulting to the prior values
- preserve zero device caps on trial subscription replacements instead of falling back to default limits