### PR TITLE
feat: block registration with disposable email addresses

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -237,6 +237,8 @@ class Settings(BaseSettings):
     BLACKLIST_UPDATE_INTERVAL_HOURS: int = 24
     BLACKLIST_IGNORE_ADMINS: bool = True
 
+    DISPOSABLE_EMAIL_CHECK_ENABLED: bool = True
+
     # Настройки простой покупки
     SIMPLE_SUBSCRIPTION_ENABLED: bool = False
     SIMPLE_SUBSCRIPTION_PERIOD_DAYS: int = 30

--- a/app/services/disposable_email_service.py
+++ b/app/services/disposable_email_service.py
@@ -1,0 +1,109 @@
+"""Service for blocking disposable/temporary email domains."""
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+import aiohttp
+
+from app.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class DisposableEmailService:
+    """
+    Downloads and caches a list of disposable email domains from GitHub.
+
+    Domains are stored in a frozenset for O(1) thread-safe lookups.
+    The list is refreshed every 24 hours via an asyncio background task.
+    If the download fails, the service falls back to an empty set (no blocking).
+    """
+
+    DOMAINS_URL = 'https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.txt'
+    UPDATE_INTERVAL_HOURS = 24
+
+    def __init__(self) -> None:
+        self._domains: frozenset[str] = frozenset()
+        self._task: asyncio.Task[None] | None = None
+        self._last_updated: datetime | None = None
+        self._domain_count: int = 0
+
+    async def start(self) -> None:
+        """Load domains and start periodic refresh task."""
+        await self._update_domains()
+        self._task = asyncio.create_task(self._periodic_loop())
+        logger.info('DisposableEmailService started (%d domains loaded)', self._domain_count)
+
+    async def stop(self) -> None:
+        """Cancel periodic refresh task."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info('DisposableEmailService stopped')
+
+    async def _update_domains(self) -> None:
+        """Fetch domains.txt from GitHub and swap the in-memory set."""
+        try:
+            async with aiohttp.ClientSession() as session, session.get(self.DOMAINS_URL) as resp:
+                if resp.status != 200:
+                    logger.error(
+                        'Failed to fetch disposable domains: HTTP %d',
+                        resp.status,
+                    )
+                    return
+
+                text = await resp.text()
+
+            domains = frozenset(
+                line.strip().lower() for line in text.splitlines() if line.strip() and not line.startswith('#')
+            )
+
+            self._domains = domains
+            self._domain_count = len(domains)
+            self._last_updated = datetime.now(UTC)
+            logger.info('Disposable email domains updated: %d domains', self._domain_count)
+
+        except Exception:
+            logger.exception('Error updating disposable email domains')
+
+    async def _periodic_loop(self) -> None:
+        """Sleep then refresh, repeating forever until cancelled."""
+        while True:
+            await asyncio.sleep(self.UPDATE_INTERVAL_HOURS * 3600)
+            await self._update_domains()
+
+    def is_disposable(self, email: str) -> bool:
+        """Check if the email uses a disposable domain.
+
+        Returns False when the feature is disabled via settings.
+        """
+        if not getattr(settings, 'DISPOSABLE_EMAIL_CHECK_ENABLED', True):
+            return False
+
+        if not self._domains:
+            return False
+
+        try:
+            domain = email.rsplit('@', 1)[1].lower()
+        except IndexError:
+            return False
+
+        return domain in self._domains
+
+    def get_status(self) -> dict:
+        """Return service status for monitoring / health checks."""
+        return {
+            'enabled': getattr(settings, 'DISPOSABLE_EMAIL_CHECK_ENABLED', True),
+            'domain_count': self._domain_count,
+            'last_updated': self._last_updated.isoformat() if self._last_updated else None,
+            'running': self._task is not None and not self._task.done(),
+        }
+
+
+disposable_email_service = DisposableEmailService()

--- a/app/webserver/unified_app.py
+++ b/app/webserver/unified_app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.cabinet.routes import router as cabinet_router
 from app.config import settings
+from app.services.disposable_email_service import disposable_email_service
 from app.services.payment_service import PaymentService
 from app.webapi.app import create_web_api_app
 from app.webapi.docs import add_redoc_endpoint
@@ -143,6 +144,14 @@ def create_unified_app(
         app.include_router(telegram.create_telegram_router(bot, dispatcher, processor=telegram_processor))
     else:
         telegram_processor = None
+
+    @app.on_event('startup')
+    async def start_disposable_email_service() -> None:  # pragma: no cover - event hook
+        await disposable_email_service.start()
+
+    @app.on_event('shutdown')
+    async def stop_disposable_email_service() -> None:  # pragma: no cover - event hook
+        await disposable_email_service.stop()
 
     miniapp_mounted, miniapp_path = _mount_miniapp_static(app)
 


### PR DESCRIPTION
## Summary

- Добавлен `DisposableEmailService` — загружает ~72k временных email-доменов из [disposable/disposable-email-domains](https://github.com/disposable/disposable-email-domains) в `frozenset` при старте, обновляет каждые 24 часа
- Блокировка интегрирована в 3 точки входа email в `auth.py`: регистрация (link), standalone-регистрация, смена email
- Настройка `DISPOSABLE_EMAIL_CHECK_ENABLED` (по умолчанию `true`) — можно отключить через `.env` или админку
- Если загрузка списка не удалась, сервис работает без блокировки (fallback на пустой set)

## Changes

- `app/services/disposable_email_service.py` — новый сервис
- `app/config.py` — добавлена настройка `DISPOSABLE_EMAIL_CHECK_ENABLED`
- `app/webserver/unified_app.py` — startup/shutdown хуки сервиса
- `app/cabinet/routes/auth.py` — проверка disposable email в `register_email`, `register_email_standalone`, `request_email_change`