### PR TITLE
Add configurable RemnaWave user tags for trial and paid subscriptions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,8 @@ DEFAULT_DISPLAY_NAME_BANNED_KEYWORDS = [
     "joingroup",
 ]
 
+USER_TAG_PATTERN = re.compile(r"^[A-Z0-9_]{1,16}$")
+
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +90,7 @@ class Settings(BaseSettings):
     TRIAL_ADD_REMAINING_DAYS_TO_PAID: bool = False
     TRIAL_PAYMENT_ENABLED: bool = False
     TRIAL_ACTIVATION_PRICE: int = 0
+    TRIAL_USER_TAG: Optional[str] = None
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
@@ -119,6 +122,7 @@ class Settings(BaseSettings):
     PRICE_90_DAYS: int = 269000
     PRICE_180_DAYS: int = 499000
     PRICE_360_DAYS: int = 899000
+    PAID_SUBSCRIPTION_USER_TAG: Optional[str] = None
 
     PRICE_TRAFFIC_5GB: int = 2000
     PRICE_TRAFFIC_10GB: int = 3500
@@ -776,12 +780,47 @@ class Settings(BaseSettings):
     
     def kopeks_to_rubles(self, kopeks: int) -> float:
         return kopeks / 100
-    
+
     def rubles_to_kopeks(self, rubles: float) -> int:
         return int(rubles * 100)
-    
+
+    @staticmethod
+    def _normalize_user_tag(value: Optional[str], setting_name: str) -> Optional[str]:
+        if value is None:
+            return None
+
+        cleaned = str(value).strip().upper()
+        if not cleaned:
+            return None
+
+        if len(cleaned) > 16:
+            logger.warning(
+                "Некорректная длина %s: максимум 16 символов, получено %s",
+                setting_name,
+                len(cleaned),
+            )
+            return None
+
+        if not USER_TAG_PATTERN.fullmatch(cleaned):
+            logger.warning(
+                "Некорректный формат %s: допустимы только A-Z, 0-9 и подчёркивание",
+                setting_name,
+            )
+            return None
+
+        return cleaned
+
     def get_trial_warning_hours(self) -> int:
         return self.TRIAL_WARNING_HOURS
+
+    def get_trial_user_tag(self) -> Optional[str]:
+        return self._normalize_user_tag(self.TRIAL_USER_TAG, "TRIAL_USER_TAG")
+
+    def get_paid_subscription_user_tag(self) -> Optional[str]:
+        return self._normalize_user_tag(
+            self.PAID_SUBSCRIPTION_USER_TAG,
+            "PAID_SUBSCRIPTION_USER_TAG",
+        )
 
     def get_bot_username(self) -> Optional[str]:
         username = getattr(self, "BOT_USERNAME", None)

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -220,6 +220,7 @@ class BotConfigurationService:
         "PRICE_90_DAYS": "SUBSCRIPTION_PRICES",
         "PRICE_180_DAYS": "SUBSCRIPTION_PRICES",
         "PRICE_360_DAYS": "SUBSCRIPTION_PRICES",
+        "PAID_SUBSCRIPTION_USER_TAG": "SUBSCRIPTION_PRICES",
         "TRAFFIC_PACKAGES_CONFIG": "TRAFFIC_PACKAGES",
         "BASE_PROMO_GROUP_PERIOD_DISCOUNTS_ENABLED": "SUBSCRIPTIONS_CORE",
         "BASE_PROMO_GROUP_PERIOD_DISCOUNTS": "SUBSCRIPTIONS_CORE",
@@ -227,6 +228,7 @@ class BotConfigurationService:
         "DEFAULT_AUTOPAY_DAYS_BEFORE": "AUTOPAY",
         "MIN_BALANCE_FOR_AUTOPAY_KOPEKS": "AUTOPAY",
         "TRIAL_WARNING_HOURS": "TRIAL",
+        "TRIAL_USER_TAG": "TRIAL",
         "SUPPORT_USERNAME": "SUPPORT",
         "SUPPORT_MENU_ENABLED": "SUPPORT",
         "SUPPORT_SYSTEM_MODE": "SUPPORT",
@@ -642,6 +644,24 @@ class BotConfigurationService:
             "example": "123456789",
             "warning": "Несовпадение ID блокирует обновление токена, предотвращая его подмену на другом боте.",
             "dependencies": "Результат вызова getMe() в Telegram Bot API",
+        },
+        "TRIAL_USER_TAG": {
+            "description": (
+                "Тег, который бот передаст пользователю при активации триальной подписки в панели RemnaWave."
+            ),
+            "format": "До 16 символов: заглавные A-Z, цифры и подчёркивание.",
+            "example": "TRIAL_USER",
+            "warning": "Неверный формат будет проигнорирован при создании пользователя.",
+            "dependencies": "Активация триала и включенная интеграция с RemnaWave",
+        },
+        "PAID_SUBSCRIPTION_USER_TAG": {
+            "description": (
+                "Тег, который бот ставит пользователю при покупке платной подписки в панели RemnaWave."
+            ),
+            "format": "До 16 символов: заглавные A-Z, цифры и подчёркивание.",
+            "example": "PAID_USER",
+            "warning": "Если тег не задан или невалиден, существующий тег не будет изменён.",
+            "dependencies": "Оплата подписки и интеграция с RemnaWave",
         },
     }
 


### PR DESCRIPTION
## Summary
- add optional settings to configure RemnaWave user tags for trial activation and paid subscriptions
- validate configured tags and expose descriptions in system settings UI
- apply configured tags when creating or updating RemnaWave users during trial activation or paid purchases
