### PR TITLE
fix: handle mixed types in traffic sort

### DIFF
--- a/app/cabinet/routes/admin_traffic.py
+++ b/app/cabinet/routes/admin_traffic.py
@@ -197,6 +197,8 @@ def _build_traffic_items(
     if sort_by.startswith('node_'):
         node_uuid = sort_by[5:]
         items.sort(key=lambda x: x.node_traffic.get(node_uuid, 0), reverse=sort_desc)
+    elif sort_by in ('full_name', 'tariff_name'):
+        items.sort(key=lambda x: (getattr(x, sort_by, None) or '').lower(), reverse=sort_desc)
     else:
         items.sort(key=lambda x: getattr(x, sort_by, 0) or 0, reverse=sort_desc)
 


### PR DESCRIPTION
## Summary
- Fix `TypeError: '<' not supported between instances of 'str' and 'int'` when sorting by `tariff_name` or `full_name`
- `None` values were falling back to `0` (int) via `or 0`, causing mixed-type comparison with string values
- String fields now use `or ''` fallback with case-insensitive `.lower()` comparison

## Test plan
- [ ] Sort by tariff column — no crash, users without tariff appear at top/bottom
- [ ] Sort by user name column — works case-insensitively
- [ ] Sort by total bytes / devices / traffic limit — still works as before