### PR TITLE
feat: return 30-day daily breakdown for node usage

### DIFF
--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -231,13 +231,15 @@ class UserNodeUsageItem(BaseModel):
     node_name: str
     country_code: str = ''
     total_bytes: int
+    daily_bytes: list[int] = []
 
 
 class UserNodeUsageResponse(BaseModel):
-    """Node usage response."""
+    """Node usage response with 30-day daily breakdown."""
 
     items: list[UserNodeUsageItem]
-    period_days: int
+    categories: list[str] = []
+    period_days: int = 30
 
 
 # === User Actions ===


### PR DESCRIPTION
Always fetch 30 days with daily_bytes per node. Frontend computes period totals locally.