### PR TITLE
Add media upload endpoint and include media URLs

### DIFF
--- a/app/webapi/app.py
+++ b/app/webapi/app.py
@@ -28,6 +28,7 @@ from .routes import (
     transactions,
     users,
     logs,
+    media,
 )
 
 
@@ -161,5 +162,6 @@ def create_web_api_app() -> FastAPI:
     app.include_router(miniapp.router, prefix="/miniapp", tags=["miniapp"])
     app.include_router(polls.router, prefix="/polls", tags=["polls"])
     app.include_router(logs.router, prefix="/logs", tags=["logs"])
+    app.include_router(media.router, tags=["media"])
 
     return app

--- a/app/webapi/routes/__init__.py
+++ b/app/webapi/routes/__init__.py
@@ -16,6 +16,7 @@ from . import (
     transactions,
     users,
     logs,
+    media,
 )
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "transactions",
     "users",
     "logs",
+    "media",
 ]

--- a/app/webapi/routes/media.py
+++ b/app/webapi/routes/media.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from aiogram import Bot
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+from aiogram.types import Message
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+
+from app.config import settings
+
+from ..dependencies import require_api_token
+from ..schemas.media import MediaUploadResponse
+from ..utils.media import build_media_url
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _detect_media_type(upload: UploadFile, explicit_type: Optional[str]) -> str:
+    if explicit_type:
+        return explicit_type.lower()
+
+    content_type = (upload.content_type or "").lower()
+    if content_type.startswith("image"):
+        return "photo"
+    if content_type.startswith("video"):
+        return "video"
+    if content_type.startswith("audio"):
+        return "voice"
+    return "document"
+
+
+async def _send_media(bot: Bot, chat_id: int, upload: UploadFile, media_type: str, caption: Optional[str]) -> Message:
+    file = upload.file
+    file.seek(0)
+
+    if media_type == "photo":
+        return await bot.send_photo(chat_id, photo=file, caption=caption)
+    if media_type == "video":
+        return await bot.send_video(chat_id, video=file, caption=caption)
+    if media_type == "voice":
+        return await bot.send_voice(chat_id, voice=file, caption=caption)
+    return await bot.send_document(chat_id, document=file, caption=caption, disable_content_type_detection=True)
+
+
+def _extract_file_id(message: Message, media_type: str) -> Optional[str]:
+    if media_type == "photo" and message.photo:
+        return message.photo[-1].file_id
+    if media_type == "video" and message.video:
+        return message.video.file_id
+    if media_type == "voice" and message.voice:
+        return message.voice.file_id
+    if message.document:
+        return message.document.file_id
+    return None
+
+
+@router.post("/upload", response_model=MediaUploadResponse, status_code=status.HTTP_201_CREATED)
+async def upload_media(
+    _: Any = Depends(require_api_token),
+    file: UploadFile = File(...),
+    media_type: Optional[str] = Form(default=None),
+    caption: Optional[str] = Form(default=None),
+) -> MediaUploadResponse:
+    chat_id = settings.get_admin_notifications_chat_id()
+    if chat_id is None:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Upload target chat is not configured")
+
+    detected_type = _detect_media_type(file, media_type)
+
+    bot = Bot(
+        token=settings.BOT_TOKEN,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+    try:
+        message = await _send_media(bot, chat_id, file, detected_type, caption)
+        file_id = _extract_file_id(message, detected_type)
+        if not file_id:
+            raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to obtain file_id from Telegram")
+
+        media_url = await build_media_url(bot, file_id)
+        file_size = None
+        if message.document and message.document.file_size:
+            file_size = message.document.file_size
+        elif message.photo:
+            file_size = message.photo[-1].file_size
+        elif message.video and message.video.file_size:
+            file_size = message.video.file_size
+        elif message.voice and message.voice.file_size:
+            file_size = message.voice.file_size
+
+        return MediaUploadResponse(
+            file_id=file_id,
+            media_type=detected_type,
+            media_url=media_url,
+            file_name=getattr(message.document, "file_name", file.filename),
+            file_size=file_size,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to upload media to Telegram: %s", exc)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to upload media") from exc
+    finally:
+        await bot.session.close()

--- a/app/webapi/schemas/media.py
+++ b/app/webapi/schemas/media.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class MediaUploadResponse(BaseModel):
+    file_id: str
+    media_type: str
+    media_url: Optional[str] = None
+    file_name: Optional[str] = None
+    file_size: Optional[int] = None

--- a/app/webapi/schemas/tickets.py
+++ b/app/webapi/schemas/tickets.py
@@ -67,3 +67,4 @@ class TicketMediaResponse(BaseModel):
     media_type: str
     media_file_id: str
     media_caption: Optional[str] = None
+    media_url: Optional[str] = None

--- a/app/webapi/utils/media.py
+++ b/app/webapi/utils/media.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from aiogram import Bot
+
+logger = logging.getLogger(__name__)
+
+
+async def build_media_url(bot: Bot, file_id: str) -> Optional[str]:
+    """Resolve Telegram file_id to direct download URL.
+
+    Returns None if file_path cannot be fetched.
+    """
+
+    try:
+        file = await bot.get_file(file_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch Telegram file info: %s", exc)
+        return None
+
+    if not file or not file.file_path:
+        return None
+
+    return f"https://api.telegram.org/file/bot{bot.token}/{file.file_path}"


### PR DESCRIPTION
## Summary
- add a media upload endpoint that stores files via Telegram and returns file metadata
- expose direct media URLs in ticket media responses using resolved Telegram file paths
- wire the new media router into the admin web API and extend schemas to include upload responses
