### PR TITLE
Stop duplicate Telegram Stars top-up notifications

### DIFF
--- a/app/handlers/stars_payments.py
+++ b/app/handlers/stars_payments.py
@@ -115,40 +115,10 @@ async def handle_successful_payment(
         )
         
         if success:
-            rubles_amount = TelegramStarsService.calculate_rubles_from_stars(payment.total_amount)
-            amount_kopeks = int((rubles_amount * Decimal(100)).to_integral_value(rounding=ROUND_HALF_UP))
-            amount_text = settings.format_price(amount_kopeks).replace(" ₽", "")
-
-            keyboard = await payment_service.build_topup_success_keyboard(user)
-
-            transaction_id_short = payment.telegram_payment_charge_id[:8]
-
-            await message.answer(
-                texts.t(
-                    "STARS_PAYMENT_SUCCESS",
-                    "🎉 <b>Платеж успешно обработан!</b>\n\n"
-                    "⭐ Потрачено звезд: {stars_spent}\n"
-                    "💰 Зачислено на баланс: {amount} ₽\n"
-                    "🆔 ID транзакции: {transaction_id}...\n\n"
-                    "⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                    "Обязательно активируйте подписку отдельно!\n\n"
-                    "🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                    "подписка будет приобретена автоматически после пополнения баланса.\n\n"
-                    "Спасибо за пополнение! 🚀",
-                ).format(
-                    stars_spent=payment.total_amount,
-                    amount=amount_text,
-                    transaction_id=transaction_id_short,
-                ),
-                parse_mode="HTML",
-                reply_markup=keyboard,
-            )
-
             logger.info(
-                "✅ Stars платеж успешно обработан: пользователь %s, %s звезд → %s",
+                "✅ Stars платеж успешно обработан: пользователь %s, %s звезд",
                 user.id,
                 payment.total_amount,
-                settings.format_price(amount_kopeks),
             )
         else:
             logger.error(f"Ошибка обработки Stars платежа для пользователя {user.id}")

--- a/app/services/payment/common.py
+++ b/app/services/payment/common.py
@@ -19,6 +19,9 @@ from app.config import settings
 from app.database.crud.user import get_user_by_telegram_id
 from app.database.database import get_db
 from app.localization.texts import get_texts
+from app.services.subscription_auto_purchase_service import (
+    auto_purchase_saved_cart_after_topup,
+)
 from app.services.subscription_checkout_service import (
     has_subscription_checkout_draft,
     should_offer_checkout_resume,
@@ -110,6 +113,65 @@ class PaymentCommonMixin:
 
         return InlineKeyboardMarkup(inline_keyboard=keyboard_rows)
 
+    async def build_cart_message_after_topup(
+        self,
+        db: AsyncSession,
+        user: Any,
+        amount_kopeks: int,
+        *,
+        bot: Any | None = None,
+    ) -> str:
+        """Возвращает текст напоминания о сохранённой корзине и запускает автопокупку."""
+
+        user_id = getattr(user, "id", None)
+        if not user_id:
+            return ""
+
+        try:
+            has_saved_cart = await user_cart_service.has_user_cart(user_id)
+        except Exception as cart_error:  # pragma: no cover - диагностический лог
+            logger.warning(
+                "Не удалось проверить наличие сохраненной корзины у пользователя %s: %s",
+                user_id,
+                cart_error,
+            )
+            return ""
+
+        if has_saved_cart:
+            try:
+                auto_purchase_success = await auto_purchase_saved_cart_after_topup(
+                    db,
+                    user,
+                    bot=bot or getattr(self, "bot", None),
+                )
+            except Exception as auto_error:  # pragma: no cover - диагностический лог
+                logger.error(
+                    "Ошибка автоматической покупки подписки для пользователя %s: %s",
+                    user_id,
+                    auto_error,
+                    exc_info=True,
+                )
+                auto_purchase_success = False
+
+            if auto_purchase_success:
+                has_saved_cart = False
+
+        if not has_saved_cart:
+            return ""
+
+        try:
+            texts = get_texts(getattr(user, "language", "ru"))
+            return "\n\n" + texts.BALANCE_TOPUP_CART_REMINDER_DETAILED.format(
+                total_amount=settings.format_price(amount_kopeks)
+            )
+        except Exception as text_error:  # pragma: no cover - диагностический лог
+            logger.warning(
+                "Не удалось сформировать напоминание о сохраненной корзине для пользователя %s: %s",
+                user_id,
+                text_error,
+            )
+            return ""
+
     async def _send_payment_success_notification(
         self,
         telegram_id: int,
@@ -118,6 +180,7 @@ class PaymentCommonMixin:
         *,
         db: AsyncSession | None = None,
         payment_method_title: str | None = None,
+        cart_message: str | None = None,
     ) -> None:
         """Отправляет пользователю уведомление об успешном платеже."""
         if not getattr(self, "bot", None):
@@ -144,6 +207,9 @@ class PaymentCommonMixin:
                 f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
                 f"подписка будет приобретена автоматически после пополнения баланса."
             )
