### PR TITLE
feat: tariff filter + fix traffic data aggregation

### DIFF
--- a/app/cabinet/schemas/traffic.py
+++ b/app/cabinet/schemas/traffic.py
@@ -29,6 +29,7 @@ class TrafficUsageResponse(BaseModel):
     offset: int
     limit: int
     period_days: int
+    available_tariffs: list[str]
 
 
 class ExportCsvRequest(BaseModel):


### PR DESCRIPTION
## Summary
- **Fix traffic data bug**: Switched from `get_bandwidth_stats_node_users` (returned UUIDs that didn't match bot DB) to `get_bandwidth_stats_user` per user — the same API used by the working AdminUserDetail page
- **Add tariff filter**: New `tariffs` query param (comma-separated), `available_tariffs` in response, filtering in `_build_traffic_items`
- **Concurrency control**: Parallel per-user bandwidth stats fetching with `asyncio.Semaphore(20)`

## Test plan
- [ ] Open admin traffic usage page — verify traffic data shows non-zero values for active users
- [ ] Filter by tariff — verify filtering works correctly
- [ ] Export CSV — verify CSV contains actual traffic data
- [ ] Check performance with large user base (caching should prevent repeated API calls within 5 min)