### PR TITLE
chore: sync dev → main (v3.5.0)

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -36,15 +36,15 @@ jobs:
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🏷️ Собираем релизную версию: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/main ]]; then
-          VERSION="v3.4.0-$(git rev-parse --short HEAD)"
+          VERSION="v3.5.0-$(git rev-parse --short HEAD)"
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🚀 Собираем версию из main: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-          VERSION="v3.4.0-dev-$(git rev-parse --short HEAD)"
+          VERSION="v3.5.0-dev-$(git rev-parse --short HEAD)"
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:dev,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🧪 Собираем dev версию: $VERSION"
         else
-          VERSION="v3.4.0-pr-$(git rev-parse --short HEAD)"
+          VERSION="v3.5.0-pr-$(git rev-parse --short HEAD)"
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:pr-$(git rev-parse --short HEAD)"
           echo "🔀 Собираем PR версию: $VERSION"
         fi

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -49,13 +49,13 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
             echo "🏷️ Building release version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION="v3.4.0-$(git rev-parse --short HEAD)"
+            VERSION="v3.5.0-$(git rev-parse --short HEAD)"
             echo "🚀 Building main version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-            VERSION="v3.4.0-dev-$(git rev-parse --short HEAD)"
+            VERSION="v3.5.0-dev-$(git rev-parse --short HEAD)"
             echo "🧪 Building dev version: $VERSION"
           else
-            VERSION="v3.4.0-pr-$(git rev-parse --short HEAD)"
+            VERSION="v3.5.0-pr-$(git rev-parse --short HEAD)"
             echo "🔀 Building PR version: $VERSION"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM python:3.13-slim
 
-ARG VERSION="v3.4.0"
+ARG VERSION="v3.5.0"
 ARG BUILD_DATE
 ARG VCS_REF
 

--- a/uv.lock
+++ b/uv.lock
@@ -1150,7 +1150,7 @@ wheels = [
 
 [[package]]
 name = "remnawave-bedolaga-telegram-bot"
-version = "3.4.0"
+version = "3.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
Sync dev branch to main — version bump to 3.5.0 in Dockerfile and CI workflows.

This is a chore/sync PR, not a new release.