### PR TITLE
feat: introduce pluggable email backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,11 @@ CABINET_PASSWORD_RESET_EXPIRE_HOURS=1
 # Время жизни кода подтверждения смены email в минутах
 CABINET_EMAIL_CHANGE_CODE_EXPIRE_MINUTES=15
 
-# ===== SMTP НАСТРОЙКИ (для email в личном кабинете) =====
+# ===== EMAIL НАСТРОЙКИ (для email в личном кабинете) =====
+# Транспорт: smtp (по умолчанию) | custom (загрузка класса из EMAIL_BACKEND_CLASS)
+# EMAIL_BACKEND=smtp
+# EMAIL_BACKEND_CLASS=                  # для custom: package.module:BackendClass
+
 # SMTP сервер (например: smtp.gmail.com, smtp.yandex.ru)
 SMTP_HOST=
 SMTP_PORT=587

--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -910,60 +910,73 @@ async def register_email(
         }
 
     # Update user
-    user.email = request.email
-    user.password_hash = hash_password(request.password)
-
+    sent = False
     if not settings.is_cabinet_email_verification_enabled():
         # Верификация отключена — сразу помечаем email как verified
+        user.email = request.email
+        user.password_hash = hash_password(request.password)
         user.email_verified = True
         user.email_verified_at = datetime.now(UTC)
         await db.commit()
     else:
+        # Early check: email backend must be available before committing changes
+        if not email_service.is_configured():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail='Email service is not configured',
+            )
+
         # Generate verification token
         verification_token = generate_verification_token()
         verification_expires = get_verification_expires_at()
 
+        # Save email + password + token atomically
+        user.email = request.email
+        user.password_hash = hash_password(request.password)
         user.email_verified = False
         user.email_verification_token = verification_token
         user.email_verification_expires = verification_expires
         await db.commit()
 
-        # Send verification email asynchronously (smtplib is blocking)
-        if email_service.is_configured():
-            cabinet_url = settings.CABINET_URL
-            verification_url = f'{cabinet_url}/verify-email'
-            lang = user.language or 'ru'
-            full_url = f'{verification_url}?token={verification_token}'
-            expire_hours = settings.get_cabinet_email_verification_expire_hours()
+        cabinet_url = settings.CABINET_URL
+        verification_url = f'{cabinet_url}/verify-email'
+        lang = user.language or 'ru'
+        full_url = f'{verification_url}?token={verification_token}'
+        expire_hours = settings.get_cabinet_email_verification_expire_hours()
 
-            # Check for admin template override
-            override = await get_rendered_override(
-                'email_verification',
-                lang,
-                context={
-                    'username': user.first_name or '',
-                    'verification_url': full_url,
-                    'expire_hours': str(expire_hours),
-                },
-                db=db,
-            )
-            custom_subject, custom_body = override or (None, None)
+        # Check for admin template override
+        override = await get_rendered_override(
+            'email_verification',
+            lang,
+            context={
+                'username': user.first_name or '',
+                'verification_url': full_url,
+                'expire_hours': str(expire_hours),
+            },
+            db=db,
+        )
+        custom_subject, custom_body = override or (None, None)
 
-            await asyncio.to_thread(
-                email_service.send_verification_email,
-                to_email=request.email,
-                verification_token=verification_token,
-                verification_url=verification_url,
-                username=user.first_name,
-                language=lang,
-                custom_subject=custom_subject,
-                custom_body_html=custom_body,
-            )
+        sent = await asyncio.to_thread(
+            email_service.send_verification_email,
+            to_email=request.email,
+            verification_token=verification_token,
+            verification_url=verification_url,
+            username=user.first_name,
+            language=lang,
+            custom_subject=custom_subject,
+            custom_body_html=custom_body,
+        )
+
+    if not settings.is_cabinet_email_verification_enabled():
+        message = 'Email linked successfully'
+    elif sent:
+        message = 'Verification email sent'
+    else:
+        message = 'Email linked, but verification email could not be sent. Please request resend.'
 
     return {
-        'message': 'Email linked successfully'
-        if not settings.is_cabinet_email_verification_enabled()
-        else 'Verification email sent',
+        'message': message,
         'email': request.email,
     }
 
@@ -1042,6 +1055,13 @@ async def register_email_standalone(
                     referral_code=request.referral_code,
                 )
 
