### PR TITLE
Restrict blacklist URL input to waiting state

### DIFF
--- a/app/states.py
+++ b/app/states.py
@@ -197,3 +197,7 @@ class AdminSubmenuStates(StatesGroup):
     in_communications_submenu = State()
     in_settings_submenu = State()
     in_system_submenu = State()
+
+
+class BlacklistStates(StatesGroup):
+    waiting_for_blacklist_url = State()


### PR DESCRIPTION
## Summary
- add a dedicated FSM state for blacklist URL input
- restrict the blacklist URL message handler to the expected state to avoid intercepting unrelated messages