+
+            if cart_message:
+                message += f"\n\n{cart_message}"
 
             await self.bot.send_message(
                 chat_id=telegram_id,

--- a/app/services/payment/cryptobot.py
+++ b/app/services/payment/cryptobot.py
@@ -13,9 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database.database import AsyncSessionLocal
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.services.subscription_renewal_service import (
     SubscriptionRenewalChargeError,
     SubscriptionRenewalPricing,
@@ -51,14 +48,6 @@ class _UserNotificationPayload:
     reply_markup: Any
     amount_rubles: float
     asset: str
-
-
-@dataclass(slots=True)
-class _SavedCartNotificationPayload:
-    telegram_id: int
-    text: str
-    reply_markup: Any
-    user_id: int
 
 
 class CryptoBotPaymentMixin:
@@ -315,7 +304,6 @@ class CryptoBotPaymentMixin:
 
                 admin_notification: Optional[_AdminNotificationContext] = None
                 user_notification: Optional[_UserNotificationPayload] = None
-                saved_cart_notification: Optional[_SavedCartNotificationPayload] = None
 
                 bot_instance = getattr(self, "bot", None)
                 if bot_instance:
@@ -328,6 +316,12 @@ class CryptoBotPaymentMixin:
                     )
 
                     try:
+                        cart_message = await self.build_cart_message_after_topup(
+                            db,
+                            user,
+                            payment.amount_kopeks,
+                            bot=bot_instance,
+                        )
                         keyboard = await self.build_topup_success_keyboard(user)
                         message_text = (
                             "✅ <b>Пополнение успешно!</b>\n\n"
@@ -336,6 +330,7 @@ class CryptoBotPaymentMixin:
                             f"💱 Курс: 1 USD = {conversion_rate:.2f}₽\n"
                             f"🆔 Транзакция: {invoice_id[:8]}...\n\n"
                             "Баланс пополнен автоматически!"
+                            f"{cart_message}"
                         )
                         user_notification = _UserNotificationPayload(
                             telegram_id=user.telegram_id,
@@ -349,84 +344,14 @@ class CryptoBotPaymentMixin:
                         logger.error(
                             "Ошибка подготовки уведомления о пополнении CryptoBot: %s",
                             error,
+                            exc_info=True,
                         )
-
-                # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-                try:
-                    from app.services.user_cart_service import user_cart_service
-                    from aiogram import types
-
-                    has_saved_cart = await user_cart_service.has_user_cart(user.id)
-                    auto_purchase_success = False
-                    if has_saved_cart:
-                        try:
-                            auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                                db,
-                                user,
-                                bot=bot_instance,
-                            )
-                        except Exception as auto_error:
-                            logger.error(
-                                "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                                user.id,
-                                auto_error,
-                                exc_info=True,
-                            )
-
-                        if auto_purchase_success:
-                            has_saved_cart = False
-
-                    if has_saved_cart and bot_instance:
-                        from app.localization.texts import get_texts
-
-                        texts = get_texts(user.language)
-                        cart_message = texts.BALANCE_TOPUP_CART_REMINDER_DETAILED.format(
-                            total_amount=settings.format_price(payment.amount_kopeks)
-                        )
-
-                        keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                            [types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu"
-                            )]
-                        ])
-
-                        saved_cart_notification = _SavedCartNotificationPayload(
-                            telegram_id=user.telegram_id,
-                            text=(
-                                f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                                f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                                f"Обязательно активируйте подписку отдельно!\n\n"
-                                f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                                f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}"
-                            ),
-                            reply_markup=keyboard,
-                            user_id=user.id,
-                        )
-                except Exception as error:
-                    logger.error(
-                        "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                        user.id,
-                        error,
-                        exc_info=True,
-                    )
 
                 if admin_notification:
                     await self._deliver_admin_topup_notification(admin_notification)
 
                 if user_notification and bot_instance:
                     await self._deliver_user_topup_notification(user_notification)
-
-                if saved_cart_notification and bot_instance:
-                    await self._deliver_saved_cart_reminder(saved_cart_notification)
 
             return True
 
