### PR TITLE
README.md микроправка блока server в nginx.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,8 @@ http {
     # Hooks + API домен
     server {
         listen 80;
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name hooks.domain.com;
 
         ssl_certificate /etc/ssl/private/hooks.fullchain.pem;
@@ -846,7 +847,8 @@ http {
     # Miniapp домен (статика + API)
     server {
         listen 80;
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name miniapp.domain.com;
 
         ssl_certificate /etc/ssl/private/miniapp.fullchain.pem;


### PR DESCRIPTION
вынес http2 в отдельную строку чтобы не было предупреждений   [warn] 1#1: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/nginx.conf