### PR TITLE
fix: sync uv.lock version with pyproject.toml 3.23.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "remnawave-bedolaga-telegram-bot"
-version = "3.23.0"
+version = "3.23.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
release-please обновляет version в pyproject.toml, но не перегенерирует uv.lock — Docker build падает на uv sync --locked.