@@ -674,31 +599,6 @@ class CryptoBotPaymentMixin:
             logger.error(
                 "Ошибка отправки уведомления о пополнении CryptoBot: %s",
                 error,
-            )
-
-    async def _deliver_saved_cart_reminder(
-        self, payload: _SavedCartNotificationPayload
-    ) -> None:
-        bot_instance = getattr(self, "bot", None)
-        if not bot_instance:
-            return
-
-        try:
-            await bot_instance.send_message(
-                chat_id=payload.telegram_id,
-                text=payload.text,
-                reply_markup=payload.reply_markup,
-            )
-            logger.info(
-                "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                payload.user_id,
-            )
-        except Exception as error:
-            logger.error(
-                "Ошибка отправки уведомления о сохраненной корзине для пользователя %s: %s",
-                payload.user_id,
-                error,
-                exc_info=True,
             )
 
     async def get_cryptobot_payment_status(

--- a/app/services/payment/heleket.py
+++ b/app/services/payment/heleket.py
@@ -331,6 +331,12 @@ class HeleketPaymentMixin:
             await db.commit()
             await db.refresh(user)
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
             referrer_info = format_referrer_info(user)
@@ -378,7 +384,7 @@ class HeleketPaymentMixin:
 
                 await self.bot.send_message(
                     chat_id=user.telegram_id,
-                    text="\n".join(message_lines),
+                    text="\n".join(message_lines) + cart_message,
                     parse_mode="HTML",
                     reply_markup=keyboard,
                 )

--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -11,9 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -288,6 +285,12 @@ class MulenPayPaymentMixin:
                     "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
                 )
 
+                cart_message = await self.build_cart_message_after_topup(
+                    db,
+                    user,
+                    payment.amount_kopeks,
+                )
+
                 if getattr(self, "bot", None):
                     try:
                         from app.services.admin_notification_service import (
@@ -323,6 +326,7 @@ class MulenPayPaymentMixin:
                                 f"🦊 Способ: {display_name_html}\n"
                                 f"🆔 Транзакция: {transaction.id}\n\n"
                                 "Баланс пополнен автоматически!"
+                                f"{cart_message}"
                             ),
                             parse_mode="HTML",
                             reply_markup=keyboard,
@@ -334,75 +338,7 @@ class MulenPayPaymentMixin:
                             error,
                         )
 
-                # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-                try:
-                    from app.services.user_cart_service import user_cart_service
-                    from aiogram import types
-
-                    has_saved_cart = await user_cart_service.has_user_cart(user.id)
-                    auto_purchase_success = False
-                    if has_saved_cart:
-                        try:
-                            auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                                db,
-                                user,
-                                bot=getattr(self, "bot", None),
-                            )
-                        except Exception as auto_error:
-                            logger.error(
-                                "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                                user.id,
-                                auto_error,
-                                exc_info=True,
-                            )
-
-                        if auto_purchase_success:
-                            has_saved_cart = False
-
-                    if has_saved_cart and getattr(self, "bot", None):
-                        # Если у пользователя есть сохраненная корзина,
-                        # отправляем ему уведомление с кнопкой вернуться к оформлению
-                        from app.localization.texts import get_texts
-                        
-                        texts = get_texts(user.language)
-                        cart_message = texts.t(
-                            "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                            "🛒 У вас есть неоформленный заказ.\n\n"
-                            "Вы можете продолжить оформление с теми же параметрами."
-                        )
-                        
-                        # Создаем клавиатуру с кнопками
-                        keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                            [types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu"
-                            )]
-                        ])
-                        
-                        await self.bot.send_message(
-                            chat_id=user.telegram_id,
-                            text=f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                                 f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                                 f"Обязательно активируйте подписку отдельно!\n\n"
-                                 f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                                 f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}",
-                            reply_markup=keyboard
-                        )
-                        logger.info(
-                            "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                            user.id,
-                        )
-                except Exception as e:
-                    logger.error(f"Ошибка при работе с сохраненной корзиной для пользователя {user.id}: {e}", exc_info=True)
-
+                
                 logger.info(
                     "✅ Обработан %s платеж %s для пользователя %s",
                     display_name,

--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -13,9 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
 from app.services.pal24_service import Pal24APIError
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -419,6 +416,12 @@ class Pal24PaymentMixin:
                     error,
                 )
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            payment.amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
@@ -430,6 +433,7 @@ class Pal24PaymentMixin:
                         "🦊 Способ: PayPalych\n"
                         f"🆔 Транзакция: {transaction.id}\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -439,88 +443,6 @@ class Pal24PaymentMixin:
                     "Ошибка отправки уведомления пользователю Pal24: %s",
                     error,
                 )
