### PR TITLE
Add toggle for trial deactivation on channel unsubscribe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ SUBSCRIPTION_RENEWAL_BALANCE_THRESHOLD_KOPEKS=20000    # Порог баланс
 CHANNEL_SUB_ID= # Опционально ID твоего канала (-100)
 CHANNEL_IS_REQUIRED_SUB=false # Обязательна ли подписка на канал
 CHANNEL_LINK= # Опционально ссылка на канал
+CHANNEL_DISABLE_TRIAL_ON_UNSUBSCRIBE=true # Отключать триальные подписки при отписке от канала
 
 # ===== DATABASE CONFIGURATION =====
 # Режим базы данных: "auto", "postgresql", "sqlite"

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,7 @@ class Settings(BaseSettings):
     CHANNEL_SUB_ID: Optional[str] = None
     CHANNEL_LINK: Optional[str] = None
     CHANNEL_IS_REQUIRED_SUB: bool = False
+    CHANNEL_DISABLE_TRIAL_ON_UNSUBSCRIBE: bool = True
     
     DATABASE_URL: Optional[str] = None
     

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -507,6 +507,12 @@ class MonitoringService:
         if not settings.CHANNEL_IS_REQUIRED_SUB:
             return
 
+        if not settings.CHANNEL_DISABLE_TRIAL_ON_UNSUBSCRIBE:
+            logger.debug(
+                "ℹ️ Проверка отписок от канала отключена — деактивация триальных подписок не требуется"
+            )
+            return
+
         channel_id = settings.CHANNEL_SUB_ID
         if not channel_id:
             return


### PR DESCRIPTION
## Summary
- add configuration flag to control trial subscription deactivation when users leave the required channel
- respect the new flag in channel middleware and monitoring checks to avoid disabling subscriptions when desired
- document the new environment variable in the example configuration