### PR TITLE
Ensure balance fields exposed in subscription events API

### DIFF
--- a/app/handlers/promocode.py
+++ b/app/handlers/promocode.py
@@ -59,6 +59,8 @@ async def activate_promocode_for_registration(
                         user,
                         result.get("promocode", {"code": code}),
                         result["description"],
+                        result.get("balance_before_kopeks"),
+                        result.get("balance_after_kopeks"),
                     )
             except Exception as notify_error:
                 logger.error(

--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -744,6 +744,8 @@ class AdminNotificationService:
         user: User,
         promocode_data: Dict[str, Any],
         effect_description: str,
+        balance_before_kopeks: int | None = None,
+        balance_after_kopeks: int | None = None,
     ) -> bool:
         try:
             await self._record_subscription_event(
@@ -766,6 +768,8 @@ class AdminNotificationService:
                         if isinstance(promocode_data.get("valid_until"), datetime)
                         else promocode_data.get("valid_until")
                     ),
+                    "balance_before_kopeks": balance_before_kopeks,
+                    "balance_after_kopeks": balance_after_kopeks,
                 },
             )
         except Exception:
@@ -820,6 +824,13 @@ class AdminNotificationService:
 
             message_lines.extend(
                 [
+                    "",
+                    "💼 <b>Баланс:</b>",
+                    (
+                        f"{settings.format_price(balance_before_kopeks)} → {settings.format_price(balance_after_kopeks)}"
+                        if balance_before_kopeks is not None and balance_after_kopeks is not None
+                        else "ℹ️ Баланс не изменился"
+                    ),
                     "",
                     "📝 <b>Эффект:</b>",
                     effect_description.strip() or "✅ Промокод активирован",

--- a/app/services/promocode_service.py
+++ b/app/services/promocode_service.py
@@ -52,7 +52,10 @@ class PromoCodeService:
             if existing_use:
                 return {"success": False, "error": "already_used_by_user"}
             
+            balance_before_kopeks = user.balance_kopeks
+
             result_description = await self._apply_promocode_effects(db, user, promocode)
+            balance_after_kopeks = user.balance_kopeks
 
             if promocode.type == PromoCodeType.SUBSCRIPTION_DAYS.value and promocode.subscription_days > 0:
                 from app.utils.user_utils import mark_user_as_had_paid_subscription
@@ -123,6 +126,8 @@ class PromoCodeService:
                 "success": True,
                 "description": result_description,
                 "promocode": promocode_data,
+                "balance_before_kopeks": balance_before_kopeks,
+                "balance_after_kopeks": balance_after_kopeks,
             }
             
         except Exception as e:

--- a/app/webapi/routes/subscription_events.py
+++ b/app/webapi/routes/subscription_events.py
@@ -59,6 +59,13 @@ async def _ensure_transaction_exists(db: AsyncSession, transaction_id: Optional[
 def _serialize_event(event: SubscriptionEvent) -> SubscriptionEventResponse:
     user = event.user
 
+    extra = event.extra or {}
+
+    if event.event_type == "promocode_activation":
+        extra = {**extra}
+        extra.setdefault("balance_before_kopeks", None)
+        extra.setdefault("balance_after_kopeks", None)
+
     return SubscriptionEventResponse(
         id=event.id,
         event_type=event.event_type,
@@ -73,7 +80,7 @@ def _serialize_event(event: SubscriptionEvent) -> SubscriptionEventResponse:
         message=event.message,
         occurred_at=event.occurred_at,
         created_at=event.created_at,
-        extra=event.extra or {},
+        extra=extra,
     )
 
 


### PR DESCRIPTION
## Summary
- ensure promocode activation subscription events expose old and new balance values in API responses
- default balance fields are provided in the extra payload for promocode events even when missing from stored data