### PR TITLE
fix: resolve HWID reset and webhook FK violation

### DIFF
--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -1328,6 +1328,27 @@ class YooKassaPaymentMixin:
             )
             return None
 
+        # Verify user exists before creating FK-linked record
+        try:
+            from app.database.crud.user import get_user_by_id
+
+            user = await get_user_by_id(db, user_id)
+            if not user:
+                logger.warning(
+                    'Webhook YooKassa %s: user_id=%s не найден в БД, пропускаем восстановление платежа',
+                    yookassa_payment_id,
+                    user_id,
+                )
+                return None
+        except Exception as e:
+            logger.warning(
+                'Webhook YooKassa %s: не удалось проверить user_id=%s: %s',
+                yookassa_payment_id,
+                user_id,
+                e,
+            )
+            return None
+
         amount_info = event_object.get('amount') or {}
         amount_value = amount_info.get('value')
         currency = (amount_info.get('currency') or 'RUB').upper()

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -1439,12 +1439,14 @@ class RemnaWaveService:
 
                 # Используем один API клиент для всех операций сброса HWID
                 hwid_api_client = None
+                hwid_api_cm = None
                 try:
-                    hwid_api_client = self.get_api_client()
-                    await hwid_api_client.__aenter__()
+                    hwid_api_cm = self.get_api_client()
+                    hwid_api_client = await hwid_api_cm.__aenter__()
                 except Exception as api_init_error:
                     logger.warning(f'⚠️ Не удалось создать API клиент для сброса HWID: {api_init_error}')
                     hwid_api_client = None
+                    hwid_api_cm = None
 
                 try:
                     for telegram_id, db_user in users_to_deactivate:
@@ -1565,9 +1567,9 @@ class RemnaWaveService:
 
                 finally:
                     # Закрываем API клиент
-                    if hwid_api_client:
+                    if hwid_api_cm:
                         try:
-                            await hwid_api_client.__aexit__(None, None, None)
+                            await hwid_api_cm.__aexit__(None, None, None)
                         except Exception:
                             pass
 


### PR DESCRIPTION
## Summary

- **HWID reset bug**: `__aenter__()` result was not captured — `hwid_api_client` held the context manager instead of the API client, causing `AttributeError: '_AsyncGeneratorContextManager' object has no attribute 'reset_user_devices'`
- **Webhook FK violation**: `_restore_missing_yookassa_payment` tried INSERT into `yookassa_payments` without verifying `user_id` exists in `users` table, causing `ForeignKeyViolationError`

## Changes

| File | Fix |
|------|-----|
| `app/services/remnawave_service.py` | Split context manager (`hwid_api_cm`) from client (`hwid_api_client`), assign `__aenter__()` result properly, `__aexit__` on the CM |
| `app/services/payment/yookassa.py` | Add `get_user_by_id` check before creating FK-linked payment record in `_restore_missing_yookassa_payment` |

## Test plan

- [ ] Trigger user sync with panel — verify HWID reset works without AttributeError
- [ ] Send YooKassa webhook for payment with non-existent user_id — verify graceful skip instead of FK crash