### PR TITLE
Add admin web panel miniapp toggle

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -330,6 +330,8 @@ class Settings(BaseSettings):
 
     MAIN_MENU_MODE: str = "default"
     CONNECT_BUTTON_MODE: str = "guide"
+    ADMIN_WEB_PANEL_ENABLED: bool = True
+    ADMIN_WEB_PANEL_URL: str = "https://bedolagam.ru"
     MINIAPP_CUSTOM_URL: str = ""
     MINIAPP_STATIC_PATH: str = "miniapp"
     MINIAPP_PURCHASE_URL: str = ""
@@ -855,6 +857,13 @@ class Settings(BaseSettings):
 
     def is_text_main_menu_mode(self) -> bool:
         return self.get_main_menu_mode() == "text"
+
+    def get_admin_web_panel_url(self) -> Optional[str]:
+        value = (getattr(self, "ADMIN_WEB_PANEL_URL", None) or "").strip()
+        return value or None
+
+    def is_admin_web_panel_enabled(self) -> bool:
+        return bool(self.ADMIN_WEB_PANEL_ENABLED and self.get_admin_web_panel_url())
 
     def get_main_menu_miniapp_url(self) -> Optional[str]:
         for candidate in [self.MINIAPP_CUSTOM_URL, self.MINIAPP_PURCHASE_URL]:

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -270,9 +270,21 @@ def _build_text_main_menu_keyboard(
         ])
 
     if is_admin:
-        keyboard_rows.append([
+        admin_buttons = [
             InlineKeyboardButton(text=texts.MENU_ADMIN, callback_data="admin_panel")
-        ])
+        ]
+
+        if settings.is_admin_web_panel_enabled():
+            admin_web_url = settings.get_admin_web_panel_url()
+            if admin_web_url:
+                admin_buttons.append(
+                    InlineKeyboardButton(
+                        text=texts.t("MENU_ADMIN_WEB", "🌐 Вебадминка"),
+                        web_app=types.WebAppInfo(url=admin_web_url),
+                    )
+                )
+
+        keyboard_rows.append(admin_buttons)
     elif is_moderator:
         keyboard_rows.append([
             InlineKeyboardButton(text="🧑‍⚖️ Модерация", callback_data="moderator_panel")
@@ -471,9 +483,22 @@ def get_main_menu_keyboard(
     if is_admin:
         if settings.DEBUG:
             print("DEBUG KEYBOARD: Админ кнопка ДОБАВЛЕНА!")
-        keyboard.append([
+
+        admin_buttons = [
             InlineKeyboardButton(text=texts.MENU_ADMIN, callback_data="admin_panel")
-        ])
+        ]
+
+        if settings.is_admin_web_panel_enabled():
+            admin_web_url = settings.get_admin_web_panel_url()
+            if admin_web_url:
+                admin_buttons.append(
+                    InlineKeyboardButton(
+                        text=texts.t("MENU_ADMIN_WEB", "🌐 Вебадминка"),
+                        web_app=types.WebAppInfo(url=admin_web_url),
+                    )
+                )
+
+        keyboard.append(admin_buttons)
     else:
         if settings.DEBUG:
             print("DEBUG KEYBOARD: Админ кнопка НЕ добавлена")

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -1038,6 +1038,7 @@
   "MANAGE_DEVICES_BUTTON": "🔧 Manage devices",
   "MARK_AS_ANSWERED": "✅ Mark as answered",
   "MENU_ADMIN": "⚙️ Admin panel",
+  "MENU_ADMIN_WEB": "🌐 Web admin",
   "MENU_BALANCE": "💰 Balance",
   "MENU_BUY_SUBSCRIPTION": "💎 Buy subscription",
   "MENU_EXTEND_SUBSCRIPTION": "⏰ Extend subscription",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -1050,6 +1050,7 @@
   "MANAGE_DEVICES_BUTTON": "🔧 Управление устройствами",
   "MARK_AS_ANSWERED": "✅ Отметить как отвеченный",
   "MENU_ADMIN": "⚙️ Админ-панель",
+  "MENU_ADMIN_WEB": "🌐 Вебадминка",
   "MENU_BALANCE": "💰 Баланс",
   "MENU_BUY_SUBSCRIPTION": "💎 Купить подписку",
   "MENU_EXTEND_SUBSCRIPTION": "⏰ Продлить подписку",

--- a/app/localization/locales/ua.json
+++ b/app/localization/locales/ua.json
@@ -983,6 +983,7 @@
  "MANAGE_DEVICES_BUTTON": "🔧 Керування пристроями",
  "MARK_AS_ANSWERED": "✅ Позначити як такий, що отримав відповідь",
  "MENU_ADMIN": "⚙️ Адмін-панель",
+ "MENU_ADMIN_WEB": "🌐 Веб-адмінка",
  "MENU_BALANCE": "💰 Баланс",
  "MENU_BUY_SUBSCRIPTION": "💎 Купити підписку",
  "MENU_EXTEND_SUBSCRIPTION": "⏰ Продовжити підписку",

--- a/app/localization/locales/zh.json
+++ b/app/localization/locales/zh.json
@@ -982,6 +982,7 @@
 "MANAGE_DEVICES_BUTTON":"🔧设备管理",
 "MARK_AS_ANSWERED":"✅标记为已回复",
 "MENU_ADMIN":"⚙️管理面板",
+"MENU_ADMIN_WEB":"🌐 Web admin",
 "MENU_BALANCE":"💰余额",
 "MENU_BUY_SUBSCRIPTION":"💎购买订阅",
 "MENU_EXTEND_SUBSCRIPTION":"⏰延长订阅",

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -320,6 +320,7 @@ class BotConfigurationService:
         "HAPP_": "HAPP",
         "SKIP_": "SKIP",
         "MINIAPP_": "MINIAPP",
+        "ADMIN_WEB_PANEL_": "EXTERNAL_ADMIN",
         "MONITORING_": "MONITORING",
         "NOTIFICATION_": "NOTIFICATIONS",
         "SERVER_STATUS": "SERVER_STATUS",
@@ -457,6 +458,18 @@ class BotConfigurationService:
             "description": "Объём трафика, включённый в простую подписку (0 = безлимит).",
             "format": "Выберите пакет трафика.",
             "example": "Безлимит",
+        },
+        "ADMIN_WEB_PANEL_ENABLED": {
+            "description": "Показывает кнопку веб-админки в главном меню администраторов.",
+            "format": "Булево значение.",
+            "example": "true",
+            "warning": "Кнопка доступна только администраторам и требует валидного URL.",
+        },
+        "ADMIN_WEB_PANEL_URL": {
+            "description": "Ссылка для открытия веб-админки в Telegram Mini App.",
+            "format": "Полный URL с https://",
+            "example": "https://bedolagam.ru",
+            "warning": "URL должен быть доступен из Telegram, иначе кнопка будет скрыта.",
         },
         "SIMPLE_SUBSCRIPTION_SQUAD_UUID": {
             "description": (


### PR DESCRIPTION
## Summary
- add configurable Admin Web panel button linking to bedolagam.ru for administrators
- expose enable/URL settings in bot configuration categories with localization updates
- show the web admin mini app beside the admin panel button in both menu layouts when enabled