### PR TITLE
Add Platega payment support to miniapp

### DIFF
--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -128,6 +128,7 @@ class PlategaPaymentMixin:
             "status": status,
             "expires_at": expires_at,
             "correlation_id": correlation_id,
+            "payload": payload_token,
         }
 
     async def process_platega_webhook(

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -125,6 +125,7 @@ from ..schemas.miniapp import (
     MiniAppPaymentMethod,
     MiniAppPaymentMethodsRequest,
     MiniAppPaymentMethodsResponse,
+    MiniAppPaymentOption,
     MiniAppPaymentStatusQuery,
     MiniAppPaymentStatusRequest,
     MiniAppPaymentStatusResponse,
@@ -708,6 +709,24 @@ async def get_payment_methods(
                 min_amount_kopeks=settings.PAL24_MIN_AMOUNT_KOPEKS,
                 max_amount_kopeks=settings.PAL24_MAX_AMOUNT_KOPEKS,
                 integration_type=MiniAppPaymentIntegrationType.REDIRECT,
+                options=[
+                    MiniAppPaymentOption(
+                        id="sbp",
+                        icon="🏦",
+                        title_key="topup.method.pal24.option.sbp.title",
+                        description_key="topup.method.pal24.option.sbp.description",
+                        title="Faster Payments (SBP)",
+                        description="Instant SBP transfer with no fees.",
+                    ),
+                    MiniAppPaymentOption(
+                        id="card",
+                        icon="💳",
+                        title_key="topup.method.pal24.option.card.title",
+                        description_key="topup.method.pal24.option.card.description",
+                        title="Bank card",
+                        description="Pay with a bank card via PayPalych.",
+                    ),
+                ],
             )
         )
 
@@ -721,6 +740,37 @@ async def get_payment_methods(
                 min_amount_kopeks=settings.WATA_MIN_AMOUNT_KOPEKS,
                 max_amount_kopeks=settings.WATA_MAX_AMOUNT_KOPEKS,
                 integration_type=MiniAppPaymentIntegrationType.REDIRECT,
+            )
+        )
+
+    if settings.is_platega_enabled() and settings.get_platega_active_methods():
+        platega_methods = settings.get_platega_active_methods()
+        definitions = settings.get_platega_method_definitions()
+        options: List[MiniAppPaymentOption] = []
+
+        for method_code in platega_methods:
+            info = definitions.get(method_code, {})
+            options.append(
+                MiniAppPaymentOption(
+                    id=str(method_code),
+                    icon=info.get("icon") or ("🏦" if method_code == 2 else "💳"),
+                    title_key=f"topup.method.platega.option.{method_code}.title",
+                    description_key=f"topup.method.platega.option.{method_code}.description",
+                    title=info.get("title") or info.get("name") or f"Platega {method_code}",
+                    description=info.get("description") or info.get("name"),
+                )
+            )
+
+        methods.append(
+            MiniAppPaymentMethod(
+                id="platega",
+                icon="💳",
+                requires_amount=True,
+                currency=settings.PLATEGA_CURRENCY,
+                min_amount_kopeks=settings.PLATEGA_MIN_AMOUNT_KOPEKS,
+                max_amount_kopeks=settings.PLATEGA_MAX_AMOUNT_KOPEKS,
+                integration_type=MiniAppPaymentIntegrationType.REDIRECT,
+                options=options,
             )
         )
 
@@ -769,10 +819,11 @@ async def get_payment_methods(
         "yookassa": 3,
         "mulenpay": 4,
         "pal24": 5,
-        "wata": 6,
-        "cryptobot": 7,
-        "heleket": 8,
-        "tribute": 9,
+        "platega": 6,
+        "wata": 7,
+        "cryptobot": 8,
+        "heleket": 9,
+        "tribute": 10,
     }
     methods.sort(key=lambda item: order_map.get(item.id, 99))
 
