### PR TITLE
fix: reset QR photo when returning to referral

### DIFF
--- a/app/utils/photo_message.py
+++ b/app/utils/photo_message.py
@@ -29,7 +29,7 @@ def _resolve_media(message: types.Message):
         return get_logo_media()
     if settings.ENABLE_LOGO_MODE and not is_qr_message(message):
         return get_logo_media()
-    if message.photo:
+    if message.photo and not is_qr_message(message):
         return message.photo[-1].file_id
     return get_logo_media()
 


### PR DESCRIPTION
## Описание
Этот PR исправляет баг, когда фото QR-кода остается в сообщении после возвращения в раздел партнёрки.

## Проблема
При входе в раздел показа QR все работает корректно. Однако при возвращении обратно в раздел партнёрки вместо фото логотипа остается фото QR-кода.

## Решение
Добавлена проверка, чтобы фото использовалось только для не-QR сообщений и корректно сбрасывалось.

## Как тестировать
1. Открыть раздел "Партнёрка".
2. Открыть раздел "Показать QR код".
3. Вернуться обратно в раздел партнёрки.
4. Убедиться, что отображается логотип, а не QR.