### PR TITLE
Fix callback reuse after node actions

### DIFF
--- a/app/handlers/admin/remnawave.py
+++ b/app/handlers/admin/remnawave.py
@@ -1397,14 +1397,12 @@ async def manage_node(
    else:
        await callback.answer("❌ Ошибка выполнения действия", show_alert=True)
    
+   refreshed_callback = callback.model_copy(
+       update={"data": f"admin_node_manage_{node_uuid}"}
+   )
+
    await show_node_details(
-       types.CallbackQuery(
-           id=callback.id,
-           from_user=callback.from_user,
-           chat_instance=callback.chat_instance,
-           data=f"admin_node_manage_{node_uuid}",
-           message=callback.message
-       ),
+       refreshed_callback,
        db_user,
        db
    )


### PR DESCRIPTION
## Summary
- avoid constructing unmounted CallbackQuery objects when refreshing node details
- reuse existing callback data while updating the view after node actions