@@ -945,6 +996,54 @@ async def create_payment_link(
             extra={
                 "local_payment_id": result.get("local_payment_id"),
                 "payment_id": result.get("mulen_payment_id"),
+                "requested_at": _current_request_timestamp(),
+            },
+        )
+
+    if method == "platega":
+        if not settings.is_platega_enabled() or not settings.get_platega_active_methods():
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Payment method is unavailable")
+        if amount_kopeks is None or amount_kopeks <= 0:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Amount must be positive")
+        if amount_kopeks < settings.PLATEGA_MIN_AMOUNT_KOPEKS:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Amount is below minimum")
+        if amount_kopeks > settings.PLATEGA_MAX_AMOUNT_KOPEKS:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Amount exceeds maximum")
+
+        active_methods = settings.get_platega_active_methods()
+        method_option = payload.payment_option or str(active_methods[0])
+        try:
+            method_code = int(str(method_option).strip())
+        except (TypeError, ValueError):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid Platega payment option")
+
+        if method_code not in active_methods:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Selected Platega method is unavailable")
+
+        payment_service = PaymentService()
+        result = await payment_service.create_platega_payment(
+            db=db,
+            user_id=user.id,
+            amount_kopeks=amount_kopeks,
+            description=settings.get_balance_payment_description(amount_kopeks),
+            language=user.language or settings.DEFAULT_LANGUAGE,
+            payment_method_code=method_code,
+        )
+
+        redirect_url = result.get("redirect_url") if result else None
+        if not result or not redirect_url:
+            raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="Failed to create payment")
+
+        return MiniAppPaymentCreateResponse(
+            method=method,
+            payment_url=redirect_url,
+            amount_kopeks=amount_kopeks,
+            extra={
+                "local_payment_id": result.get("local_payment_id"),
+                "payment_id": result.get("transaction_id"),
+                "correlation_id": result.get("correlation_id"),
+                "selected_option": str(method_code),
+                "payload": result.get("payload"),
                 "requested_at": _current_request_timestamp(),
             },
         )
@@ -1243,6 +1342,8 @@ async def _resolve_payment_status_entry(
         )
     if method == "mulenpay":
         return await _resolve_mulenpay_payment_status(payment_service, db, user, query)
+    if method == "platega":
+        return await _resolve_platega_payment_status(payment_service, db, user, query)
     if method == "wata":
         return await _resolve_wata_payment_status(payment_service, db, user, query)
     if method == "pal24":
@@ -1392,6 +1493,85 @@ async def _resolve_mulenpay_payment_status(
             "payload": query.payload,
             "started_at": query.started_at,
         },
+    )
+
+
+async def _resolve_platega_payment_status(
+    payment_service: PaymentService,
+    db: AsyncSession,
+    user: User,
+    query: MiniAppPaymentStatusQuery,
+) -> MiniAppPaymentStatusResult:
+    from app.database.crud.platega import (
+        get_platega_payment_by_correlation_id,
+        get_platega_payment_by_id,
+        get_platega_payment_by_transaction_id,
+    )
+
+    payment = None
+    local_id = query.local_payment_id
+    if local_id:
+        payment = await get_platega_payment_by_id(db, local_id)
+
+    if not payment and query.payment_id:
+        payment = await get_platega_payment_by_transaction_id(db, query.payment_id)
+
+    if not payment and query.payload:
+        correlation = str(query.payload).replace("platega:", "")
+        payment = await get_platega_payment_by_correlation_id(db, correlation)
+
+    if not payment or payment.user_id != user.id:
+        return MiniAppPaymentStatusResult(
+            method="platega",
+            status="pending",
+            is_paid=False,
+            amount_kopeks=query.amount_kopeks,
+            message="Payment not found",
+            extra={
+                "local_payment_id": query.local_payment_id,
+                "payment_id": query.payment_id,
+                "payload": query.payload,
+                "started_at": query.started_at,
+            },
+        )
+
+    status_info = await payment_service.get_platega_payment_status(db, payment.id)
+    refreshed_payment = (status_info or {}).get("payment") or payment
+
+    status_raw = (status_info or {}).get("status") or getattr(payment, "status", None)
+    is_paid_flag = bool((status_info or {}).get("is_paid") or getattr(payment, "is_paid", False))
+    status_value = _classify_status(status_raw, is_paid_flag)
+
+    completed_at = (
+        getattr(refreshed_payment, "paid_at", None)
+        or getattr(refreshed_payment, "updated_at", None)
+        or getattr(refreshed_payment, "created_at", None)
+    )
+
+    extra: Dict[str, Any] = {
+        "local_payment_id": refreshed_payment.id,
+        "payment_id": refreshed_payment.platega_transaction_id,
+        "correlation_id": refreshed_payment.correlation_id,
+        "status": status_raw,
+        "is_paid": getattr(refreshed_payment, "is_paid", False),
+        "payload": query.payload,
+        "started_at": query.started_at,
+    }
+
+    if status_info and status_info.get("remote"):
+        extra["remote"] = status_info.get("remote")
+
+    return MiniAppPaymentStatusResult(
+        method="platega",
+        status=status_value,
+        is_paid=status_value == "paid",
+        amount_kopeks=refreshed_payment.amount_kopeks,
+        currency=refreshed_payment.currency,
+        completed_at=completed_at,
+        transaction_id=refreshed_payment.transaction_id,
+        external_id=refreshed_payment.platega_transaction_id,
+        message=None,
+        extra=extra,
     )
 
 

