### PR TITLE
fix: use accessible nodes API and fix date format for node usage

### DIFF
--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -229,6 +229,7 @@ class UserNodeUsageItem(BaseModel):
 
     node_uuid: str
     node_name: str
+    country_code: str = ''
     total_bytes: int
 
 


### PR DESCRIPTION
## Summary
- Use `GET /api/users/{uuid}/accessible-nodes` to fetch user's available nodes
- Fix date format from ISO datetime to date-only (`%Y-%m-%d`) — fixes 400 validation error
- Show all accessible nodes in response (with zero traffic if no bandwidth stats available)
- Add `country_code` to `UserNodeUsageItem` schema