### PR TITLE
Handle Telegram parse errors gracefully

### DIFF
--- a/app/utils/photo_message.py
+++ b/app/utils/photo_message.py
@@ -1,3 +1,6 @@
+import html
+import re
+
 from aiogram import types
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import FSInputFile, InputMediaPhoto
@@ -33,6 +36,14 @@ def _get_language(callback: types.CallbackQuery) -> str | None:
     return None
 
 
+def _strip_html(text: str | None) -> str:
+    if not text:
+        return ""
+
+    plain_text = html.unescape(re.sub(r"<[^>]+>", "", text))
+    return plain_text.strip()
+
+
 def _build_base_kwargs(keyboard: types.InlineKeyboardMarkup | None, parse_mode: str | None):
     kwargs: dict[str, object] = {}
     if parse_mode is not None:
@@ -57,6 +68,19 @@ async def _answer_text(
         kwargs = prepare_privacy_safe_kwargs(kwargs)
 
     kwargs.setdefault("parse_mode", parse_mode or "HTML")
+    try:
+        await callback.message.answer(
+            caption,
+            **kwargs,
+        )
+        return
+    except TelegramBadRequest as send_error:
+        if is_privacy_restricted_error(send_error):
+            caption = append_privacy_hint(caption, language)
+            kwargs = prepare_privacy_safe_kwargs(kwargs)
+        else:
+            caption = _strip_html(caption)
+            kwargs.pop("parse_mode", None)
 
     await callback.message.answer(
         caption,


### PR DESCRIPTION
## Summary
- add HTML-stripping fallback for caption sending when Telegram rejects HTML entities
- retry message sending without parse mode for non-privacy errors to avoid menu crashes
