### PR TITLE
Add user details to subscription event API responses

### DIFF
--- a/app/database/crud/subscription_event.py
+++ b/app/database/crud/subscription_event.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 from sqlalchemy import and_, func, select
+from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.models import SubscriptionEvent
@@ -62,7 +63,8 @@ async def list_subscription_events(
     total = await db.scalar(total_query) or 0
 
     result = await db.execute(
-        base_query.order_by(SubscriptionEvent.occurred_at.desc())
+        base_query.options(selectinload(SubscriptionEvent.user))
+        .order_by(SubscriptionEvent.occurred_at.desc())
         .offset(offset)
         .limit(limit)
     )

--- a/app/webapi/schemas/subscription_events.py
+++ b/app/webapi/schemas/subscription_events.py
@@ -30,6 +30,9 @@ class SubscriptionEventResponse(BaseModel):
     id: int
     event_type: str
     user_id: int
+    user_full_name: str
+    user_username: Optional[str] = None
+    user_telegram_id: int
     subscription_id: Optional[int] = None
     transaction_id: Optional[int] = None
     amount_kopeks: Optional[int] = None


### PR DESCRIPTION
## Summary
- extend subscription event responses with user full name, username, and Telegram ID
- ensure created and listed events include loaded user data for serialization