### PR TITLE
Add balance details to promocode notifications

### DIFF
--- a/app/handlers/promocode.py
+++ b/app/handlers/promocode.py
@@ -59,6 +59,8 @@ async def activate_promocode_for_registration(
                         user,
                         result.get("promocode", {"code": code}),
                         result["description"],
+                        result.get("balance_before_kopeks"),
+                        result.get("balance_after_kopeks"),
                     )
             except Exception as notify_error:
                 logger.error(

--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -744,6 +744,8 @@ class AdminNotificationService:
         user: User,
         promocode_data: Dict[str, Any],
         effect_description: str,
+        balance_before_kopeks: int | None = None,
+        balance_after_kopeks: int | None = None,
     ) -> bool:
         try:
             await self._record_subscription_event(
@@ -766,6 +768,8 @@ class AdminNotificationService:
                         if isinstance(promocode_data.get("valid_until"), datetime)
                         else promocode_data.get("valid_until")
                     ),
+                    "balance_before_kopeks": balance_before_kopeks,
+                    "balance_after_kopeks": balance_after_kopeks,
                 },
             )
         except Exception:
@@ -820,6 +824,13 @@ class AdminNotificationService:
 
             message_lines.extend(
                 [
+                    "",
+                    "💼 <b>Баланс:</b>",
+                    (
+                        f"{settings.format_price(balance_before_kopeks)} → {settings.format_price(balance_after_kopeks)}"
+                        if balance_before_kopeks is not None and balance_after_kopeks is not None
+                        else "ℹ️ Баланс не изменился"
+                    ),
                     "",
                     "📝 <b>Эффект:</b>",
                     effect_description.strip() or "✅ Промокод активирован",

--- a/app/services/promocode_service.py
+++ b/app/services/promocode_service.py
@@ -52,7 +52,10 @@ class PromoCodeService:
             if existing_use:
                 return {"success": False, "error": "already_used_by_user"}
             
+            balance_before_kopeks = user.balance_kopeks
+
             result_description = await self._apply_promocode_effects(db, user, promocode)
+            balance_after_kopeks = user.balance_kopeks
 
             if promocode.type == PromoCodeType.SUBSCRIPTION_DAYS.value and promocode.subscription_days > 0:
                 from app.utils.user_utils import mark_user_as_had_paid_subscription
@@ -123,6 +126,8 @@ class PromoCodeService:
                 "success": True,
                 "description": result_description,
                 "promocode": promocode_data,
+                "balance_before_kopeks": balance_before_kopeks,
+                "balance_after_kopeks": balance_after_kopeks,
             }
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- record user balance before and after applying promocodes and return it from the service
- include old and new balance values in promocode activation notifications and stored events
