### PR TITLE
feat: tariff reorder API endpoint

### DIFF
--- a/app/cabinet/routes/admin_tariffs.py
+++ b/app/cabinet/routes/admin_tariffs.py
@@ -14,6 +14,7 @@ from app.database.crud.tariff import (
     get_tariff_by_id,
     get_tariff_subscriptions_count,
     load_period_prices_from_db,
+    reorder_tariffs,
     set_tariff_promo_groups,
     update_tariff,
 )
@@ -29,6 +30,7 @@ from ..schemas.tariffs import (
     TariffDetailResponse,
     TariffListItem,
     TariffListResponse,
+    TariffSortOrderRequest,
     TariffStatsResponse,
     TariffToggleResponse,
     TariffTrialResponse,
@@ -155,6 +157,21 @@ async def get_available_servers(
         )
         for server in servers
     ]
+
+
+@router.put('/order')
+async def update_tariff_order(
+    request: TariffSortOrderRequest,
+    admin: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Update the display order of tariffs."""
+    await reorder_tariffs(db, request.tariff_ids)
+    await db.commit()
+
+    logger.info(f'Admin {admin.id} updated tariff order: {request.tariff_ids}')
+
+    return {'message': 'Tariff order updated successfully'}
 
 
 @router.get('/{tariff_id}', response_model=TariffDetailResponse)

--- a/app/cabinet/schemas/tariffs.py
+++ b/app/cabinet/schemas/tariffs.py
@@ -194,6 +194,12 @@ class TariffUpdateRequest(BaseModel):
     traffic_reset_mode: str | None = None  # DAY, WEEK, MONTH, NO_RESET, None = глобальная настройка
 
 
+class TariffSortOrderRequest(BaseModel):
+    """Request to reorder tariffs."""
+
+    tariff_ids: list[int] = Field(..., min_length=1, description='Ordered list of tariff IDs')
+
+
 class TariffToggleResponse(BaseModel):
     """Response after toggling tariff."""
 

--- a/app/database/crud/tariff.py
+++ b/app/database/crud/tariff.py
@@ -486,8 +486,6 @@ async def reorder_tariffs(
     for order, tariff_id in enumerate(tariff_order):
         await db.execute(update(Tariff).where(Tariff.id == tariff_id).values(display_order=order))
 
-    await db.commit()
-
     logger.info('Изменен порядок тарифов: %s', tariff_order)
 
 


### PR DESCRIPTION
## Summary
- Add `PUT /cabinet/admin/tariffs/order` endpoint for drag-and-drop tariff sorting
- Add `TariffSortOrderRequest` Pydantic schema
- Move `db.commit()` from `reorder_tariffs()` CRUD to route level for consistency

## Test plan
- [ ] Call `PUT /cabinet/admin/tariffs/order` with `{ "tariff_ids": [3, 1, 2] }` — verify tariffs reordered
- [ ] Verify tariff list returns in new `display_order`
- [ ] Verify bot shows tariffs to users in updated order