+    # Early check: if verification is required, email backend must be available
+    if not is_test_email and settings.is_cabinet_email_verification_enabled() and not email_service.is_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Email service is not configured',
+        )
+
     # Создать пользователя
     user = await create_user_by_email(
         db=db,
@@ -1073,34 +1093,42 @@ async def register_email_standalone(
         await db.commit()
 
         # Отправить email верификации
-        if settings.is_cabinet_email_verification_enabled() and email_service.is_configured():
-            cabinet_url = settings.CABINET_URL
-            verification_url = f'{cabinet_url}/verify-email'
-            lang = user.language or request.language or 'ru'
-            full_url = f'{verification_url}?token={verification_token}'
-            expire_hours = settings.get_cabinet_email_verification_expire_hours()
+        cabinet_url = settings.CABINET_URL
+        verification_url = f'{cabinet_url}/verify-email'
+        lang = user.language or request.language or 'ru'
+        full_url = f'{verification_url}?token={verification_token}'
+        expire_hours = settings.get_cabinet_email_verification_expire_hours()
 
-            override = await get_rendered_override(
-                'email_verification',
-                lang,
-                context={
-                    'username': user.first_name or 'User',
-                    'verification_url': full_url,
-                    'expire_hours': str(expire_hours),
-                },
-                db=db,
-            )
-            custom_subject, custom_body = override or (None, None)
+        override = await get_rendered_override(
+            'email_verification',
+            lang,
+            context={
+                'username': user.first_name or 'User',
+                'verification_url': full_url,
+                'expire_hours': str(expire_hours),
+            },
+            db=db,
+        )
+        custom_subject, custom_body = override or (None, None)
 
-            await asyncio.to_thread(
-                email_service.send_verification_email,
-                to_email=request.email,
-                verification_token=verification_token,
-                verification_url=verification_url,
-                username=user.first_name or 'User',
-                language=lang,
-                custom_subject=custom_subject,
-                custom_body_html=custom_body,
+        sent = await asyncio.to_thread(
+            email_service.send_verification_email,
+            to_email=request.email,
+            verification_token=verification_token,
+            verification_url=verification_url,
+            username=user.first_name or 'User',
+            language=lang,
+            custom_subject=custom_subject,
+            custom_body_html=custom_body,
+        )
+        if not sent:
+            # Delete user to avoid stuck state — user can't re-register (email taken)
+            # or resend (/email/resend requires auth). Referral not yet processed.
+            await db.delete(user)
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail='Failed to send verification email. Please try again.',
             )
 
     # Обработать реферальную регистрацию (если есть реферер)
@@ -1199,6 +1227,22 @@ async def resend_verification(
             detail='Email is already verified',
         )
 
+    # Early checks before invalidating the current token
+    if not settings.is_cabinet_email_verification_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Email verification is disabled',
+        )
+    if not email_service.is_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Email service is not configured',
+        )
+
+    # Save old token so we can restore on send failure
+    old_token = user.email_verification_token
+    old_expires = user.email_verification_expires
+
     # Generate new token
     verification_token = generate_verification_token()
     verification_expires = get_verification_expires_at()
@@ -1208,45 +1252,42 @@ async def resend_verification(
 
     await db.commit()
 
-    # Send verification email asynchronously (smtplib is blocking)
-    if settings.is_cabinet_email_verification_enabled() and email_service.is_configured():
-        cabinet_url = settings.CABINET_URL
-        verification_url = f'{cabinet_url}/verify-email'
-        lang = user.language or 'ru'
-        full_url = f'{verification_url}?token={verification_token}'
-        expire_hours = settings.get_cabinet_email_verification_expire_hours()
+    cabinet_url = settings.CABINET_URL
+    verification_url = f'{cabinet_url}/verify-email'
+    lang = user.language or 'ru'
+    full_url = f'{verification_url}?token={verification_token}'
+    expire_hours = settings.get_cabinet_email_verification_expire_hours()
 
-        override = await get_rendered_override(
-            'email_verification',
-            lang,
-            context={
-                'username': user.first_name or '',
-                'verification_url': full_url,
-                'expire_hours': str(expire_hours),
-            },
-            db=db,
-        )
-        custom_subject, custom_body = override or (None, None)
+    override = await get_rendered_override(
+        'email_verification',
+        lang,
+        context={
+            'username': user.first_name or '',
+            'verification_url': full_url,
+            'expire_hours': str(expire_hours),
+        },
+        db=db,
+    )
+    custom_subject, custom_body = override or (None, None)
 
-        await asyncio.to_thread(
-            email_service.send_verification_email,
-            to_email=user.email,
-            verification_token=verification_token,
-            verification_url=verification_url,
-            username=user.first_name,
-            language=lang,
-            custom_subject=custom_subject,
-            custom_body_html=custom_body,
-        )
-    elif not settings.is_cabinet_email_verification_enabled():
+    sent = await asyncio.to_thread(
+        email_service.send_verification_email,
+        to_email=user.email,
+        verification_token=verification_token,
+        verification_url=verification_url,
+        username=user.first_name,
+        language=lang,
+        custom_subject=custom_subject,
+        custom_body_html=custom_body,
+    )
+    if not sent:
+        # Restore previous token so existing verification link stays valid
+        user.email_verification_token = old_token
+        user.email_verification_expires = old_expires
+        await db.commit()
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Email verification is disabled',
-        )
-    elif not email_service.is_configured():
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail='Email service is not configured',
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Failed to send verification email',
         )
 
     return {'message': 'Verification email sent'}
@@ -1668,6 +1709,12 @@ async def request_email_change(
 
     # Unverified email: replace directly and send verification to new address
     if not user.email_verified:
+        if settings.is_cabinet_email_verification_enabled() and not email_service.is_configured():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail='Email service is not configured',
+            )
+
         old_email = user.email
         user.email = request.new_email.lower()
         user.email_verified = False
@@ -1686,6 +1733,7 @@ async def request_email_change(
                 detail='This email is already registered',
             )
 
+        sent = False
         if settings.is_cabinet_email_verification_enabled() and email_service.is_configured():
             cabinet_url = settings.CABINET_URL
             verification_url = f'{cabinet_url}/verify-email'