--- a/app/webapi/schemas/miniapp.py
+++ b/app/webapi/schemas/miniapp.py
@@ -373,6 +373,17 @@ class MiniAppPaymentIntegrationType(str, Enum):
     REDIRECT = "redirect"
 
 
+class MiniAppPaymentOption(BaseModel):
+    id: str
+    icon: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    title_key: Optional[str] = Field(default=None, alias="titleKey")
+    description_key: Optional[str] = Field(default=None, alias="descriptionKey")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class MiniAppPaymentIframeConfig(BaseModel):
     expected_origin: str
 
@@ -402,6 +413,7 @@ class MiniAppPaymentMethod(BaseModel):
     max_amount_kopeks: Optional[int] = None
     amount_step_kopeks: Optional[int] = None
     integration_type: MiniAppPaymentIntegrationType
+    options: List[MiniAppPaymentOption] = Field(default_factory=list)
     iframe_config: Optional[MiniAppPaymentIframeConfig] = None
 
     @model_validator(mode="after")

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -5615,6 +5615,18 @@
                 'topup.method.yookassa.description': 'Pay securely with a bank card',
                 'topup.method.mulenpay.title': 'Bank card (Mulen Pay)',
                 'topup.method.mulenpay.description': 'Fast payment with bank card',
+                'topup.method.platega.title': 'Platega.io',
+                'topup.method.platega.description': 'Bank cards and SBP via Platega',
+                'topup.method.platega.option.2.title': 'SBP (QR)',
+                'topup.method.platega.option.2.description': 'Pay with Faster Payments QR code.',
+                'topup.method.platega.option.10.title': 'Bank cards (RUB)',
+                'topup.method.platega.option.10.description': 'Russian bank cards through Platega.',
+                'topup.method.platega.option.11.title': 'Bank cards',
+                'topup.method.platega.option.11.description': 'Local bank cards via Platega.',
+                'topup.method.platega.option.12.title': 'International cards',
+                'topup.method.platega.option.12.description': 'International cards supported by Platega.',
+                'topup.method.platega.option.13.title': 'Cryptocurrency',
+                'topup.method.platega.option.13.description': 'Top up balance with crypto via Platega.',
                 'topup.method.wata.title': 'Bank card (Wata)',
                 'topup.method.wata.description': 'Pay with a bank card via Wata',
                 'topup.method.pal24.title': 'SBP (PayPalych)',
@@ -6021,6 +6033,18 @@
                 'topup.method.yookassa.description': 'Безопасная оплата банковской картой',
                 'topup.method.mulenpay.title': 'Банковская карта (Mulen Pay)',
                 'topup.method.mulenpay.description': 'Мгновенное списание с карты',
+                'topup.method.platega.title': 'Platega.io',
+                'topup.method.platega.description': 'Карта или СБП через Platega',
+                'topup.method.platega.option.2.title': 'СБП (QR)',
+                'topup.method.platega.option.2.description': 'Оплата по QR-коду через СБП.',
+                'topup.method.platega.option.10.title': 'Банковские карты (RUB)',
+                'topup.method.platega.option.10.description': 'Российские карты через Platega.',
+                'topup.method.platega.option.11.title': 'Банковские карты',
+                'topup.method.platega.option.11.description': 'Оплата картами через Platega.',
+                'topup.method.platega.option.12.title': 'Международные карты',
+                'topup.method.platega.option.12.description': 'Оплата международными картами.',
+                'topup.method.platega.option.13.title': 'Криптовалюта',
+                'topup.method.platega.option.13.description': 'Пополнение через криптовалюту в Platega.',
                 'topup.method.wata.title': 'Банковская карта (Wata)',
                 'topup.method.wata.description': 'Оплата банковской картой через Wata',
                 'topup.method.pal24.title': 'СБП (PayPalych)',
@@ -6841,13 +6865,18 @@
                 return;
             }
 
