### PR TITLE
Track and clean balance top-up prompts for cleanup

### DIFF
--- a/app/handlers/balance/cryptobot.py
+++ b/app/handlers/balance/cryptobot.py
@@ -72,10 +72,17 @@ async def start_cryptobot_payment(
             # Вставляем кнопки быстрого выбора перед кнопкой "Назад"
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
     
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML"
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
     
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -159,7 +166,7 @@ async def process_cryptobot_payment_amount(
             [types.InlineKeyboardButton(text=texts.BACK, callback_data="balance_topup")]
         ])
         
-        await message.answer(
+        sent_message = await message.answer(
             f"🪙 <b>Оплата криптовалютой</b>\n\n"
             f"💰 Сумма к зачислению: {amount_rubles:.0f} ₽\n"
             f"💵 К оплате: {amount_usd:.2f} USD\n"
@@ -176,6 +183,12 @@ async def process_cryptobot_payment_amount(
             f"❓ Если возникнут проблемы, обратитесь в {settings.get_support_contact_display_html()}",
             reply_markup=keyboard,
             parse_mode="HTML"
+        )
+
+        await payment_service.remember_topup_invoice_message(
+            db_user.id,
+            message.chat.id,
+            sent_message.message_id,
         )
         
         await state.clear()

--- a/app/handlers/balance/mulenpay.py
+++ b/app/handlers/balance/mulenpay.py
@@ -52,10 +52,17 @@ async def start_mulenpay_payment(
         if quick_amount_buttons:
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
 
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML",
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
 
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -163,10 +170,16 @@ async def process_mulenpay_payment_amount(
             mulenpay_name_html=mulenpay_name_html,
         )
 
-        await message.answer(
+        sent_message = await message.answer(
             message_text,
             reply_markup=keyboard,
             parse_mode="HTML",
+        )
+
+        await payment_service.remember_topup_invoice_message(
+            db_user.id,
+            message.chat.id,
+            sent_message.message_id,
         )
 
         await state.clear()

--- a/app/handlers/balance/pal24.py
+++ b/app/handlers/balance/pal24.py
@@ -204,10 +204,16 @@ async def _send_pal24_payment_message(
             support=settings.get_support_contact_display_html(),
         )
 
-        await message.answer(
+        sent_message = await message.answer(
             message_text,
             reply_markup=keyboard,
             parse_mode="HTML",
+        )
+
+        await payment_service.remember_topup_invoice_message(
+            db_user.id,
+            message.chat.id,
+            sent_message.message_id,
         )
 
         await state.clear()
@@ -270,10 +276,17 @@ async def start_pal24_payment(
         if quick_amount_buttons:
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
 
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML",
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
 
     await state.set_state(BalanceStates.waiting_for_amount)

--- a/app/handlers/balance/stars.py
+++ b/app/handlers/balance/stars.py
@@ -47,9 +47,16 @@ async def start_stars_payment(
             # Вставляем кнопки быстрого выбора перед кнопкой "Назад"
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
     
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
     
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -76,10 +83,11 @@ async def process_stars_payment_amount(
         stars_rate = settings.get_stars_rate() 
         
         payment_service = PaymentService(message.bot)
+        invoice_payload = f"balance_{db_user.id}_{amount_kopeks}"
         invoice_link = await payment_service.create_stars_invoice(
             amount_kopeks=amount_kopeks,
             description=f"Пополнение баланса на {texts.format_price(amount_kopeks)}",
-            payload=f"balance_{db_user.id}_{amount_kopeks}"
+            payload=invoice_payload
         )
         
         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
@@ -87,7 +95,7 @@ async def process_stars_payment_amount(
             [types.InlineKeyboardButton(text=texts.BACK, callback_data="balance_topup")]
         ])
         
-        await message.answer(
+        sent_message = await message.answer(
             f"⭐ <b>Оплата через Telegram Stars</b>\n\n"
             f"💰 Сумма: {texts.format_price(amount_kopeks)}\n"
             f"⭐ К оплате: {stars_amount} звезд\n"
@@ -96,6 +104,19 @@ async def process_stars_payment_amount(
             reply_markup=keyboard,
             parse_mode="HTML"
         )
+
+        try:
+            await payment_service.remember_stars_invoice_message(
+                payload=invoice_payload,
+                chat_id=message.chat.id,
+                message_id=sent_message.message_id,
+            )
+        except Exception as store_error:
+            logger.warning(
+                "Не удалось сохранить сообщение инвойса Stars %s: %s",
+                invoice_payload,
+                store_error,
+            )
         
         await state.clear()
         

--- a/app/handlers/balance/wata.py
+++ b/app/handlers/balance/wata.py
@@ -49,10 +49,17 @@ async def start_wata_payment(
         if quick_amount_buttons:
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
 
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML",
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
 
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -159,10 +166,16 @@ async def process_wata_payment_amount(
         support=settings.get_support_contact_display_html(),
     )
 
-    await message.answer(
+    sent_message = await message.answer(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML",
+    )
+
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        message.chat.id,
+        sent_message.message_id,
     )
 
     await state.clear()

--- a/app/handlers/balance/yookassa.py
+++ b/app/handlers/balance/yookassa.py
@@ -53,10 +53,17 @@ async def start_yookassa_payment(
             # Вставляем кнопки быстрого выбора перед кнопкой "Назад"
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
     
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML"
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
     
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -103,10 +110,17 @@ async def start_yookassa_sbp_payment(
             # Вставляем кнопки быстрого выбора перед кнопкой "Назад"
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
     
-    await callback.message.edit_text(
+    edited_message = await callback.message.edit_text(
         message_text,
         reply_markup=keyboard,
         parse_mode="HTML"
+    )
+
+    payment_service = PaymentService(callback.bot)
+    await payment_service.remember_topup_invoice_message(
+        db_user.id,
+        callback.message.chat.id,
+        edited_message.message_id,
     )
     
     await state.set_state(BalanceStates.waiting_for_amount)
@@ -172,7 +186,7 @@ async def process_yookassa_payment_amount(
             [types.InlineKeyboardButton(text=texts.BACK, callback_data="balance_topup")]
         ])
         
-        await message.answer(
+        sent_message = await message.answer(
             f"💳 <b>Оплата банковской картой</b>\n\n"
             f"💰 Сумма: {settings.format_price(amount_kopeks)}\n"
             f"🆔 ID платежа: {payment_result['yookassa_payment_id'][:8]}...\n\n"
@@ -186,6 +200,12 @@ async def process_yookassa_payment_amount(
             f"❓ Если возникнут проблемы, обратитесь в {settings.get_support_contact_display_html()}",
             reply_markup=keyboard,
             parse_mode="HTML"
+        )
+
+        await payment_service.remember_topup_invoice_message(
+            db_user.id,
+            message.chat.id,
+            sent_message.message_id,
         )
         
         await state.clear()
@@ -352,7 +372,7 @@ async def process_yookassa_sbp_payment_amount(
         # Если есть QR-код, отправляем его как медиа-сообщение
         if qr_photo:
             # Используем метод отправки медиа-группы или фото с описанием
-            await message.answer_photo(
+            sent_message = await message.answer_photo(
                 photo=qr_photo,
                 caption=message_text,
                 reply_markup=keyboard,
@@ -360,11 +380,17 @@ async def process_yookassa_sbp_payment_amount(
             )
         else:
             # Если QR-код недоступен, отправляем обычное текстовое сообщение
-            await message.answer(
+            sent_message = await message.answer(
                 message_text,
                 reply_markup=keyboard,
                 parse_mode="HTML"
             )
+
+        await payment_service.remember_topup_invoice_message(
+            db_user.id,
+            message.chat.id,
+            sent_message.message_id,
+        )
         
         logger.info(f"Создан платеж YooKassa СБП для пользователя {db_user.telegram_id}: "
                    f"{amount_kopeks//100}₽, ID: {payment_result['yookassa_payment_id']}")

--- a/app/handlers/stars_payments.py
+++ b/app/handlers/stars_payments.py
@@ -113,42 +113,16 @@ async def handle_successful_payment(
             payload=payment.invoice_payload,
             telegram_payment_charge_id=payment.telegram_payment_charge_id
         )
-        
+
         if success:
-            rubles_amount = TelegramStarsService.calculate_rubles_from_stars(payment.total_amount)
-            amount_kopeks = int((rubles_amount * Decimal(100)).to_integral_value(rounding=ROUND_HALF_UP))
-            amount_text = settings.format_price(amount_kopeks).replace(" ₽", "")
-
-            keyboard = await payment_service.build_topup_success_keyboard(user)
-
-            transaction_id_short = payment.telegram_payment_charge_id[:8]
-
-            await message.answer(
-                texts.t(
-                    "STARS_PAYMENT_SUCCESS",
-                    "🎉 <b>Платеж успешно обработан!</b>\n\n"
-                    "⭐ Потрачено звезд: {stars_spent}\n"
-                    "💰 Зачислено на баланс: {amount} ₽\n"
-                    "🆔 ID транзакции: {transaction_id}...\n\n"
-                    "⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                    "Обязательно активируйте подписку отдельно!\n\n"
-                    "🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                    "подписка будет приобретена автоматически после пополнения баланса.\n\n"
-                    "Спасибо за пополнение! 🚀",
-                ).format(
-                    stars_spent=payment.total_amount,
-                    amount=amount_text,
-                    transaction_id=transaction_id_short,
-                ),
-                parse_mode="HTML",
-                reply_markup=keyboard,
+            await payment_service.delete_stars_invoice_message(
+                payment.invoice_payload,
+                chat_id=message.chat.id,
             )
-
             logger.info(
-                "✅ Stars платеж успешно обработан: пользователь %s, %s звезд → %s",
+                "✅ Stars платеж успешно обработан: пользователь %s, %s звезд",
                 user.id,
                 payment.total_amount,
-                settings.format_price(amount_kopeks),
             )
         else:
             logger.error(f"Ошибка обработки Stars платежа для пользователя {user.id}")

--- a/app/services/payment/heleket.py
+++ b/app/services/payment/heleket.py
@@ -331,6 +331,17 @@ class HeleketPaymentMixin:
             await db.commit()
             await db.refresh(user)
 
+        await self.delete_topup_invoice_message(
+            user.id,
+            chat_id=user.telegram_id,
+        )
+
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
             referrer_info = format_referrer_info(user)
@@ -378,7 +389,7 @@ class HeleketPaymentMixin:
 
                 await self.bot.send_message(
                     chat_id=user.telegram_id,
-                    text="\n".join(message_lines),
+                    text="\n".join(message_lines) + cart_message,
                     parse_mode="HTML",
                     reply_markup=keyboard,
                 )

--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -11,9 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -288,6 +285,17 @@ class MulenPayPaymentMixin:
                     "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
                 )
 
+                await self.delete_topup_invoice_message(
+                    user.id,
+                    chat_id=user.telegram_id,
+                )
+
+                cart_message = await self.build_cart_message_after_topup(
+                    db,
+                    user,
+                    payment.amount_kopeks,
+                )
+
                 if getattr(self, "bot", None):
                     try:
                         from app.services.admin_notification_service import (
@@ -323,6 +331,7 @@ class MulenPayPaymentMixin:
                                 f"🦊 Способ: {display_name_html}\n"
                                 f"🆔 Транзакция: {transaction.id}\n\n"
                                 "Баланс пополнен автоматически!"
+                                f"{cart_message}"
                             ),
                             parse_mode="HTML",
                             reply_markup=keyboard,
@@ -334,75 +343,7 @@ class MulenPayPaymentMixin:
                             error,
                         )
 
-                # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-                try:
-                    from app.services.user_cart_service import user_cart_service
-                    from aiogram import types
-
-                    has_saved_cart = await user_cart_service.has_user_cart(user.id)
-                    auto_purchase_success = False
-                    if has_saved_cart:
-                        try:
-                            auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                                db,
-                                user,
-                                bot=getattr(self, "bot", None),
-                            )
-                        except Exception as auto_error:
-                            logger.error(
-                                "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                                user.id,
-                                auto_error,
-                                exc_info=True,
-                            )
-
-                        if auto_purchase_success:
-                            has_saved_cart = False
-
-                    if has_saved_cart and getattr(self, "bot", None):
-                        # Если у пользователя есть сохраненная корзина,
-                        # отправляем ему уведомление с кнопкой вернуться к оформлению
-                        from app.localization.texts import get_texts
-                        
-                        texts = get_texts(user.language)
-                        cart_message = texts.t(
-                            "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                            "🛒 У вас есть неоформленный заказ.\n\n"
-                            "Вы можете продолжить оформление с теми же параметрами."
-                        )
-                        
-                        # Создаем клавиатуру с кнопками
-                        keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-                            [types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance"
-                            )],
-                            [types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu"
-                            )]
-                        ])
-                        
-                        await self.bot.send_message(
-                            chat_id=user.telegram_id,
-                            text=f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                                 f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                                 f"Обязательно активируйте подписку отдельно!\n\n"
-                                 f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                                 f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}",
-                            reply_markup=keyboard
-                        )
-                        logger.info(
-                            "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                            user.id,
-                        )
-                except Exception as e:
-                    logger.error(f"Ошибка при работе с сохраненной корзиной для пользователя {user.id}: {e}", exc_info=True)
-
+                
                 logger.info(
                     "✅ Обработан %s платеж %s для пользователя %s",
                     display_name,

--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -13,9 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
 from app.services.platega_service import PlategaService
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -399,6 +396,17 @@ class PlategaPaymentMixin:
             await db.commit()
             await db.refresh(user)
 
+        await self.delete_topup_invoice_message(
+            user.id,
+            chat_id=user.telegram_id,
+        )
+
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            payment.amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             try:
                 from app.services.admin_notification_service import AdminNotificationService
@@ -430,6 +438,7 @@ class PlategaPaymentMixin:
                         f"🦊 Способ: {method_title}\n"
                         f"🆔 Транзакция: {transaction.id}\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -437,83 +446,7 @@ class PlategaPaymentMixin:
             except Exception as error:
                 logger.error("Ошибка отправки уведомления пользователю Platega: %s", error)
 
-        try:
-            from app.services.user_cart_service import user_cart_service
-            from aiogram import types
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                from app.localization.texts import get_texts
-
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    chat_id=user.telegram_id,
-                    text=(
-                        f"✅ Баланс пополнен на {settings.format_price(payment.amount_kopeks)}!\n\n"
-                        f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                        f"Обязательно активируйте подписку отдельно!\n\n"
-                        f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                        f"подписка будет приобретена автоматически после пополнения баланса.\n\n"
-                        f"{cart_message}"
-                    ),
-                    reply_markup=keyboard,
-                )
-        except Exception as error:
-            logger.error(
-                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                payment.user_id,
-                error,
-                exc_info=True,
-            )
-
+        
         metadata["balance_change"] = {
             "old_balance": old_balance,
             "new_balance": user.balance_kopeks,

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -6,11 +6,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_UP
-from typing import Optional
+from typing import Any, Optional
 
 from aiogram.types import LabeledPrice
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,9 +21,6 @@ from app.database.crud.transaction import create_transaction
 from app.database.crud.user import get_user_by_id
 from app.database.models import PaymentMethod, TransactionType
 from app.external.telegram_stars import TelegramStarsService
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.utils.user_utils import format_referrer_info
 
 logger = logging.getLogger(__name__)
@@ -38,6 +36,57 @@ class _SimpleSubscriptionPayload:
 
 class TelegramStarsMixin:
     """Mixin с операциями создания и обработки платежей через Telegram Stars."""
+
+    _stars_invoice_messages: dict[str, tuple[int, int]] = {}
+    _stars_invoice_lock: asyncio.Lock = asyncio.Lock()
+
+    async def remember_stars_invoice_message(
+        self,
+        payload: str,
+        chat_id: int,
+        message_id: int,
+    ) -> None:
+        """Сохраняет ID сообщения с инвойсом, чтобы удалить его после оплаты."""
+
+        if not payload:
+            return
+
+        async with self._stars_invoice_lock:
+            self._stars_invoice_messages[payload] = (chat_id, message_id)
+
+    async def delete_stars_invoice_message(
+        self,
+        payload: str,
+        *,
+        chat_id: int | None = None,
+        bot: Any | None = None,
+    ) -> None:
+        """Удаляет сообщение с инвойсом Stars, если оно было сохранено."""
+
+        bot_instance = bot or getattr(self, "bot", None)
+
+        if not bot_instance or not payload:
+            return
+
+        async with self._stars_invoice_lock:
+            message_info = self._stars_invoice_messages.pop(payload, None)
+
+        if not message_info:
+            return
+
+        invoice_chat_id, invoice_message_id = message_info
+
+        # Если по каким-то причинам чат не сохранился, пытаемся использовать переданный chat_id
+        target_chat_id = invoice_chat_id or chat_id
+        if not target_chat_id:
+            return
+
+        try:
+            await bot_instance.delete_message(target_chat_id, invoice_message_id)
+        except Exception as error:  # pragma: no cover - диагностический лог
+            logger.warning(
+                "Не удалось удалить сообщение с инвойсом Stars %s: %s", payload, error
+            )
 
     async def create_stars_invoice(
         self,
@@ -493,6 +542,12 @@ class TelegramStarsMixin:
             amount_kopeks,
         )
 
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            amount_kopeks,
+        )
+
         if getattr(self, "bot", None):
             try:
                 from app.services.admin_notification_service import AdminNotificationService
@@ -530,6 +585,7 @@ class TelegramStarsMixin:
                         "🦊 Способ: Telegram Stars\n"
                         f"🆔 Транзакция: {charge_id_short}...\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -544,84 +600,6 @@ class TelegramStarsMixin:
                     "Ошибка отправки уведомления о пополнении Stars: %s",
                     error,
                 )
-
-        # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
-        try:
-            from aiogram import types
-            from app.localization.texts import get_texts
-            from app.services.user_cart_service import user_cart_service
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:  # pragma: no cover - диагностический лог
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    chat_id=user.telegram_id,
-                    text=f"✅ Баланс пополнен на {settings.format_price(amount_kopeks)}!\n\n"
-                         f"⚠️ <b>Важно:</b> Пополнение баланса не активирует подписку автоматически. "
-                         f"Обязательно активируйте подписку отдельно!\n\n"
-                         f"🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
-                         f"подписка будет приобретена автоматически после пополнения баланса.\n\n{cart_message}",
-                    reply_markup=keyboard,
-                )
-                logger.info(
-                    "Отправлено уведомление с кнопкой возврата к оформлению подписки пользователю %s",
-                    user.id,
-                )
-        except Exception as error:  # pragma: no cover - диагностический лог
-            logger.error(
-                "Ошибка при работе с сохраненной корзиной для пользователя %s: %s",
-                user.id,
-                error,
-                exc_info=True,
-            )
 
         logger.info(
             "✅ Обработан Stars платеж: пользователь %s, %s звезд → %s",

--- a/app/services/payment/wata.py
+++ b/app/services/payment/wata.py
@@ -12,9 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import PaymentMethod, TransactionType
-from app.services.subscription_auto_purchase_service import (
-    auto_purchase_saved_cart_after_topup,
-)
 from app.services.wata_service import WataAPIError, WataService
 from app.utils.user_utils import format_referrer_info
 
@@ -469,6 +466,17 @@ class WataPaymentMixin:
         referrer_info = format_referrer_info(user)
         topup_status = "🆕 Первое пополнение" if was_first_topup else "🔄 Пополнение"
 
+        await self.delete_topup_invoice_message(
+            user.id,
+            chat_id=user.telegram_id,
+        )
+
+        cart_message = await self.build_cart_message_after_topup(
+            db,
+            user,
+            payment.amount_kopeks,
+        )
+
         try:
             from app.services.referral_service import process_referral_topup
 
@@ -519,6 +527,7 @@ class WataPaymentMixin:
                         "🔄 При наличии сохранённой корзины подписки и включенной автопокупке, "
                         "подписка будет приобретена автоматически после пополнения баланса.\n\n"
                         "Баланс пополнен автоматически!"
+                        f"{cart_message}"
                     ),
                     parse_mode="HTML",
                     reply_markup=keyboard,
@@ -526,69 +535,5 @@ class WataPaymentMixin:
             except Exception as error:
                 logger.error("Ошибка отправки уведомления пользователю WATA: %s", error)
 
-        try:
-            from app.services.user_cart_service import user_cart_service
-            from aiogram import types
-
-            has_saved_cart = await user_cart_service.has_user_cart(user.id)
-            auto_purchase_success = False
-            if has_saved_cart:
-                try:
-                    auto_purchase_success = await auto_purchase_saved_cart_after_topup(
-                        db,
-                        user,
-                        bot=getattr(self, "bot", None),
-                    )
-                except Exception as auto_error:
-                    logger.error(
-                        "Ошибка автоматической покупки подписки для пользователя %s: %s",
-                        user.id,
-                        auto_error,
-                        exc_info=True,
-                    )
-
-                if auto_purchase_success:
-                    has_saved_cart = False
-
-            if has_saved_cart and getattr(self, "bot", None):
-                from app.localization.texts import get_texts
-
-                texts = get_texts(user.language)
-                cart_message = texts.t(
-                    "BALANCE_TOPUP_CART_REMINDER_DETAILED",
-                    "🛒 У вас есть неоформленный заказ.\n\n"
-                    "Вы можете продолжить оформление с теми же параметрами.",
-                )
-
-                keyboard = types.InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            types.InlineKeyboardButton(
-                                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                                callback_data="return_to_saved_cart",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="💰 Мой баланс",
-                                callback_data="menu_balance",
-                            )
-                        ],
-                        [
-                            types.InlineKeyboardButton(
-                                text="🏠 Главное меню",
-                                callback_data="back_to_menu",
-                            )
-                        ],
-                    ]
-                )
-
-                await self.bot.send_message(
-                    user.telegram_id,
-                    cart_message,
-                    reply_markup=keyboard,
-                )
-        except Exception as error:
-            logger.debug("Не удалось отправить напоминание о корзине после WATA: %s", error)
-
+        
         return payment


### PR DESCRIPTION
## Summary
- remember amount-prompt messages for all balance top-up handlers so they can be removed after successful payment
- reuse PaymentService cleanup to clear Platega, YooKassa, WATA, CryptoBot, Heleket, PayPalych, MulenPay, and Stars prompts once payment completes