### PR TITLE
feat: API эндпоинт для создания платёжной ссылки

### DIFF
--- a/app/services/payment/kassa_ai.py
+++ b/app/services/payment/kassa_ai.py
@@ -29,6 +29,8 @@ class KassaAiPaymentMixin:
         description: str = 'Пополнение баланса',
         email: str | None = None,
         language: str = 'ru',
+        payment_system_id: int | None = None,
+        extra_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """
         Создает платеж KassaAI.
@@ -86,6 +88,8 @@ class KassaAiPaymentMixin:
             'language': language,
             'type': 'balance_topup',
         }
+        if extra_metadata:
+            metadata.update(extra_metadata)
 
         try:
             # Используем API для создания заказа
@@ -348,6 +352,23 @@ class KassaAiPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки уведомления пользователю KassaAI', error=error)
 
+        # Авто-подписка если в metadata указан тариф
+        try:
+            meta = {}
+            if payment.metadata_json:
+                meta = json.loads(payment.metadata_json) if isinstance(payment.metadata_json, str) else payment.metadata_json
+            meta_tariff_id = meta.get('tariff_id')
+            meta_duration_days = meta.get('duration_days')
+
+            if meta_tariff_id and meta_duration_days:
+                await self._auto_create_subscription_from_metadata(
+                    db, user, int(meta_tariff_id), int(meta_duration_days), payment.amount_kopeks
+                )
+        except Exception as error:
+            logger.error(
+                'Ошибка авто-подписки из metadata KassaAI', user_id=user.id, error=error, exc_info=True
+            )
+
         # Автопокупка подписки и уведомление о корзине
         try:
             from app.services.payment.common import send_cart_notification_after_topup
@@ -366,6 +387,99 @@ class KassaAiPaymentMixin:
         )
 
         return True
+
+    async def _auto_create_subscription_from_metadata(
+        self,
+        db: AsyncSession,
+        user: Any,
+        tariff_id: int,
+        duration_days: int,
+        amount_kopeks: int,
+    ) -> None:
+        """Создаёт подписку автоматически после оплаты если в metadata указан тариф."""
+        from app.database.crud.server_squad import get_all_server_squads
+        from app.database.crud.subscription import create_paid_subscription, get_subscription_by_user_id
+        from app.database.crud.tariff import get_tariff_by_id
+        from app.database.crud.transaction import create_transaction
+        from app.database.crud.user import subtract_user_balance
+        from app.services.subscription_service import SubscriptionService
+
+        tariff = await get_tariff_by_id(db, tariff_id)
+        if not tariff or not tariff.is_active:
+            logger.warning('Авто-подписка: тариф не найден или неактивен', tariff_id=tariff_id)
+            return
+
+        price = tariff.get_price_for_period(duration_days)
+        if price is None:
+            logger.warning('Авто-подписка: период недоступен', tariff_id=tariff_id, duration_days=duration_days)
+            return
+
+        final_price = int(price)
+        if user.balance_kopeks < final_price:
+            logger.warning(
+                'Авто-подписка: недостаточно средств',
+                user_id=user.id,
+                balance=user.balance_kopeks,
+                price=final_price,
+            )
+            return
+
+        # Проверяем существующую подписку
+        existing = await get_subscription_by_user_id(db, user.id)
+        if existing:
+            logger.info('Авто-подписка: у пользователя уже есть подписка, пропускаем', user_id=user.id)
+            return
+
+        # Списываем баланс
+        description = f'Покупка тарифа {tariff.name} на {duration_days} дней (авто)'
+        success = await subtract_user_balance(db, user, final_price, description)
+        if not success:
+            logger.error('Авто-подписка: не удалось списать баланс', user_id=user.id)
+            return
+
+        # Серверы из тарифа
+        squads = tariff.allowed_squads or []
+        if not squads:
+            all_servers, _ = await get_all_server_squads(db, available_only=True)
+            squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
+
+        # Создаём подписку
+        subscription = await create_paid_subscription(
+            db=db,
+            user_id=user.id,
+            duration_days=duration_days,
+            traffic_limit_gb=tariff.traffic_limit_gb,
+            device_limit=tariff.device_limit,
+            connected_squads=squads,
+            tariff_id=tariff.id,
+        )
+
+        # Транзакция
+        try:
+            await create_transaction(
+                db=db,
+                user_id=user.id,
+                type=TransactionType.SUBSCRIPTION_PAYMENT,
+                amount_kopeks=final_price,
+                description=description,
+            )
+        except Exception as tx_error:
+            logger.warning('Авто-подписка: не удалось создать транзакцию', error=tx_error)
+
+        # Remnawave
+        try:
+            subscription_service = SubscriptionService()
+            await subscription_service.create_remnawave_user(db, subscription, reset_traffic=True, reset_reason='авто-подписка API')
+        except Exception as rw_error:
+            logger.warning('Авто-подписка: не удалось обновить Remnawave', error=rw_error)
+
+        logger.info(
+            '✅ Авто-подписка создана',
+            user_id=user.id,
+            tariff_id=tariff_id,
+            duration_days=duration_days,
+            price=final_price,
+        )
 
     async def check_kassa_ai_payment_status(
         self,

--- a/app/webapi/routes/users.py
+++ b/app/webapi/routes/users.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +31,8 @@ from app.services.subscription_service import SubscriptionService
 from ..dependencies import get_db_session, require_api_token
 from ..schemas.users import (
     BalanceUpdateRequest,
+    PaymentLinkRequest,
+    PaymentLinkResponse,
     PromoGroupSummary,
     SubscriptionSummary,
     UserCreateRequest,
@@ -39,6 +42,8 @@ from ..schemas.users import (
     UserUpdateRequest,
 )
 
+
+logger = structlog.get_logger(__name__)
 
 router = APIRouter()
 
@@ -329,6 +334,83 @@ async def update_balance(
         found_user = await get_user_by_id(db, found_user.id)
 
     return _serialize_user(found_user)
+
+
+@router.post('/{user_id}/payment-link', response_model=PaymentLinkResponse)
+async def create_payment_link(
+    user_id: int,
+    payload: PaymentLinkRequest,
+    _: Any = Security(require_api_token),
+    db: AsyncSession = Depends(get_db_session),
+) -> PaymentLinkResponse:
+    """
+    Создать платёжную ссылку KassaAI для пользователя.
+    Если указан tariff_id + duration_days — после оплаты подписка создастся автоматически.
+    """
+    user = await get_user_by_telegram_id(db, user_id)
+    if not user:
+        user = await get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, 'User not found')
+
+    amount_kopeks = payload.amount_kopeks
+    extra_metadata: dict[str, Any] = {}
+
+    if payload.tariff_id is not None:
+        from app.database.crud.tariff import get_tariff_by_id
+
+        tariff = await get_tariff_by_id(db, payload.tariff_id)
+        if not tariff:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, 'Tariff not found')
+        if not tariff.is_active:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, 'Tariff is not active')
+
+        if payload.duration_days is None:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, 'duration_days is required when tariff_id is specified')
+
+        price = tariff.get_price_for_period(payload.duration_days)
+        if price is None:
+            available = tariff.get_available_periods()
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f'Period {payload.duration_days} days is not available for this tariff. Available: {available}',
+            )
+
+        if amount_kopeks is None:
+            amount_kopeks = int(price)
+
+        extra_metadata['tariff_id'] = payload.tariff_id
+        extra_metadata['duration_days'] = payload.duration_days
+
+    if amount_kopeks is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, 'amount_kopeks is required (or specify tariff_id)')
+
+    if amount_kopeks <= 0:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, 'amount_kopeks must be positive')
+
+    from app.services.payment_service import PaymentService
+
+    payment_service = PaymentService()
+    result = await payment_service.create_kassa_ai_payment(
+        db,
+        user_id=user.id,
+        amount_kopeks=amount_kopeks,
+        description=payload.description or 'Оплата через API',
+        payment_system_id=payload.payment_system_id,
+        extra_metadata=extra_metadata or None,
+    )
+
+    if not result:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, 'Failed to create payment link')
+
+    return PaymentLinkResponse(
+        payment_url=result['payment_url'],
+        order_id=result['order_id'],
+        amount_kopeks=result['amount_kopeks'],
+        amount_rubles=result['amount_rubles'],
+        expires_at=result['expires_at'],
+        local_payment_id=result['local_payment_id'],
+    )
 
 
 async def _get_user_by_id_or_telegram_id(db: AsyncSession, user_id: int) -> User:

--- a/app/webapi/schemas/users.py
+++ b/app/webapi/schemas/users.py
@@ -97,3 +97,24 @@ class UserSubscriptionCreateRequest(BaseModel):
     squad_uuid: str | None = None
     connected_squads: list[str] | None = None
     replace_existing: bool = False
+
+
+class PaymentLinkRequest(BaseModel):
+    """Запрос на создание платёжной ссылки KassaAI."""
+
+    amount_kopeks: int | None = None
+    tariff_id: int | None = None
+    duration_days: int | None = None
+    payment_system_id: int | None = None
+    description: str | None = None
+
+
+class PaymentLinkResponse(BaseModel):
+    """Ответ с данными платёжной ссылки."""
+
+    payment_url: str
+    order_id: str
+    amount_kopeks: int
+    amount_rubles: float
+    expires_at: str
+    local_payment_id: int


### PR DESCRIPTION
## Описание

Новый эндпоинт `POST /users/{user_id}/payment-link` — создаёт ссылку на оплату через любую подключённую платёжную систему.

## Поддерживаемые платёжки

`kassa_ai` (по умолчанию), `freekassa`, `yookassa`, `cryptobot`, `heleket`, `mulenpay`, `pal24`, `wata`, `platega`, `cloudpayments`

## Пример

```bash
curl -X POST /users/123/payment-link \
  -H "X-API-Key: <token>" \
  -d '{"payment_method": "kassa_ai", "amount_kopeks": 19900}'
```

Ответ:
```json
{
  "payment_url": "https://paymentt.kassa.ai/?id=...",
  "payment_method": "kassa_ai",
  "order_id": "k123_abc",
  "amount_kopeks": 19900,
  "amount_rubles": 199.0,
  "expires_at": "2026-03-05T08:00:00+00:00",
  "local_payment_id": 30
}
```

## Изменения

- `app/webapi/schemas/users.py` — `PaymentLinkRequest` / `PaymentLinkResponse`
- `app/webapi/routes/users.py` — эндпоинт + диспатчер `_dispatch_payment`
- Модули оплаты не затронуты