-
-        try:
-            from app.services.user_cart_service import user_cart_service
-            from aiogram import types
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                from app.localization.texts import get_texts
-
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER",
-                    "У вас есть незавершенное оформление подписки. Вернуться?",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.t(
-                                    "BALANCE_TOPUP_CART_BUTTON",
-                                    "🛒 Продолжить оформление",
-                                ),
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    chat_id=user.telegram_id,
-                    text=(
-                        "✅ Баланс пополнен на "
-                        f"{settings.format_price(payment.amount_kopeks)}!\n\n"
-                        f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                        f"Обязательно активируйте подписку отдельно!\n\n"
-                        f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                        f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}"
-                    ),
-                    reply_markup=keyboard,
-                )
-                logger.info(
-                    "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                    user.id,
-                )
-            else:
-                logger.info(
-                    "У пользователя %s нет сохраненной корзины или автопокупка выполнена",
-                    user.id,
-                )
-        except Exception as error:
-            logger.error(
-                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                user.id,
-                error,
-                exc_info=True,
-            )
 
         logger.info(
             "✅ Обработан Pal24 платеж %s для пользователя %s (trigger=%s)",

--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -13,9 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
 from app.services.platega_service import PlategaService
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -399,6 +396,12 @@ class PlategaPaymentMixin:
             await db.commit()
             await db.refresh(user)
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            payment.amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             try:
                 from app.services.admin_notification_service import AdminNotificationService
@@ -430,6 +433,7 @@ class PlategaPaymentMixin:
                         f"🦊 Способ: {method_title}\n"
                         f"🆔 Транзакция: {transaction.id}\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -437,83 +441,7 @@ class PlategaPaymentMixin:
             except Exception as error:
                 logger.error("Ошибка отправки уведомления пользователю Platega: %s", error)
 
-        try:
-            from app.services.user_cart_service import user_cart_service
-            from aiogram import types
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                from app.localization.texts import get_texts
-
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    chat_id=user.telegram_id,
-                    text=(
-                        f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                        f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                        f"Обязательно активируйте подписку отдельно!\n\n"
-                        f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                        f"подписка будет приобретена автоматически после пополнения баланса.\n\n"
-                        f"{cart_message}"
-                    ),
-                    reply_markup=keyboard,
-                )
-        except Exception as error:
-            logger.error(
-                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                payment.user_id,
-                error,
-                exc_info=True,
-            )
-
+        
         metadata["balance_change"] = {
             "old_balance": old_balance,
             "new_balance": user.balance_kopeks,

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -20,9 +20,6 @@ from app.database.crud.transaction import create_transaction
 from app.database.crud.user import get_user_by_id
 from app.database.models import PaymentMethod, TransactionType
 from app.external.telegram_stars import TelegramStarsService
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -493,6 +490,12 @@ class TelegramStarsMixin:
             amount_kopeks,
         )
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             try:
                 from app.services.admin_notification_service import AdminNotificationService
@@ -530,6 +533,7 @@ class TelegramStarsMixin:
                         "🦊 Способ: Telegram Stars\n"
                         f"🆔 Транзакция: {charge_id_short}...\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -544,84 +548,6 @@ class TelegramStarsMixin:
                     "Ошибка отправки уведомления о пополнении Stars: %s",
                     error,
                 )
-
-        # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-        try:
-            from aiogram import types
-            from app.localization.texts import get_texts
-            from app.services.user_cart_service import user_cart_service
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:  # pragma: no cover - диагностический лог
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    chat_id=user.telegram_id,
-                    text=f"✅ Баланс пополнен на {settings.format_price(amount_kopeks)}!\n\n"
-                         f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                         f"Обязательно активируйте подписку отдельно!\n\n"
-                         f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                         f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}",
-                    reply_markup=keyboard,
-                )
-                logger.info(
-                    "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                    user.id,
-                )
-        except Exception as error:  # pragma: no cover - диагностический лог
-            logger.error(
-                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                user.id,
-                error,
-                exc_info=True,
-            )
 
         logger.info(
             "✅ Обработан Stars платеж: пользователь %s, %s звезд → %s",

--- a/app/services/payment/wata.py
+++ b/app/services/payment/wata.py
@@ -12,9 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.services.wata_service import WataAPIError, WataService
 from app.utils.user_utils import format_referrer_info
 
@@ -469,6 +466,12 @@ class WataPaymentMixin:
         referrer_info = format_referrer_info(user)
         topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            payment.amount_kopeks,
+        )
+
         try:
             from app.services.referral_service import process_referral_topup
 
