### PR TITLE
Clean up Platega and YooKassa invoices after payment

### DIFF
--- a/app/handlers/balance/platega.py
+++ b/app/handlers/balance/platega.py
@@ -98,6 +98,10 @@ async def _prompt_amount(
     )
 
     await state.set_state(BalanceStates.waiting_for_amount)
+    await state.update_data(
+        platega_prompt_message_id=message.message_id,
+        platega_prompt_chat_id=message.chat.id,
+    )
 
 
 @error_handler
@@ -300,7 +304,25 @@ async def process_platega_payment_amount(
         ),
     )
 
-    await message.answer(
+    state_data = await state.get_data()
+    prompt_message_id = state_data.get("platega_prompt_message_id")
+    prompt_chat_id = state_data.get("platega_prompt_chat_id", message.chat.id)
+
+    try:
+        await message.delete()
+    except Exception as delete_error:  # pragma: no cover - зависит от прав бота
+        logger.warning("Не удалось удалить сообщение с суммой Platega: %s", delete_error)
+
+    if prompt_message_id:
+        try:
+            await message.bot.delete_message(prompt_chat_id, prompt_message_id)
+        except Exception as delete_error:  # pragma: no cover - диагностический лог
+            logger.warning(
+                "Не удалось удалить сообщение с запросом суммы Platega: %s",
+                delete_error,
+            )
+
+    invoice_message = await message.answer(
         instructions_template.format(
             method=method_title,
             amount=settings.format_price(amount_kopeks),
@@ -309,6 +331,29 @@ async def process_platega_payment_amount(
         ),
         reply_markup=keyboard,
         parse_mode="HTML",
+    )
+
+    try:
+        from app.services import payment_service as payment_module
+
+        payment = await payment_module.get_platega_payment_by_id(db, local_payment_id)
+        if payment:
+            payment_metadata = dict(getattr(payment, "metadata_json", {}) or {})
+            payment_metadata["invoice_message"] = {
+                "chat_id": invoice_message.chat.id,
+                "message_id": invoice_message.message_id,
+            }
+            await payment_module.update_platega_payment(
+                db,
+                payment=payment,
+                metadata=payment_metadata,
+            )
+    except Exception as error:  # pragma: no cover - диагностический лог
+        logger.warning("Не удалось сохранить данные сообщения Platega: %s", error)
+
+    await state.update_data(
+        platega_invoice_message_id=invoice_message.message_id,
+        platega_invoice_chat_id=invoice_message.chat.id,
     )
 
     await state.clear()

--- a/app/handlers/balance/stars.py
+++ b/app/handlers/balance/stars.py
@@ -1,11 +1,10 @@
 import logging
 from aiogram import types
 from aiogram.fsm.context import FSMContext
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import User
-from app.keyboards.inline import get_back_keyboard, get_payment_methods_keyboard
+from app.keyboards.inline import get_back_keyboard
 from app.localization.texts import get_texts
 from app.services.payment_service import PaymentService
 from app.states import BalanceStates
@@ -22,11 +21,11 @@ async def start_stars_payment(
     state: FSMContext
 ):
     texts = get_texts(db_user.language)
-    
+
     if not settings.TELEGRAM_STARS_ENABLED:
         await callback.answer("❌ Пополнение через Stars временно недоступно", show_alert=True)
         return
-    
+
     # Формируем текст сообщения в зависимости от настройки
     if settings.YOOKASSA_QUICK_AMOUNT_SELECTION_ENABLED and not settings.DISABLE_TOPUP_BUTTONS:
         message_text = (
@@ -35,10 +34,10 @@ async def start_stars_payment(
         )
     else:
         message_text = texts.TOP_UP_AMOUNT
-    
+
     # Создаем клавиатуру
     keyboard = get_back_keyboard(db_user.language)
-    
+
     # Если включен быстрый выбор суммы и не отключены кнопки, добавляем кнопки
     if settings.YOOKASSA_QUICK_AMOUNT_SELECTION_ENABLED and not settings.DISABLE_TOPUP_BUTTONS:
         from .main import get_quick_amount_buttons
@@ -46,12 +45,17 @@ async def start_stars_payment(
         if quick_amount_buttons:
             # Вставляем кнопки быстрого выбора перед кнопкой "Назад"
             keyboard.inline_keyboard = quick_amount_buttons + keyboard.inline_keyboard
-    
+
     await callback.message.edit_text(
         message_text,
         reply_markup=keyboard
     )
-    
+
+    await state.update_data(
+        stars_prompt_message_id=callback.message.message_id,
+        stars_prompt_chat_id=callback.message.chat.id,
+    )
+
     await state.set_state(BalanceStates.waiting_for_amount)
     await state.update_data(payment_method="stars")
     await callback.answer()
@@ -65,29 +69,48 @@ async def process_stars_payment_amount(
     state: FSMContext
 ):
     texts = get_texts(db_user.language)
-    
+
     if not settings.TELEGRAM_STARS_ENABLED:
         await message.answer("⚠️ Оплата Stars временно недоступна")
         return
-    
+
     try:
         amount_rubles = amount_kopeks / 100
         stars_amount = TelegramStarsService.calculate_stars_from_rubles(amount_rubles)
-        stars_rate = settings.get_stars_rate() 
-        
+        stars_rate = settings.get_stars_rate()
+
         payment_service = PaymentService(message.bot)
         invoice_link = await payment_service.create_stars_invoice(
             amount_kopeks=amount_kopeks,
             description=f"Пополнение баланса на {texts.format_price(amount_kopeks)}",
             payload=f"balance_{db_user.id}_{amount_kopeks}"
         )
-        
+
         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
             [types.InlineKeyboardButton(text="⭐ Оплатить", url=invoice_link)],
             [types.InlineKeyboardButton(text=texts.BACK, callback_data="balance_topup")]
         ])
-        
-        await message.answer(
+
+        state_data = await state.get_data()
+
+        prompt_message_id = state_data.get("stars_prompt_message_id")
+        prompt_chat_id = state_data.get("stars_prompt_chat_id", message.chat.id)
+
+        try:
+            await message.delete()
+        except Exception as delete_error:  # pragma: no cover - зависит от прав бота
+            logger.warning("Не удалось удалить сообщение с суммой Stars: %s", delete_error)
+
+        if prompt_message_id:
+            try:
+                await message.bot.delete_message(prompt_chat_id, prompt_message_id)
+            except Exception as delete_error:  # pragma: no cover - диагностический лог
+                logger.warning(
+                    "Не удалось удалить сообщение с запросом суммы Stars: %s",
+                    delete_error,
+                )
+
+        invoice_message = await message.answer(
             f"⭐ <b>Оплата через Telegram Stars</b>\n\n"
             f"💰 Сумма: {texts.format_price(amount_kopeks)}\n"
             f"⭐ К оплате: {stars_amount} звезд\n"
@@ -96,9 +119,14 @@ async def process_stars_payment_amount(
             reply_markup=keyboard,
             parse_mode="HTML"
         )
-        
-        await state.clear()
-        
+
+        await state.update_data(
+            stars_invoice_message_id=invoice_message.message_id,
+            stars_invoice_chat_id=invoice_message.chat.id,
+        )
+
+        await state.set_state(None)
+
     except Exception as e:
         logger.error(f"Ошибка создания Stars invoice: {e}")
         await message.answer("⚠️ Ошибка создания платежа")

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -515,36 +515,6 @@ class TelegramStarsMixin:
                     exc_info=True,
                 )
 
-        if getattr(self, "bot", None):
-            try:
-                keyboard = await self.build_topup_success_keyboard(user)
-
-                charge_id_short = (telegram_payment_charge_id or getattr(transaction, "external_id", ""))[:8]
-
-                await self.bot.send_message(
-                    user.telegram_id,
-                    (
-                        "✅ <b>Пополнение успешно!</b>\n\n"
-                        f"⭐ Звезд: {stars_amount}\n"
-                        f"💰 Сумма: {settings.format_price(amount_kopeks)}\n"
-                        "🦊 Способ: Telegram Stars\n"
-                        f"🆔 Транзакция: {charge_id_short}...\n\n"
-                        "Баланс пополнен автоматически!"
-                    ),
-                    parse_mode="HTML",
-                    reply_markup=keyboard,
-                )
-                logger.info(
-                    "✅ Отправлено уведомление пользователю %s о пополнении на %s",
-                    user.telegram_id,
-                    settings.format_price(amount_kopeks),
-                )
-            except Exception as error:  # pragma: no cover - диагностический лог
-                logger.error(
-                    "Ошибка отправки уведомления о пополнении Stars: %s",
-                    error,
-                )
-
         # Проверяем наличие сохраненной корзины для возврата к оформлению подписки
         try:
             from aiogram import types

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -437,6 +437,22 @@ class YooKassaPaymentMixin:
             except Exception as parse_error:
                 logger.error(f"Ошибка парсинга метаданных платежа: {parse_error}")
 
+            invoice_message = payment_metadata.get("invoice_message") or {}
+            if getattr(self, "bot", None):
+                chat_id = invoice_message.get("chat_id")
+                message_id = invoice_message.get("message_id")
+                if chat_id and message_id:
+                    try:
+                        await self.bot.delete_message(chat_id, message_id)
+                    except Exception as delete_error:  # pragma: no cover - depends on bot rights
+                        logger.warning(
+                            "Не удалось удалить сообщение YooKassa %s: %s",
+                            message_id,
+                            delete_error,
+                        )
+                    else:
+                        payment_metadata.pop("invoice_message", None)
+
             processing_completed = bool(payment_metadata.get("processing_completed"))
 
             transaction = None


### PR DESCRIPTION
## Summary
- store Platega and YooKassa invoice message references in payment metadata so they can be removed after successful processing
- delete stored Platega and YooKassa invoice messages when payments finish to prevent chat clutter
