### PR TITLE
Add internal squad management for users and trials

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,7 @@ class Settings(BaseSettings):
     TRIAL_PAYMENT_ENABLED: bool = False
     TRIAL_ACTIVATION_PRICE: int = 0
     TRIAL_USER_TAG: Optional[str] = None
+    TRIAL_INTERNAL_SQUADS: Optional[str] = None
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
@@ -815,6 +816,28 @@ class Settings(BaseSettings):
 
     def get_trial_user_tag(self) -> Optional[str]:
         return self._normalize_user_tag(self.TRIAL_USER_TAG, "TRIAL_USER_TAG")
+
+    def get_trial_internal_squads(self) -> list[str]:
+        raw_value = self.TRIAL_INTERNAL_SQUADS
+        if raw_value is None:
+            return []
+
+        if isinstance(raw_value, str):
+            items = [item.strip() for item in re.split(r"[,\n]", raw_value) if item.strip()]
+        elif isinstance(raw_value, (list, tuple, set)):
+            items = [str(item).strip() for item in raw_value if str(item).strip()]
+        else:
+            return []
+
+        seen = set()
+        unique_items: list[str] = []
+        for item in items:
+            lowered = item.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            unique_items.append(item)
+        return unique_items
 
     def get_paid_subscription_user_tag(self) -> Optional[str]:
         return self._normalize_user_tag(

--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 import string
 from datetime import datetime, timedelta
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Iterable
 from sqlalchemy import select, and_, or_, func, case, nullslast, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, joinedload
@@ -32,6 +32,26 @@ def generate_referral_code() -> str:
     alphabet = string.ascii_letters + string.digits
     code_suffix = ''.join(secrets.choice(alphabet) for _ in range(8))
     return f"ref{code_suffix}"
+
+
+def _normalize_internal_squads(value: Optional[Iterable[str]]) -> Optional[list[str]]:
+    if value is None:
+        return None
+
+    try:
+        items = [str(item).strip() for item in value if str(item).strip()]
+    except TypeError:
+        return None
+
+    seen = set()
+    normalized: list[str] = []
+    for item in items:
+        lowered = item.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalized.append(item)
+    return normalized
 
 
 async def get_user_by_id(db: AsyncSession, user_id: int) -> Optional[User]:
@@ -171,7 +191,8 @@ async def create_user_no_commit(
     last_name: str = None,
     language: str = "ru",
     referred_by_id: int = None,
-    referral_code: str = None
+    referral_code: str = None,
+    active_internal_squads: Optional[Iterable[str]] = None,
 ) -> User:
     """
     Создает пользователя без немедленного коммита для пакетной обработки
@@ -197,6 +218,7 @@ async def create_user_no_commit(
         has_had_paid_subscription=False,
         has_made_first_topup=False,
         promo_group_id=promo_group_id,
+        active_internal_squads=_normalize_internal_squads(active_internal_squads),
     )
 
     db.add(user)
@@ -222,7 +244,8 @@ async def create_user(
     last_name: str = None,
     language: str = "ru",
     referred_by_id: int = None,
-    referral_code: str = None
+    referral_code: str = None,
+    active_internal_squads: Optional[Iterable[str]] = None,
 ) -> User:
     
     if not referral_code:
@@ -248,6 +271,7 @@ async def create_user(
             has_had_paid_subscription=False,
             has_made_first_topup=False,
             promo_group_id=promo_group_id,
+            active_internal_squads=_normalize_internal_squads(active_internal_squads),
         )
 
         db.add(user)
@@ -295,6 +319,8 @@ async def update_user(
     for field, value in kwargs.items():
         if field in ("first_name", "last_name"):
             value = sanitize_telegram_name(value)
+        if field == "active_internal_squads":
+            value = _normalize_internal_squads(value)
         if hasattr(user, field):
             setattr(user, field, value)
     

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -600,6 +600,7 @@ class User(Base):
     promo_offer_discount_source = Column(String(100), nullable=True)
     promo_offer_discount_expires_at = Column(DateTime, nullable=True)
     last_remnawave_sync = Column(DateTime, nullable=True)
+    active_internal_squads = Column(JSON, nullable=True)
     trojan_password = Column(String(255), nullable=True)
     vless_uuid = Column(String(255), nullable=True)
     ss_password = Column(String(255), nullable=True)

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -4606,7 +4606,11 @@ async def admin_buy_subscription_execute(
                                 username=target_user.username,
                                 telegram_id=target_user.telegram_id
                             ),
-                            active_internal_squads=subscription.connected_squads,
+                            active_internal_squads=(
+                                list(target_user.active_internal_squads or [])
+                                if target_user.active_internal_squads is not None
+                                else list(subscription.connected_squads or [])
+                            ),
                         )
 
                         if hwid_limit is not None:
@@ -4632,7 +4636,11 @@ async def admin_buy_subscription_execute(
                                 username=target_user.username,
                                 telegram_id=target_user.telegram_id
                             ),
-                            active_internal_squads=subscription.connected_squads,
+                            active_internal_squads=(
+                                list(target_user.active_internal_squads or [])
+                                if target_user.active_internal_squads is not None
+                                else list(subscription.connected_squads or [])
+                            ),
                         )
 
                         if hwid_limit is not None:

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -312,7 +312,11 @@ class MonitoringService:
                         username=user.username,
                         telegram_id=user.telegram_id
                     ),
-                    active_internal_squads=subscription.connected_squads,
+                    active_internal_squads=(
+                        list(user.active_internal_squads or [])
+                        if user.active_internal_squads is not None
+                        else list(subscription.connected_squads or [])
+                    ),
                 )
 
                 if hwid_limit is not None:

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -846,32 +846,59 @@ class RemnaWaveService:
         except Exception as e:
             logger.error(f"Error updating squad inbounds: {e}")
             return False
-    
+
+    @staticmethod
+    def _serialize_internal_squad(squad) -> Dict[str, Any]:
+        inbounds = [
+            asdict(inbound) if is_dataclass(inbound) else inbound
+            for inbound in getattr(squad, "inbounds", []) or []
+        ]
+        return {
+            'uuid': getattr(squad, 'uuid', ''),
+            'name': getattr(squad, 'name', ''),
+            'members_count': getattr(squad, 'members_count', 0),
+            'inbounds_count': getattr(squad, 'inbounds_count', 0),
+            'inbounds': inbounds,
+        }
+
     async def get_all_squads(self) -> List[Dict[str, Any]]:
-        
+
         try:
             async with self.get_api_client() as api:
                 squads = await api.get_internal_squads()
 
                 result = []
                 for squad in squads:
-                    inbounds = [
-                        asdict(inbound) if is_dataclass(inbound) else inbound
-                        for inbound in squad.inbounds or []
-                    ]
-                    result.append({
-                        'uuid': squad.uuid,
-                        'name': squad.name,
-                        'members_count': squad.members_count,
-                        'inbounds_count': squad.inbounds_count,
-                        'inbounds': inbounds,
-                    })
-                
+                    result.append(self._serialize_internal_squad(squad))
+
                 logger.info(f"✅ Получено {len(result)} сквадов из Remnawave")
                 return result
-                
+
         except Exception as e:
             logger.error(f"Ошибка получения сквадов из Remnawave: {e}")
+            return []
+
+    async def get_internal_squad(self, uuid: str) -> Optional[Dict[str, Any]]:
+        try:
+            async with self.get_api_client() as api:
+                squad = await api.get_internal_squad_by_uuid(uuid)
+                if not squad:
+                    return None
+                return self._serialize_internal_squad(squad)
+        except Exception as error:
+            logger.error("Ошибка получения internal squad %s: %s", uuid, error)
+            return None
+
+    async def get_internal_squad_accessible_nodes(self, uuid: str) -> List[Dict[str, Any]]:
+        try:
+            async with self.get_api_client() as api:
+                nodes = await api.get_internal_squad_accessible_nodes(uuid)
+                return [
+                    asdict(node) if is_dataclass(node) else node
+                    for node in nodes or []
+                ]
+        except Exception as error:
+            logger.error("Ошибка получения нод internal squad %s: %s", uuid, error)
             return []
     
     async def create_squad(self, name: str, inbounds: List[str]) -> Optional[str]:
@@ -1704,6 +1731,12 @@ class RemnaWaveService:
                                 telegram_id=user.telegram_id,
                             )
 
+                            internal_squads = (
+                                list(user.active_internal_squads or [])
+                                if user.active_internal_squads is not None
+                                else list(subscription.connected_squads or [])
+                            )
+
                             create_kwargs = dict(
                                 username=username,
                                 expire_at=expire_at,
@@ -1716,7 +1749,7 @@ class RemnaWaveService:
                                     username=user.username,
                                     telegram_id=user.telegram_id
                                 ),
-                                active_internal_squads=subscription.connected_squads,
+                                active_internal_squads=internal_squads,
                             )
 
                             if hwid_limit is not None:
@@ -1730,7 +1763,7 @@ class RemnaWaveService:
                                     traffic_limit_bytes=create_kwargs['traffic_limit_bytes'],
                                     traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                                     description=create_kwargs['description'],
-                                    active_internal_squads=subscription.connected_squads,
+                                    active_internal_squads=internal_squads,
                                 )
 
                                 if hwid_limit is not None:

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -139,6 +139,63 @@ class SubscriptionService:
 
         return settings.get_paid_subscription_user_tag()
 
+    @staticmethod
+    def _normalize_internal_squads(value: Optional[Iterable[str]]) -> Optional[list[str]]:
+        if value is None:
+            return None
+
+        try:
+            items = [str(item).strip() for item in value if str(item).strip()]
+        except TypeError:
+            return None
+
+        seen = set()
+        normalized: list[str] = []
+        for item in items:
+            lowered = item.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            normalized.append(item)
+        return normalized
+
+    @staticmethod
+    def _select_internal_squads(user: User, subscription: Subscription) -> Optional[list[str]]:
+        if user.active_internal_squads is not None:
+            return SubscriptionService._normalize_internal_squads(user.active_internal_squads)
+        return SubscriptionService._normalize_internal_squads(subscription.connected_squads)
+
+    async def _resolve_internal_squad_uuids(
+        self,
+        api: RemnaWaveAPI,
+        squads: Optional[Iterable[str]],
+    ) -> Optional[list[str]]:
+        normalized = self._normalize_internal_squads(squads)
+        if normalized is None:
+            return None
+        if not normalized:
+            return []
+
+        try:
+            available = await api.get_internal_squads()
+            uuid_lookup = {squad.uuid.lower(): squad.uuid for squad in available}
+            name_lookup = {squad.name.lower(): squad.uuid for squad in available}
+        except Exception as error:
+            logger.warning("Не удалось получить список internal squads: %s", error)
+            return normalized
+
+        resolved: list[str] = []
+        for item in normalized:
+            lowered = item.lower()
+            if lowered in uuid_lookup:
+                resolved.append(uuid_lookup[lowered])
+                continue
+            if lowered in name_lookup:
+                resolved.append(name_lookup[lowered])
+                continue
+            logger.warning("Не удалось сопоставить internal squad '%s' с панелью", item)
+        return resolved
+
     @property
     def is_configured(self) -> bool:
         return self._config_error is None
@@ -175,16 +232,24 @@ class SubscriptionService:
             if not user:
                 logger.error(f"Пользователь {subscription.user_id} не найден")
                 return None
-            
+
             validation_success = await self.validate_and_clean_subscription(db, subscription, user)
             if not validation_success:
                 logger.error(f"Ошибка валидации подписки для пользователя {user.telegram_id}")
                 return None
 
             user_tag = self._resolve_user_tag(subscription)
+            requested_internal_squads = self._select_internal_squads(user, subscription)
 
             async with self.get_api_client() as api:
                 hwid_limit = resolve_hwid_device_limit_for_payload(subscription)
+                resolved_internal_squads = await self._resolve_internal_squad_uuids(
+                    api,
+                    requested_internal_squads,
+                )
+                internal_squads_payload = (
+                    resolved_internal_squads if resolved_internal_squads is not None else []
+                )
                 existing_users = await api.get_user_by_telegram_id(user.telegram_id)
                 if existing_users:
                     logger.info(f"🔄 Найден существующий пользователь в панели для {user.telegram_id}")
@@ -207,7 +272,7 @@ class SubscriptionService:
                             username=user.username,
                             telegram_id=user.telegram_id
                         ),
-                        active_internal_squads=subscription.connected_squads,
+                        active_internal_squads=internal_squads_payload,
                     )
 
                     if user_tag is not None:
@@ -245,7 +310,7 @@ class SubscriptionService:
                             username=user.username,
                             telegram_id=user.telegram_id
                         ),
-                        active_internal_squads=subscription.connected_squads,
+                        active_internal_squads=internal_squads_payload,
                     )
 
                     if user_tag is not None:
@@ -313,9 +378,17 @@ class SubscriptionService:
                 logger.info(f"🔔 Статус подписки {subscription.id} автоматически изменен на 'expired'")
 
             user_tag = self._resolve_user_tag(subscription)
+            requested_internal_squads = self._select_internal_squads(user, subscription)
 
             async with self.get_api_client() as api:
                 hwid_limit = resolve_hwid_device_limit_for_payload(subscription)
+                resolved_internal_squads = await self._resolve_internal_squad_uuids(
+                    api,
+                    requested_internal_squads,
+                )
+                internal_squads_payload = (
+                    resolved_internal_squads if resolved_internal_squads is not None else []
+                )
 
                 update_kwargs = dict(
                     uuid=user.remnawave_uuid,
@@ -328,7 +401,7 @@ class SubscriptionService:
                         username=user.username,
                         telegram_id=user.telegram_id
                     ),
-                    active_internal_squads=subscription.connected_squads,
+                    active_internal_squads=internal_squads_payload,
                 )
 
                 if user_tag is not None:

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -654,6 +654,15 @@ class BotConfigurationService:
             "warning": "Неверный формат будет проигнорирован при создании пользователя.",
             "dependencies": "Активация триала и включенная интеграция с RemnaWave",
         },
+        "TRIAL_INTERNAL_SQUADS": {
+            "description": (
+                "Список internal squads, которые нужно назначать пользователям с триальной подпиской."
+            ),
+            "format": "Укажите названия сквадов через запятую или с новой строки.",
+            "example": "Default, Trial Access",
+            "warning": "При оплате подписки эти сквады будут сброшены.",
+            "dependencies": "RemnaWave API и активированный триал",
+        },
         "PAID_SUBSCRIPTION_USER_TAG": {
             "description": (
                 "Тег, который бот ставит пользователю при покупке платной подписки в панели RemnaWave."

--- a/app/webapi/routes/users.py
+++ b/app/webapi/routes/users.py
@@ -88,6 +88,7 @@ def _serialize_user(user: User) -> UserResponse:
         created_at=user.created_at,
         updated_at=user.updated_at,
         last_activity=user.last_activity,
+        active_internal_squads=list(user.active_internal_squads or []),
         promo_group=_serialize_promo_group(promo_group),
         subscription=_serialize_subscription(subscription),
     )
@@ -205,6 +206,7 @@ async def create_user_endpoint(
         last_name=payload.last_name,
         language=payload.language,
         referred_by_id=payload.referred_by_id,
+        active_internal_squads=payload.active_internal_squads,
     )
 
     if payload.promo_group_id and payload.promo_group_id != user.promo_group_id:
@@ -262,6 +264,9 @@ async def update_user_endpoint(
         if not promo_group:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Promo group not found")
         updates["promo_group_id"] = promo_group.id
+
+    if payload.active_internal_squads is not None:
+        updates["active_internal_squads"] = payload.active_internal_squads
 
     if payload.referral_code is not None and payload.referral_code != found_user.referral_code:
         existing_code_owner = await get_user_by_referral_code(db, payload.referral_code)

--- a/app/webapi/schemas/remnawave.py
+++ b/app/webapi/schemas/remnawave.py
@@ -137,6 +137,20 @@ class RemnaWaveSquadListResponse(BaseModel):
     total: int
 
 
+class RemnaWaveAccessibleNode(BaseModel):
+    uuid: str
+    node_name: str
+    country_code: str
+    config_profile_uuid: str
+    config_profile_name: str
+    active_inbounds: List[str] = Field(default_factory=list)
+
+
+class RemnaWaveAccessibleNodeListResponse(BaseModel):
+    items: List[RemnaWaveAccessibleNode]
+    total: int
+
+
 class RemnaWaveSquadCreateRequest(BaseModel):
     name: str
     inbound_uuids: List[str] = Field(default_factory=list)

--- a/app/webapi/schemas/users.py
+++ b/app/webapi/schemas/users.py
@@ -49,6 +49,7 @@ class UserResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     last_activity: Optional[datetime] = None
+    active_internal_squads: List[str] = Field(default_factory=list)
     promo_group: Optional[PromoGroupSummary] = None
     subscription: Optional[SubscriptionSummary] = None
 
@@ -68,6 +69,7 @@ class UserCreateRequest(BaseModel):
     language: str = "ru"
     referred_by_id: Optional[int] = None
     promo_group_id: Optional[int] = None
+    active_internal_squads: Optional[List[str]] = Field(default=None)
 
 
 class UserUpdateRequest(BaseModel):
@@ -80,6 +82,7 @@ class UserUpdateRequest(BaseModel):
     referral_code: Optional[str] = None
     has_had_paid_subscription: Optional[bool] = None
     has_made_first_topup: Optional[bool] = None
+    active_internal_squads: Optional[List[str]] = Field(default=None)
 
 
 class BalanceUpdateRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add persistent `active_internal_squads` support for users with DB migration, API payloads, and normalization
- allow configuring trial internal squads, syncing them to RemnaWave users and clearing them after purchase
- expose internal squad listing/details and accessible nodes via the RemnaWave web API endpoints
