### PR TITLE
feat: traffic filters, date range & risk columns in CSV export

### DIFF
--- a/app/cabinet/schemas/traffic.py
+++ b/app/cabinet/schemas/traffic.py
@@ -40,6 +40,8 @@ class ExportCsvRequest(BaseModel):
     tariffs: str | None = None
     statuses: str | None = None
     nodes: str | None = None
+    total_threshold_gb: float | None = Field(None, ge=0, description='Total GB/day threshold for risk column')
+    node_threshold_gb: float | None = Field(None, ge=0, description='Per-node GB/day threshold for risk column')
 
 
 class ExportCsvResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Node/status filters and custom date range support for admin traffic endpoint
- Risk columns in CSV export: Total GB/day, Risk Level, Risk Ratio, Risk GB/day
- New optional fields `total_threshold_gb` / `node_threshold_gb` in ExportCsvRequest
- Risk calculation matches frontend logic (low/medium/high/critical thresholds)

## Test plan
- [ ] Export CSV with thresholds set — verify 4 risk columns appear
- [ ] Export CSV without thresholds — no risk columns, backward compatible
- [ ] Node filter in export correctly limits CSV columns and recalculates totals
- [ ] Custom date range export produces correct period_days for GB/day calculation