### PR TITLE
Ensure photo replies default to HTML parse mode

### DIFF
--- a/app/utils/message_patch.py
+++ b/app/utils/message_patch.py
@@ -90,6 +90,9 @@ async def _answer_with_photo(self: Message, text: str = None, **kwargs):
         pass
     language = _get_language(self)
 
+    # По умолчанию используем HTML, чтобы Telegram корректно распознавал разметку
+    kwargs.setdefault("parse_mode", "HTML")
+
     if LOGO_PATH.exists():
         try:
             # Отправляем caption как есть; при ошибке парсинга ниже сработает фоллбек


### PR DESCRIPTION
## Summary
- set a default HTML parse mode when sending photo-based answers
- prevent Telegram parse errors for menu captions that include HTML formatting