@@ -1706,7 +1754,7 @@ async def request_email_change(
             custom_subject, custom_body = override or (None, None)
 
             try:
-                await asyncio.to_thread(
+                sent = await asyncio.to_thread(
                     email_service.send_verification_email,
                     to_email=request.new_email,
                     verification_token=verification_token,
@@ -1728,8 +1776,13 @@ async def request_email_change(
             'Unverified email replaced for user', user_id=user.id, old_email=old_email, new_email=request.new_email
         )
 
+        message = (
+            'Email replaced, verification sent to new address'
+            if sent
+            else 'Email replaced, but verification email could not be sent. Please request resend.'
+        )
         return EmailChangeResponse(
-            message='Email replaced, verification sent to new address',
+            message=message,
             new_email=request.new_email,
             expires_in_minutes=0,
         )
@@ -1760,7 +1813,7 @@ async def request_email_change(
         )
         custom_subject, custom_body = override or (None, None)
 
-        await asyncio.to_thread(
+        sent = await asyncio.to_thread(
             email_service.send_email_change_code,
             to_email=request.new_email,
             code=code,
@@ -1769,6 +1822,12 @@ async def request_email_change(
             custom_subject=custom_subject,
             custom_body_html=custom_body,
         )
+        if not sent:
+            await clear_email_change_pending(db, user)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail='Failed to send verification code',
+            )
     else:
         # Clear pending change if email service is not configured
         await clear_email_change_pending(db, user)

--- a/app/cabinet/services/email_backends.py
+++ b/app/cabinet/services/email_backends.py
@@ -1,0 +1,156 @@
+"""Pluggable email transport backends.
+
+Usage:
+    EMAIL_BACKEND=smtp          # default, uses smtplib
+    EMAIL_BACKEND=custom        # loads class from EMAIL_BACKEND_CLASS
+
+    EMAIL_BACKEND_CLASS=package.module:ClassName
+"""
+
+from __future__ import annotations
+
+import importlib
+import smtplib
+from dataclasses import dataclass
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate, make_msgid
+from typing import Protocol
+
+import structlog
+
+from app.config import settings
+
+logger = structlog.get_logger(__name__)
+
+# Dedup flags — log config errors once, not on every _get_backend() call
+_backend_error_logged = False
+_custom_error_logged = False
+
+
+@dataclass(frozen=True, slots=True)
+class EmailMessage:
+    """Structured email payload passed to backends."""
+
+    from_email: str
+    from_name: str
+    to_email: str
+    subject: str
+    body_html: str
+    body_text: str | None = None
+
+
+class EmailBackend(Protocol):
+    """Interface that every email backend must implement."""
+
+    def is_configured(self) -> bool: ...
+
+    def send(self, message: EmailMessage) -> bool: ...
+
+
+class DisabledBackend:
+    """Returned when backend cannot be resolved. Never sends."""
+
+    def is_configured(self) -> bool:
+        return False
+
+    def send(self, message: EmailMessage) -> bool:
+        return False
+
+
+class SmtpBackend:
+    """Email backend using Python's built-in smtplib."""
+
+    def is_configured(self) -> bool:
+        return settings.is_smtp_configured()
+
+    def _get_connection(self) -> smtplib.SMTP:
+        smtp = smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT, timeout=30)
+        smtp.ehlo()
+
+        if settings.SMTP_USE_TLS:
+            smtp.starttls()
+            smtp.ehlo()
+
+        if settings.SMTP_USER and settings.SMTP_PASSWORD:
+            if smtp.has_extn('auth'):
+                smtp.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
+            else:
+                logger.debug(
+                    'SMTP server does not support AUTH, skipping authentication',
+                    host=settings.SMTP_HOST,
+                )
+
+        return smtp
+
+    def send(self, message: EmailMessage) -> bool:
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = message.subject
+        msg['From'] = f'{message.from_name} <{message.from_email}>'
+        msg['To'] = message.to_email
+        msg['Date'] = formatdate(localtime=False)
+        msg['Message-ID'] = make_msgid(domain=message.from_email.split('@')[-1])
+
+        if message.body_text is not None:
+            msg.attach(MIMEText(message.body_text, 'plain', 'utf-8'))
+        msg.attach(MIMEText(message.body_html, 'html', 'utf-8'))
+
+        with self._get_connection() as smtp:
+            smtp.sendmail(message.from_email, message.to_email, msg.as_string())
+
+        return True
+
+
+def _load_custom_backend() -> EmailBackend:
+    global _custom_error_logged
+
+    class_path = settings.EMAIL_BACKEND_CLASS
+    if not class_path:
+        if not _custom_error_logged:
+            logger.error('EMAIL_BACKEND=custom but EMAIL_BACKEND_CLASS is empty, email disabled')
+            _custom_error_logged = True
+        return DisabledBackend()
+
+    try:
+        module_path, class_name = class_path.rsplit(':', 1)
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+        instance = cls()
+    except Exception as e:
+        if not _custom_error_logged:
+            logger.error(
+                'Failed to load custom email backend, email disabled',
+                class_path=class_path,
+                error=e,
+            )
+            _custom_error_logged = True
+        return DisabledBackend()
+
+    if not callable(getattr(instance, 'is_configured', None)) or not callable(
+        getattr(instance, 'send', None)
+    ):
+        if not _custom_error_logged:
+            logger.error(
+                'Custom email backend missing is_configured/send methods, email disabled',
+                class_path=class_path,
+            )
+            _custom_error_logged = True
+        return DisabledBackend()
+
+    return instance
+
+
+def get_backend() -> EmailBackend:
+    """Instantiate the email backend selected by EMAIL_BACKEND setting."""
+    global _backend_error_logged
+
+    name = (settings.EMAIL_BACKEND or 'smtp').lower()
+    if name == 'smtp':
+        return SmtpBackend()
+    if name == 'custom':
+        return _load_custom_backend()
+
+    if not _backend_error_logged:
+        logger.error('Unknown EMAIL_BACKEND, email disabled', backend=name)
+        _backend_error_logged = True
+    return DisabledBackend()

--- a/app/cabinet/services/email_service.py
+++ b/app/cabinet/services/email_service.py
@@ -1,37 +1,22 @@
 """Email service for sending verification and password reset emails."""
 
 import html
-import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from email.utils import formatdate, make_msgid
+import re
 
 import structlog
 
 from app.config import settings
 
+from .email_backends import EmailMessage, get_backend
 
 logger = structlog.get_logger(__name__)
 
 
 class EmailService:
-    """Service for sending emails via SMTP."""
+    """Service for sending emails.
 
-    @property
-    def host(self) -> str | None:
-        return settings.SMTP_HOST
-
-    @property
-    def port(self) -> int:
-        return settings.SMTP_PORT
-
-    @property
-    def user(self) -> str | None:
-        return settings.SMTP_USER
-
-    @property
-    def password(self) -> str | None:
-        return settings.SMTP_PASSWORD
+    Delegates transport to the backend selected by EMAIL_BACKEND setting.
+    """
 
     @property
     def from_email(self) -> str | None:
@@ -41,31 +26,13 @@ class EmailService:
     def from_name(self) -> str:
         return settings.SMTP_FROM_NAME
 
-    @property
-    def use_tls(self) -> bool:
-        return settings.SMTP_USE_TLS
+    def _get_backend(self):
+        """Resolve backend on every call (singleton is imported early)."""
+        return get_backend()
 
     def is_configured(self) -> bool:
-        """Check if SMTP is properly configured."""
-        return settings.is_smtp_configured()
-
-    def _get_smtp_connection(self) -> smtplib.SMTP:
-        """Create and return SMTP connection."""
-        smtp = smtplib.SMTP(self.host, self.port, timeout=30)
-        smtp.ehlo()
-
-        if self.use_tls:
-            smtp.starttls()
-            smtp.ehlo()
-
-        # Only attempt login if credentials are provided AND server supports AUTH
-        if self.user and self.password:
-            if smtp.has_extn('auth'):
-                smtp.login(self.user, self.password)
-            else:
-                logger.debug('SMTP server does not support AUTH, skipping authentication', host=self.host)
-
-        return smtp
+        """Check if the active email backend is properly configured."""
+        return self._get_backend().is_configured()
 
     def send_email(
         self,
@@ -87,50 +54,43 @@ class EmailService:
             True if email was sent successfully, False otherwise
         """
         if not self.is_configured():
-            logger.warning('SMTP is not configured, cannot send email')
+            logger.warning('Email backend is not configured, cannot send email')
             return False
 
         sender_email = self.from_email
         if not sender_email or '@' not in sender_email:
-            logger.error('Invalid or missing SMTP from_email, cannot send email', from_email=sender_email)
+            logger.error('Invalid or missing from_email, cannot send email', from_email=sender_email)
             return False
 
         # Defensive: strip newlines to prevent header injection
         to_email = to_email.strip().replace('\n', '').replace('\r', '')
         subject = subject.replace('\n', '').replace('\r', '')
+        safe_from_name = self.from_name.replace('\n', '').replace('\r', '') if self.from_name else ''
+        safe_from_email = sender_email.replace('\n', '').replace('\r', '')
+
+        # Plain text fallback
+        if body_text is None:
+            body_text = re.sub(r'<[^>]+>', '', body_html)
+            body_text = body_text.replace('&nbsp;', ' ')
+            body_text = body_text.replace('&amp;', '&')
+            body_text = body_text.replace('&lt;', '<')
+            body_text = body_text.replace('&gt;', '>')
 
         try:
-            msg = MIMEMultipart('alternative')
-            msg['Subject'] = subject
-            safe_from_name = self.from_name.replace('\n', '').replace('\r', '') if self.from_name else ''
-            safe_from_email = sender_email.replace('\n', '').replace('\r', '')
-            msg['From'] = f'{safe_from_name} <{safe_from_email}>'
-            msg['To'] = to_email
-            msg['Date'] = formatdate(localtime=False)
-            msg['Message-ID'] = make_msgid(domain=safe_from_email.split('@')[-1])
-
-            # Plain text version
-            if body_text is None:
-                # Simple HTML to text conversion
-                import re
-
-                body_text = re.sub(r'<[^>]+>', '', body_html)
-                body_text = body_text.replace('&nbsp;', ' ')
-                body_text = body_text.replace('&amp;', '&')
-                body_text = body_text.replace('&lt;', '<')
-                body_text = body_text.replace('&gt;', '>')
-
-            part1 = MIMEText(body_text, 'plain', 'utf-8')
-            part2 = MIMEText(body_html, 'html', 'utf-8')
-
-            msg.attach(part1)
-            msg.attach(part2)
-
-            with self._get_smtp_connection() as smtp:
-                smtp.sendmail(safe_from_email, to_email, msg.as_string())
-
-            logger.info('Email sent successfully to', to_email=to_email)
-            return True
+            message = EmailMessage(
+                from_email=safe_from_email,
+                from_name=safe_from_name,
+                to_email=to_email,
+                subject=subject,
+                body_html=body_html,
+                body_text=body_text,
+            )
+            result = self._get_backend().send(message)
+            if result:
+                logger.info('Email sent successfully to', to_email=to_email)
+            else:
+                logger.error('Email backend returned failure for', to_email=to_email)
+            return bool(result)
 
         except Exception as e:
             logger.error('Failed to send email to', to_email=to_email, error=e)

--- a/app/config.py
+++ b/app/config.py
@@ -806,6 +806,10 @@ class Settings(BaseSettings):
     OAUTH_VK_CLIENT_SECRET: str = ''
     OAUTH_VK_ENABLED: bool = False
 
+    # Email backend: smtp (default) | custom
+    EMAIL_BACKEND: str = 'smtp'
+    EMAIL_BACKEND_CLASS: str = ''  # for custom: package.module:ClassName
+
     # SMTP settings for cabinet email
     SMTP_HOST: str | None = None
     SMTP_PORT: int = 587

--- a/tests/services/test_email_auth_flows.py
+++ b/tests/services/test_email_auth_flows.py
@@ -1,0 +1,419 @@
+"""Tests for auth flow email error handling (503/502 guards).
+
+Tests the critical state transitions added by the email backend abstraction:
+- 503 when email backend is not configured but verification is required
+- 502 + user cleanup when send fails during standalone registration
+- Retry after 502 succeeds (user was deleted, email is free)
+"""
+
+import os
+import sys
+import types as _types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# --- Pre-import stubs (must happen before any app imports) ---
+
+# redis.exceptions stub
+if 'redis.exceptions' not in sys.modules:
+    _redis_exc = _types.ModuleType('redis.exceptions')
+
+    class _NoScriptError(Exception):
+        pass
+
+    class _ConnectionError(Exception):
+        pass
+
+    _redis_exc.NoScriptError = _NoScriptError
+    _redis_exc.ConnectionError = _ConnectionError
+    sys.modules['redis.exceptions'] = _redis_exc
+
+    if 'redis' not in sys.modules or not hasattr(sys.modules['redis'], 'exceptions'):
+        _redis_mod = sys.modules.get('redis') or _types.ModuleType('redis')
+        _redis_mod.exceptions = _redis_exc
+        sys.modules['redis'] = _redis_mod
+
+# Backup directory — backup_service uses /app/data/backups by default, override for tests
+os.environ.setdefault('BACKUP_LOCATION', str(Path('data/backups').resolve()))
+Path('data/backups').mkdir(parents=True, exist_ok=True)
+
+import tests.conftest  # noqa: F401
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a minimal test app with the auth router
+# ---------------------------------------------------------------------------
+
+def _make_test_app(monkeypatch, db_mock=None, current_user=None):
+    """Create a FastAPI app with auth router and mocked dependencies."""
+    from app.cabinet.dependencies import get_cabinet_db, get_current_cabinet_user
+    from app.cabinet.routes.auth import router
+
+    app = FastAPI()
+    app.include_router(router, prefix='/cabinet')
+
+    async def override_db():
+        yield db_mock or AsyncMock()
+
+    app.dependency_overrides[get_cabinet_db] = override_db
+
+    if current_user is not None:
+        app.dependency_overrides[get_current_cabinet_user] = lambda: current_user
+
+    return app
+
+
+def _mock_db():
+    """Create a mock AsyncSession with commit/delete/rollback/execute."""
+    db = AsyncMock()
+    # Make execute().scalar_one_or_none() return None (no existing user)
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    db.execute.return_value = result_mock
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Test: standalone registration returns 503 when email backend not configured
+# ---------------------------------------------------------------------------
+
+def test_register_standalone_503_when_email_unconfigured(monkeypatch):
+    """Verification enabled + email not configured → 503, no user created."""
+    db = _mock_db()
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_AUTH_ENABLED', True)
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(settings, 'TEST_EMAIL', '')
+    monkeypatch.setattr(settings, 'TEST_EMAIL_PASSWORD', '')
+
+    # Disposable email check
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.disposable_email_service',
+        SimpleNamespace(is_disposable=lambda email: False),
+    )
+    # Rate limiter
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.RateLimitCache',
+        SimpleNamespace(is_ip_rate_limited=AsyncMock(return_value=False)),
+    )
+
+    # Email service is NOT configured
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: False,
+        send_verification_email=MagicMock(return_value=False),
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    app = _make_test_app(monkeypatch, db)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/register/standalone', json={
+        'email': 'new@test.com',
+        'password': 'StrongPass123!',
+    })
+
+    assert resp.status_code == 503
+    assert 'not configured' in resp.json()['detail']
+    # User should NOT have been created — db.delete should not be called
+    db.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: standalone registration deletes user + returns 502 when send fails
+# ---------------------------------------------------------------------------
+
+def test_register_standalone_502_and_user_deleted_when_send_fails(monkeypatch):
+    """Backend configured but send returns False → user deleted + 502."""
+    db = _mock_db()
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_AUTH_ENABLED', True)
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(settings, 'TEST_EMAIL', '')
+    monkeypatch.setattr(settings, 'TEST_EMAIL_PASSWORD', '')
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://example.com')
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_EXPIRE_HOURS', 24)
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.disposable_email_service',
+        SimpleNamespace(is_disposable=lambda email: False),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.RateLimitCache',
+        SimpleNamespace(is_ip_rate_limited=AsyncMock(return_value=False)),
+    )
+
+    # Email service IS configured but send FAILS
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: True,
+        send_verification_email=MagicMock(return_value=False),
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    # Mock create_user_by_email to return a fake user
+    fake_user = MagicMock()
+    fake_user.id = 999
+    fake_user.email = 'new@test.com'
+    fake_user.first_name = 'Test'
+    fake_user.language = 'en'
+    fake_user.email_verification_token = None
+    fake_user.email_verification_expires = None
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.create_user_by_email',
+        AsyncMock(return_value=fake_user),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.get_rendered_override',
+        AsyncMock(return_value=None),
+    )
+
+    app = _make_test_app(monkeypatch, db)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/register/standalone', json={
+        'email': 'new@test.com',
+        'password': 'StrongPass123!',
+    })
+
+    assert resp.status_code == 502
+    assert 'Failed to send' in resp.json()['detail']
+    # User must be deleted to avoid stuck state
+    db.delete.assert_called_once_with(fake_user)
+
+
+# ---------------------------------------------------------------------------
+# Test: retry after 502 succeeds (user was deleted, email is free)
+# ---------------------------------------------------------------------------
+
+def test_register_standalone_retry_after_502(monkeypatch):
+    """After 502 (user deleted), re-registration with same email works."""
+    db = _mock_db()
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_AUTH_ENABLED', True)
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(settings, 'TEST_EMAIL', '')
+    monkeypatch.setattr(settings, 'TEST_EMAIL_PASSWORD', '')
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://example.com')
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_EXPIRE_HOURS', 24)
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.disposable_email_service',
+        SimpleNamespace(is_disposable=lambda email: False),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.RateLimitCache',
+        SimpleNamespace(is_ip_rate_limited=AsyncMock(return_value=False)),
+    )
+
+    # This time send succeeds
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: True,
+        send_verification_email=MagicMock(return_value=True),
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    fake_user = MagicMock()
+    fake_user.id = 1000
+    fake_user.email = 'new@test.com'
+    fake_user.first_name = 'Test'
+    fake_user.language = 'en'
+    fake_user.email_verification_token = None
+    fake_user.email_verification_expires = None
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.create_user_by_email',
+        AsyncMock(return_value=fake_user),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.get_rendered_override',
+        AsyncMock(return_value=None),
+    )
+
+    app = _make_test_app(monkeypatch, db)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/register/standalone', json={
+        'email': 'new@test.com',
+        'password': 'StrongPass123!',
+    })
+
+    assert resp.status_code == 200
+    assert resp.json()['requires_verification'] is True
+    db.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for authenticated flows (link email, resend)
+# ---------------------------------------------------------------------------
+
+def _make_fake_user(**overrides):
+    """Create a fake User object for authenticated endpoints."""
+    user = MagicMock()
+    user.id = overrides.get('id', 1)
+    user.email = overrides.get('email', None)
+    user.email_verified = overrides.get('email_verified', False)
+    user.email_verified_at = None
+    user.email_verification_token = overrides.get('email_verification_token', 'old-token')
+    user.email_verification_expires = overrides.get('email_verification_expires', None)
+    user.first_name = overrides.get('first_name', 'Test')
+    user.language = 'en'
+    user.password_hash = None
+    user.telegram_id = overrides.get('telegram_id', 12345)
+    user.status = MagicMock()
+    user.status.value = 'active'
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Test: link email returns 503 when backend not configured
+# ---------------------------------------------------------------------------
+
+def test_link_email_503_when_email_unconfigured(monkeypatch):
+    """Link email + verification enabled + backend not configured → 503, no commit."""
+    db = _mock_db()
+    user = _make_fake_user(telegram_id=12345)
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.disposable_email_service',
+        SimpleNamespace(is_disposable=lambda email: False),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.RateLimitCache',
+        SimpleNamespace(is_ip_rate_limited=AsyncMock(return_value=False)),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.is_email_taken',
+        AsyncMock(return_value=False),
+    )
+
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: False,
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    app = _make_test_app(monkeypatch, db, current_user=user)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/register', json={
+        'email': 'link@test.com',
+        'password': 'StrongPass123!',
+    })
+
+    assert resp.status_code == 503
+    assert 'not configured' in resp.json()['detail']
+
+
+# ---------------------------------------------------------------------------
+# Test: link email returns honest message when send fails (not 502)
+# ---------------------------------------------------------------------------
+
+def test_link_email_honest_message_when_send_fails(monkeypatch):
+    """Link email + send fails → 200 with warning message, not 502."""
+    db = _mock_db()
+    user = _make_fake_user(telegram_id=12345)
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://example.com')
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_EXPIRE_HOURS', 24)
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.disposable_email_service',
+        SimpleNamespace(is_disposable=lambda email: False),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.RateLimitCache',
+        SimpleNamespace(is_ip_rate_limited=AsyncMock(return_value=False)),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.is_email_taken',
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.get_rendered_override',
+        AsyncMock(return_value=None),
+    )
+
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: True,
+        send_verification_email=MagicMock(return_value=False),
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    app = _make_test_app(monkeypatch, db, current_user=user)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/register', json={
+        'email': 'link@test.com',
+        'password': 'StrongPass123!',
+    })
+
+    assert resp.status_code == 200
+    assert 'could not be sent' in resp.json()['message']
+
+
+# ---------------------------------------------------------------------------
+# Test: resend returns 503 when backend not configured (before token change)
+# ---------------------------------------------------------------------------
+
+def test_resend_503_when_email_unconfigured(monkeypatch):
+    """Resend + backend not configured → 503, old token preserved."""
+    db = _mock_db()
+    user = _make_fake_user(email='user@test.com', email_verified=False)
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: False,
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    app = _make_test_app(monkeypatch, db, current_user=user)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/resend')
+
+    assert resp.status_code == 503
+    # Old token must NOT have been replaced
+    assert user.email_verification_token == 'old-token'
+
+
+# ---------------------------------------------------------------------------
+# Test: resend restores old token when send fails
+# ---------------------------------------------------------------------------
+
+def test_resend_restores_token_when_send_fails(monkeypatch):
+    """Resend + send fails → 502, old token restored."""
+    db = _mock_db()
+    user = _make_fake_user(email='user@test.com', email_verified=False)
+
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_ENABLED', True)
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://example.com')
+    monkeypatch.setattr(settings, 'CABINET_EMAIL_VERIFICATION_EXPIRE_HOURS', 24)
+    monkeypatch.setattr(
+        'app.cabinet.routes.auth.get_rendered_override',
+        AsyncMock(return_value=None),
+    )
+
+    mock_email_svc = SimpleNamespace(
+        is_configured=lambda: True,
+        send_verification_email=MagicMock(return_value=False),
+    )
+    monkeypatch.setattr('app.cabinet.routes.auth.email_service', mock_email_svc)
+
+    app = _make_test_app(monkeypatch, db, current_user=user)
+    client = TestClient(app)
+
+    resp = client.post('/cabinet/auth/email/resend')
+
+    assert resp.status_code == 502
+    # Old token must be restored
+    assert user.email_verification_token == 'old-token'

--- a/tests/services/test_email_backends.py
+++ b/tests/services/test_email_backends.py
@@ -1,0 +1,203 @@
+"""Tests for email backend abstraction and EmailService delegation."""
+
+import os
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Pre-import stubs for compatibility when running alongside auth flow tests
+if 'redis.exceptions' not in sys.modules:
+    _redis_exc = _types.ModuleType('redis.exceptions')
+    _redis_exc.NoScriptError = type('NoScriptError', (Exception,), {})
+    _redis_exc.ConnectionError = type('ConnectionError', (Exception,), {})
+    sys.modules['redis.exceptions'] = _redis_exc
+    if 'redis' not in sys.modules or not hasattr(sys.modules['redis'], 'exceptions'):
+        _redis_mod = sys.modules.get('redis') or _types.ModuleType('redis')
+        _redis_mod.exceptions = _redis_exc
+        sys.modules['redis'] = _redis_mod
+
+os.environ.setdefault('BACKUP_LOCATION', str(Path('data/backups').resolve()))
+Path('data/backups').mkdir(parents=True, exist_ok=True)
+
+from app.cabinet.services.email_backends import (
+    DisabledBackend,
+    EmailMessage,
+    SmtpBackend,
+    get_backend,
+    _load_custom_backend,
+)
+from app.cabinet.services.email_service import EmailService
+from app.config import settings
+
+
+# --- get_backend() tests ---
+
+
+def test_default_backend_is_smtp(monkeypatch):
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'smtp')
+    backend = get_backend()
+    assert isinstance(backend, SmtpBackend)
+
+
+def test_empty_backend_defaults_to_smtp(monkeypatch):
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', '')
+    backend = get_backend()
+    assert isinstance(backend, SmtpBackend)
+
+
+def test_unknown_backend_returns_disabled(monkeypatch):
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'nonexistent')
+    monkeypatch.setattr(mod, '_backend_error_logged', False)
+    backend = get_backend()
+    assert isinstance(backend, DisabledBackend)
+
+
+def test_unknown_backend_does_not_crash_is_configured(monkeypatch):
+    """EMAIL_BACKEND=nonexistent -> is_configured() returns False, no exception."""
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'nonexistent')
+    monkeypatch.setattr(mod, '_backend_error_logged', False)
+    service = EmailService()
+    assert service.is_configured() is False
+
+
+def test_custom_backend_empty_class_returns_disabled(monkeypatch):
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'custom')
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND_CLASS', '')
+    monkeypatch.setattr(mod, '_custom_error_logged', False)
+    backend = get_backend()
+    assert isinstance(backend, DisabledBackend)
+
+
+def test_custom_backend_bad_import_returns_disabled(monkeypatch):
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'custom')
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND_CLASS', 'nonexistent.module:Cls')
+    monkeypatch.setattr(mod, '_custom_error_logged', False)
+    backend = get_backend()
+    assert isinstance(backend, DisabledBackend)
+
+
+def test_custom_backend_missing_contract_returns_disabled(monkeypatch):
+    """Class exists but doesn't implement is_configured/send."""
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'custom')
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND_CLASS', 'builtins:object')
+    monkeypatch.setattr(mod, '_custom_error_logged', False)
+    backend = get_backend()
+    assert isinstance(backend, DisabledBackend)
+
+
+def test_custom_backend_valid_class_loaded(monkeypatch):
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'custom')
+    monkeypatch.setattr(
+        settings, 'EMAIL_BACKEND_CLASS',
+        'app.cabinet.services.email_backends:DisabledBackend',
+    )
+    monkeypatch.setattr(mod, '_custom_error_logged', False)
+    backend = get_backend()
+    assert isinstance(backend, DisabledBackend)
+    assert backend.is_configured() is False
+
+
+# --- DisabledBackend tests ---
+
+
+def test_disabled_backend_is_not_configured():
+    backend = DisabledBackend()
+    assert backend.is_configured() is False
+
+
+def test_disabled_backend_send_returns_false():
+    backend = DisabledBackend()
+    msg = EmailMessage(
+        from_email='a@b.com', from_name='Test',
+        to_email='c@d.com', subject='Hi', body_html='<p>hi</p>',
+    )
+    assert backend.send(msg) is False
+
+
+# --- EmailService delegation tests ---
+
+
+def test_send_email_returns_false_when_not_configured(monkeypatch):
+    """send_email() returns False when backend is not configured."""
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'nonexistent')
+    monkeypatch.setattr(mod, '_backend_error_logged', False)
+    service = EmailService()
+    result = service.send_email('to@test.com', 'Subject', '<p>body</p>')
+    assert result is False
+
+
+def test_backend_send_exception_returns_false(monkeypatch):
+    """If backend.send() raises, send_email() catches and returns False."""
+    class ExplodingBackend:
+        def is_configured(self):
+            return True
+        def send(self, message):
+            raise RuntimeError('boom')
+
+    monkeypatch.setattr(settings, 'SMTP_FROM_EMAIL', 'from@test.com')
+    monkeypatch.setattr(settings, 'SMTP_FROM_NAME', 'Test')
+
+    service = EmailService()
+    service._get_backend = lambda: ExplodingBackend()
+    result = service.send_email('to@test.com', 'Subject', '<p>body</p>')
+    assert result is False
+
+
+def test_send_email_delegates_to_backend(monkeypatch):
+    """send_email() builds EmailMessage and passes it to backend.send()."""
+    captured = {}
+
+    class SpyBackend:
+        def is_configured(self):
+            return True
+        def send(self, message):
+            captured['message'] = message
+            return True
+
+    monkeypatch.setattr(settings, 'SMTP_FROM_EMAIL', 'from@test.com')
+    monkeypatch.setattr(settings, 'SMTP_FROM_NAME', 'Sender')
+
+    service = EmailService()
+    service._get_backend = lambda: SpyBackend()
+    result = service.send_email('to@test.com', 'Hello', '<p>world</p>')
+
+    assert result is True
+    msg = captured['message']
+    assert isinstance(msg, EmailMessage)
+    assert msg.from_email == 'from@test.com'
+    assert msg.from_name == 'Sender'
+    assert msg.to_email == 'to@test.com'
+    assert msg.subject == 'Hello'
+    assert msg.body_html == '<p>world</p>'
+    assert msg.body_text is not None  # auto-generated from HTML
+
+
+# --- Log dedup tests ---
+
+
+def test_log_dedup_only_logs_once(monkeypatch):
+    """Config error should only be logged once, not on every call."""
+    import app.cabinet.services.email_backends as mod
+    monkeypatch.setattr(settings, 'EMAIL_BACKEND', 'nonexistent')
+    monkeypatch.setattr(mod, '_backend_error_logged', False)
+
+    log_calls = []
+    monkeypatch.setattr(mod.logger, 'error', lambda *a, **kw: log_calls.append(1))
+
+    get_backend()
+    get_backend()
+    get_backend()
+
+    assert len(log_calls) == 1


### PR DESCRIPTION
## Summary

- Replace hardcoded smtplib transport in EmailService with a pluggable backend abstraction (`EMAIL_BACKEND=smtp|custom`, `EMAIL_BACKEND_CLASS` for custom backends via import string)
- SMTP remains the default; zero changes for existing deployments without new env vars
- Fix silent-failure auth flows where endpoints returned "email sent" when backend was unconfigured or send failed

## Changes

- **email_backends.py** (new): `EmailBackend` Protocol, `EmailMessage` dataclass, `SmtpBackend`, `DisabledBackend`, `get_backend()` factory with contract validation and log dedup
- **email_service.py**: delegates to active backend via lazy `_get_backend()`, bool contract preserved
- **auth.py**: 503/502 guards for standalone registration, link email, resend, email change flows; user cleanup on failed send to prevent stuck state
- **config.py**: `EMAIL_BACKEND`, `EMAIL_BACKEND_CLASS` settings
- **21 tests** covering backend layer and auth flow state transitions

## Test plan

- [ ] Deploy with no new env vars — SMTP behavior unchanged
- [ ] Deploy with `EMAIL_BACKEND=custom` + valid class — custom backend loads
- [ ] Deploy with `EMAIL_BACKEND=custom` + invalid class — graceful fallback, email disabled
- [ ] Register with email when backend unconfigured — 503, no user created
- [ ] Register with email when send fails — 502, user deleted, retry works
