### PR TITLE
Fix autopay renewal pricing for promo groups

### DIFF
--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -912,12 +912,17 @@ class MonitoringService:
             
             result = await db.execute(
                 select(Subscription)
-                .options(selectinload(Subscription.user))
+                .options(
+                    selectinload(Subscription.user).options(
+                        selectinload(User.promo_group),
+                        selectinload(User.user_promo_groups).selectinload(UserPromoGroup.promo_group),
+                    )
+                )
                 .where(
                     and_(
                         Subscription.status == SubscriptionStatus.ACTIVE.value,
                         Subscription.autopay_enabled == True,
-                        Subscription.is_trial == False 
+                        Subscription.is_trial == False
                     )
                 )
             )


### PR DESCRIPTION
## Summary
- preload promo group relations when fetching subscriptions for autopay to avoid async lazy-load errors during renewal pricing