-            if (monitor.method.id === 'pal24') {
-                const option = (monitor.option || 'sbp').toLowerCase();
-                const optionKey = option === 'card' ? 'card' : 'sbp';
-                const fallback = optionKey === 'card'
-                    ? 'Bank card payment'
-                    : 'Faster Payments (SBP)';
-                setTopupModalSubtitle(`topup.method.pal24.option.${optionKey}.title`, fallback);
+            const optionsMap = (Array.isArray(monitor.method.options) ? monitor.method.options : []).reduce((map, item) => {
+                map[String(item.id)] = item;
+                return map;
+            }, {});
+
+            if (monitor.method.id === 'pal24' || monitor.method.id === 'platega') {
+                const option = (monitor.option || monitor.extra?.selected_option || 'sbp').toString();
+                const optionKey = ['card', 'sbp'].includes(option) ? option : option;
+                const optionConfig = optionsMap[optionKey];
+                const fallback = optionConfig?.title || (optionKey === 'card' ? 'Bank card payment' : 'Faster Payments (SBP)');
+                const titleKey = optionConfig?.titleKey || optionConfig?.title_key || `topup.method.${monitor.method.id}.option.${optionKey}.title`;
+                setTopupModalSubtitle(titleKey, fallback || monitor.method.id);
                 return;
             }
 
@@ -6876,6 +6905,11 @@
             if (extra.payment_id) {
                 query.paymentId = extra.payment_id;
                 identifiers.paymentId = extra.payment_id;
+            }
+
+            if (extra.correlation_id && !query.payload) {
+                query.payload = extra.correlation_id;
+                identifiers.payload = extra.correlation_id;
             }
 
             const payloadValue = extra.payload || extra.invoice_payload;
@@ -11503,32 +11537,44 @@
                 form.appendChild(hint);
             }
 
