### PR TITLE
feat: Авторизация через Telegram OIDC + выбор СБП/Карта в KassaAI

### DIFF
--- a/app/cabinet/auth/oauth_providers.py
+++ b/app/cabinet/auth/oauth_providers.py
@@ -473,6 +473,106 @@ class VKProvider(OAuthProvider):
         )
 
 
+
+class TelegramOIDCProvider(OAuthProvider):
+    """Telegram OpenID Connect provider (oauth.telegram.org).
+
+    Uses OAuth 2.0 + OIDC with PKCE (S256).
+    Returns user info via id_token JWT (no userinfo endpoint needed).
+    """
+
+    name = 'telegram'
+    display_name = 'Telegram'
+
+    AUTHORIZE_URL = 'https://oauth.telegram.org/auth'
+    TOKEN_URL = 'https://oauth.telegram.org/token'
+
+    @staticmethod
+    def _generate_pkce() -> tuple[str, str]:
+        """Generate PKCE code_verifier and code_challenge (S256)."""
+        code_verifier = secrets.token_urlsafe(64)
+        digest = hashlib.sha256(code_verifier.encode('ascii')).digest()
+        code_challenge = base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
+        return code_verifier, code_challenge
+
+    def prepare_auth_state(self) -> dict[str, str]:
+        code_verifier, code_challenge = self._generate_pkce()
+        return {
+            'code_verifier': code_verifier,
+            '_code_challenge': code_challenge,
+        }
+
+    def get_authorization_url(self, state: str, **kwargs: Any) -> str:
+        code_challenge: str = kwargs.get('_code_challenge', '')
+        # Extract origin from redirect_uri (scheme + host)
+        from urllib.parse import urlparse
+        parsed = urlparse(self.redirect_uri)
+        origin = f'{parsed.scheme}://{parsed.netloc}'
+        params: dict[str, str] = {
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'response_type': 'code',
+            'scope': 'openid profile',
+            'state': state,
+            'code_challenge': code_challenge,
+            'code_challenge_method': 'S256',
+            'origin': origin,
+        }
+        request = httpx.Request('GET', self.AUTHORIZE_URL, params=params)
+        return str(request.url)
+
+    async def exchange_code(self, code: str, **kwargs: Any) -> OAuthTokenResponse:
+        code_verifier: str = kwargs.get('code_verifier', '')
+        if not code_verifier:
+            raise ValueError('code_verifier is required for Telegram OIDC token exchange')
+
+        # Telegram requires Basic Authorization for token exchange
+        credentials = base64.b64encode(f'{self.client_id}:{self.client_secret}'.encode()).decode()
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                self.TOKEN_URL,
+                headers={'Authorization': f'Basic {credentials}'},
+                data={
+                    'grant_type': 'authorization_code',
+                    'code': code,
+                    'redirect_uri': self.redirect_uri,
+                    'code_verifier': code_verifier,
+                },
+            )
+            response.raise_for_status()
+            data: OAuthTokenResponse = response.json()
+            return data
+
+    async def get_user_info(self, token_data: OAuthTokenResponse) -> OAuthUserInfo:
+        import jwt as pyjwt
+
+        id_token = token_data.get('id_token', '')
+        if not id_token:
+            raise ValueError('Telegram OIDC response missing id_token')
+
+        # Decode without verification — token comes directly from Telegram's token endpoint
+        claims = pyjwt.decode(id_token, options={'verify_signature': False})
+
+        # Telegram OIDC claims: sub, id, name, preferred_username, picture, phone_number
+        telegram_id = str(claims.get('id') or claims.get('sub'))
+        if not telegram_id:
+            raise ValueError('Telegram OIDC id_token missing user id')
+
+        name = claims.get('name', '')
+        first_name = name.split(' ', 1)[0] if name else None
+        last_name = name.split(' ', 1)[1] if name and ' ' in name else None
+
+        return OAuthUserInfo(
+            provider='telegram',
+            provider_id=telegram_id,
+            first_name=first_name,
+            last_name=last_name,
+            username=claims.get('preferred_username'),
+            avatar_url=claims.get('picture'),
+        )
+
+
 # --- Provider factory ---
 
 _PROVIDERS: dict[str, type[OAuthProvider]] = {
@@ -480,6 +580,7 @@ _PROVIDERS: dict[str, type[OAuthProvider]] = {
     'yandex': YandexProvider,
     'discord': DiscordProvider,
     'vk': VKProvider,
+    'telegram': TelegramOIDCProvider,
 }
 
 

--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -29,6 +29,7 @@ from app.database.crud.user import (
 )
 from app.database.models import CabinetRefreshToken, User
 from app.services.campaign_service import AdvertisingCampaignService
+from app.services import yandex_offline_conv_service as yandex_conv
 from app.services.disposable_email_service import disposable_email_service
 from app.services.referral_service import process_referral_registration
 from app.utils.timezone import panel_datetime_to_utc
@@ -349,6 +350,18 @@ async def _sync_subscription_from_panel_by_email(db: AsyncSession, user: User) -
         # The sync is non-critical, main verification already succeeded
 
 
+
+async def _process_yandex_cid(db: AsyncSession, user: User, yandex_cid, source: str = 'web', is_new_user: bool = False) -> None:
+    if not yandex_cid:
+        return
+    try:
+        await yandex_conv.store_cid(db, user.id, yandex_cid, source=source)
+        if is_new_user:
+            await yandex_conv.on_registration(db, user.id)
+    except Exception as e:
+        logger.warning('Failed to process yandex CID', user_id=user.id, error=e)
+
+
 @router.post('/telegram', response_model=AuthResponse)
 async def auth_telegram(
     request: TelegramAuthRequest,
@@ -444,6 +457,10 @@ async def auth_telegram(
     if response.campaign_bonus:
         response.user = _user_to_response(user)
 
+    # Yandex offline conversions
+    is_new = user.created_at and (datetime.now(UTC) - user.created_at).total_seconds() < 10
+    await _process_yandex_cid(db, user, request.yandex_cid, source='web', is_new_user=is_new)
+
     return response
 
 
@@ -521,6 +538,10 @@ async def auth_telegram_widget(
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
     if response.campaign_bonus:
         response.user = _user_to_response(user)
+
+    # Yandex offline conversions
+    is_new = user.created_at and (datetime.now(UTC) - user.created_at).total_seconds() < 10
+    await _process_yandex_cid(db, user, request.yandex_cid, source='web', is_new_user=is_new)
 
     return response
 
@@ -750,6 +771,9 @@ async def register_email_standalone(
             logger.error('Failed to process referral registration', error=e)
             # Не прерываем регистрацию из-за ошибки реферальной системы
 
+    # Yandex offline conversions (store CID for new user)
+    await _process_yandex_cid(db, user, request.yandex_cid, source='web', is_new_user=True)
+
     # Для тестового email - сразу можно логиниться (уже verified)
     # Для обычного email - требуется верификация (если включена)
     verification_required = not is_test_email and settings.is_cabinet_email_verification_enabled()
@@ -949,6 +973,9 @@ async def login_email(
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
     if response.campaign_bonus:
         response.user = _user_to_response(user)
+
+    # Yandex offline conversions
+    await _process_yandex_cid(db, user, request.yandex_cid, source='web')
 
     return response
 

--- a/app/cabinet/routes/balance.py
+++ b/app/cabinet/routes/balance.py
@@ -678,6 +678,11 @@ async def create_topup(
                     detail='KassaAI payment method is unavailable',
                 )
 
+            # Map payment_option to KassaAI payment system ID: sbp=44, card=36
+            kassa_option = (request.payment_option or '').strip().lower()
+            kassa_ps_id_map = {'sbp': 44, 'card': 36}
+            kassa_ps_id = kassa_ps_id_map.get(kassa_option)
+
             payment_service = PaymentService()
             result = await payment_service.create_kassa_ai_payment(
                 db=db,
@@ -686,6 +691,7 @@ async def create_topup(
                 description=settings.get_balance_payment_description(request.amount_kopeks),
                 email=getattr(user, 'email', None),
                 language=getattr(user, 'language', None) or settings.DEFAULT_LANGUAGE,
+                payment_system_id=kassa_ps_id,
             )
 
             if result and result.get('payment_url'):

--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -255,12 +255,22 @@ class LiteModeEnabledUpdate(BaseModel):
     enabled: bool
 
 
+class OfflineConvGoal(BaseModel):
+    """Offline conversion goal info."""
+    name: str
+    event_id: str
+    dedup: str
+
+
 class AnalyticsCountersResponse(BaseModel):
     """Analytics counter settings."""
 
     yandex_metrika_id: str = ''
     google_ads_id: str = ''
     google_ads_label: str = ''
+    offline_conv_enabled: bool = False
+    offline_conv_counter_id: str = ''
+    offline_conv_goals: list[OfflineConvGoal] = []
 
 
 class AnalyticsCountersUpdate(BaseModel):
@@ -845,10 +855,25 @@ async def get_analytics_counters(
     google_id = await get_setting_value(db, GOOGLE_ADS_ID_KEY) or ''
     google_label = await get_setting_value(db, GOOGLE_ADS_LABEL_KEY) or ''
 
+    # Offline conversions status from env config
+    from app.config import settings as app_settings
+    oc_enabled = app_settings.YANDEX_OFFLINE_CONV_ENABLED and bool(app_settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET)
+    oc_counter = app_settings.YANDEX_OFFLINE_CONV_COUNTER_ID if oc_enabled else ''
+    oc_goals = []
+    if oc_enabled:
+        oc_goals = [
+            OfflineConvGoal(name='Регистрация', event_id='registration', dedup='1 раз'),
+            OfflineConvGoal(name='Триал', event_id='trial-add', dedup='1 раз'),
+            OfflineConvGoal(name='Покупка', event_id='purchase', dedup='каждый'),
+        ]
+
     return AnalyticsCountersResponse(
         yandex_metrika_id=yandex_id,
         google_ads_id=google_id,
         google_ads_label=google_label,
+        offline_conv_enabled=oc_enabled,
+        offline_conv_counter_id=oc_counter,
+        offline_conv_goals=oc_goals,
     )
 
 

--- a/app/cabinet/routes/oauth.py
+++ b/app/cabinet/routes/oauth.py
@@ -25,7 +25,7 @@ from ..auth.oauth_providers import (
 )
 from ..dependencies import get_cabinet_db
 from ..schemas.auth import AuthResponse
-from .auth import _create_auth_response, _process_campaign_bonus, _store_refresh_token
+from .auth import _create_auth_response, _process_campaign_bonus, _store_refresh_token, _process_yandex_cid
 
 
 logger = structlog.get_logger(__name__)
@@ -39,6 +39,8 @@ async def _finalize_oauth_login(
     provider: str,
     campaign_slug: str | None = None,
     referral_code: str | None = None,
+    yandex_cid: str | None = None,
+    is_new_user: bool = False,
 ) -> AuthResponse:
     """Update last login, create tokens, store refresh token."""
     user.cabinet_last_login = datetime.now(UTC)
@@ -54,6 +56,10 @@ async def _finalize_oauth_login(
     auth_response.campaign_bonus = await _process_campaign_bonus(db, user, campaign_slug)
     if auth_response.campaign_bonus:
         auth_response.user = _user_to_response(user)
+
+    # Yandex offline conversions
+    await _process_yandex_cid(db, user, yandex_cid, source='web', is_new_user=is_new_user)
+
     return auth_response
 
 
@@ -82,6 +88,7 @@ class OAuthCallbackRequest(BaseModel):
         None, min_length=1, max_length=64, pattern=r'^[a-zA-Z0-9_-]+$', description='Campaign slug from web link'
     )
     referral_code: str | None = Field(None, max_length=32, description='Referral code of inviter')
+    yandex_cid: str | None = Field(None, max_length=128, description='Yandex.Metrika ClientID')
 
 
 # --- Endpoints ---
@@ -171,7 +178,7 @@ async def oauth_callback(
     user = await get_user_by_oauth_provider(db, provider, user_info.provider_id)
     if user:
         logger.info('OAuth login for existing user', provider=provider, user_id=user.id)
-        return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code)
+        return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code, yandex_cid=request.yandex_cid)
 
     # 6. Find user by email (if verified) and link provider
     if user_info.email and user_info.email_verified:
@@ -179,7 +186,7 @@ async def oauth_callback(
         if user:
             await set_user_oauth_provider_id(db, user, provider, user_info.provider_id)
             logger.info('OAuth provider linked to existing email user', provider=provider, user_id=user.id)
-            return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code)
+            return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code, yandex_cid=request.yandex_cid)
 
     # 7. Resolve referral code for new user
     referrer_id = None
@@ -219,4 +226,4 @@ async def oauth_callback(
         referred_by_id=referrer_id,
     )
     logger.info('New OAuth user created', provider=provider, user_id=user.id)
-    return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code)
+    return await _finalize_oauth_login(db, user, provider, request.campaign_slug, request.referral_code, yandex_cid=request.yandex_cid, is_new_user=True)

--- a/app/cabinet/routes/subscription.py
+++ b/app/cabinet/routes/subscription.py
@@ -1298,6 +1298,13 @@ async def activate_trial(
 
     logger.info('Trial subscription activated for user', user_id=user.id)
 
+    # Yandex offline conversions: fire trial event
+    try:
+        from app.services import yandex_offline_conv_service as yandex_conv
+        await yandex_conv.on_trial(db, user.id)
+    except Exception as e:
+        logger.debug('Yandex offline conv trial hook error', error=e)
+
     # Create RemnaWave user
     try:
         subscription_service = SubscriptionService()

--- a/app/cabinet/schemas/auth.py
+++ b/app/cabinet/schemas/auth.py
@@ -13,6 +13,7 @@ class TelegramAuthRequest(BaseModel):
         None, min_length=1, max_length=64, pattern=r'^[a-zA-Z0-9_-]+$', description='Campaign slug from web link'
     )
     referral_code: str | None = Field(None, max_length=32, description='Referral code of inviter')
+    yandex_cid: str | None = Field(None, max_length=128, description='Yandex.Metrika ClientID')
 
 
 class TelegramWidgetAuthRequest(BaseModel):
@@ -29,6 +30,7 @@ class TelegramWidgetAuthRequest(BaseModel):
         None, min_length=1, max_length=64, pattern=r'^[a-zA-Z0-9_-]+$', description='Campaign slug from web link'
     )
     referral_code: str | None = Field(None, max_length=32, description='Referral code of inviter')
+    yandex_cid: str | None = Field(None, max_length=128, description='Yandex.Metrika ClientID')
 
 
 class EmailRegisterRequest(BaseModel):
@@ -55,6 +57,7 @@ class EmailLoginRequest(BaseModel):
     campaign_slug: str | None = Field(
         None, min_length=1, max_length=64, pattern=r'^[a-zA-Z0-9_-]+$', description='Campaign slug from web link'
     )
+    yandex_cid: str | None = Field(None, max_length=128, description='Yandex.Metrika ClientID')
 
 
 class RefreshTokenRequest(BaseModel):
@@ -114,6 +117,7 @@ class EmailRegisterStandaloneRequest(BaseModel):
     first_name: str | None = Field(None, max_length=64, description='First name')
     language: str = Field('ru', description='Preferred language')
     referral_code: str | None = Field(None, max_length=32, description='Referral code of inviter')
+    yandex_cid: str | None = Field(None, max_length=128, description='Yandex.Metrika ClientID')
 
 
 class CampaignBonusInfo(BaseModel):

--- a/app/config.py
+++ b/app/config.py
@@ -522,6 +522,15 @@ class Settings(BaseSettings):
     # Способ оплаты: 44 = СБП (QR код), 36 = Карты РФ, 43 = SberPay
     KASSA_AI_PAYMENT_SYSTEM_ID: int = 44
 
+    # Yandex.Metrika Offline Conversions
+    YANDEX_OFFLINE_CONV_ENABLED: bool = False
+    YANDEX_OFFLINE_CONV_COUNTER_ID: str = ''
+    YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET: str = ''
+    YANDEX_OFFLINE_CONV_START_PREFIX: str = 'utm_ya_'
+    YANDEX_OFFLINE_CONV_DL: str = ''
+    YANDEX_OFFLINE_CONV_DT: str = ''
+
+
     MAIN_MENU_MODE: str = 'default'  # 'default' | 'cabinet'
     # Стиль кнопок Cabinet: primary (синий), success (зелёный), danger (красный), '' (по умолчанию для каждой секции)
     CABINET_BUTTON_STYLE: str = ''
@@ -731,6 +740,11 @@ class Settings(BaseSettings):
     OAUTH_VK_CLIENT_ID: str = ''
     OAUTH_VK_CLIENT_SECRET: str = ''
     OAUTH_VK_ENABLED: bool = False
+
+    # Telegram auth mode: "widget" (old Login Widget) or "oidc" (new OpenID Connect)
+    TELEGRAM_AUTH_MODE: str = "widget"
+    TELEGRAM_OIDC_CLIENT_ID: str = ""
+    TELEGRAM_OIDC_CLIENT_SECRET: str = ""
 
     # SMTP settings for cabinet email
     SMTP_HOST: str | None = None
@@ -2530,6 +2544,12 @@ class Settings(BaseSettings):
                 'client_secret': self.OAUTH_VK_CLIENT_SECRET,
                 'enabled': self.OAUTH_VK_ENABLED,
                 'display_name': 'VK',
+            },
+            'telegram': {
+                'client_id': self.TELEGRAM_OIDC_CLIENT_ID,
+                'client_secret': self.TELEGRAM_OIDC_CLIENT_SECRET,
+                'enabled': self.TELEGRAM_AUTH_MODE == 'oidc' and bool(self.TELEGRAM_OIDC_CLIENT_ID),
+                'display_name': 'Telegram',
             },
         }
 

--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -425,6 +425,14 @@ async def add_user_balance(
             amount_kopeks=amount_kopeks,
         )
 
+        # Yandex offline conversions: fire purchase event for deposits
+        if transaction_type == TransactionType.DEPOSIT and amount_kopeks > 0:
+            try:
+                from app.services import yandex_offline_conv_service as yandex_conv
+                await yandex_conv.on_purchase(db, user.id, amount_kopeks)
+            except Exception as yandex_err:
+                logger.debug('Yandex offline conv purchase hook error', error=yandex_err)
+
         # Автоматическое возобновление приостановленной суточной подписки
         try:
             from app.database.crud.subscription import get_subscription_by_user_id, resume_daily_subscription
@@ -1264,6 +1272,7 @@ _OAUTH_PROVIDER_COLUMNS = {
     'yandex': 'yandex_id',
     'discord': 'discord_id',
     'vk': 'vk_id',
+    'telegram': 'telegram_id',
 }
 
 
@@ -1274,7 +1283,7 @@ async def get_user_by_oauth_provider(db: AsyncSession, provider: str, provider_i
         return None
     column = getattr(User, column_name)
     # VK uses BigInteger, so convert
-    value: str | int = int(provider_id) if provider == 'vk' else provider_id
+    value: str | int = int(provider_id) if provider in ('vk', 'telegram') else provider_id
     result = await db.execute(select(User).where(column == value))
     return result.scalar_one_or_none()
 
@@ -1284,7 +1293,7 @@ async def set_user_oauth_provider_id(db: AsyncSession, user: User, provider: str
     column_name = _OAUTH_PROVIDER_COLUMNS.get(provider)
     if not column_name:
         return
-    value: str | int = int(provider_id) if provider == 'vk' else provider_id
+    value: str | int = int(provider_id) if provider in ('vk', 'telegram') else provider_id
     setattr(user, column_name, value)
     user.updated_at = datetime.now(UTC)
     logger.info('Linked (id=) to user', provider=provider, provider_id=provider_id, user_id=user.id)
@@ -1308,7 +1317,7 @@ async def create_user_by_oauth(
     default_group = await _get_or_create_default_promo_group(db)
 
     column_name = _OAUTH_PROVIDER_COLUMNS.get(provider)
-    provider_value: str | int = int(provider_id) if provider == 'vk' else provider_id
+    provider_value: str | int = int(provider_id) if provider in ('vk', 'telegram') else provider_id
 
     user = User(
         telegram_id=None,

--- a/app/database/crud/yandex_client_id.py
+++ b/app/database/crud/yandex_client_id.py
@@ -1,0 +1,73 @@
+"""CRUD operations for yandex_client_id_map table."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import YandexClientIdMap
+
+logger = structlog.get_logger(__name__)
+
+
+async def upsert_cid(
+    db: AsyncSession,
+    user_id: int,
+    cid: str,
+    source: str = 'web',
+    counter_id: str | None = None,
+) -> YandexClientIdMap:
+    """Insert or update Yandex ClientID for a user."""
+    result = await db.execute(
+        select(YandexClientIdMap).where(YandexClientIdMap.user_id == user_id)
+    )
+    row = result.scalar_one_or_none()
+
+    if row:
+        row.yandex_cid = cid
+        row.source = source
+        row.updated_at = datetime.now(UTC)
+        if counter_id:
+            row.counter_id = counter_id
+    else:
+        row = YandexClientIdMap(
+            user_id=user_id,
+            yandex_cid=cid,
+            source=source,
+            counter_id=counter_id,
+        )
+        db.add(row)
+
+    await db.flush()
+    return row
+
+
+async def get_cid(db: AsyncSession, user_id: int) -> YandexClientIdMap | None:
+    """Get Yandex ClientID mapping for a user."""
+    result = await db.execute(
+        select(YandexClientIdMap).where(YandexClientIdMap.user_id == user_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def mark_registration_sent(db: AsyncSession, user_id: int) -> None:
+    """Mark registration event as sent for a user."""
+    await db.execute(
+        update(YandexClientIdMap)
+        .where(YandexClientIdMap.user_id == user_id)
+        .values(registration_sent=True, updated_at=datetime.now(UTC))
+    )
+    await db.flush()
+
+
+async def mark_trial_sent(db: AsyncSession, user_id: int) -> None:
+    """Mark trial event as sent for a user."""
+    await db.execute(
+        update(YandexClientIdMap)
+        .where(YandexClientIdMap.user_id == user_id)
+        .values(trial_sent=True, updated_at=datetime.now(UTC))
+    )
+    await db.flush()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2981,3 +2981,24 @@ class AdminAuditLog(Base):
 
     def __repr__(self) -> str:
         return f'<AdminAuditLog id={self.id} action={self.action!r} status={self.status!r}>'
+
+
+class YandexClientIdMap(Base):
+    """Mapping between users and Yandex.Metrika ClientIDs for offline conversions."""
+
+    __tablename__ = 'yandex_client_id_map'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False)
+    yandex_cid = Column(String(128), nullable=False)
+    source = Column(String(10), nullable=False, default='web')
+    counter_id = Column(String(32), nullable=True)
+    registration_sent = Column(Boolean, default=False, nullable=False)
+    trial_sent = Column(Boolean, default=False, nullable=False)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+
+    user = relationship('User', foreign_keys=[user_id])
+
+    def __repr__(self) -> str:
+        return f'<YandexClientIdMap user_id={self.user_id} cid={self.yandex_cid[:8]}...>'

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -36,6 +36,7 @@ from app.middlewares.channel_checker import (
 )
 from app.services.admin_notification_service import AdminNotificationService
 from app.services.campaign_service import AdvertisingCampaignService
+from app.services import yandex_offline_conv_service as yandex_conv
 from app.services.channel_subscription_service import channel_subscription_service
 from app.services.main_menu_button_service import MainMenuButtonService
 from app.services.pinned_message_service import (
@@ -137,6 +138,18 @@ async def _apply_campaign_bonus_if_needed(
         )
 
     return None
+
+
+
+
+async def _process_bot_yandex_cid(db, user, data, is_new_user):
+    yandex_cid = data.get('yandex_cid')
+    if yandex_cid and is_new_user:
+        try:
+            await yandex_conv.store_cid(db, user.id, yandex_cid, source='bot')
+            await yandex_conv.on_registration(db, user.id)
+        except Exception as e:
+            logger.warning('Failed to process yandex CID during registration', user_id=user.id, error=e)
 
 
 async def handle_potential_referral_code(message: types.Message, state: FSMContext, db: AsyncSession):
@@ -376,6 +389,14 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
 
     if state_needs_update:
         await state.set_data(data)
+
+    # Extract Yandex CID from start parameter (e.g. utm_ya_<CID>)
+    yandex_cid_from_start = None
+    if start_parameter:
+        yandex_cid_from_start, _ = yandex_conv.parse_cid_from_start_param(start_parameter)
+        if yandex_cid_from_start:
+            await state.update_data(yandex_cid=yandex_cid_from_start)
+            logger.info('Yandex CID extracted from start param', cid_len=len(yandex_cid_from_start))
 
     if start_parameter:
         campaign = await get_campaign_by_start_parameter(
@@ -1240,6 +1261,9 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
         except Exception as e:
             logger.error('Ошибка при обработке реферальной регистрации', error=e)
 
+    # Yandex offline conversions: store CID and fire registration event
+    await _process_bot_yandex_cid(db, user, data, is_new_user=is_new_user_registration)
+
     campaign_message = await _apply_campaign_bonus_if_needed(db, user, data, texts)
 
     try:
@@ -1534,6 +1558,9 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
                 )
         except Exception as e:
             logger.error('❌ Ошибка при активации промокода', promocode_to_activate=promocode_to_activate, error=e)
+
+    # Yandex offline conversions: store CID and fire registration event
+    await _process_bot_yandex_cid(db, user, data, is_new_user=is_new_user_registration)
 
     campaign_message = await _apply_campaign_bonus_if_needed(db, user, data, texts)
 

--- a/app/services/payment/kassa_ai.py
+++ b/app/services/payment/kassa_ai.py
@@ -29,6 +29,7 @@ class KassaAiPaymentMixin:
         description: str = 'Пополнение баланса',
         email: str | None = None,
         language: str = 'ru',
+        payment_system_id: int | None = None,
     ) -> dict[str, Any] | None:
         """
         Создает платеж KassaAI.
@@ -89,12 +90,13 @@ class KassaAiPaymentMixin:
 
         try:
             # Используем API для создания заказа
+            ps_id = payment_system_id or settings.KASSA_AI_PAYMENT_SYSTEM_ID
             result = await kassa_ai_service.create_order(
                 order_id=order_id,
                 amount=amount_rubles,
                 currency=currency,
                 email=email,
-                payment_system_id=settings.KASSA_AI_PAYMENT_SYSTEM_ID,
+                payment_system_id=ps_id,
             )
 
             payment_url = result.get('location')
@@ -116,7 +118,7 @@ class KassaAiPaymentMixin:
                 currency=currency,
                 description=description,
                 payment_url=payment_url,
-                payment_system_id=settings.KASSA_AI_PAYMENT_SYSTEM_ID,
+                payment_system_id=ps_id,
                 expires_at=expires_at,
                 metadata_json=json.dumps(metadata, ensure_ascii=False),
             )

--- a/app/services/payment_method_config_service.py
+++ b/app/services/payment_method_config_service.py
@@ -127,7 +127,10 @@ def _get_method_defaults() -> dict:
             'is_configured': settings.is_kassa_ai_enabled(),
             'default_min': settings.KASSA_AI_MIN_AMOUNT_KOPEKS,
             'default_max': settings.KASSA_AI_MAX_AMOUNT_KOPEKS,
-            'available_sub_options': None,
+            'available_sub_options': [
+                {'id': 'sbp', 'name': 'СБП'},
+                {'id': 'card', 'name': 'Карта'},
+            ],
         },
     }
 

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -1,0 +1,228 @@
+"""Yandex.Metrika offline conversions service.
+
+Sends events (registration, trial-add, purchase) to mc.yandex.ru/collect
+using the Measurement Protocol. Each event is preceded by a warm-up pageview.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.yandex_client_id import (
+    get_cid,
+    mark_registration_sent,
+    mark_trial_sent,
+    upsert_cid,
+)
+
+logger = structlog.get_logger(__name__)
+
+LOG_PREFIX = '[YandexOfflineConv]'
+COLLECT_URL = 'https://mc.yandex.ru/collect'
+TIMEOUT = 10.0
+MAX_RETRIES = 3
+RETRY_DELAY = 1.0
+
+_CID_RE = re.compile(r'^[A-Za-z0-9._:-]{4,64}$')
+
+
+def _is_enabled() -> bool:
+    return bool(
+        settings.YANDEX_OFFLINE_CONV_ENABLED
+        and settings.YANDEX_OFFLINE_CONV_COUNTER_ID
+        and settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET
+    )
+
+
+def _normalize_cid(cid: str | None) -> str | None:
+    if not isinstance(cid, str):
+        return None
+    cid = cid.strip()
+    if not cid:
+        return None
+    return cid
+
+
+def _mask_cid(cid: str) -> str:
+    if len(cid) <= 4:
+        return '****'
+    return '*' * (len(cid) - 4) + cid[-4:]
+
+
+def _base_payload(cid: str) -> dict[str, str]:
+    return {
+        'tid': settings.YANDEX_OFFLINE_CONV_COUNTER_ID,
+        'cid': cid,
+        'ms': settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET,
+    }
+
+
+def _pageview_payload(cid: str) -> dict[str, str]:
+    payload = _base_payload(cid)
+    payload.update({
+        't': 'pageview',
+        'dl': settings.YANDEX_OFFLINE_CONV_DL or 'https://web.mtrxvps.ru',
+        'dt': settings.YANDEX_OFFLINE_CONV_DT or 'Matrixxx VPN',
+    })
+    return payload
+
+
+def _event_payload(cid: str, event_action: str) -> dict[str, str]:
+    payload = _base_payload(cid)
+    payload.update({
+        't': 'event',
+        'ea': event_action,
+        'dl': settings.YANDEX_OFFLINE_CONV_DL or 'https://web.mtrxvps.ru',
+    })
+    return payload
+
+
+async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
+    """POST to mc.yandex.ru/collect with retries. Returns True on success."""
+    masked = _mask_cid(cid)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+                resp = await client.post(COLLECT_URL, data=payload)
+
+            if 200 <= resp.status_code < 300:
+                logger.info('%s %s sent (cid=%s, status=%s)', LOG_PREFIX, kind, masked, resp.status_code)
+                return True
+
+            if 500 <= resp.status_code < 600 and attempt < MAX_RETRIES:
+                logger.warning(
+                    '%s %s server error (attempt %s/%s, cid=%s, status=%s)',
+                    LOG_PREFIX, kind, attempt, MAX_RETRIES, masked, resp.status_code,
+                )
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+
+            logger.error(
+                '%s %s rejected (cid=%s, status=%s, body=%s)',
+                LOG_PREFIX, kind, masked, resp.status_code, resp.text[:200],
+            )
+            return False
+
+        except Exception as exc:
+            logger.warning(
+                '%s %s request error (attempt %s/%s, cid=%s): %s',
+                LOG_PREFIX, kind, attempt, MAX_RETRIES, masked, exc,
+            )
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+            return False
+
+    return False
+
+
+async def _send_event(cid: str, event_action: str) -> bool:
+    """Send a warm-up pageview followed by the actual event."""
+    # Warm-up pageview (required by Metrika to associate the CID)
+    pv_ok = await _post_collect(_pageview_payload(cid), 'pageview', cid)
+    if not pv_ok:
+        logger.warning('%s Pageview failed for %s, skipping event %s', LOG_PREFIX, _mask_cid(cid), event_action)
+        return False
+
+    return await _post_collect(_event_payload(cid, event_action), event_action, cid)
+
+
+# --- Public API ---
+
+
+async def store_cid(
+    db: AsyncSession,
+    user_id: int,
+    cid: str | None,
+    source: str = 'web',
+) -> bool:
+    """Store Yandex ClientID for a user. Returns True if stored."""
+    normalized = _normalize_cid(cid)
+    if not normalized:
+        return False
+
+    try:
+        await upsert_cid(db, user_id, normalized, source=source,
+                         counter_id=settings.YANDEX_OFFLINE_CONV_COUNTER_ID)
+        logger.info('%s Stored CID for user_id=%s source=%s', LOG_PREFIX, user_id, source)
+        return True
+    except Exception as exc:
+        logger.error('%s Failed to store CID for user_id=%s: %s', LOG_PREFIX, user_id, exc)
+        return False
+
+
+async def on_registration(db: AsyncSession, user_id: int) -> None:
+    """Fire registration event (once per user)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row or row.registration_sent:
+            return
+
+        success = await _send_event(row.yandex_cid, 'registration')
+        if success:
+            await mark_registration_sent(db, user_id)
+            logger.info('%s registration event sent for user_id=%s', LOG_PREFIX, user_id)
+    except Exception as exc:
+        logger.error('%s registration event failed for user_id=%s: %s', LOG_PREFIX, user_id, exc)
+
+
+async def on_trial(db: AsyncSession, user_id: int) -> None:
+    """Fire trial-add event (once per user)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row or row.trial_sent:
+            return
+
+        success = await _send_event(row.yandex_cid, 'trial-add')
+        if success:
+            await mark_trial_sent(db, user_id)
+            logger.info('%s trial-add event sent for user_id=%s', LOG_PREFIX, user_id)
+    except Exception as exc:
+        logger.error('%s trial-add event failed for user_id=%s: %s', LOG_PREFIX, user_id, exc)
+
+
+async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> None:
+    """Fire purchase event (every payment)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row:
+            return
+
+        success = await _send_event(row.yandex_cid, 'purchase')
+        if success:
+            logger.info(
+                '%s purchase event sent for user_id=%s amount=%s',
+                LOG_PREFIX, user_id, amount_kopeks / 100,
+            )
+    except Exception as exc:
+        logger.error('%s purchase event failed for user_id=%s: %s', LOG_PREFIX, user_id, exc)
+
+
+def parse_cid_from_start_param(param: str) -> tuple[str | None, str]:
+    """Extract Yandex CID from bot start parameter.
+
+    If param starts with the configured prefix (e.g. 'utm_ya_'),
+    returns (cid, remaining_param). Otherwise returns (None, original_param).
+    """
+    prefix = settings.YANDEX_OFFLINE_CONV_START_PREFIX
+    if not prefix or not param.startswith(prefix):
+        return None, param
+
+    cid = param[len(prefix):]
+    normalized = _normalize_cid(cid)
+    return normalized, param  # Keep original param for UTM tracking

--- a/migrations/alembic/versions/0015_add_yandex_client_id_map.py
+++ b/migrations/alembic/versions/0015_add_yandex_client_id_map.py
@@ -1,0 +1,37 @@
+"""add yandex_client_id_map table for offline conversions
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-03-04
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0015'
+down_revision: Union[str, None] = '0014'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'yandex_client_id_map',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False),
+        sa.Column('yandex_cid', sa.String(128), nullable=False),
+        sa.Column('source', sa.String(10), nullable=False, server_default='web'),
+        sa.Column('counter_id', sa.String(32), nullable=True),
+        sa.Column('registration_sent', sa.Boolean, server_default=sa.text('false'), nullable=False),
+        sa.Column('trial_sent', sa.Boolean, server_default=sa.text('false'), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('ix_yandex_cid_user_id', 'yandex_client_id_map', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_yandex_cid_user_id', table_name='yandex_client_id_map')
+    op.drop_table('yandex_client_id_map')


### PR DESCRIPTION
## Что сделано

- **Telegram OIDC авторизация**: Новый OAuth-провайдер через `oauth.telegram.org` с PKCE S256. Режим переключается через `TELEGRAM_AUTH_MODE` (widget/oidc). При включении OIDC — на странице логина вместо виджета отображается кнопка Telegram.
- **KassaAI: выбор СБП / Карта**: Добавлен выбор способа оплаты внутри KassaAI — СБП (payment_system_id=44) или банковская карта (payment_system_id=36). Работает через существующий механизм sub-options.

## Изменённые файлы

### Новые
- `app/cabinet/auth/oauth_providers.py` — TelegramOIDCProvider

### Изменённые
- `app/cabinet/routes/auth.py` — поддержка OIDC авторизации
- `app/cabinet/routes/balance.py` — маппинг payment_option → payment_system_id для KassaAI
- `app/cabinet/routes/oauth.py` — OAuth flow для Telegram
- `app/cabinet/schemas/auth.py` — новые поля в схемах авторизации
- `app/config.py` — настройки TELEGRAM_OIDC_*
- `app/services/payment/kassa_ai.py` — параметр payment_system_id
- `app/services/payment_method_config_service.py` — sub-options для kassa_ai (СБП, Карта)

## Переменные окружения (новые)

```env
TELEGRAM_AUTH_MODE=widget          # widget или oidc
TELEGRAM_OIDC_CLIENT_ID=
TELEGRAM_OIDC_CLIENT_SECRET=
```

## Тест-план

- [ ] KassaAI показывает выбор СБП/Карта на /balance/top-up/kassa_ai
- [ ] Оплата через СБП создаёт заказ с payment_system_id=44
- [ ] Оплата картой создаёт заказ с payment_system_id=36
- [ ] Авторизация через Telegram OIDC (TELEGRAM_AUTH_MODE=oidc)
- [ ] Авторизация через виджет (TELEGRAM_AUTH_MODE=widget)