### PR TITLE
feat: node/status filters + custom date range for traffic page

### DIFF
--- a/app/cabinet/schemas/traffic.py
+++ b/app/cabinet/schemas/traffic.py
@@ -30,10 +30,16 @@ class TrafficUsageResponse(BaseModel):
     limit: int
     period_days: int
     available_tariffs: list[str]
+    available_statuses: list[str]
 
 
 class ExportCsvRequest(BaseModel):
     period: int = Field(30, ge=1, le=30)
+    start_date: str | None = None
+    end_date: str | None = None
+    tariffs: str | None = None
+    statuses: str | None = None
+    nodes: str | None = None
 
 
 class ExportCsvResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Add node filter (checkbox dropdown) — filters traffic data by selected nodes, recalculates totals
- Add status filter (checkbox dropdown) — filters by subscription status (active/trial/expired/disabled)
- Add custom date range support — `start_date`/`end_date` params alongside existing period buttons
- Refactor `_aggregate_traffic` to use date string cache keys with 5-min truncation
- Add cache eviction for expired entries
- CSV export respects all active filters and custom date range
- Extract `_get_status` helper, add `_compute_date_range` helper

## Test plan
- [ ] Select 2 nodes → table shows only those node columns, totals recalculated
- [ ] Select "Active" status → only active subscriptions shown
- [ ] Switch to date mode → pick custom range → data loads for that range
- [ ] Export CSV with filters active → CSV matches filtered view
- [ ] Verify rate limiting protection (semaphore=5) still works