### PR TITLE
Support user-specific internal squads

### DIFF
--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -171,7 +171,8 @@ async def create_user_no_commit(
     last_name: str = None,
     language: str = "ru",
     referred_by_id: int = None,
-    referral_code: str = None
+    referral_code: str = None,
+    active_internal_squads: Optional[List[str]] = None,
 ) -> User:
     """
     Создает пользователя без немедленного коммита для пакетной обработки
@@ -197,6 +198,7 @@ async def create_user_no_commit(
         has_had_paid_subscription=False,
         has_made_first_topup=False,
         promo_group_id=promo_group_id,
+        active_internal_squads=active_internal_squads,
     )
 
     db.add(user)
@@ -222,7 +224,8 @@ async def create_user(
     last_name: str = None,
     language: str = "ru",
     referred_by_id: int = None,
-    referral_code: str = None
+    referral_code: str = None,
+    active_internal_squads: Optional[List[str]] = None,
 ) -> User:
     
     if not referral_code:
@@ -248,6 +251,7 @@ async def create_user(
             has_had_paid_subscription=False,
             has_made_first_topup=False,
             promo_group_id=promo_group_id,
+            active_internal_squads=active_internal_squads,
         )
 
         db.add(user)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -585,6 +585,7 @@ class User(Base):
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
     last_activity = Column(DateTime, default=func.now())
     remnawave_uuid = Column(String(255), nullable=True, unique=True)
+    active_internal_squads = Column(JSON, nullable=True)
     broadcasts = relationship("BroadcastHistory", back_populates="admin")
     referrals = relationship("User", backref="referrer", remote_side=[id], foreign_keys="User.referred_by_id")
     subscription = relationship("Subscription", back_populates="user", uselist=False)

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -38,6 +38,7 @@ from app.database.crud.user import (
     subtract_user_balance,
     cleanup_expired_promo_offer_discounts,
 )
+from app.utils.internal_squads import resolve_user_internal_squads
 from app.utils.timezone import format_local_datetime
 from app.utils.subscription_utils import (
     resolve_hwid_device_limit_for_payload,
@@ -312,7 +313,9 @@ class MonitoringService:
                         username=user.username,
                         telegram_id=user.telegram_id
                     ),
-                    active_internal_squads=subscription.connected_squads,
+                    active_internal_squads=resolve_user_internal_squads(
+                        user, subscription
+                    ),
                 )
 
                 if hwid_limit is not None:

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -11,6 +11,7 @@ from app.external.remnawave_api import (
     TrafficLimitStrategy, RemnaWaveAPIError
 )
 from app.database.crud.user import get_user_by_id
+from app.utils.internal_squads import resolve_user_internal_squads
 from app.utils.pricing_utils import (
     calculate_months_from_days,
     get_remaining_months,
@@ -207,7 +208,9 @@ class SubscriptionService:
                             username=user.username,
                             telegram_id=user.telegram_id
                         ),
-                        active_internal_squads=subscription.connected_squads,
+                        active_internal_squads=resolve_user_internal_squads(
+                            user, subscription
+                        ),
                     )
 
                     if user_tag is not None:
@@ -245,7 +248,9 @@ class SubscriptionService:
                             username=user.username,
                             telegram_id=user.telegram_id
                         ),
-                        active_internal_squads=subscription.connected_squads,
+                        active_internal_squads=resolve_user_internal_squads(
+                            user, subscription
+                        ),
                     )
 
                     if user_tag is not None:
@@ -328,7 +333,9 @@ class SubscriptionService:
                         username=user.username,
                         telegram_id=user.telegram_id
                     ),
-                    active_internal_squads=subscription.connected_squads,
+                    active_internal_squads=resolve_user_internal_squads(
+                        user, subscription
+                    ),
                 )
 
                 if user_tag is not None:

--- a/app/utils/internal_squads.py
+++ b/app/utils/internal_squads.py
@@ -1,0 +1,21 @@
+from typing import List, Optional
+
+from app.database.models import Subscription, User
+
+
+def resolve_user_internal_squads(
+    user: Optional[User], subscription: Optional[Subscription]
+) -> List[str]:
+    """Возвращает список Internal Squads для пользователя.
+
+    Приоритет у персональных сквадов пользователя. Если они не заданы,
+    используется список сквадов из подписки.
+    """
+
+    if user and getattr(user, "active_internal_squads", None) is not None:
+        return list(user.active_internal_squads or [])
+
+    if subscription:
+        return list(subscription.connected_squads or [])
+
+    return []

--- a/app/webapi/schemas/users.py
+++ b/app/webapi/schemas/users.py
@@ -51,6 +51,7 @@ class UserResponse(BaseModel):
     last_activity: Optional[datetime] = None
     promo_group: Optional[PromoGroupSummary] = None
     subscription: Optional[SubscriptionSummary] = None
+    active_internal_squads: List[str] = Field(default_factory=list)
 
 
 class UserListResponse(BaseModel):
@@ -68,6 +69,10 @@ class UserCreateRequest(BaseModel):
     language: str = "ru"
     referred_by_id: Optional[int] = None
     promo_group_id: Optional[int] = None
+    active_internal_squads: Optional[List[str]] = Field(
+        default=None,
+        description="Названия или UUID Internal Squads, которые нужно назначить пользователю"
+    )
 
 
 class UserUpdateRequest(BaseModel):
@@ -80,6 +85,10 @@ class UserUpdateRequest(BaseModel):
     referral_code: Optional[str] = None
     has_had_paid_subscription: Optional[bool] = None
     has_made_first_topup: Optional[bool] = None
+    active_internal_squads: Optional[List[str]] = Field(
+        default=None,
+        description="Названия или UUID Internal Squads, которые нужно назначить пользователю"
+    )
 
 
 class BalanceUpdateRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add persistent user-level internal squad assignments and expose them via the web API
- resolve internal squad names from Remnawave to UUIDs and reuse them when syncing users with the panel
- prefer user-specific squads when updating Remnawave users and keep migrations in sync with the new column
