### PR TITLE
Добавлено передача telegram_user_id в описание платежа

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1326,10 +1326,18 @@ class Settings(BaseSettings):
         except (ValueError, AttributeError):
             return [30, 90, 180]
 
-    def get_balance_payment_description(self, amount_kopeks: int) -> str:
+    def get_balance_payment_description(self, amount_kopeks: int, telegram_user_id: Optional[int] = None) -> str:
+        # Базовое описание
+        description = f"{self.PAYMENT_BALANCE_DESCRIPTION} на {self.format_price(amount_kopeks)}"
+        
+        # Если передан user_id, добавляем его
+        if telegram_user_id is not None:
+            description += f" (ID {telegram_user_id})"
+        
+        # Формируем финальную строку по шаблону
         return self.PAYMENT_BALANCE_TEMPLATE.format(
             service_name=self.PAYMENT_SERVICE_NAME,
-            description=f"{self.PAYMENT_BALANCE_DESCRIPTION} на {self.format_price(amount_kopeks)}"
+            description=description
         )
     
     def get_subscription_payment_description(self, period_days: int, amount_kopeks: int) -> str:

--- a/app/handlers/admin/bot_configuration.py
+++ b/app/handlers/admin/bot_configuration.py
@@ -1984,7 +1984,7 @@ async def test_payment_provider(
             return
 
         amount_kopeks = 10 * 100
-        description = settings.get_balance_payment_description(amount_kopeks)
+        description = settings.get_balance_payment_description(amount_kopeks, telegram_user_id=db_user.telegram_id),
         payment_result = await payment_service.create_yookassa_payment(
             db=db,
             user_id=db_user.id,

--- a/app/handlers/balance/yookassa.py
+++ b/app/handlers/balance/yookassa.py
@@ -175,7 +175,7 @@ async def process_yookassa_payment_amount(
             db=db,
             user_id=db_user.id,
             amount_kopeks=amount_kopeks,
-            description=settings.get_balance_payment_description(amount_kopeks),
+            description=settings.get_balance_payment_description(amount_kopeks, telegram_user_id=db_user.telegram_id),
             receipt_email=None,
             receipt_phone=None,
             metadata={
@@ -321,7 +321,7 @@ async def process_yookassa_sbp_payment_amount(
             db=db,
             user_id=db_user.id,
             amount_kopeks=amount_kopeks,
-            description=settings.get_balance_payment_description(amount_kopeks),
+            description=settings.get_balance_payment_description(amount_kopeks, telegram_user_id=db_user.telegram_id),
             receipt_email=None,
             receipt_phone=None,
             metadata={


### PR DESCRIPTION
Добавил возможность включать Telegram ID пользователя в описание платежа YooKassa.
Это облегчает поиск и сопоставление платежей с пользователями.