### PR TITLE
fix: add naive datetime guards to fromisoformat() in Redis cache readers

### DIFF
--- a/app/services/maintenance_service.py
+++ b/app/services/maintenance_service.py
@@ -415,10 +415,16 @@ API снова отвечает на запросы.""",
             self._status.consecutive_failures = status_data.get('consecutive_failures', 0)
 
             if status_data.get('enabled_at'):
-                self._status.enabled_at = datetime.fromisoformat(status_data['enabled_at'])
+                dt = datetime.fromisoformat(status_data['enabled_at'])
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                self._status.enabled_at = dt
 
             if status_data.get('last_check'):
-                self._status.last_check = datetime.fromisoformat(status_data['last_check'])
+                dt = datetime.fromisoformat(status_data['last_check'])
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                self._status.last_check = dt
 
             logger.info('🔥 Состояние техработ загружено из кеша: активен', is_active=self._status.is_active)
 

--- a/app/services/traffic_monitoring_service.py
+++ b/app/services/traffic_monitoring_service.py
@@ -154,7 +154,10 @@ class TrafficMonitoringServiceV2:
         try:
             time_str = await cache.get(TRAFFIC_SNAPSHOT_TIME_KEY)
             if time_str:
-                return datetime.fromisoformat(time_str)
+                dt = datetime.fromisoformat(time_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                return dt
             return None
         except Exception as e:
             logger.error('❌ Ошибка получения времени snapshot', error=e)
@@ -176,7 +179,10 @@ class TrafficMonitoringServiceV2:
             key = cache_key(TRAFFIC_NOTIFICATION_CACHE_KEY, user_uuid)
             time_str = await cache.get(key)
             if time_str:
-                return datetime.fromisoformat(time_str)
+                dt = datetime.fromisoformat(time_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                return dt
             return None
         except Exception as e:
             logger.error('❌ Ошибка получения времени уведомления', error=e)


### PR DESCRIPTION
Old Redis entries saved before utcnow→now(UTC) migration lack timezone info, causing TypeError on subtraction with aware datetimes.