@@ -519,6 +522,7 @@ class WataPaymentMixin:
                         "🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
                         "подписка будет приобретена автоматически после пополнения баланса.\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -526,69 +530,5 @@ class WataPaymentMixin:
             except Exception as error:
                 logger.error("Ошибка отправки уведомления пользователю WATA: %s", error)
 
-        try:
-            from app.services.user_cart_service import user_cart_service
-            from aiogram import types
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                from app.localization.texts import get_texts
-
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    user.telegram_id,
-                    cart_message,
-                    reply_markup=keyboard,
-                )
-        except Exception as error:
-            logger.debug("Не удалось отправить напоминание о корзине после WATA: %s", error)
-
+        
         return payment

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -16,9 +16,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -627,6 +624,12 @@ class YooKassaPaymentMixin:
 
                     await db.refresh(user)
 
+                    cart_message = await self.build_cart_message_after_topup(
+                        db,
+                        user,
+                        payment.amount_kopeks,
+                    )
+
                     # Отправляем уведомления админам
                     if getattr(self, "bot", None):
                         try:
@@ -668,6 +671,7 @@ class YooKassaPaymentMixin:
                                 user=None,  # Передаем None, чтобы _ensure_user_snapshot загрузил данные сам
                                 db=db,
                                 payment_method_title="Банковская карта (YooKassa)",
+                                cart_message=cart_message,
                             )
                             logger.info("Уведомление пользователю о платеже отправлено успешно")
                         except Exception as error:
@@ -676,95 +680,6 @@ class YooKassaPaymentMixin:
                                 error,
                                 exc_info=True,  # Добавляем полный стек вызовов для отладки
                             )
-
-                    # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-                    # ВАЖНО: этот код должен выполняться даже при ошибках в уведомлениях
-                    logger.info(f"Проверяем наличие сохраненной корзины для пользователя {user.id}")
-                    from app.services.user_cart_service import user_cart_service
-                    try:
-                        has_saved_cart = await user_cart_service.has_user_cart(user.id)
-                        logger.info(
-                            "Результат проверки корзины для пользователя %s: %s",
-                            user.id,
-                            has_saved_cart,
-                        )
-
-                        auto_purchase_success = False
-                        if has_saved_cart:
-                            try:
-                                auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                                    db,
-                                    user,
-                                    bot=getattr(self, "bot", None),
-                                )
-                            except Exception as auto_error:
-                                logger.error(
-                                    "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                                    user.id,
-                                    auto_error,
-                                    exc_info=True,
-                                )
-
-                            if auto_purchase_success:
-                                has_saved_cart = False
-
-                        if has_saved_cart and getattr(self, "bot", None):
-                            # Если у пользователя есть сохраненная корзина,
-                            # отправляем ему уведомление с кнопкой вернуться к оформлению
-                            from app.localization.texts import get_texts
-                            from aiogram import types
-
-                            texts = get_texts(user.language)
-                            cart_message = texts.BALANCE_TOPUP_CART_REMINDER_DETAILED.format(
-                                total_amount=settings.format_price(payment.amount_kopeks)
-                            )
-
-                            # Создаем клавиатуру с кнопками
-                            keyboard = types.InlineKeyboardMarkup(
-                                inline_keyboard=[
-                                    [
-                                        types.InlineKeyboardButton(
-                                            text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                            callback_data="return_to_saved_cart",
-                                        )
-                                    ],
-                                    [
-                                        types.InlineKeyboardButton(
-                                            text="💰 Мой баланс",
-                                            callback_data="menu_balance",
-                                        )
-                                    ],
-                                    [
-                                        types.InlineKeyboardButton(
-                                            text="🏠 Главное меню",
-                                            callback_data="back_to_menu",
-                                        )
-                                    ],
-                                ]
-                            )
-
-                            await self.bot.send_message(
-                                chat_id=user.telegram_id,
-                                text=f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                                     f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                                     f"Обязательно активируйте подписку отдельно!\n\n"
-                                     f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                                     f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}",
-                                reply_markup=keyboard,
-                            )
-                            logger.info(
-                                f"Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю {user.id}"
-                            )
-                        else:
-                            logger.info(
-                                "У пользователя %s нет сохраненной корзины, бот недоступен или покупка уже выполнена",
-                                user.id,
-                            )
-                    except Exception as e:
-                        logger.error(
-                            f"Критическая ошибка при работе с сохраненной корзиной для пользователя {user.id}: {e}",
-                            exc_info=True,
-                        )
 
                 if is_simple_subscription:
                     logger.info(f"Обнаружен платеж простой покупки подписки для пользователя {user.id}")


### PR DESCRIPTION
## Summary
- remove the extra Stars payment success reply from the webhook handler so only the consolidated PaymentService notification is sent