### PR TITLE
feat: add configurable email domain blacklist and whitelist

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -626,6 +626,27 @@ async def register_email_standalone(
             detail='Disposable email addresses are not allowed',
         )
 
+    # Check email domain blacklist
+    if settings.is_email_domain_blocked(request.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                'code': 'email_domain_blocked',
+                'params': {'message': 'This email domain is not allowed'},
+            },
+        )
+
+    # Check email domain whitelist
+    if not settings.is_email_domain_allowed(request.email):
+        allowed = settings.get_email_allowed_domains()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                'code': 'email_domain_not_allowed',
+                'params': {'domains': ', '.join(sorted(allowed)), 'message': 'This email service is not supported. Use: ' + ', '.join(sorted(allowed))},
+            },
+        )
+
     # Проверить что email не занят
     existing = await db.execute(select(User).where(User.email == request.email))
     if existing.scalar_one_or_none():

--- a/app/config.py
+++ b/app/config.py
@@ -710,6 +710,8 @@ class Settings(BaseSettings):
     CABINET_PASSWORD_RESET_EXPIRE_HOURS: int = 1
     CABINET_EMAIL_CHANGE_CODE_EXPIRE_MINUTES: int = 15  # Email change verification code expiration
     CABINET_EMAIL_AUTH_ENABLED: bool = True  # Enable email registration/login in cabinet
+    CABINET_EMAIL_ALLOWED_DOMAINS: str = ''  # Comma-separated whitelist of allowed email domains (empty = allow all)
+    CABINET_EMAIL_BLOCKED_DOMAINS: str = ''  # Comma-separated blacklist of blocked email domains (empty = block none)
     CABINET_URL: str = 'https://example.com/cabinet'  # Base URL for cabinet (used in verification emails)
 
     # OAuth 2.0 provider settings for cabinet
@@ -2476,6 +2478,61 @@ class Settings(BaseSettings):
 
     def is_cabinet_email_auth_enabled(self) -> bool:
         return bool(self.CABINET_EMAIL_AUTH_ENABLED)
+
+    def get_email_allowed_domains(self) -> set[str]:
+        """Return the set of allowed email domains from CABINET_EMAIL_ALLOWED_DOMAINS.
+
+        Returns:
+            Set of lowercase domain strings. Empty set means all domains are allowed.
+        """
+        if not self.CABINET_EMAIL_ALLOWED_DOMAINS:
+            return set()
+        return {d.strip().lower() for d in self.CABINET_EMAIL_ALLOWED_DOMAINS.split(',') if d.strip()}
+
+    def is_email_domain_allowed(self, email: str) -> bool:
+        """Check whether the email domain is in the allowed domains whitelist.
+
+        Args:
+            email: Full email address to check.
+
+        Returns:
+            True if no whitelist is configured or the domain is whitelisted.
+        """
+        allowed = self.get_email_allowed_domains()
+        if not allowed:
+            return True
+        domain = email.rsplit('@', 1)[-1].lower()
+        return domain in allowed
+
+    def get_email_blocked_domains(self) -> set[str]:
+        """Return the set of blocked email domains from CABINET_EMAIL_BLOCKED_DOMAINS.
+
+        Returns:
+            Set of lowercase domain strings. Empty set means no domains are blocked.
+        """
+        if not self.CABINET_EMAIL_BLOCKED_DOMAINS:
+            return set()
+        return {d.strip().lower() for d in self.CABINET_EMAIL_BLOCKED_DOMAINS.split(',') if d.strip()}
+
+    def is_email_domain_blocked(self, email: str) -> bool:
+        """Check whether the email domain is in the blocked domains blacklist.
+
+        Blacklist is ignored when a whitelist is configured.
+
+        Args:
+            email: Full email address to check.
+
+        Returns:
+            True if the domain is blacklisted (and no whitelist is active).
+        """
+        if self.get_email_allowed_domains():
+            return False
+        blocked = self.get_email_blocked_domains()
+        if not blocked:
+            return False
+        domain = email.rsplit('@', 1)[-1].lower()
+        return domain in blocked
+
 
     def is_smtp_configured(self) -> bool:
         # For servers without AUTH, only host and from_email are required


### PR DESCRIPTION
Добавлены переменные окружения `CABINET_EMAIL_ALLOWED_DOMAINS` и `CABINET_EMAIL_BLOCKED_DOMAINS` для управления разрешёнными доменами при регистрации по email.

- Режим whitelist: регистрация только с указанных доменов (пусто = все разрешены)
- Режим blacklist: указанные домены заблокированы (игнорируется при активном whitelist)
- Возвращает структурированные коды ошибок (`email_domain_blocked`, `email_domain_not_allowed`) со списком разрешённых доменов для отображения на фронтенде