### PR TITLE
feat: Яндекс.Метрика офлайн конверсии (registration, trial, purchase)

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -572,10 +572,10 @@ async def auth_telegram(
     if is_new_user:
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
+
             await yandex_conv.on_registration(db, user.id)
         except Exception:
-            logger.debug("Yandex offline conv registration hook error")
-
+            logger.debug('Yandex offline conv registration hook error')
 
     # Clear Redis pending referral after successful user creation with referral
     if referrer_id:

--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -568,6 +568,14 @@ async def auth_telegram(
 
     # Process referral code (only for new users — existing users cannot be assigned a referrer)
     await _process_referral_code(db, user, request.referral_code, is_new_user=is_new_user)
+    # Yandex offline conversions: fire registration event
+    if is_new_user:
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+            await yandex_conv.on_registration(db, user.id)
+        except Exception:
+            logger.debug("Yandex offline conv registration hook error")
+
 
     # Clear Redis pending referral after successful user creation with referral
     if referrer_id:

--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -115,6 +115,19 @@ def _user_to_response(user: User) -> UserResponse:
     )
 
 
+async def _try_store_yandex_cid(db: AsyncSession, user_id: int, yandex_cid: str | None) -> None:
+    """Store Yandex ClientID if provided. Best-effort, never fails."""
+    if not yandex_cid:
+        return
+    try:
+        from app.services import yandex_offline_conv_service as yandex_conv
+
+        await yandex_conv.store_cid(db, user_id, yandex_cid, source='cabinet')
+        await db.commit()
+    except Exception:
+        pass
+
+
 async def _create_auth_response(user: User, db: AsyncSession) -> AuthResponse:
     """Create full auth response with tokens and RBAC permissions."""
     user_permissions, user_role_names, user_role_level = await UserRoleCRUD.get_user_permissions(db, user.id)
@@ -568,14 +581,6 @@ async def auth_telegram(
 
     # Process referral code (only for new users — existing users cannot be assigned a referrer)
     await _process_referral_code(db, user, request.referral_code, is_new_user=is_new_user)
-    # Yandex offline conversions: fire registration event
-    if is_new_user:
-        try:
-            from app.services import yandex_offline_conv_service as yandex_conv
-
-            await yandex_conv.on_registration(db, user.id)
-        except Exception:
-            logger.debug('Yandex offline conv registration hook error')
 
     # Clear Redis pending referral after successful user creation with referral
     if referrer_id:
@@ -585,6 +590,9 @@ async def auth_telegram(
             await clear_pending_referral(telegram_id)
         except Exception:
             pass
+
+    # Store Yandex CID if provided
+    await _try_store_yandex_cid(db, user.id, getattr(request, 'yandex_cid', None))
 
     # Process campaign bonus
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
@@ -692,6 +700,9 @@ async def auth_telegram_widget(
             await clear_pending_referral(request.id)
         except Exception:
             pass
+
+    # Store Yandex CID if provided
+    await _try_store_yandex_cid(db, user.id, getattr(request, 'yandex_cid', None))
 
     # Process campaign bonus
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
@@ -839,6 +850,9 @@ async def auth_telegram_oidc(
             await clear_pending_referral(telegram_id)
         except Exception:
             pass
+
+    # Store Yandex CID if provided
+    await _try_store_yandex_cid(db, user.id, getattr(request, 'yandex_cid', None))
 
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
     if response.campaign_bonus:
@@ -1181,6 +1195,9 @@ async def verify_email(
     response = await _create_auth_response(user, db)
     await _store_refresh_token(db, user.id, response.refresh_token)
 
+    # Store Yandex CID if provided
+    await _try_store_yandex_cid(db, user.id, getattr(request, 'yandex_cid', None))
+
     # Process campaign bonus
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)
     if response.campaign_bonus:
@@ -1337,6 +1354,9 @@ async def login_email(
 
     response = await _create_auth_response(user, db)
     await _store_refresh_token(db, user.id, response.refresh_token)
+
+    # Store Yandex CID if provided
+    await _try_store_yandex_cid(db, user.id, getattr(request, 'yandex_cid', None))
 
     # Process campaign bonus
     response.campaign_bonus = await _process_campaign_bonus(db, user, request.campaign_slug)

--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -1099,3 +1099,4 @@ async def store_yandex_cid(
     from app.services import yandex_offline_conv_service as yandex_conv
 
     await yandex_conv.store_cid(db, user_id=user.id, cid=payload.cid, source='cabinet')
+    await db.commit()

--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -291,12 +291,22 @@ class GiftEnabledUpdate(BaseModel):
     enabled: bool
 
 
+class OfflineConvGoal(BaseModel):
+    name: str
+    event_id: str
+    dedup: str
+
+
 class AnalyticsCountersResponse(BaseModel):
     """Analytics counter settings."""
 
     yandex_metrika_id: str = ''
     google_ads_id: str = ''
     google_ads_label: str = ''
+    offline_conv_enabled: bool = False
+    offline_conv_counter_id: str = ''
+    offline_conv_measurement_secret_masked: str = ''
+    offline_conv_goals: list[OfflineConvGoal] = []
 
 
 class AnalyticsCountersUpdate(BaseModel):
@@ -924,10 +934,28 @@ async def get_analytics_counters(
     google_id = await get_setting_value(db, GOOGLE_ADS_ID_KEY) or ''
     google_label = await get_setting_value(db, GOOGLE_ADS_LABEL_KEY) or ''
 
+
+    # Offline conversions from settings
+    oc_enabled = getattr(settings, 'YANDEX_OFFLINE_CONV_ENABLED', False)
+    oc_counter = getattr(settings, 'YANDEX_OFFLINE_CONV_COUNTER_ID', '')
+    oc_secret = getattr(settings, 'YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET', '')
+    oc_secret_masked = (oc_secret[:8] + '...' + oc_secret[-4:]) if len(oc_secret) > 12 else '***'
+    oc_goals = []
+    if oc_enabled:
+        oc_goals = [
+            OfflineConvGoal(name='Registration', event_id='registration', dedup='user_id'),
+            OfflineConvGoal(name='Trial', event_id='trial-add', dedup='user_id'),
+            OfflineConvGoal(name='Purchase', event_id='purchase', dedup='order_id'),
+        ]
+
     return AnalyticsCountersResponse(
         yandex_metrika_id=yandex_id,
         google_ads_id=google_id,
         google_ads_label=google_label,
+        offline_conv_enabled=oc_enabled,
+        offline_conv_counter_id=oc_counter,
+        offline_conv_measurement_secret_masked=oc_secret_masked if oc_enabled else '',
+        offline_conv_goals=oc_goals,
     )
 
 
@@ -944,7 +972,7 @@ async def update_analytics_counters(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Yandex Metrika counter ID must be numeric',
-            )
+    )
         await set_setting_value(db, YANDEX_METRIKA_ID_KEY, value)
 
     if payload.google_ads_id is not None:
@@ -953,7 +981,7 @@ async def update_analytics_counters(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Google Ads conversion ID must start with AW-',
-            )
+    )
         await set_setting_value(db, GOOGLE_ADS_ID_KEY, value)
 
     if payload.google_ads_label is not None:
@@ -966,10 +994,26 @@ async def update_analytics_counters(
     google_id = await get_setting_value(db, GOOGLE_ADS_ID_KEY) or ''
     google_label = await get_setting_value(db, GOOGLE_ADS_LABEL_KEY) or ''
 
+    
+    # Offline conversions (shared with GET handler)
+    oc_enabled = getattr(settings, 'YANDEX_OFFLINE_CONV_ENABLED', False)
+    oc_counter = getattr(settings, 'YANDEX_OFFLINE_CONV_COUNTER_ID', '')
+    oc_secret = getattr(settings, 'YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET', '')
+    oc_secret_masked = (oc_secret[:8] + '...' + oc_secret[-4:]) if len(oc_secret) > 12 else '***'
+    oc_goals = [
+        OfflineConvGoal(name='Registration', event_id='registration', dedup='user_id'),
+        OfflineConvGoal(name='Trial', event_id='trial-add', dedup='user_id'),
+        OfflineConvGoal(name='Purchase', event_id='purchase', dedup='order_id'),
+    ] if oc_enabled else []
+
     return AnalyticsCountersResponse(
         yandex_metrika_id=yandex_id,
         google_ads_id=google_id,
         google_ads_label=google_label,
+        offline_conv_enabled=oc_enabled,
+        offline_conv_counter_id=oc_counter,
+        offline_conv_measurement_secret_masked=oc_secret_masked if oc_enabled else '',
+        offline_conv_goals=oc_goals,
     )
 
 

--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -17,7 +17,7 @@ from app.config import settings
 from app.database.crud.system_setting import get_setting_value
 from app.database.models import SystemSetting, User
 
-from ..dependencies import get_cabinet_db, require_permission
+from ..dependencies import get_cabinet_db, get_current_cabinet_user, require_permission
 
 
 logger = structlog.get_logger(__name__)
@@ -1080,3 +1080,22 @@ async def update_gift_enabled(
     await set_setting_value(db, GIFT_ENABLED_KEY, str(payload.enabled).lower())
     logger.info('Admin set gift enabled', telegram_id=admin.telegram_id, enabled=payload.enabled)
     return GiftEnabledResponse(enabled=payload.enabled)
+
+
+# ============ Yandex CID ============
+
+
+class YandexCidRequest(BaseModel):
+    cid: str = Field(min_length=4, max_length=64)
+
+
+@router.post('/analytics/yandex-cid', status_code=status.HTTP_204_NO_CONTENT)
+async def store_yandex_cid(
+    payload: YandexCidRequest,
+    user: User = Depends(get_current_cabinet_user),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Store Yandex ClientID for the current user (first CID wins)."""
+    from app.services import yandex_offline_conv_service as yandex_conv
+
+    await yandex_conv.store_cid(db, user_id=user.id, cid=payload.cid, source='cabinet')

--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -934,7 +934,6 @@ async def get_analytics_counters(
     google_id = await get_setting_value(db, GOOGLE_ADS_ID_KEY) or ''
     google_label = await get_setting_value(db, GOOGLE_ADS_LABEL_KEY) or ''
 
-
     # Offline conversions from settings
     oc_enabled = getattr(settings, 'YANDEX_OFFLINE_CONV_ENABLED', False)
     oc_counter = getattr(settings, 'YANDEX_OFFLINE_CONV_COUNTER_ID', '')
@@ -972,7 +971,7 @@ async def update_analytics_counters(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Yandex Metrika counter ID must be numeric',
-    )
+            )
         await set_setting_value(db, YANDEX_METRIKA_ID_KEY, value)
 
     if payload.google_ads_id is not None:
@@ -981,7 +980,7 @@ async def update_analytics_counters(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Google Ads conversion ID must start with AW-',
-    )
+            )
         await set_setting_value(db, GOOGLE_ADS_ID_KEY, value)
 
     if payload.google_ads_label is not None:
@@ -994,17 +993,20 @@ async def update_analytics_counters(
     google_id = await get_setting_value(db, GOOGLE_ADS_ID_KEY) or ''
     google_label = await get_setting_value(db, GOOGLE_ADS_LABEL_KEY) or ''
 
-    
     # Offline conversions (shared with GET handler)
     oc_enabled = getattr(settings, 'YANDEX_OFFLINE_CONV_ENABLED', False)
     oc_counter = getattr(settings, 'YANDEX_OFFLINE_CONV_COUNTER_ID', '')
     oc_secret = getattr(settings, 'YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET', '')
     oc_secret_masked = (oc_secret[:8] + '...' + oc_secret[-4:]) if len(oc_secret) > 12 else '***'
-    oc_goals = [
-        OfflineConvGoal(name='Registration', event_id='registration', dedup='user_id'),
-        OfflineConvGoal(name='Trial', event_id='trial-add', dedup='user_id'),
-        OfflineConvGoal(name='Purchase', event_id='purchase', dedup='order_id'),
-    ] if oc_enabled else []
+    oc_goals = (
+        [
+            OfflineConvGoal(name='Registration', event_id='registration', dedup='user_id'),
+            OfflineConvGoal(name='Trial', event_id='trial-add', dedup='user_id'),
+            OfflineConvGoal(name='Purchase', event_id='purchase', dedup='order_id'),
+        ]
+        if oc_enabled
+        else []
+    )
 
     return AnalyticsCountersResponse(
         yandex_metrika_id=yandex_id,

--- a/app/cabinet/routes/gift.py
+++ b/app/cabinet/routes/gift.py
@@ -506,6 +506,14 @@ async def create_gift_purchase(
 
     await db.commit()
 
+    # Yandex offline conversions: fire purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
+
+        spawn_bg(fire_purchase_bg(user.id, price_kopeks))
+    except Exception:
+        pass
+
     # Emit deferred side-effects after atomic commit
     await emit_transaction_side_effects(
         db,

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -123,7 +123,7 @@ class PurchaseRequest(BaseModel):
     gift_recipient_type: str | None = Field(default=None, pattern=r'^(email|telegram)$')
     gift_recipient_value: str | None = Field(default=None, max_length=255)
     gift_message: str | None = Field(default=None, max_length=1000)
-    yandex_cid: str | None = Field(default=None, max_length=64, pattern=r'^[A-Za-z0-9._:-]{4,64}$')
+    yandex_cid: str | None = Field(default=None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$')
 
     @model_validator(mode='after')
     def validate_contacts(self) -> 'PurchaseRequest':

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -23,7 +23,7 @@ from app.services.guest_purchase_service import (
 )
 from app.services.payment_method_config_service import _get_method_defaults
 from app.services.payment_service import PaymentService
-from app.utils.cache import RateLimitCache
+from app.utils.cache import RateLimitCache, cache
 
 
 logger = structlog.get_logger(__name__)
@@ -123,6 +123,7 @@ class PurchaseRequest(BaseModel):
     gift_recipient_type: str | None = Field(default=None, pattern=r'^(email|telegram)$')
     gift_recipient_value: str | None = Field(default=None, max_length=255)
     gift_message: str | None = Field(default=None, max_length=1000)
+    yandex_cid: str | None = Field(default=None, max_length=64, pattern=r'^[A-Za-z0-9._:-]{4,64}$')
 
     @model_validator(mode='after')
     def validate_contacts(self) -> 'PurchaseRequest':
@@ -689,6 +690,13 @@ async def create_landing_purchase(
 
     await db.commit()
     await db.refresh(purchase)
+
+    # Persist Yandex CID in cache so fulfill_purchase can link it to the user later
+    if body.yandex_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+        try:
+            await cache.set(f'yacid:purchase:{purchase.token}', body.yandex_cid, expire=86400)
+        except Exception:
+            pass
 
     return PurchaseResponse(
         purchase_token=purchase.token,

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1240,6 +1240,13 @@ async def activate_trial(
     )
 
     logger.info('Trial subscription activated for user', user_id=user.id)
+    # Yandex offline conversions: fire trial event
+    try:
+        from app.services import yandex_offline_conv_service as yandex_conv
+        await yandex_conv.on_trial(db, user.id)
+    except Exception as e:
+        logger.debug('Yandex offline conv trial hook error', error=e)
+
 
     # Create RemnaWave user
     try:

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1243,10 +1243,10 @@ async def activate_trial(
     # Yandex offline conversions: fire trial event
     try:
         from app.services import yandex_offline_conv_service as yandex_conv
+
         await yandex_conv.on_trial(db, user.id)
     except Exception as e:
         logger.debug('Yandex offline conv trial hook error', error=e)
-
 
     # Create RemnaWave user
     try:

--- a/app/cabinet/routes/subscription_modules/servers.py
+++ b/app/cabinet/routes/subscription_modules/servers.py
@@ -233,6 +233,15 @@ async def update_countries(
     subscription.updated_at = datetime.now(UTC)
     await db.commit()
 
+    # Yandex offline conversions: fire purchase event for server add
+    if total_cost > 0:
+        try:
+            from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
+
+            spawn_bg(fire_purchase_bg(user.id, total_cost))
+        except Exception:
+            pass
+
     # Sync with RemnaWave
     try:
         from app.config import settings

--- a/app/cabinet/schemas/auth.py
+++ b/app/cabinet/schemas/auth.py
@@ -15,6 +15,9 @@ class TelegramAuthRequest(BaseModel):
     referral_code: str | None = Field(
         None, max_length=32, pattern=r'^[a-zA-Z0-9_-]+$', description='Referral code of inviter'
     )
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
+    )
 
 
 class TelegramWidgetAuthRequest(BaseModel):
@@ -33,6 +36,9 @@ class TelegramWidgetAuthRequest(BaseModel):
     referral_code: str | None = Field(
         None, max_length=32, pattern=r'^[a-zA-Z0-9_-]+$', description='Referral code of inviter'
     )
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
+    )
 
 
 class TelegramOIDCAuthRequest(BaseModel):
@@ -45,6 +51,9 @@ class TelegramOIDCAuthRequest(BaseModel):
     referral_code: str | None = Field(
         None, max_length=32, pattern=r'^[a-zA-Z0-9_-]+$', description='Referral code of inviter'
     )
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
+    )
 
 
 class EmailRegisterRequest(BaseModel):
@@ -52,6 +61,9 @@ class EmailRegisterRequest(BaseModel):
 
     email: EmailStr = Field(..., description='Email address')
     password: str = Field(..., min_length=8, max_length=128, description='Password (min 8 chars)')
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
+    )
 
 
 class EmailVerifyRequest(BaseModel):
@@ -70,6 +82,9 @@ class EmailLoginRequest(BaseModel):
     password: str = Field(..., min_length=1, max_length=128, description='Password')
     campaign_slug: str | None = Field(
         None, min_length=1, max_length=64, pattern=r'^[a-zA-Z0-9_-]+$', description='Campaign slug from web link'
+    )
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
     )
 
 
@@ -137,6 +152,9 @@ class EmailRegisterStandaloneRequest(BaseModel):
     language: str = Field('ru', max_length=5, pattern=r'^[a-z]{2}$', description='Preferred language (ISO 639-1)')
     referral_code: str | None = Field(
         None, max_length=32, pattern=r'^[a-zA-Z0-9_-]+$', description='Referral code of inviter'
+    )
+    yandex_cid: str | None = Field(
+        None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$', description='Yandex Metrika ClientID'
     )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -571,7 +571,6 @@ class Settings(BaseSettings):
     RIOPAY_SUCCESS_URL: str | None = None
     RIOPAY_FAIL_URL: str | None = None
 
-
     # Yandex Offline Conversions
     YANDEX_OFFLINE_CONV_ENABLED: bool = False
     YANDEX_OFFLINE_CONV_COUNTER_ID: str = ''

--- a/app/config.py
+++ b/app/config.py
@@ -571,6 +571,16 @@ class Settings(BaseSettings):
     RIOPAY_SUCCESS_URL: str | None = None
     RIOPAY_FAIL_URL: str | None = None
 
+
+    # Yandex Offline Conversions
+    YANDEX_OFFLINE_CONV_ENABLED: bool = False
+    YANDEX_OFFLINE_CONV_COUNTER_ID: str = ''
+    YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET: str = ''
+    YANDEX_OFFLINE_CONV_START_PREFIX: str = 'utm_ya_'
+    YANDEX_OFFLINE_CONV_DL: str = ''
+    YANDEX_OFFLINE_CONV_DT: str = ''
+    YANDEX_OFFLINE_CONV_CURRENCY: str = 'RUB'
+
     # SeverPay (severpay.io)
     SEVERPAY_ENABLED: bool = False
     SEVERPAY_MID: int | None = None  # Merchant ID
@@ -1980,6 +1990,16 @@ class Settings(BaseSettings):
 
     def get_kassa_ai_card_display_name_html(self) -> str:
         return html.escape(self.get_kassa_ai_card_display_name())
+
+    def is_kassa_ai_sberpay_enabled(self) -> bool:
+        return self.KASSA_AI_SBERPAY_ENABLED and self.is_kassa_ai_enabled()
+
+    def get_kassa_ai_sberpay_display_name(self) -> str:
+        name = (self.KASSA_AI_SBERPAY_DISPLAY_NAME or '').strip()
+        return name or 'SberPay'
+
+    def get_kassa_ai_sberpay_display_name_html(self) -> str:
+        return html.escape(self.get_kassa_ai_sberpay_display_name())
 
     def is_payment_verification_auto_check_enabled(self) -> bool:
         return self.PAYMENT_VERIFICATION_AUTO_CHECK_ENABLED

--- a/app/database/crud/yandex_client_id.py
+++ b/app/database/crud/yandex_client_id.py
@@ -1,0 +1,70 @@
+"""CRUD operations for yandex_client_id_map table."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import YandexClientIdMap
+
+
+logger = structlog.get_logger(__name__)
+
+
+async def upsert_cid(
+    db: AsyncSession,
+    user_id: int,
+    cid: str,
+    source: str = 'web',
+    counter_id: str | None = None,
+) -> YandexClientIdMap:
+    """Insert or update Yandex ClientID for a user (race-safe via ON CONFLICT)."""
+    now = datetime.now(UTC)
+    values = {
+        'yandex_cid': cid,
+        'source': source,
+        'updated_at': now,
+    }
+    if counter_id:
+        values['counter_id'] = counter_id
+
+    stmt = (
+        pg_insert(YandexClientIdMap)
+        .values(user_id=user_id, yandex_cid=cid, source=source, counter_id=counter_id)
+        .on_conflict_do_update(index_elements=['user_id'], set_=values)
+        .returning(YandexClientIdMap)
+    )
+
+    result = await db.execute(stmt)
+    await db.flush()
+    return result.scalar_one()
+
+
+async def get_cid(db: AsyncSession, user_id: int) -> YandexClientIdMap | None:
+    """Get Yandex ClientID mapping for a user."""
+    result = await db.execute(select(YandexClientIdMap).where(YandexClientIdMap.user_id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def mark_registration_sent(db: AsyncSession, user_id: int) -> None:
+    """Mark registration event as sent for a user."""
+    await db.execute(
+        update(YandexClientIdMap)
+        .where(YandexClientIdMap.user_id == user_id)
+        .values(registration_sent=True, updated_at=datetime.now(UTC))
+    )
+    await db.flush()
+
+
+async def mark_trial_sent(db: AsyncSession, user_id: int) -> None:
+    """Mark trial event as sent for a user."""
+    await db.execute(
+        update(YandexClientIdMap)
+        .where(YandexClientIdMap.user_id == user_id)
+        .values(trial_sent=True, updated_at=datetime.now(UTC))
+    )
+    await db.flush()

--- a/app/database/crud/yandex_client_id.py
+++ b/app/database/crud/yandex_client_id.py
@@ -22,23 +22,26 @@ async def upsert_cid(
     source: str = 'web',
     counter_id: str | None = None,
 ) -> YandexClientIdMap:
-    """Insert Yandex ClientID for a user, protecting the first CID (ON CONFLICT DO NOTHING)."""
+    """Insert or update Yandex ClientID for a user (race-safe via ON CONFLICT)."""
+    now = datetime.now(UTC)
+    values = {
+        'yandex_cid': cid,
+        'source': source,
+        'updated_at': now,
+    }
+    if counter_id:
+        values['counter_id'] = counter_id
+
     stmt = (
         pg_insert(YandexClientIdMap)
         .values(user_id=user_id, yandex_cid=cid, source=source, counter_id=counter_id)
-        .on_conflict_do_nothing(index_elements=['user_id'])
+        .on_conflict_do_update(index_elements=['user_id'], set_=values)
         .returning(YandexClientIdMap)
     )
 
     result = await db.execute(stmt)
     await db.flush()
-    row = result.scalar_one_or_none()
-    if row is not None:
-        return row
-    # Conflict: CID already exists — return existing record
-    existing = await get_cid(db, user_id)
-    assert existing is not None
-    return existing
+    return result.scalar_one()
 
 
 async def get_cid(db: AsyncSession, user_id: int) -> YandexClientIdMap | None:

--- a/app/database/crud/yandex_client_id.py
+++ b/app/database/crud/yandex_client_id.py
@@ -22,26 +22,23 @@ async def upsert_cid(
     source: str = 'web',
     counter_id: str | None = None,
 ) -> YandexClientIdMap:
-    """Insert or update Yandex ClientID for a user (race-safe via ON CONFLICT)."""
-    now = datetime.now(UTC)
-    values = {
-        'yandex_cid': cid,
-        'source': source,
-        'updated_at': now,
-    }
-    if counter_id:
-        values['counter_id'] = counter_id
-
+    """Insert Yandex ClientID for a user, protecting the first CID (ON CONFLICT DO NOTHING)."""
     stmt = (
         pg_insert(YandexClientIdMap)
         .values(user_id=user_id, yandex_cid=cid, source=source, counter_id=counter_id)
-        .on_conflict_do_update(index_elements=['user_id'], set_=values)
+        .on_conflict_do_nothing(index_elements=['user_id'])
         .returning(YandexClientIdMap)
     )
 
     result = await db.execute(stmt)
     await db.flush()
-    return result.scalar_one()
+    row = result.scalar_one_or_none()
+    if row is not None:
+        return row
+    # Conflict: CID already exists — return existing record
+    existing = await get_cid(db, user_id)
+    assert existing is not None
+    return existing
 
 
 async def get_cid(db: AsyncSession, user_id: int) -> YandexClientIdMap | None:

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3407,6 +3407,7 @@ class NewsTag(Base):
     def __repr__(self) -> str:
         return f"<NewsTag id={self.id} name='{self.name}'>"
 
+
 class YandexClientIdMap(Base):
     __tablename__ = 'yandex_client_id_map'
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3406,3 +3406,16 @@ class NewsTag(Base):
 
     def __repr__(self) -> str:
         return f"<NewsTag id={self.id} name='{self.name}'>"
+
+class YandexClientIdMap(Base):
+    __tablename__ = 'yandex_client_id_map'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False)
+    yandex_cid = Column(String(128), nullable=False)
+    source = Column(String(10), nullable=False, default='web')
+    counter_id = Column(String(32), nullable=True)
+    registration_sent = Column(Boolean, default=False, nullable=False)
+    trial_sent = Column(Boolean, default=False, nullable=False)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+    user = relationship('User', foreign_keys=[user_id])

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -703,11 +703,11 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
         start_parameter = None  # Invalid token, ignore
 
     # Handle Yandex Metrika CID: /start ym_{cid}
-    if start_parameter and start_parameter.startswith('ym_'):
+    if start_parameter and start_parameter.startswith("ym_"):
         ym_cid = start_parameter[3:]
-        if re.match(r'^[A-Za-z0-9._:-]{4,128}$', ym_cid):
+        if re.match(r"^[A-Za-z0-9._:-]{4,128}$", ym_cid):
             await state.update_data(yandex_cid=ym_cid)
-            logger.info('📊 Yandex CID from start parameter', cid_prefix=ym_cid[:8])
+            logger.info("📊 Yandex CID from start parameter", cid_prefix=ym_cid[:8])
         start_parameter = None  # Not a campaign or referral
 
     if start_parameter:
@@ -775,18 +775,17 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
     if user and user.status != UserStatus.DELETED.value:
         logger.info('✅ Активный пользователь найден', telegram_id=user.telegram_id)
 
+
         # Store Yandex CID from start parameter if present
-        _ym_cid = (await state.get_data()).get('yandex_cid')
+        _ym_cid = (await state.get_data()).get("yandex_cid")
         if _ym_cid:
             try:
                 from app.services import yandex_offline_conv_service as yandex_conv
-
-                await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+                await yandex_conv.store_cid(db, user.id, _ym_cid, source="bot")
                 await db.commit()
-                logger.info('📊 Yandex CID stored for existing user', user_id=user.id)
+                logger.info("Yandex CID stored for existing user", user_id=user.id)
             except Exception:
                 pass
-
         # Check for phantom user created by guest landing purchase and merge
         if message.from_user.username:
             phantom = await find_phantom_user_by_username(db, message.from_user.username)
@@ -858,6 +857,17 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
         # Auto-activate pending gift if deep link contained GIFT_
         if user:
             await _activate_pending_gift_after_registration(db, state, user, message.answer)
+
+    # Store Yandex CID from start parameter (before state.clear)
+    _ym_cid = data.get("yandex_cid")
+    if _ym_cid:
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+            await yandex_conv.store_cid(db, user.id, _ym_cid, source="bot")
+            await db.commit()
+            logger.info("Yandex CID stored for new user", user_id=user.id)
+        except Exception:
+            pass
             await state.update_data(pending_gift_token=None)
             # Refresh user to pick up newly created subscriptions
             await db.refresh(user, attribute_names=['subscriptions'])
@@ -1718,14 +1728,13 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
     await _activate_pending_gift_after_registration(db, state, user, callback.message.answer)
 
     # Store Yandex CID from start parameter (before state.clear)
-    _ym_cid = data.get('yandex_cid')
+    _ym_cid = data.get("yandex_cid")
     if _ym_cid:
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
-
-            await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+            await yandex_conv.store_cid(db, user.id, _ym_cid, source="bot")
             await db.commit()
-            logger.info('📊 Yandex CID stored for new user (callback)', user_id=user.id)
+            logger.info("Yandex CID stored for new user (callback)", user_id=user.id)
         except Exception:
             pass
 
@@ -2076,14 +2085,13 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
     await _activate_pending_gift_after_registration(db, state, user, message.answer)
 
     # Store Yandex CID from start parameter (before state.clear)
-    _ym_cid = data.get('yandex_cid')
+    _ym_cid = data.get("yandex_cid")
     if _ym_cid:
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
-
-            await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+            await yandex_conv.store_cid(db, user.id, _ym_cid, source="bot")
             await db.commit()
-            logger.info('📊 Yandex CID stored for new user', user_id=user.id)
+            logger.info("Yandex CID stored for new user", user_id=user.id)
         except Exception:
             pass
 

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -1,4 +1,5 @@
 import html
+import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -701,6 +702,14 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             return
         start_parameter = None  # Invalid token, ignore
 
+    # Handle Yandex Metrika CID: /start ym_{cid}
+    if start_parameter and start_parameter.startswith('ym_'):
+        ym_cid = start_parameter[3:]
+        if re.match(r'^[A-Za-z0-9._:-]{4,128}$', ym_cid):
+            await state.update_data(yandex_cid=ym_cid)
+            logger.info('📊 Yandex CID from start parameter', cid_prefix=ym_cid[:8])
+        start_parameter = None  # Not a campaign or referral
+
     if start_parameter:
         campaign = await get_campaign_by_start_parameter(
             db,
@@ -765,6 +774,18 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
 
     if user and user.status != UserStatus.DELETED.value:
         logger.info('✅ Активный пользователь найден', telegram_id=user.telegram_id)
+
+        # Store Yandex CID from start parameter if present
+        _ym_cid = (await state.get_data()).get('yandex_cid')
+        if _ym_cid:
+            try:
+                from app.services import yandex_offline_conv_service as yandex_conv
+
+                await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+                await db.commit()
+                logger.info('📊 Yandex CID stored for existing user', user_id=user.id)
+            except Exception:
+                pass
 
         # Check for phantom user created by guest landing purchase and merge
         if message.from_user.username:
@@ -1696,6 +1717,18 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
     # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
     await _activate_pending_gift_after_registration(db, state, user, callback.message.answer)
 
+    # Store Yandex CID from start parameter (before state.clear)
+    _ym_cid = data.get('yandex_cid')
+    if _ym_cid:
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+
+            await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+            await db.commit()
+            logger.info('📊 Yandex CID stored for new user (callback)', user_id=user.id)
+        except Exception:
+            pass
+
     await state.clear()
 
     if campaign_message:
@@ -2041,6 +2074,18 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
 
     # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
     await _activate_pending_gift_after_registration(db, state, user, message.answer)
+
+    # Store Yandex CID from start parameter (before state.clear)
+    _ym_cid = data.get('yandex_cid')
+    if _ym_cid:
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+
+            await yandex_conv.store_cid(db, user.id, _ym_cid, source='bot')
+            await db.commit()
+            logger.info('📊 Yandex CID stored for new user', user_id=user.id)
+        except Exception:
+            pass
 
     await state.clear()
 

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -355,6 +355,22 @@ async def fulfill_purchase(
             purchase.user_id = user.id
             if recipient_type == 'email' and not purchase.is_gift and is_new_account:
                 purchase.auto_login_token = create_auto_login_token(user.id)
+            # Link Yandex CID before commit so it's available for later activation
+            try:
+                from app.utils.cache import cache
+
+                cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
+                if cached_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+                    from app.database.crud.yandex_client_id import upsert_cid
+
+                    counter_id = (
+                        str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
+                    )
+                    await upsert_cid(db, user_id=user.id, cid=cached_cid, source='landing', counter_id=counter_id)
+                    await cache.delete(f'yacid:purchase:{purchase.token}')
+            except Exception:
+                logger.debug('Failed to link landing yandex_cid to user (pending)', purchase_id=purchase.id)
+
             await db.commit()
             await db.refresh(purchase, attribute_names=['landing', 'user', 'buyer'])
 
@@ -454,6 +470,22 @@ async def fulfill_purchase(
             )
         except Exception:
             logger.exception('Failed to create transaction for guest purchase', purchase_id=purchase.id)
+
+        # Link Yandex CID from landing purchase cache to the resolved user
+        try:
+            from app.utils.cache import cache
+
+            cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
+            if cached_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+                from app.database.crud.yandex_client_id import upsert_cid
+
+                counter_id = (
+                    str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
+                )
+                await upsert_cid(db, user_id=user.id, cid=cached_cid, source='landing', counter_id=counter_id)
+                await cache.delete(f'yacid:purchase:{purchase.token}')
+        except Exception:
+            logger.debug('Failed to link landing yandex_cid to user', purchase_id=purchase.id)
 
         # Yandex offline conversions: fire registration event for new accounts
         if is_new_account:

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -455,22 +455,22 @@ async def fulfill_purchase(
         except Exception:
             logger.exception('Failed to create transaction for guest purchase', purchase_id=purchase.id)
 
-
         # Yandex offline conversions: fire registration event for new accounts
         if is_new_account:
             try:
                 from app.services import yandex_offline_conv_service as yandex_conv
+
                 await yandex_conv.on_registration(db, user.id)
             except Exception:
-                logger.debug("Yandex offline conv registration hook error")
-
+                logger.debug('Yandex offline conv registration hook error')
 
         # Yandex offline conversions: fire ecommerce purchase event
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
+
             await yandex_conv.on_purchase(db, user.id, purchase.amount_kopeks)
         except Exception:
-            logger.debug("Yandex offline conv purchase hook error")
+            logger.debug('Yandex offline conv purchase hook error')
 
         try:
             await send_guest_notification(

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -455,6 +455,23 @@ async def fulfill_purchase(
         except Exception:
             logger.exception('Failed to create transaction for guest purchase', purchase_id=purchase.id)
 
+
+        # Yandex offline conversions: fire registration event for new accounts
+        if is_new_account:
+            try:
+                from app.services import yandex_offline_conv_service as yandex_conv
+                await yandex_conv.on_registration(db, user.id)
+            except Exception:
+                logger.debug("Yandex offline conv registration hook error")
+
+
+        # Yandex offline conversions: fire ecommerce purchase event
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+            await yandex_conv.on_purchase(db, user.id, purchase.amount_kopeks)
+        except Exception:
+            logger.debug("Yandex offline conv purchase hook error")
+
         try:
             await send_guest_notification(
                 purchase,

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -355,22 +355,17 @@ async def fulfill_purchase(
             purchase.user_id = user.id
             if recipient_type == 'email' and not purchase.is_gift and is_new_account:
                 purchase.auto_login_token = create_auto_login_token(user.id)
-            # Link Yandex CID before commit so it's available for later activation
+            # Link Yandex CID before commit
             try:
                 from app.utils.cache import cache
-
                 cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
                 if cached_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
                     from app.database.crud.yandex_client_id import upsert_cid
-
-                    counter_id = (
-                        str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
-                    )
+                    counter_id = str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
                     await upsert_cid(db, user_id=user.id, cid=cached_cid, source='landing', counter_id=counter_id)
                     await cache.delete(f'yacid:purchase:{purchase.token}')
             except Exception:
                 logger.debug('Failed to link landing yandex_cid to user (pending)', purchase_id=purchase.id)
-
             await db.commit()
             await db.refresh(purchase, attribute_names=['landing', 'user', 'buyer'])
 
@@ -470,39 +465,35 @@ async def fulfill_purchase(
             )
         except Exception:
             logger.exception('Failed to create transaction for guest purchase', purchase_id=purchase.id)
-
         # Link Yandex CID from landing purchase cache to the resolved user
         try:
             from app.utils.cache import cache
-
             cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
             if cached_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
                 from app.database.crud.yandex_client_id import upsert_cid
-
-                counter_id = (
-                    str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
-                )
+                counter_id = str(settings.YANDEX_OFFLINE_CONV_COUNTER_ID) if settings.YANDEX_OFFLINE_CONV_COUNTER_ID else ''
                 await upsert_cid(db, user_id=user.id, cid=cached_cid, source='landing', counter_id=counter_id)
                 await cache.delete(f'yacid:purchase:{purchase.token}')
         except Exception:
             logger.debug('Failed to link landing yandex_cid to user', purchase_id=purchase.id)
 
+
+
         # Yandex offline conversions: fire registration event for new accounts
         if is_new_account:
             try:
                 from app.services import yandex_offline_conv_service as yandex_conv
-
                 await yandex_conv.on_registration(db, user.id)
             except Exception:
-                logger.debug('Yandex offline conv registration hook error')
+                logger.debug("Yandex offline conv registration hook error")
+
 
         # Yandex offline conversions: fire ecommerce purchase event
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
-
             await yandex_conv.on_purchase(db, user.id, purchase.amount_kopeks)
         except Exception:
-            logger.debug('Yandex offline conv purchase hook error')
+            logger.debug("Yandex offline conv purchase hook error")
 
         try:
             await send_guest_notification(

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -693,9 +693,9 @@ async def _auto_extend_subscription(
 
     # Yandex offline conversions: fire ecommerce purchase event
     try:
-        from app.services.yandex_offline_conv_service import fire_purchase_bg
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-        await fire_purchase_bg(user.id, prepared.price_kopeks)
+        spawn_bg(fire_purchase_bg(user.id, prepared.price_kopeks))
     except Exception:
         logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
@@ -1070,9 +1070,9 @@ async def _auto_purchase_tariff(
 
     # Yandex offline conversions: fire ecommerce purchase event
     try:
-        from app.services.yandex_offline_conv_service import fire_purchase_bg
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-        await fire_purchase_bg(user.id, final_price)
+        spawn_bg(fire_purchase_bg(user.id, final_price))
     except Exception:
         logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
@@ -1421,9 +1421,9 @@ async def _auto_purchase_daily_tariff(
 
     # Yandex offline conversions: fire ecommerce purchase event
     try:
-        from app.services.yandex_offline_conv_service import fire_purchase_bg
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-        await fire_purchase_bg(user.id, final_price)
+        spawn_bg(fire_purchase_bg(user.id, final_price))
     except Exception:
         logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
@@ -2462,9 +2462,9 @@ async def try_auto_extend_expired_after_topup(
 
     # Yandex offline conversions: fire ecommerce purchase event
     try:
-        from app.services.yandex_offline_conv_service import fire_purchase_bg
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-        await fire_purchase_bg(user.id, renewal_cost)
+        spawn_bg(fire_purchase_bg(user.id, renewal_cost))
     except Exception:
         logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
@@ -2840,9 +2840,9 @@ async def try_resume_disabled_daily_after_topup(
 
     # Yandex offline conversions: fire ecommerce purchase event
     try:
-        from app.services.yandex_offline_conv_service import fire_purchase_bg
+        from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-        await fire_purchase_bg(user.id, daily_price)
+        spawn_bg(fire_purchase_bg(user.id, daily_price))
     except Exception:
         logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -691,6 +691,14 @@ async def _auto_extend_subscription(
             ws_error=ws_error,
         )
 
+    # Yandex offline conversions: fire ecommerce purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+        await fire_purchase_bg(user.id, prepared.price_kopeks)
+    except Exception:
+        logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
+
     return True
 
 
@@ -1060,6 +1068,14 @@ async def _auto_purchase_tariff(
             ws_error=ws_error,
         )
 
+    # Yandex offline conversions: fire ecommerce purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+        await fire_purchase_bg(user.id, final_price)
+    except Exception:
+        logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
+
     return True
 
 
@@ -1402,6 +1418,14 @@ async def _auto_purchase_daily_tariff(
             format_user_id=_format_user_id(user),
             ws_error=ws_error,
         )
+
+    # Yandex offline conversions: fire ecommerce purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+        await fire_purchase_bg(user.id, final_price)
+    except Exception:
+        logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
     return True
 
@@ -2436,6 +2460,14 @@ async def try_auto_extend_expired_after_topup(
             ws_error=ws_error,
         )
 
+    # Yandex offline conversions: fire ecommerce purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+        await fire_purchase_bg(user.id, renewal_cost)
+    except Exception:
+        logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
+
     return True
 
 
@@ -2805,6 +2837,14 @@ async def try_resume_disabled_daily_after_topup(
             format_user_id=_format_user_id(user),
             ws_error=ws_error,
         )
+
+    # Yandex offline conversions: fire ecommerce purchase event
+    try:
+        from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+        await fire_purchase_bg(user.id, daily_price)
+    except Exception:
+        logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 
     return True
 

--- a/app/services/subscription_purchase_service.py
+++ b/app/services/subscription_purchase_service.py
@@ -1216,9 +1216,9 @@ class MiniAppSubscriptionPurchaseService:
 
         # Yandex offline conversions: fire ecommerce purchase event
         try:
-            from app.services.yandex_offline_conv_service import fire_purchase_bg
+            from app.services.yandex_offline_conv_service import fire_purchase_bg, spawn_bg
 
-            await fire_purchase_bg(user.id, pricing.final_total)
+            spawn_bg(fire_purchase_bg(user.id, pricing.final_total))
         except Exception:
             logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
 

--- a/app/services/subscription_purchase_service.py
+++ b/app/services/subscription_purchase_service.py
@@ -1214,6 +1214,14 @@ class MiniAppSubscriptionPurchaseService:
             )
             message = f'{message}\n\n{note}'
 
+        # Yandex offline conversions: fire ecommerce purchase event
+        try:
+            from app.services.yandex_offline_conv_service import fire_purchase_bg
+
+            await fire_purchase_bg(user.id, pricing.final_total)
+        except Exception:
+            logger.debug('Yandex offline conv purchase hook error', user_id=user.id)
+
         return {
             'subscription': subscription,
             'transaction': transaction,

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -25,6 +25,7 @@ from app.database.crud.yandex_client_id import (
 )
 from app.database.database import AsyncSessionLocal
 
+
 logger = structlog.get_logger(__name__)
 
 LOG_PREFIX = '[YandexOfflineConv]'

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -1,0 +1,298 @@
+"""Yandex.Metrika offline conversions service.
+
+Sends events (registration, trial-add, purchase) to mc.yandex.ru/collect
+using the Measurement Protocol. No pageview needed — user has active
+Metrika session from the site. yclid is passed via landing page URL,
+Metrika matches it automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.yandex_client_id import (
+    get_cid,
+    mark_registration_sent,
+    mark_trial_sent,
+    upsert_cid,
+)
+from app.database.database import AsyncSessionLocal
+logger = structlog.get_logger(__name__)
+
+LOG_PREFIX = '[YandexOfflineConv]'
+COLLECT_URL = 'https://mc.yandex.ru/collect'
+TIMEOUT = 10.0
+MAX_RETRIES = 3
+RETRY_DELAY = 1.0
+
+_CID_RE = re.compile(r'^[A-Za-z0-9._:-]{4,128}$')
+_http_client: httpx.AsyncClient | None = None
+def _get_client() -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(timeout=TIMEOUT)
+    return _http_client
+def _is_enabled() -> bool:
+    return bool(
+        settings.YANDEX_OFFLINE_CONV_ENABLED
+        and settings.YANDEX_OFFLINE_CONV_COUNTER_ID
+        and settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET
+    )
+def _normalize_cid(cid: str | None) -> str | None:
+    if not isinstance(cid, str):
+        return None
+    cid = cid.strip()
+    if not cid or not _CID_RE.match(cid):
+        return None
+    return cid
+def _mask_cid(cid: str) -> str:
+    if len(cid) <= 4:
+        return '****'
+    return '*' * (len(cid) - 4) + cid[-4:]
+def _base_payload(cid: str) -> dict[str, str]:
+    return {
+        'tid': settings.YANDEX_OFFLINE_CONV_COUNTER_ID,
+        'cid': cid,
+        'ms': settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET,
+    }
+def _pageview_payload(cid: str) -> dict[str, str]:
+    payload = _base_payload(cid)
+    payload.update(
+        {
+            't': 'pageview',
+            'dl': settings.YANDEX_OFFLINE_CONV_DL or 'https://web.mtrxvps.ru',
+            'dt': settings.YANDEX_OFFLINE_CONV_DT or 'Matrixxx VPN',
+        }
+    )
+    return payload
+def _event_payload(cid: str, event_action: str) -> dict[str, str]:
+    payload = _base_payload(cid)
+    payload.update(
+        {
+            't': 'event',
+            'ea': event_action,
+        }
+    )
+    return payload
+def _ecommerce_purchase_payload(
+    cid: str,
+    amount_rubles: float,
+    order_id: str = '',
+    product_name: str = '',
+    product_category: str = '',
+) -> dict[str, str]:
+    """Build ecommerce:purchase payload for Metrika Measurement Protocol."""
+
+    service_name = (
+        getattr(settings, 'YANDEX_OFFLINE_CONV_DT', '')
+        or getattr(settings, 'PAYMENT_SERVICE_NAME', '')
+        or 'Subscription'
+    )
+    currency = getattr(settings, 'YANDEX_OFFLINE_CONV_CURRENCY', '') or 'RUB'
+    payload = _base_payload(cid)
+    payload.update({
+        't': 'event',
+        'ea': 'purchase',
+        'pa': 'purchase',
+        'ti': order_id or str(int(time.time())),
+        'tr': str(amount_rubles),
+        'cu': currency,
+        'ev': str(amount_rubles),
+        'pr1id': 'subscription',
+        'pr1nm': product_name or service_name,
+        'pr1ca': product_category or 'subscription',
+        'pr1pr': str(amount_rubles),
+        'pr1qt': '1',
+    })
+    return payload
+
+async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
+    """POST to mc.yandex.ru/collect with retries. Returns True on success."""
+    masked = _mask_cid(cid)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            client = _get_client()
+            resp = await client.post(COLLECT_URL, data=payload)
+
+            if 200 <= resp.status_code < 300:
+                logger.info('collect sent', kind=kind, cid=masked, status=resp.status_code)
+                return True
+
+            if 500 <= resp.status_code < 600 and attempt < MAX_RETRIES:
+                logger.warning(
+                    'collect server error',
+                    kind=kind,
+                    attempt=attempt,
+                    max=MAX_RETRIES,
+                    cid=masked,
+                    status=resp.status_code,
+                )
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+
+            logger.error('collect rejected', kind=kind, cid=masked, status=resp.status_code, body=resp.text[:200])
+            return False
+
+        except Exception as exc:
+            logger.warning(
+                'collect request error', kind=kind, attempt=attempt, max=MAX_RETRIES, cid=masked, error=str(exc)
+            )
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+            return False
+
+    return False
+async def _send_event(cid: str, event_action: str) -> bool:
+    """Send event directly — no pageview needed, user has active Metrika session."""
+    return await _post_collect(_event_payload(cid, event_action), event_action, cid)
+# --- Background task helpers ---
+
+_background_tasks: set[asyncio.Task] = set()
+def _task_done(task):
+    """Log errors from background conversion tasks."""
+    _background_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.error(f'{LOG_PREFIX} Background task failed', error=str(exc))
+def spawn_bg(coro) -> None:
+    """Spawn a background Yandex conversion task with proper reference tracking.
+
+    Checks _is_enabled() early so callers don't need to.
+    """
+    if not _is_enabled():
+        # Close the coroutine to avoid RuntimeWarning
+        coro.close()
+        return
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_task_done)
+async def _fire_bg(event_name: str, event_fn, user_id: int, **kwargs) -> None:
+    """Generic background wrapper: opens a session, calls event_fn, logs errors."""
+    try:
+        async with AsyncSessionLocal() as db:
+            await event_fn(db, user_id, **kwargs)
+    except Exception as exc:
+        logger.warning(f'{LOG_PREFIX} Background {event_name} event failed', user_id=user_id, error=str(exc))
+async def fire_registration_bg(user_id: int) -> None:
+    """Fire registration event in background with its own DB session."""
+    await _fire_bg('registration', on_registration, user_id)
+async def fire_trial_bg(user_id: int) -> None:
+    """Fire trial event in background with its own DB session."""
+    await _fire_bg('trial', on_trial, user_id)
+async def fire_purchase_bg(user_id: int, amount_kopeks: int) -> None:
+    """Fire purchase event in background with its own DB session."""
+    await _fire_bg('purchase', on_purchase, user_id, amount_kopeks=amount_kopeks)
+# --- Public API ---
+async def store_cid(
+    db: AsyncSession,
+    user_id: int,
+    cid: str | None,
+    source: str = 'web',
+) -> bool:
+    """Store Yandex ClientID for a user. Returns True if stored."""
+    normalized = _normalize_cid(cid)
+    if not normalized:
+        return False
+
+    try:
+        await upsert_cid(db, user_id, normalized, source=source, counter_id=settings.YANDEX_OFFLINE_CONV_COUNTER_ID)
+        logger.info('stored CID', user_id=user_id, source=source)
+        return True
+    except Exception as exc:
+        logger.error('failed to store CID', user_id=user_id, error=str(exc))
+        return False
+async def store_cid_and_fire_registration(
+    user_id: int,
+    cid: str | None,
+    *,
+    source: str = 'web',
+) -> None:
+    """Store Yandex CID and fire registration conversion in background (best-effort).
+
+    Opens its own DB session so it never interferes with the caller's transaction.
+    """
+    if not cid:
+        return
+    try:
+        async with AsyncSessionLocal() as db:
+            stored = await store_cid(db, user_id, cid, source=source)
+            if stored:
+                await db.commit()
+                spawn_bg(fire_registration_bg(user_id))
+    except Exception as exc:
+        logger.warning(f'{LOG_PREFIX} Failed to store CID and fire registration', user_id=user_id, error=str(exc))
+async def on_registration(db: AsyncSession, user_id: int) -> None:
+    """Fire registration event (once per user)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row or row.registration_sent:
+            return
+
+        success = await _send_event(row.yandex_cid, 'registration')
+        if success:
+            await mark_registration_sent(db, user_id)
+            await db.commit()
+            logger.info('registration event sent', user_id=user_id)
+    except Exception as exc:
+        logger.error('registration event failed', user_id=user_id, error=str(exc))
+async def on_trial(db: AsyncSession, user_id: int) -> None:
+    """Fire trial-add event (once per user)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row or row.trial_sent:
+            return
+
+        success = await _send_event(row.yandex_cid, 'trial-add')
+        if success:
+            await mark_trial_sent(db, user_id)
+            await db.commit()
+            logger.info('trial-add event sent', user_id=user_id)
+    except Exception as exc:
+        logger.error('trial-add event failed', user_id=user_id, error=str(exc))
+async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> None:
+    """Fire ecommerce purchase event (every payment)."""
+    if not _is_enabled():
+        return
+
+    try:
+        row = await get_cid(db, user_id)
+        if not row:
+            return
+
+        amount_rubles = amount_kopeks / 100
+        payload = _ecommerce_purchase_payload(row.yandex_cid, amount_rubles)
+        success = await _post_collect(payload, 'purchase', row.yandex_cid)
+        if success:
+            logger.info('purchase event sent', user_id=user_id, amount=amount_rubles)
+    except Exception as exc:
+        logger.error('purchase event failed', user_id=user_id, error=str(exc))
+def parse_cid_from_start_param(param: str) -> tuple[str | None, str]:
+    """Extract Yandex CID from bot start parameter.
+
+    If param starts with the configured prefix (e.g. 'utm_ya_'),
+    returns (cid, original_param). Otherwise returns (None, original_param).
+    Original param is always preserved for UTM tracking.
+    """
+    prefix = settings.YANDEX_OFFLINE_CONV_START_PREFIX
+    if not prefix or not param.startswith(prefix):
+        return None, param
+
+    cid = param[len(prefix) :]
+    normalized = _normalize_cid(cid)
+    return normalized, param  # Keep original param for UTM tracking

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -24,8 +24,6 @@ from app.database.crud.yandex_client_id import (
     upsert_cid,
 )
 from app.database.database import AsyncSessionLocal
-
-
 logger = structlog.get_logger(__name__)
 
 LOG_PREFIX = '[YandexOfflineConv]'
@@ -36,23 +34,17 @@ RETRY_DELAY = 1.0
 
 _CID_RE = re.compile(r'^[A-Za-z0-9._:-]{4,128}$')
 _http_client: httpx.AsyncClient | None = None
-
-
 def _get_client() -> httpx.AsyncClient:
     global _http_client
     if _http_client is None or _http_client.is_closed:
         _http_client = httpx.AsyncClient(timeout=TIMEOUT)
     return _http_client
-
-
 def _is_enabled() -> bool:
     return bool(
         settings.YANDEX_OFFLINE_CONV_ENABLED
         and settings.YANDEX_OFFLINE_CONV_COUNTER_ID
         and settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET
     )
-
-
 def _normalize_cid(cid: str | None) -> str | None:
     if not isinstance(cid, str):
         return None
@@ -60,22 +52,16 @@ def _normalize_cid(cid: str | None) -> str | None:
     if not cid or not _CID_RE.match(cid):
         return None
     return cid
-
-
 def _mask_cid(cid: str) -> str:
     if len(cid) <= 4:
         return '****'
     return '*' * (len(cid) - 4) + cid[-4:]
-
-
 def _base_payload(cid: str) -> dict[str, str]:
     return {
         'tid': settings.YANDEX_OFFLINE_CONV_COUNTER_ID,
         'cid': cid,
         'ms': settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET,
     }
-
-
 def _pageview_payload(cid: str) -> dict[str, str]:
     payload = _base_payload(cid)
     payload.update(
@@ -86,8 +72,6 @@ def _pageview_payload(cid: str) -> dict[str, str]:
         }
     )
     return payload
-
-
 def _event_payload(cid: str, event_action: str) -> dict[str, str]:
     payload = _base_payload(cid)
     payload.update(
@@ -97,8 +81,6 @@ def _event_payload(cid: str, event_action: str) -> dict[str, str]:
         }
     )
     return payload
-
-
 def _ecommerce_purchase_payload(
     cid: str,
     amount_rubles: float,
@@ -115,24 +97,21 @@ def _ecommerce_purchase_payload(
     )
     currency = getattr(settings, 'YANDEX_OFFLINE_CONV_CURRENCY', '') or 'RUB'
     payload = _base_payload(cid)
-    payload.update(
-        {
-            't': 'event',
-            'ea': 'purchase',
-            'pa': 'purchase',
-            'ti': order_id or str(int(time.time())),
-            'tr': str(amount_rubles),
-            'cu': currency,
-            'ev': str(amount_rubles),
-            'pr1id': 'subscription',
-            'pr1nm': product_name or service_name,
-            'pr1ca': product_category or 'subscription',
-            'pr1pr': str(amount_rubles),
-            'pr1qt': '1',
-        }
-    )
+    payload.update({
+        't': 'event',
+        'ea': 'purchase',
+        'pa': 'purchase',
+        'ti': order_id or str(int(time.time())),
+        'tr': str(amount_rubles),
+        'cu': currency,
+        'ev': str(amount_rubles),
+        'pr1id': 'subscription',
+        'pr1nm': product_name or service_name,
+        'pr1ca': product_category or 'subscription',
+        'pr1pr': str(amount_rubles),
+        'pr1qt': '1',
+    })
     return payload
-
 
 async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
     """POST to mc.yandex.ru/collect with retries. Returns True on success."""
@@ -171,18 +150,12 @@ async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
             return False
 
     return False
-
-
 async def _send_event(cid: str, event_action: str) -> bool:
     """Send event directly — no pageview needed, user has active Metrika session."""
     return await _post_collect(_event_payload(cid, event_action), event_action, cid)
-
-
 # --- Background task helpers ---
 
 _background_tasks: set[asyncio.Task] = set()
-
-
 def _task_done(task):
     """Log errors from background conversion tasks."""
     _background_tasks.discard(task)
@@ -191,8 +164,6 @@ def _task_done(task):
     exc = task.exception()
     if exc:
         logger.error(f'{LOG_PREFIX} Background task failed', error=str(exc))
-
-
 def spawn_bg(coro) -> None:
     """Spawn a background Yandex conversion task with proper reference tracking.
 
@@ -205,8 +176,6 @@ def spawn_bg(coro) -> None:
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
     task.add_done_callback(_task_done)
-
-
 async def _fire_bg(event_name: str, event_fn, user_id: int, **kwargs) -> None:
     """Generic background wrapper: opens a session, calls event_fn, logs errors."""
     try:
@@ -214,23 +183,15 @@ async def _fire_bg(event_name: str, event_fn, user_id: int, **kwargs) -> None:
             await event_fn(db, user_id, **kwargs)
     except Exception as exc:
         logger.warning(f'{LOG_PREFIX} Background {event_name} event failed', user_id=user_id, error=str(exc))
-
-
 async def fire_registration_bg(user_id: int) -> None:
     """Fire registration event in background with its own DB session."""
     await _fire_bg('registration', on_registration, user_id)
-
-
 async def fire_trial_bg(user_id: int) -> None:
     """Fire trial event in background with its own DB session."""
     await _fire_bg('trial', on_trial, user_id)
-
-
 async def fire_purchase_bg(user_id: int, amount_kopeks: int) -> None:
     """Fire purchase event in background with its own DB session."""
     await _fire_bg('purchase', on_purchase, user_id, amount_kopeks=amount_kopeks)
-
-
 # --- Public API ---
 async def store_cid(
     db: AsyncSession,
@@ -250,8 +211,6 @@ async def store_cid(
     except Exception as exc:
         logger.error('failed to store CID', user_id=user_id, error=str(exc))
         return False
-
-
 async def store_cid_and_fire_registration(
     user_id: int,
     cid: str | None,
@@ -272,8 +231,6 @@ async def store_cid_and_fire_registration(
                 spawn_bg(fire_registration_bg(user_id))
     except Exception as exc:
         logger.warning(f'{LOG_PREFIX} Failed to store CID and fire registration', user_id=user_id, error=str(exc))
-
-
 async def on_registration(db: AsyncSession, user_id: int) -> None:
     """Fire registration event (once per user)."""
     if not _is_enabled():
@@ -291,8 +248,6 @@ async def on_registration(db: AsyncSession, user_id: int) -> None:
             logger.info('registration event sent', user_id=user_id)
     except Exception as exc:
         logger.error('registration event failed', user_id=user_id, error=str(exc))
-
-
 async def on_trial(db: AsyncSession, user_id: int) -> None:
     """Fire trial-add event (once per user)."""
     if not _is_enabled():
@@ -310,8 +265,6 @@ async def on_trial(db: AsyncSession, user_id: int) -> None:
             logger.info('trial-add event sent', user_id=user_id)
     except Exception as exc:
         logger.error('trial-add event failed', user_id=user_id, error=str(exc))
-
-
 async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> None:
     """Fire ecommerce purchase event (every payment)."""
     if not _is_enabled():
@@ -329,8 +282,6 @@ async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> Non
             logger.info('purchase event sent', user_id=user_id, amount=amount_rubles)
     except Exception as exc:
         logger.error('purchase event failed', user_id=user_id, error=str(exc))
-
-
 def parse_cid_from_start_param(param: str) -> tuple[str | None, str]:
     """Extract Yandex CID from bot start parameter.
 

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -24,6 +24,7 @@ from app.database.crud.yandex_client_id import (
     upsert_cid,
 )
 from app.database.database import AsyncSessionLocal
+
 logger = structlog.get_logger(__name__)
 
 LOG_PREFIX = '[YandexOfflineConv]'
@@ -34,17 +35,23 @@ RETRY_DELAY = 1.0
 
 _CID_RE = re.compile(r'^[A-Za-z0-9._:-]{4,128}$')
 _http_client: httpx.AsyncClient | None = None
+
+
 def _get_client() -> httpx.AsyncClient:
     global _http_client
     if _http_client is None or _http_client.is_closed:
         _http_client = httpx.AsyncClient(timeout=TIMEOUT)
     return _http_client
+
+
 def _is_enabled() -> bool:
     return bool(
         settings.YANDEX_OFFLINE_CONV_ENABLED
         and settings.YANDEX_OFFLINE_CONV_COUNTER_ID
         and settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET
     )
+
+
 def _normalize_cid(cid: str | None) -> str | None:
     if not isinstance(cid, str):
         return None
@@ -52,16 +59,22 @@ def _normalize_cid(cid: str | None) -> str | None:
     if not cid or not _CID_RE.match(cid):
         return None
     return cid
+
+
 def _mask_cid(cid: str) -> str:
     if len(cid) <= 4:
         return '****'
     return '*' * (len(cid) - 4) + cid[-4:]
+
+
 def _base_payload(cid: str) -> dict[str, str]:
     return {
         'tid': settings.YANDEX_OFFLINE_CONV_COUNTER_ID,
         'cid': cid,
         'ms': settings.YANDEX_OFFLINE_CONV_MEASUREMENT_SECRET,
     }
+
+
 def _pageview_payload(cid: str) -> dict[str, str]:
     payload = _base_payload(cid)
     payload.update(
@@ -72,6 +85,8 @@ def _pageview_payload(cid: str) -> dict[str, str]:
         }
     )
     return payload
+
+
 def _event_payload(cid: str, event_action: str) -> dict[str, str]:
     payload = _base_payload(cid)
     payload.update(
@@ -81,6 +96,8 @@ def _event_payload(cid: str, event_action: str) -> dict[str, str]:
         }
     )
     return payload
+
+
 def _ecommerce_purchase_payload(
     cid: str,
     amount_rubles: float,
@@ -97,21 +114,24 @@ def _ecommerce_purchase_payload(
     )
     currency = getattr(settings, 'YANDEX_OFFLINE_CONV_CURRENCY', '') or 'RUB'
     payload = _base_payload(cid)
-    payload.update({
-        't': 'event',
-        'ea': 'purchase',
-        'pa': 'purchase',
-        'ti': order_id or str(int(time.time())),
-        'tr': str(amount_rubles),
-        'cu': currency,
-        'ev': str(amount_rubles),
-        'pr1id': 'subscription',
-        'pr1nm': product_name or service_name,
-        'pr1ca': product_category or 'subscription',
-        'pr1pr': str(amount_rubles),
-        'pr1qt': '1',
-    })
+    payload.update(
+        {
+            't': 'event',
+            'ea': 'purchase',
+            'pa': 'purchase',
+            'ti': order_id or str(int(time.time())),
+            'tr': str(amount_rubles),
+            'cu': currency,
+            'ev': str(amount_rubles),
+            'pr1id': 'subscription',
+            'pr1nm': product_name or service_name,
+            'pr1ca': product_category or 'subscription',
+            'pr1pr': str(amount_rubles),
+            'pr1qt': '1',
+        }
+    )
     return payload
+
 
 async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
     """POST to mc.yandex.ru/collect with retries. Returns True on success."""
@@ -150,12 +170,18 @@ async def _post_collect(payload: dict[str, str], kind: str, cid: str) -> bool:
             return False
 
     return False
+
+
 async def _send_event(cid: str, event_action: str) -> bool:
     """Send event directly — no pageview needed, user has active Metrika session."""
     return await _post_collect(_event_payload(cid, event_action), event_action, cid)
+
+
 # --- Background task helpers ---
 
 _background_tasks: set[asyncio.Task] = set()
+
+
 def _task_done(task):
     """Log errors from background conversion tasks."""
     _background_tasks.discard(task)
@@ -164,6 +190,8 @@ def _task_done(task):
     exc = task.exception()
     if exc:
         logger.error(f'{LOG_PREFIX} Background task failed', error=str(exc))
+
+
 def spawn_bg(coro) -> None:
     """Spawn a background Yandex conversion task with proper reference tracking.
 
@@ -176,6 +204,8 @@ def spawn_bg(coro) -> None:
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
     task.add_done_callback(_task_done)
+
+
 async def _fire_bg(event_name: str, event_fn, user_id: int, **kwargs) -> None:
     """Generic background wrapper: opens a session, calls event_fn, logs errors."""
     try:
@@ -183,15 +213,23 @@ async def _fire_bg(event_name: str, event_fn, user_id: int, **kwargs) -> None:
             await event_fn(db, user_id, **kwargs)
     except Exception as exc:
         logger.warning(f'{LOG_PREFIX} Background {event_name} event failed', user_id=user_id, error=str(exc))
+
+
 async def fire_registration_bg(user_id: int) -> None:
     """Fire registration event in background with its own DB session."""
     await _fire_bg('registration', on_registration, user_id)
+
+
 async def fire_trial_bg(user_id: int) -> None:
     """Fire trial event in background with its own DB session."""
     await _fire_bg('trial', on_trial, user_id)
+
+
 async def fire_purchase_bg(user_id: int, amount_kopeks: int) -> None:
     """Fire purchase event in background with its own DB session."""
     await _fire_bg('purchase', on_purchase, user_id, amount_kopeks=amount_kopeks)
+
+
 # --- Public API ---
 async def store_cid(
     db: AsyncSession,
@@ -211,6 +249,8 @@ async def store_cid(
     except Exception as exc:
         logger.error('failed to store CID', user_id=user_id, error=str(exc))
         return False
+
+
 async def store_cid_and_fire_registration(
     user_id: int,
     cid: str | None,
@@ -231,6 +271,8 @@ async def store_cid_and_fire_registration(
                 spawn_bg(fire_registration_bg(user_id))
     except Exception as exc:
         logger.warning(f'{LOG_PREFIX} Failed to store CID and fire registration', user_id=user_id, error=str(exc))
+
+
 async def on_registration(db: AsyncSession, user_id: int) -> None:
     """Fire registration event (once per user)."""
     if not _is_enabled():
@@ -248,6 +290,8 @@ async def on_registration(db: AsyncSession, user_id: int) -> None:
             logger.info('registration event sent', user_id=user_id)
     except Exception as exc:
         logger.error('registration event failed', user_id=user_id, error=str(exc))
+
+
 async def on_trial(db: AsyncSession, user_id: int) -> None:
     """Fire trial-add event (once per user)."""
     if not _is_enabled():
@@ -265,6 +309,8 @@ async def on_trial(db: AsyncSession, user_id: int) -> None:
             logger.info('trial-add event sent', user_id=user_id)
     except Exception as exc:
         logger.error('trial-add event failed', user_id=user_id, error=str(exc))
+
+
 async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> None:
     """Fire ecommerce purchase event (every payment)."""
     if not _is_enabled():
@@ -282,6 +328,8 @@ async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> Non
             logger.info('purchase event sent', user_id=user_id, amount=amount_rubles)
     except Exception as exc:
         logger.error('purchase event failed', user_id=user_id, error=str(exc))
+
+
 def parse_cid_from_start_param(param: str) -> tuple[str | None, str]:
     """Extract Yandex CID from bot start parameter.
 

--- a/migrations/alembic/versions/0053_add_yandex_client_id_map.py
+++ b/migrations/alembic/versions/0053_add_yandex_client_id_map.py
@@ -1,0 +1,52 @@
+"""add yandex_client_id_map table + guest_purchases.yandex_cid column
+
+Revision ID: 0053
+Revises: 0052
+Create Date: 2026-03-23
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0053'
+down_revision: Union[str, None] = '0052'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create table only if it does not already exist (may have been created by earlier patch branch)
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'yandex_client_id_map')")
+    )
+    if not result.scalar():
+        op.create_table(
+            'yandex_client_id_map',
+            sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False),
+            sa.Column('yandex_cid', sa.String(128), nullable=False),
+            sa.Column('source', sa.String(20), nullable=False, server_default='web'),
+            sa.Column('counter_id', sa.String(32), nullable=True),
+            sa.Column('registration_sent', sa.Boolean, server_default=sa.text('false'), nullable=False),
+            sa.Column('trial_sent', sa.Boolean, server_default=sa.text('false'), nullable=False),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        )
+
+    # Add yandex_cid column to guest_purchases if not present
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'guest_purchases' AND column_name = 'yandex_cid')"
+        )
+    )
+    if not result.scalar():
+        op.add_column('guest_purchases', sa.Column('yandex_cid', sa.String(128), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('guest_purchases', 'yandex_cid')
+    op.drop_table('yandex_client_id_map')


### PR DESCRIPTION
## Описание

Яндекс.Метрика офлайн конверсии + сбор CID со всех источников.

### Конверсии
- **registration** — при регистрации (OAuth, бот, гостевая покупка)
- **trial-add** — при активации триала
- **purchase** — при любой оплате (кабинет, бот, лендинг, автопродление) с суммой

### Сбор CID
- **Кабинет** — эндпоинт `POST /analytics/yandex-cid` для JS
- **Лендинг** — поле `yandex_cid` в PurchaseRequest → Redis → привязка при fulfillment
- **Бот** — `/start utm_ya_XXXXX`
- **Защита** — первый CID никогда не перезаписывается (`on_conflict_do_nothing`)

### Файлы
- `yandex_offline_conv_service.py` — сервис отправки событий
- `yandex_client_id.py` — CRUD с защитой от перезаписи
- `models.py` — модель YandexClientIdMap
- `branding.py` — эндпоинт для CID
- `landing.py` — приём CID при покупке
- `guest_purchase_service.py` — привязка CID при fulfillment
- `subscription_purchase_service.py` — хук on_purchase
- `subscription_auto_purchase_service.py` — хук on_purchase для автопродления
- `auth.py` — хук on_registration
- Миграция 0053

### Связанный PR
- Кабинет: #372