### PR TITLE
Fix campaign subscription logic: use trial instead of paid

### DIFF
--- a/app/services/campaign_service.py
+++ b/app/services/campaign_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database.crud.campaign import record_campaign_registration
 from app.database.crud.subscription import (
-    create_paid_subscription,
+    create_trial_subscription,
     get_subscription_by_user_id,
 )
 from app.database.crud.user import add_user_balance
@@ -139,14 +139,15 @@ class AdvertisingCampaignService:
                     error,
                 )
 
-        new_subscription = await create_paid_subscription(
+        squad_uuid = squads[0] if squads else None
+
+        new_subscription = await create_trial_subscription(
             db=db,
             user_id=user.id,
             duration_days=duration_days,
             traffic_limit_gb=traffic_limit or 0,
             device_limit=device_limit,
-            connected_squads=squads,
-            update_server_counters=True,
+            squad_uuid=squad_uuid,
         )
 
         try:


### PR DESCRIPTION
Что сделано

Исправлена логика выдачи подписки по рекламным кампаниям.

Ранее при переходе пользователя по рекламной кампании создавалась платная подписка, что не соответствовало бизнес-логике. В рамках этого PR поведение приведено в корректное состояние — теперь по рекламным кампаниям всегда создаётся триальная подписка.

⸻

Основные изменения
	•	Рекламные кампании теперь используют create_trial_subscription вместо create_paid_subscription.
	•	Для trial-подписки передаётся один squad_uuid, как предусмотрено текущей реализацией trial-логики.
	•	Убрана передача параметров, не поддерживаемых create_trial_subscription.
	•	Логика создания пользователя в RemnaWave сохранена без изменений.
	•	Поведение серверных счётчиков не дублируется и остаётся внутри create_trial_subscription.

⸻

Почему это изменение важно
	•	Рекламная кампания не должна создавать платную подписку.
	•	Trial-подписка корректно отражает источник привлечения пользователя.
	•	Trial не участвует в автоплатежах и не искажает статистику платных подписок.
	•	Логика подписок становится более прозрачной и предсказуемой.

⸻

Что не затрагивалось
	•	Логика платных подписок
	•	Автоплатежи
	•	Продление подписок
	•	Ограничения и поведение trial-подписок
	•	API для управления подписками

⸻

Результат
	•	По рекламным кампаниям выдаётся только trial-подписка.
	•	Поведение соответствует бизнес-логике и текущей модели подписок.
	•	Изменения минимальны и не влияют на существующий функционал.

P.S. Видел вроде недавно issue на эту тему, но сейчас не смогу найти, почему-то.

Буду рад комментариям и предложениям.