### PR TITLE
fix: resolve 429 rate limiting on traffic page

### DIFF
--- a/app/cabinet/routes/admin_traffic.py
+++ b/app/cabinet/routes/admin_traffic.py
@@ -101,7 +101,10 @@ async def _aggregate_traffic(
                 async with semaphore:
                     try:
                         stats = await api.get_bandwidth_stats_node_users(
-                            node.uuid, start_str, end_str, top_users_limit=9999,
+                            node.uuid,
+                            start_str,
+                            end_str,
+                            top_users_limit=9999,
                         )
                         return node.uuid, stats
                     except Exception:
@@ -127,9 +130,7 @@ async def _aggregate_traffic(
                 uid = user_entry.get('uuid', '')
                 total = int(user_entry.get('total', 0))
                 if uid and total > 0 and uid in user_uuids_set:
-                    user_traffic.setdefault(uid, {})[node_uuid] = (
-                        user_traffic.get(uid, {}).get(node_uuid, 0) + total
-                    )
+                    user_traffic.setdefault(uid, {})[node_uuid] = user_traffic.get(uid, {}).get(node_uuid, 0) + total
 
         _traffic_cache[period_days] = (now, user_traffic, nodes_info)
         return user_traffic, nodes_info

--- a/app/external/remnawave_api.py
+++ b/app/external/remnawave_api.py
@@ -386,10 +386,14 @@ class RemnaWaveAPI:
                         response_data = {'raw_response': response_text}
 
                     if response.status == 429 and attempt < max_retries:
-                        retry_after = float(response.headers.get('Retry-After', base_delay * (2 ** attempt)))
+                        retry_after = float(response.headers.get('Retry-After', base_delay * (2**attempt)))
                         logger.warning(
                             'Rate limited (429) on %s %s, retry %d/%d after %.1fs',
-                            method, endpoint, attempt + 1, max_retries, retry_after,
+                            method,
+                            endpoint,
+                            attempt + 1,
+                            max_retries,
+                            retry_after,
                         )
                         await asyncio.sleep(retry_after)
                         continue
@@ -404,8 +408,16 @@ class RemnaWaveAPI:
 
             except aiohttp.ClientError as e:
                 if attempt < max_retries:
-                    delay = base_delay * (2 ** attempt)
-                    logger.warning('Request failed on %s %s: %s, retry %d/%d after %.1fs', method, endpoint, e, attempt + 1, max_retries, delay)
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        'Request failed on %s %s: %s, retry %d/%d after %.1fs',
+                        method,
+                        endpoint,
+                        e,
+                        attempt + 1,
+                        max_retries,
+                        delay,
+                    )
                     await asyncio.sleep(delay)
                     continue
                 logger.error(f'Request failed: {e}')


### PR DESCRIPTION
## Summary
- Switched `_aggregate_traffic` from per-user API calls to per-node strategy — O(nodes) instead of O(users), ~10 requests vs ~200
- Added retry with exponential backoff (3 retries, 1s/2s/4s) for HTTP 429 in `_make_request` — protects all API callers
- Reduced `_CONCURRENCY_LIMIT` from 20 to 5 to prevent request bursts

## Test plan
- [ ] Open admin traffic page — verify data loads without 429 errors in logs
- [ ] Check traffic data matches per-user numbers on individual user pages
- [ ] Force refresh with cache expired — confirm no 429 spam
- [ ] Verify retry logic fires on rate limit (check logs for "Rate limited (429)..." warnings)