-            if (method.id === 'pal24') {
-                const optionsConfig = [
+            const providedOptions = Array.isArray(method.options) ? method.options : [];
+            const fallbackOptions = method.id === 'pal24'
+                ? [
                     {
                         id: 'sbp',
                         icon: '🏦',
                         titleKey: 'topup.method.pal24.option.sbp.title',
                         descriptionKey: 'topup.method.pal24.option.sbp.description',
-                        fallbackTitle: 'Faster Payments (SBP)',
-                        fallbackDescription: 'Instant SBP transfer with no fees.',
+                        title: 'Faster Payments (SBP)',
+                        description: 'Instant SBP transfer with no fees.',
                     },
                     {
                         id: 'card',
                         icon: '💳',
                         titleKey: 'topup.method.pal24.option.card.title',
                         descriptionKey: 'topup.method.pal24.option.card.description',
-                        fallbackTitle: 'Bank card',
-                        fallbackDescription: 'Pay with a bank card via PayPalych.',
+                        title: 'Bank card',
+                        description: 'Pay with a bank card via PayPalych.',
                     },
-                ];
+                ]
+                : [];
 
-                const selectedDefault = options.selectedOption
+            const optionsConfig = (providedOptions.length ? providedOptions : fallbackOptions).map(option => ({
+                id: String(option.id),
+                icon: option.icon || '💳',
+                titleKey: option.titleKey || option.title_key || option.titlekey,
+                descriptionKey: option.descriptionKey || option.description_key || option.descriptionkey,
+                fallbackTitle: option.title || option.name || String(option.id),
+                fallbackDescription: option.description || '',
+            }));
+
+            if (optionsConfig.length) {
+                const defaultSelection = options.selectedOption
                     || paymentMethodSelections[method.id]
-                    || 'sbp';
-                let currentOption = optionsConfig.some(option => option.id === selectedDefault)
-                    ? selectedDefault
-                    : 'sbp';
+                    || optionsConfig[0]?.id;
+                let currentOption = optionsConfig.some(option => option.id === defaultSelection)
+                    ? defaultSelection
+                    : optionsConfig[0]?.id;
                 paymentMethodSelections[method.id] = currentOption;
                 form.dataset.paymentOption = currentOption;
 
@@ -11537,7 +11583,7 @@
 
                 const optionTitle = document.createElement('div');
                 optionTitle.className = 'payment-option-title';
-                const titleKey = 'topup.method.pal24.title';
+                const titleKey = `topup.method.${method.id}.title`;
                 const titleValue = t(titleKey);
                 optionTitle.textContent = titleValue === titleKey ? 'Choose payment type' : titleValue;
                 optionGroup.appendChild(optionTitle);
@@ -11563,22 +11609,23 @@
 
                     const label = document.createElement('div');
                     label.className = 'payment-option-label';
-                    const labelValue = t(config.titleKey);
-                    label.textContent = labelValue === config.titleKey ? config.fallbackTitle : labelValue;
+                    const labelValue = config.titleKey ? t(config.titleKey) : config.fallbackTitle;
+                    label.textContent = labelValue && labelValue !== config.titleKey
+                        ? labelValue
+                        : config.fallbackTitle;
 
                     const description = document.createElement('div');
                     description.className = 'payment-option-description';
-                    const descriptionValue = t(config.descriptionKey);
-                    const finalDescription = descriptionValue === config.descriptionKey
-                        ? config.fallbackDescription
-                        : descriptionValue;
-                    description.textContent = finalDescription;
-
-                    text.appendChild(label);
+                    const descriptionValue = config.descriptionKey ? t(config.descriptionKey) : config.fallbackDescription;
+                    const finalDescription = descriptionValue && descriptionValue !== config.descriptionKey
+                        ? descriptionValue
+                        : config.fallbackDescription;
                     if (finalDescription) {
+                        description.textContent = finalDescription;
                         text.appendChild(description);
                     }
 
+                    text.appendChild(label);
                     button.appendChild(icon);
                     button.appendChild(text);
 
@@ -11816,8 +11863,19 @@
             const normalizedAmount = Number.isFinite(amountKopeks) ? Number(amountKopeks) : null;
             const monitorExtra = { ...extra };
 
+            const methodOptions = Array.isArray(method.options) ? method.options : [];
+            const optionsMap = methodOptions.reduce((map, item) => {
+                const key = String(item.id);
+                map[key] = item;
+                return map;
+            }, {});
+
             let option = null;
-            if (method.id === 'pal24') {
+            if (methodOptions.length) {
+                option = (options.providerOption || monitorExtra.selected_option || paymentMethodSelections[method.id] || methodOptions[0]?.id || '').toString();
+                paymentMethodSelections[method.id] = option;
+                monitorExtra.selected_option = option;
+            } else if (method.id === 'pal24') {
                 option = (options.providerOption || monitorExtra.selected_option || paymentMethodSelections[method.id] || 'sbp').toLowerCase();
                 if (!['card', 'sbp'].includes(option)) {
                     option = 'sbp';
@@ -11826,12 +11884,19 @@
                 monitorExtra.selected_option = option;
             }
 
-            const titleKey = method.id === 'pal24' && option
-                ? `topup.method.pal24.option.${option}.title`
-                : `topup.method.${method.id}.title`;
-            const titleFallback = method.id === 'pal24'
-                ? (option === 'card' ? 'Bank card payment' : 'Faster Payments (SBP)')
-                : method.id;
+            const selectedOption = option && (optionsMap[option] || optionsMap[String(option)]);
+            const optionTitleKey = selectedOption?.titleKey || selectedOption?.title_key;
+            const optionTitleFallback = selectedOption?.title || selectedOption?.name || option || method.id;
+            const titleKey = selectedOption && optionTitleKey
+                ? optionTitleKey
+                : option
+                    ? `topup.method.${method.id}.option.${option}.title`
+                    : `topup.method.${method.id}.title`;
+            const titleFallback = selectedOption
+                ? optionTitleFallback
+                : method.id === 'pal24'
+                    ? (option === 'card' ? 'Bank card payment' : 'Faster Payments (SBP)')
+                    : method.id;
             setTopupModalSubtitle(titleKey, titleFallback);
 
             body.innerHTML = '';
@@ -11902,8 +11967,8 @@
                 summary.appendChild(usdAmount);
             }
 
-            const descriptionKey = method.id === 'pal24' && option
-                ? `topup.method.pal24.option.${option}.description`
+            const descriptionKey = option
+                ? `topup.method.${method.id}.option.${option}.description`
                 : `topup.method.${method.id}.description`;
             const descriptionValue = t(descriptionKey);
             if (descriptionValue && descriptionValue !== descriptionKey) {


### PR DESCRIPTION
## Summary
- expose Platega payment provider and selectable methods in the miniapp payment UI and translations
- add Platega payment creation and status handling to miniapp payment APIs, including webhook payload propagation
- keep existing providers updated with shared option rendering and ordering tweaks