### PR TITLE
feat: disable trial by user type (email/telegram/all)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -112,6 +112,7 @@ class Settings(BaseSettings):
     TRIAL_PAYMENT_ENABLED: bool = False
     TRIAL_ACTIVATION_PRICE: int = 0
     TRIAL_USER_TAG: str | None = None
+    TRIAL_DISABLED_FOR: str = 'none'  # none, email, telegram, all
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
     DEFAULT_TRAFFIC_RESET_STRATEGY: str = 'MONTH'
@@ -1308,6 +1309,16 @@ class Settings(BaseSettings):
 
     def get_trial_user_tag(self) -> str | None:
         return self._normalize_user_tag(self.TRIAL_USER_TAG, 'TRIAL_USER_TAG')
+
+    def is_trial_disabled_for_user(self, auth_type: str | None) -> bool:
+        disabled_for = self.TRIAL_DISABLED_FOR
+        if disabled_for == 'all':
+            return True
+        if disabled_for == 'email' and auth_type == 'email':
+            return True
+        if disabled_for == 'telegram' and (auth_type is None or auth_type == 'telegram'):
+            return True
+        return False
 
     def get_paid_subscription_user_tag(self) -> str | None:
         return self._normalize_user_tag(

--- a/app/handlers/subscription/purchase.py
+++ b/app/handlers/subscription/purchase.py
@@ -560,6 +560,15 @@ async def show_trial_offer(callback: types.CallbackQuery, db_user: User, db: Asy
 
     texts = get_texts(db_user.language)
 
+    # Проверяем, отключён ли триал для этого типа пользователя
+    if settings.is_trial_disabled_for_user(getattr(db_user, 'auth_type', 'telegram')):
+        await callback.message.edit_text(
+            texts.t('TRIAL_DISABLED_FOR_USER_TYPE', 'Пробный период недоступен'),
+            reply_markup=get_back_keyboard(db_user.language),
+        )
+        await callback.answer()
+        return
+
     # Проверяем, использовал ли пользователь триал
     # PENDING триальные подписки не считаются - пользователь может повторить оплату
     trial_blocked = False
@@ -748,6 +757,15 @@ async def activate_trial(callback: types.CallbackQuery, db_user: User, db: Async
             f'🚫 <b>Активация подписки ограничена</b>\n\n{reason}\n\n'
             'Если вы считаете это ошибкой, вы можете обжаловать решение.',
             reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
+        )
+        await callback.answer()
+        return
+
+    # Проверяем, отключён ли триал для этого типа пользователя
+    if settings.is_trial_disabled_for_user(getattr(db_user, 'auth_type', 'telegram')):
+        await callback.message.edit_text(
+            texts.t('TRIAL_DISABLED_FOR_USER_TYPE', 'Пробный период недоступен'),
+            reply_markup=get_back_keyboard(db_user.language),
         )
         await callback.answer()
         return

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -465,6 +465,12 @@ class BotConfigurationService:
             ChoiceOption('ERROR', '❌ Error'),
             ChoiceOption('CRITICAL', '🔥 Critical'),
         ],
+        'TRIAL_DISABLED_FOR': [
+            ChoiceOption('none', '✅ Включён для всех'),
+            ChoiceOption('email', '📧 Отключён для Email'),
+            ChoiceOption('telegram', '📱 Отключён для Telegram'),
+            ChoiceOption('all', '🚫 Отключён для всех'),
+        ],
     }
 
     SETTING_HINTS: dict[str, dict[str, str]] = {

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -3047,6 +3047,9 @@ def _is_trial_available_for_user(user: User) -> bool:
     if settings.TRIAL_DURATION_DAYS <= 0:
         return False
 
+    if settings.is_trial_disabled_for_user(getattr(user, 'auth_type', 'telegram')):
+        return False
+
     if getattr(user, 'has_had_paid_subscription', False):
         return False
 


### PR DESCRIPTION
## Summary
- Новая настройка `TRIAL_DISABLED_FOR` с гранулярностью по типу пользователя: `none` / `email` / `telegram` / `all`
- Хелпер `is_trial_disabled_for_user(auth_type)` в `Settings` для единообразной проверки
- Проверка интегрирована во все точки входа триала: бот-хендлеры, cabinet API, miniapp
- Настройка автоматически появляется в админке как dropdown через CHOICES (категория "Пробный период")

## Changes
- `app/config.py` — поле `TRIAL_DISABLED_FOR` + метод `is_trial_disabled_for_user()`
- `app/services/system_settings_service.py` — CHOICES с 4 вариантами
- `app/handlers/subscription/purchase.py` — проверка в `show_trial_offer()` и `activate_trial()`
- `app/cabinet/routes/subscription.py` — проверка в `get_trial_info()` и `activate_trial()`
- `app/webapi/routes/miniapp.py` — проверка в `_is_trial_available_for_user()`

## Test plan
- [ ] Настройки → Подписки → Пробный период → видна новая настройка с dropdown
- [ ] `none` → триал доступен всем
- [ ] `email` → email-юзер не видит триал, telegram-юзер видит
- [ ] `telegram` → telegram-юзер не видит триал, email-юзер видит
- [ ] `all` → триал недоступен никому
- [ ] Проверить в боте, кабинете и miniapp