### PR TITLE
feat: add node/status filters, date range, devices to traffic page

### DIFF
--- a/app/cabinet/schemas/traffic.py
+++ b/app/cabinet/schemas/traffic.py
@@ -18,6 +18,7 @@ class UserTrafficItem(BaseModel):
     subscription_status: str | None
     traffic_limit_gb: float
     device_limit: int
+    connected_devices: int = 0
     node_traffic: dict[str, int]  # {node_uuid: total_bytes}
     total_bytes: int
 
@@ -30,10 +31,17 @@ class TrafficUsageResponse(BaseModel):
     limit: int
     period_days: int
     available_tariffs: list[str]
+    available_statuses: list[str]
 
 
 class ExportCsvRequest(BaseModel):
     period: int = Field(30, ge=1, le=30)
+    start_date: str = ''
+    end_date: str = ''
+    tariffs: str = ''
+    nodes: str = ''
+    statuses: str = ''
+    search: str = ''
 
 
 class ExportCsvResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Add node filter and status filter (comma-separated query params) to admin traffic endpoint
- Add custom date range picker (start_date/end_date) as alternative to fixed period buttons
- Fetch connected device count per user via HWID API with semaphore=10
- Cache key changed to `(start_str, end_str)` tuple — works for both period and custom date modes
- CSV export now respects all active filters (nodes, statuses, tariffs, search, dates)
- Backend validates future dates, max 31-day range constraint

## Test plan
- [ ] Select 2 nodes from filter → table shows only those node columns, totals recalculated
- [ ] Select "Active" status → only active subscriptions shown
- [ ] Switch to date mode → select 3-day range → data loads for that period
- [ ] Devices column shows `N/M` format (connected/limit)
- [ ] Export CSV with filters active → CSV matches visible data
- [ ] Send future start_date → returns 400 error