### PR TITLE
Align RemnaWave sync with new status and expiration rules

### DIFF
--- a/app/handlers/admin/remnawave.py
+++ b/app/handlers/admin/remnawave.py
@@ -2285,6 +2285,9 @@ async def show_sync_options(
         "• При полной синхронизации подписки пользователей, отсутствующих в панели, будут деактивированы\n"
         "• Рекомендуется делать полную синхронизацию ежедневно\n"
         "• Баланс пользователей НЕ удаляется\n\n"
+        "⬆️ <b>Обратная синхронизация:</b>\n"
+        "• Отправляет активных пользователей из бота в панель\n"
+        "• Используйте при сбоях панели или для восстановления данных\n\n"
         + "\n".join(status_lines)
     )
 
@@ -2293,6 +2296,12 @@ async def show_sync_options(
             types.InlineKeyboardButton(
                 text="🔄 Запустить полную синхронизацию",
                 callback_data="sync_all_users",
+            )
+        ],
+        [
+            types.InlineKeyboardButton(
+                text="⬆️ Синхронизация в панель",
+                callback_data="sync_to_panel",
             )
         ],
         [
@@ -2651,6 +2660,50 @@ async def sync_all_users(
     await callback.message.edit_text(
         text,
         reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def sync_users_to_panel(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+):
+    await callback.message.edit_text(
+        "⬆️ Выполняется синхронизация данных бота в панель Remnawave...\n\n"
+        "Это может занять несколько минут.",
+        reply_markup=None,
+    )
+
+    remnawave_service = RemnaWaveService()
+    stats = await remnawave_service.sync_users_to_panel(db)
+
+    if stats["errors"] == 0:
+        status_emoji = "✅"
+        status_text = "успешно завершена"
+    else:
+        status_emoji = "⚠️" if (stats["created"] + stats["updated"]) > 0 else "❌"
+        status_text = "завершена с предупреждениями" if status_emoji == "⚠️" else "завершена с ошибками"
+
+    text = (
+        f"{status_emoji} <b>Синхронизация в панель {status_text}</b>\n\n"
+        "📊 <b>Результаты:</b>\n"
+        f"• 🆕 Создано: {stats['created']}\n"
+        f"• 🔄 Обновлено: {stats['updated']}\n"
+        f"• ❌ Ошибок: {stats['errors']}"
+    )
+
+    keyboard = [
+        [types.InlineKeyboardButton(text="🔄 Повторить", callback_data="sync_to_panel")],
+        [types.InlineKeyboardButton(text="🔄 Полная синхронизация", callback_data="sync_all_users")],
+        [types.InlineKeyboardButton(text="⬅️ К синхронизации", callback_data="admin_rw_sync")],
+    ]
+
+    await callback.message.edit_text(
+        text,
+        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
     )
     await callback.answer()
 
@@ -3126,6 +3179,7 @@ def register_handlers(dp: Dispatcher):
     dp.callback_query.register(cancel_auto_sync_schedule, F.data == "remnawave_auto_sync_cancel")
     dp.callback_query.register(run_auto_sync_now, F.data == "remnawave_auto_sync_run")
     dp.callback_query.register(sync_all_users, F.data == "sync_all_users")
+    dp.callback_query.register(sync_users_to_panel, F.data == "sync_to_panel")
     dp.callback_query.register(show_squad_migration_menu, F.data == "admin_rw_migration")
     dp.callback_query.register(paginate_migration_source, F.data.startswith("admin_migration_source_page_"))
     dp.callback_query.register(handle_migration_source_selection, F.data.startswith("admin_migration_source_"))

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -4595,10 +4595,19 @@ async def admin_buy_subscription_execute(
 
                 if target_user.remnawave_uuid:
                     async with remnawave_service.get_api_client() as api:
+                        expire_at = remnawave_service.ensure_future_expire_at(
+                            subscription.end_date
+                        )
+                        status = (
+                            UserStatus.ACTIVE
+                            if subscription.is_active
+                            else UserStatus.DISABLED
+                        )
+
                         update_kwargs = dict(
                             uuid=target_user.remnawave_uuid,
-                            status=UserStatus.ACTIVE if subscription.is_active else UserStatus.EXPIRED,
-                            expire_at=subscription.end_date,
+                            status=status,
+                            expire_at=expire_at,
                             traffic_limit_bytes=subscription.traffic_limit_gb * (1024**3) if subscription.traffic_limit_gb > 0 else 0,
                             traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                             description=settings.format_remnawave_user_description(
@@ -4620,10 +4629,19 @@ async def admin_buy_subscription_execute(
                         telegram_id=target_user.telegram_id,
                     )
                     async with remnawave_service.get_api_client() as api:
+                        expire_at = remnawave_service.ensure_future_expire_at(
+                            subscription.end_date
+                        )
+                        status = (
+                            UserStatus.ACTIVE
+                            if subscription.is_active
+                            else UserStatus.DISABLED
+                        )
+
                         create_kwargs = dict(
                             username=username,
-                            expire_at=subscription.end_date,
-                            status=UserStatus.ACTIVE if subscription.is_active else UserStatus.EXPIRED,
+                            expire_at=expire_at,
+                            status=status,
                             traffic_limit_bytes=subscription.traffic_limit_gb * (1024**3) if subscription.traffic_limit_gb > 0 else 0,
                             traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                             telegram_id=target_user.telegram_id,

--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -1120,6 +1120,12 @@ def get_sync_options_keyboard(language: str = "ru") -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text=_t(texts, "ADMIN_SYNC_TO_PANEL", "⬆️ Синхронизация в панель"),
+                callback_data="sync_to_panel"
+            )
+        ],
+        [
+            InlineKeyboardButton(
                 text=_t(texts, "ADMIN_SYNC_ONLY_NEW", "🆕 Только новые"),
                 callback_data="sync_new_users"
             )

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -688,6 +688,7 @@
   "ADMIN_SUPPORT_SUBMENU_TITLE": "🛟 **Поддержка**\n\n",
   "ADMIN_SUPPORT_TICKETS": "🎫 Тикеты поддержки",
   "ADMIN_SYNC_BACK": "⬅️ К синхронизации",
+  "ADMIN_SYNC_TO_PANEL": "⬆️ Синхронизация в панель",
   "ADMIN_SYNC_CLEANUP": "🧹 Очистка",
   "ADMIN_SYNC_CONFIRM": "✅ Подтвердить",
   "ADMIN_SYNC_FULL": "🔄 Полная синхронизация",

--- a/app/localization/locales/ua.json
+++ b/app/localization/locales/ua.json
@@ -687,6 +687,7 @@
  "ADMIN_SUPPORT_SUBMENU_TITLE": "🛟 **Підтримка**\n\n",
  "ADMIN_SUPPORT_TICKETS": "🎫 Тікети підтримки",
  "ADMIN_SYNC_BACK": "⬅️ До синхронізації",
+ "ADMIN_SYNC_TO_PANEL": "⬆️ Синхронізація в панель",
  "ADMIN_SYNC_CLEANUP": "🧹 Очищення",
  "ADMIN_SYNC_CONFIRM": "✅ Підтвердити",
  "ADMIN_SYNC_FULL": "🔄 Повна синхронізація",

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -281,11 +281,15 @@ class MonitoringService:
                 return None
             
             current_time = datetime.utcnow()
-            is_active = (subscription.status == SubscriptionStatus.ACTIVE.value and 
-                        subscription.end_date > current_time)
+            is_active = (
+                subscription.status == SubscriptionStatus.ACTIVE.value
+                and subscription.end_date > current_time
+            )
             
-            if (subscription.status == SubscriptionStatus.ACTIVE.value and 
-                subscription.end_date <= current_time):
+            if (
+                subscription.status == SubscriptionStatus.ACTIVE.value
+                and subscription.end_date <= current_time
+            ):
                 subscription.status = SubscriptionStatus.EXPIRED.value
                 await db.commit()
                 is_active = False
@@ -301,10 +305,16 @@ class MonitoringService:
             async with self.subscription_service.get_api_client() as api:
                 hwid_limit = resolve_hwid_device_limit_for_payload(subscription)
 
+                expire_at = self.subscription_service.ensure_future_expire_at(
+                    subscription.end_date
+                )
+
+                status = UserStatus.ACTIVE if is_active else UserStatus.DISABLED
+
                 update_kwargs = dict(
                     uuid=user.remnawave_uuid,
-                    status=UserStatus.ACTIVE if is_active else UserStatus.EXPIRED,
-                    expire_at=subscription.end_date,
+                    status=status,
+                    expire_at=expire_at,
                     traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
                     traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                     description=settings.format_remnawave_user_description(


### PR DESCRIPTION
## Summary
- clamp RemnaWave sync payloads to ACTIVE/DISABLED statuses and future expiration dates
- reuse shared helpers when syncing users from admin actions, monitoring, and batch panel uploads
