### PR TITLE
feat: улучшения статистики лендингов — реферер, часовой пояс, HTTP Referer

### DIFF
--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -797,7 +797,8 @@ async def get_landing_stats(
     db: AsyncSession = Depends(get_cabinet_db),
 ) -> LandingStatsResponse:
     """Get daily statistics and tariff breakdown for a landing page."""
-    user_tz = tz if tz and len(tz) < 50 else 'UTC'
+    _valid_timezones = zoneinfo.available_timezones()
+    user_tz = tz if tz and tz in _valid_timezones else 'UTC'
 
     landing = await get_landing_by_id(db, landing_id)
     if landing is None:

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -1,5 +1,6 @@
 """Admin routes for landing page management in cabinet."""
 
+import zoneinfo
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
@@ -527,6 +528,7 @@ class LandingPurchaseItem(BaseModel):
     currency: str
     payment_method: str | None = None
     status: str
+    referrer: str | None = None
     created_at: datetime | None = None
     paid_at: datetime | None = None
 
@@ -790,10 +792,13 @@ _STATS_PERIOD_DAYS = 30
 @router.get('/{landing_id}/stats', response_model=LandingStatsResponse)
 async def get_landing_stats(
     landing_id: int,
+    tz: str = Query(default='UTC'),
     admin: User = Depends(require_permission('landings:read')),
     db: AsyncSession = Depends(get_cabinet_db),
 ) -> LandingStatsResponse:
     """Get daily statistics and tariff breakdown for a landing page."""
+    user_tz = tz if tz and len(tz) < 50 else 'UTC'
+
     landing = await get_landing_by_id(db, landing_id)
     if landing is None:
         raise HTTPException(
@@ -827,7 +832,7 @@ async def get_landing_stats(
     # -- Daily stats for last N days --
     now = datetime.now(UTC)
     cutoff = now - timedelta(days=_STATS_PERIOD_DAYS)
-    day_at_utc = func.date(func.timezone('UTC', GuestPurchase.paid_at))
+    day_at_utc = func.date(func.timezone(user_tz, GuestPurchase.paid_at))
     daily_result = await db.execute(
         select(
             day_at_utc.label('day'),
@@ -846,7 +851,7 @@ async def get_landing_stats(
     daily_rows = {str(r.day): r for r in daily_result.all()}
 
     # Created per day (all statuses, by created_at)
-    day_created_utc = func.date(func.timezone('UTC', GuestPurchase.created_at))
+    day_created_utc = func.date(func.timezone(user_tz, GuestPurchase.created_at))
     created_result = await db.execute(
         select(
             day_created_utc.label('day'),
@@ -862,7 +867,10 @@ async def get_landing_stats(
     created_rows = {str(r.day): r.created for r in created_result.all()}
 
     # Fill missing days with zeros
-    today = now.date()
+    try:
+        today = datetime.now(zoneinfo.ZoneInfo(user_tz)).date()
+    except Exception:
+        today = now.date()
     daily_stats: list[LandingDailyStat] = []
     for i in range(_STATS_PERIOD_DAYS, -1, -1):
         day = today - timedelta(days=i)
@@ -979,6 +987,7 @@ async def get_landing_purchases(
             GuestPurchase.currency,
             GuestPurchase.payment_method,
             GuestPurchase.status,
+            GuestPurchase.referrer,
             GuestPurchase.created_at,
             GuestPurchase.paid_at,
         )
@@ -1004,6 +1013,7 @@ async def get_landing_purchases(
             currency=row.currency,
             payment_method=row.payment_method,
             status=row.status,
+            referrer=row.referrer,
             created_at=row.created_at,
             paid_at=row.paid_at,
         )

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -206,6 +206,10 @@ class LandingCreateRequest(BaseModel):
     discount_ends_at: datetime | None = None
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
+    analytics_view_enabled: bool | None = None
+    analytics_view_goal: str | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_click_goal: str | None = None
 
     @field_validator('background_config')
     @classmethod
@@ -315,6 +319,10 @@ class LandingUpdateRequest(BaseModel):
     discount_ends_at: datetime | None = None
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
+    analytics_view_enabled: bool | None = None
+    analytics_view_goal: str | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_click_goal: str | None = None
 
     @field_validator('background_config')
     @classmethod
@@ -428,6 +436,10 @@ class LandingListItem(BaseModel):
     method_count: int
     purchase_stats: PurchaseStats
     has_active_discount: bool = False
+    analytics_view_enabled: bool = False
+    analytics_view_goal: str = 'landing_view'
+    analytics_click_enabled: bool = False
+    analytics_click_goal: str = 'landing_pay'
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -462,6 +474,10 @@ class LandingDetailResponse(BaseModel):
     discount_ends_at: datetime | None = None
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
+    analytics_view_enabled: bool = False
+    analytics_view_goal: str = 'landing_view'
+    analytics_click_enabled: bool = False
+    analytics_click_goal: str = 'landing_pay'
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -592,6 +608,10 @@ async def list_landings(
                     expired=stats.get('expired', 0),
                 ),
                 has_active_discount=discount_active,
+                analytics_view_enabled=landing.analytics_view_enabled or False,
+                analytics_view_goal=landing.analytics_view_goal or 'landing_view',
+                analytics_click_enabled=landing.analytics_click_enabled or False,
+                analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
                 created_at=landing.created_at,
                 updated_at=landing.updated_at,
             )
@@ -640,6 +660,10 @@ async def create_landing_page(
         discount_ends_at=request.discount_ends_at,
         discount_badge_text=request.discount_badge_text,
         background_config=request.background_config,
+        analytics_view_enabled=request.analytics_view_enabled,
+        analytics_view_goal=request.analytics_view_goal,
+        analytics_click_enabled=request.analytics_click_enabled,
+        analytics_click_goal=request.analytics_click_goal,
     )
 
     logger.info('Admin created landing page', admin_id=admin.id, slug=landing.slug, landing_id=landing.id)
@@ -1079,6 +1103,10 @@ def _landing_to_detail(landing: LandingPage) -> LandingDetailResponse:
         discount_ends_at=landing.discount_ends_at,
         discount_badge_text=landing.discount_badge_text,
         background_config=landing.background_config,
+        analytics_view_enabled=landing.analytics_view_enabled or False,
+        analytics_view_goal=landing.analytics_view_goal or 'landing_view',
+        analytics_click_enabled=landing.analytics_click_enabled or False,
+        analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
         created_at=landing.created_at,
         updated_at=landing.updated_at,
     )

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -1,6 +1,5 @@
 """Admin routes for landing page management in cabinet."""
 
-import zoneinfo
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
@@ -207,9 +206,9 @@ class LandingCreateRequest(BaseModel):
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
     analytics_view_enabled: bool | None = None
-    analytics_view_goal: str | None = None
     analytics_click_enabled: bool | None = None
-    analytics_click_goal: str | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
 
     @field_validator('background_config')
     @classmethod
@@ -320,9 +319,9 @@ class LandingUpdateRequest(BaseModel):
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
     analytics_view_enabled: bool | None = None
-    analytics_view_goal: str | None = None
     analytics_click_enabled: bool | None = None
-    analytics_click_goal: str | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
 
     @field_validator('background_config')
     @classmethod
@@ -436,10 +435,6 @@ class LandingListItem(BaseModel):
     method_count: int
     purchase_stats: PurchaseStats
     has_active_discount: bool = False
-    analytics_view_enabled: bool = False
-    analytics_view_goal: str = 'landing_view'
-    analytics_click_enabled: bool = False
-    analytics_click_goal: str = 'landing_pay'
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -474,10 +469,10 @@ class LandingDetailResponse(BaseModel):
     discount_ends_at: datetime | None = None
     discount_badge_text: dict[str, str] | None = None
     background_config: dict | None = None
-    analytics_view_enabled: bool = False
-    analytics_view_goal: str = 'landing_view'
-    analytics_click_enabled: bool = False
-    analytics_click_goal: str = 'landing_pay'
+    analytics_view_enabled: bool | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -544,7 +539,6 @@ class LandingPurchaseItem(BaseModel):
     currency: str
     payment_method: str | None = None
     status: str
-    referrer: str | None = None
     created_at: datetime | None = None
     paid_at: datetime | None = None
 
@@ -608,10 +602,6 @@ async def list_landings(
                     expired=stats.get('expired', 0),
                 ),
                 has_active_discount=discount_active,
-                analytics_view_enabled=landing.analytics_view_enabled or False,
-                analytics_view_goal=landing.analytics_view_goal or 'landing_view',
-                analytics_click_enabled=landing.analytics_click_enabled or False,
-                analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
                 created_at=landing.created_at,
                 updated_at=landing.updated_at,
             )
@@ -660,10 +650,6 @@ async def create_landing_page(
         discount_ends_at=request.discount_ends_at,
         discount_badge_text=request.discount_badge_text,
         background_config=request.background_config,
-        analytics_view_enabled=request.analytics_view_enabled,
-        analytics_view_goal=request.analytics_view_goal,
-        analytics_click_enabled=request.analytics_click_enabled,
-        analytics_click_goal=request.analytics_click_goal,
     )
 
     logger.info('Admin created landing page', admin_id=admin.id, slug=landing.slug, landing_id=landing.id)
@@ -816,14 +802,10 @@ _STATS_PERIOD_DAYS = 30
 @router.get('/{landing_id}/stats', response_model=LandingStatsResponse)
 async def get_landing_stats(
     landing_id: int,
-    tz: str = Query(default='UTC'),
     admin: User = Depends(require_permission('landings:read')),
     db: AsyncSession = Depends(get_cabinet_db),
 ) -> LandingStatsResponse:
     """Get daily statistics and tariff breakdown for a landing page."""
-    _valid_timezones = zoneinfo.available_timezones()
-    user_tz = tz if tz and tz in _valid_timezones else 'UTC'
-
     landing = await get_landing_by_id(db, landing_id)
     if landing is None:
         raise HTTPException(
@@ -857,7 +839,7 @@ async def get_landing_stats(
     # -- Daily stats for last N days --
     now = datetime.now(UTC)
     cutoff = now - timedelta(days=_STATS_PERIOD_DAYS)
-    day_at_utc = func.date(func.timezone(user_tz, GuestPurchase.paid_at))
+    day_at_utc = func.date(func.timezone('UTC', GuestPurchase.paid_at))
     daily_result = await db.execute(
         select(
             day_at_utc.label('day'),
@@ -876,7 +858,7 @@ async def get_landing_stats(
     daily_rows = {str(r.day): r for r in daily_result.all()}
 
     # Created per day (all statuses, by created_at)
-    day_created_utc = func.date(func.timezone(user_tz, GuestPurchase.created_at))
+    day_created_utc = func.date(func.timezone('UTC', GuestPurchase.created_at))
     created_result = await db.execute(
         select(
             day_created_utc.label('day'),
@@ -892,10 +874,7 @@ async def get_landing_stats(
     created_rows = {str(r.day): r.created for r in created_result.all()}
 
     # Fill missing days with zeros
-    try:
-        today = datetime.now(zoneinfo.ZoneInfo(user_tz)).date()
-    except Exception:
-        today = now.date()
+    today = now.date()
     daily_stats: list[LandingDailyStat] = []
     for i in range(_STATS_PERIOD_DAYS, -1, -1):
         day = today - timedelta(days=i)
@@ -1012,7 +991,6 @@ async def get_landing_purchases(
             GuestPurchase.currency,
             GuestPurchase.payment_method,
             GuestPurchase.status,
-            GuestPurchase.referrer,
             GuestPurchase.created_at,
             GuestPurchase.paid_at,
         )
@@ -1038,7 +1016,6 @@ async def get_landing_purchases(
             currency=row.currency,
             payment_method=row.payment_method,
             status=row.status,
-            referrer=row.referrer,
             created_at=row.created_at,
             paid_at=row.paid_at,
         )
@@ -1103,10 +1080,10 @@ def _landing_to_detail(landing: LandingPage) -> LandingDetailResponse:
         discount_ends_at=landing.discount_ends_at,
         discount_badge_text=landing.discount_badge_text,
         background_config=landing.background_config,
-        analytics_view_enabled=landing.analytics_view_enabled or False,
-        analytics_view_goal=landing.analytics_view_goal or 'landing_view',
-        analytics_click_enabled=landing.analytics_click_enabled or False,
-        analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
+        analytics_view_enabled=landing.analytics_view_enabled,
+        analytics_click_enabled=landing.analytics_click_enabled,
+        analytics_view_goal=landing.analytics_view_goal,
+        analytics_click_goal=landing.analytics_click_goal,
         created_at=landing.created_at,
         updated_at=landing.updated_at,
     )

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -209,6 +209,8 @@ class LandingCreateRequest(BaseModel):
     analytics_click_enabled: bool | None = None
     analytics_view_goal: str | None = Field(default=None, max_length=100)
     analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
+    sticky_pay_button: bool | None = False
 
     @field_validator('background_config')
     @classmethod
@@ -322,6 +324,7 @@ class LandingUpdateRequest(BaseModel):
     analytics_click_enabled: bool | None = None
     analytics_view_goal: str | None = Field(default=None, max_length=100)
     analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
 
     @field_validator('background_config')
     @classmethod
@@ -473,6 +476,7 @@ class LandingDetailResponse(BaseModel):
     analytics_click_enabled: bool | None = None
     analytics_view_goal: str | None = Field(default=None, max_length=100)
     analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -1084,6 +1088,7 @@ def _landing_to_detail(landing: LandingPage) -> LandingDetailResponse:
         analytics_click_enabled=landing.analytics_click_enabled,
         analytics_view_goal=landing.analytics_view_goal,
         analytics_click_goal=landing.analytics_click_goal,
+        sticky_pay_button=getattr(landing, "sticky_pay_button", False) or False,
         created_at=landing.created_at,
         updated_at=landing.updated_at,
     )

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -647,6 +647,11 @@ async def create_landing_purchase(
         commit=False,
     )
 
+    # Capture HTTP Referer header
+    http_referrer = raw_request.headers.get('referer') or raw_request.headers.get('referrer')
+    if http_referrer and len(http_referrer) <= 500:
+        purchase.referrer = http_referrer
+
     # Determine return URL: per-method override → default cabinet URL
     cabinet_base = (settings.CABINET_URL or '').rstrip('/')
     default_return_url = f'{cabinet_base}/buy/success/{purchase.token}'

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -31,6 +31,8 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix='/landing', tags=['Landing Pages'])
 
 
+
+
 class LandingFeature(BaseModel):
     icon: str = ''
     title: str = ''
@@ -100,6 +102,7 @@ class LandingConfigResponse(BaseModel):
     analytics_click_enabled: bool = False
     analytics_view_goal: str | None = None
     analytics_click_goal: str | None = None
+    sticky_pay_button: bool = False
 
 
 _EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
@@ -158,6 +161,8 @@ class PurchaseStatusResponse(BaseModel):
     auto_login_token: str | None = None
     recipient_in_bot: bool | None = None
     bot_link: str | None = None
+
+
 
 
 def _mask_contact(value: str) -> str:
@@ -376,6 +381,7 @@ async def _load_landing_tariffs(
     return landing_tariffs
 
 
+
 # IMPORTANT: /purchase/{token} must come BEFORE /{slug} to avoid shadowing
 # (FastAPI checks routes in definition order; "purchase" would match {slug})
 
@@ -537,6 +543,7 @@ async def get_landing_config(
         analytics_click_enabled=landing.analytics_click_enabled,
         analytics_view_goal=landing.analytics_view_goal,
         analytics_click_goal=landing.analytics_click_goal,
+        sticky_pay_button=getattr(landing, "sticky_pay_button", False) or False,
     )
 
 

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -23,7 +23,7 @@ from app.services.guest_purchase_service import (
 )
 from app.services.payment_method_config_service import _get_method_defaults
 from app.services.payment_service import PaymentService
-from app.utils.cache import RateLimitCache
+from app.utils.cache import RateLimitCache, cache
 
 
 logger = structlog.get_logger(__name__)
@@ -127,6 +127,8 @@ class PurchaseRequest(BaseModel):
     gift_recipient_type: str | None = Field(default=None, pattern=r'^(email|telegram)$')
     gift_recipient_value: str | None = Field(default=None, max_length=255)
     gift_message: str | None = Field(default=None, max_length=1000)
+    yandex_cid: str | None = Field(default=None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$')
+    referrer: str | None = Field(default=None, max_length=500)
 
     @model_validator(mode='after')
     def validate_contacts(self) -> 'PurchaseRequest':
@@ -655,10 +657,9 @@ async def create_landing_purchase(
         commit=False,
     )
 
-    # Capture HTTP Referer header
-    http_referrer = raw_request.headers.get('referer') or raw_request.headers.get('referrer')
-    if http_referrer and len(http_referrer) <= 500:
-        purchase.referrer = http_referrer
+    # Save referrer from request body (document.referrer captured on page load)
+    if body.referrer:
+        purchase.referrer = body.referrer
 
     # Determine return URL: per-method override → default cabinet URL
     cabinet_base = (settings.CABINET_URL or '').rstrip('/')
@@ -702,6 +703,13 @@ async def create_landing_purchase(
 
     await db.commit()
     await db.refresh(purchase)
+
+    # Persist Yandex CID in cache so fulfill_purchase can link it to the user later
+    if body.yandex_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+        try:
+            await cache.set(f'yacid:purchase:{purchase.token}', body.yandex_cid, expire=86400)
+        except Exception:
+            pass
 
     return PurchaseResponse(
         purchase_token=purchase.token,

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -31,7 +31,6 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix='/landing', tags=['Landing Pages'])
 
 
-# ============ Schemas ============
 
 
 class LandingFeature(BaseModel):
@@ -100,9 +99,9 @@ class LandingConfigResponse(BaseModel):
     discount: LandingDiscountInfo | None = None  # null if no active discount
     background_config: dict | None = None
     analytics_view_enabled: bool = False
-    analytics_view_goal: str = 'landing_view'
     analytics_click_enabled: bool = False
-    analytics_click_goal: str = 'landing_pay'
+    analytics_view_goal: str | None = None
+    analytics_click_goal: str | None = None
 
 
 _EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
@@ -163,7 +162,6 @@ class PurchaseStatusResponse(BaseModel):
     bot_link: str | None = None
 
 
-# ============ Helpers ============
 
 
 def _mask_contact(value: str) -> str:
@@ -382,7 +380,6 @@ async def _load_landing_tariffs(
     return landing_tariffs
 
 
-# ============ Routes ============
 
 # IMPORTANT: /purchase/{token} must come BEFORE /{slug} to avoid shadowing
 # (FastAPI checks routes in definition order; "purchase" would match {slug})
@@ -541,10 +538,10 @@ async def get_landing_config(
         meta_description=resolve_locale_text(landing.meta_description, lang) or None,
         discount=discount,
         background_config=landing.background_config,
-        analytics_view_enabled=landing.analytics_view_enabled or False,
-        analytics_view_goal=landing.analytics_view_goal or 'landing_view',
-        analytics_click_enabled=landing.analytics_click_enabled or False,
-        analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
+        analytics_view_enabled=landing.analytics_view_enabled,
+        analytics_click_enabled=landing.analytics_click_enabled,
+        analytics_view_goal=landing.analytics_view_goal,
+        analytics_click_goal=landing.analytics_click_goal,
     )
 
 

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -99,6 +99,10 @@ class LandingConfigResponse(BaseModel):
     meta_description: str | None = None
     discount: LandingDiscountInfo | None = None  # null if no active discount
     background_config: dict | None = None
+    analytics_view_enabled: bool = False
+    analytics_view_goal: str = 'landing_view'
+    analytics_click_enabled: bool = False
+    analytics_click_goal: str = 'landing_pay'
 
 
 _EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
@@ -535,6 +539,10 @@ async def get_landing_config(
         meta_description=resolve_locale_text(landing.meta_description, lang) or None,
         discount=discount,
         background_config=landing.background_config,
+        analytics_view_enabled=landing.analytics_view_enabled or False,
+        analytics_view_goal=landing.analytics_view_goal or 'landing_view',
+        analytics_click_enabled=landing.analytics_click_enabled or False,
+        analytics_click_goal=landing.analytics_click_goal or 'landing_pay',
     )
 
 

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -31,8 +31,6 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix='/landing', tags=['Landing Pages'])
 
 
-
-
 class LandingFeature(BaseModel):
     icon: str = ''
     title: str = ''
@@ -160,8 +158,6 @@ class PurchaseStatusResponse(BaseModel):
     auto_login_token: str | None = None
     recipient_in_bot: bool | None = None
     bot_link: str | None = None
-
-
 
 
 def _mask_contact(value: str) -> str:
@@ -378,7 +374,6 @@ async def _load_landing_tariffs(
         )
 
     return landing_tariffs
-
 
 
 # IMPORTANT: /purchase/{token} must come BEFORE /{slug} to avoid shadowing

--- a/app/database/crud/landing.py
+++ b/app/database/crud/landing.py
@@ -76,6 +76,10 @@ _LANDING_UPDATABLE_FIELDS = frozenset(
         'discount_ends_at',
         'discount_badge_text',
         'background_config',
+        'analytics_view_enabled',
+        'analytics_view_goal',
+        'analytics_click_enabled',
+        'analytics_click_goal',
     }
 )
 

--- a/app/database/crud/landing.py
+++ b/app/database/crud/landing.py
@@ -77,8 +77,8 @@ _LANDING_UPDATABLE_FIELDS = frozenset(
         'discount_badge_text',
         'background_config',
         'analytics_view_enabled',
-        'analytics_view_goal',
         'analytics_click_enabled',
+        'analytics_view_goal',
         'analytics_click_goal',
     }
 )

--- a/app/database/crud/landing.py
+++ b/app/database/crud/landing.py
@@ -80,6 +80,7 @@ _LANDING_UPDATABLE_FIELDS = frozenset(
         'analytics_click_enabled',
         'analytics_view_goal',
         'analytics_click_goal',
+        'sticky_pay_button',
     }
 )
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3263,6 +3263,12 @@ class LandingPage(Base):
     background_config = Column(
         JSON, nullable=True
     )  # AnimationConfig: {enabled, type, settings, opacity, blur, reducedOnMobile}
+    # Per-landing analytics goals (JS Yandex.Metrika reachGoal)
+    analytics_view_enabled = Column(Boolean, default=False, server_default='false')
+    analytics_view_goal = Column(String(100), default='landing_view', server_default='landing_view')
+    analytics_click_enabled = Column(Boolean, default=False, server_default='false')
+    analytics_click_goal = Column(String(100), default='landing_pay', server_default='landing_pay')
+
     created_at = Column(AwareDateTime(), server_default=func.now())
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3260,8 +3260,8 @@ class LandingPage(Base):
     discount_starts_at = Column(AwareDateTime(), nullable=True)
     discount_ends_at = Column(AwareDateTime(), nullable=True)
     discount_badge_text = Column(JSON, nullable=True)  # LocaleDict {"ru": "...", "en": "..."}
-    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
-    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
+    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
+    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
     analytics_view_goal = Column(String(100), nullable=True)
     analytics_click_goal = Column(String(100), nullable=True)
     background_config = Column(
@@ -3410,6 +3410,7 @@ class NewsTag(Base):
 
     def __repr__(self) -> str:
         return f"<NewsTag id={self.id} name='{self.name}'>"
+
 
 class YandexClientIdMap(Base):
     __tablename__ = 'yandex_client_id_map'

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3260,15 +3260,13 @@ class LandingPage(Base):
     discount_starts_at = Column(AwareDateTime(), nullable=True)
     discount_ends_at = Column(AwareDateTime(), nullable=True)
     discount_badge_text = Column(JSON, nullable=True)  # LocaleDict {"ru": "...", "en": "..."}
+    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
+    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
+    analytics_view_goal = Column(String(100), nullable=True)
+    analytics_click_goal = Column(String(100), nullable=True)
     background_config = Column(
         JSON, nullable=True
     )  # AnimationConfig: {enabled, type, settings, opacity, blur, reducedOnMobile}
-    # Per-landing analytics goals (JS Yandex.Metrika reachGoal)
-    analytics_view_enabled = Column(Boolean, default=False, server_default='false')
-    analytics_view_goal = Column(String(100), default='landing_view', server_default='landing_view')
-    analytics_click_enabled = Column(Boolean, default=False, server_default='false')
-    analytics_click_goal = Column(String(100), default='landing_pay', server_default='landing_pay')
-
     created_at = Column(AwareDateTime(), server_default=func.now())
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
 
@@ -3331,7 +3329,6 @@ class GuestPurchase(Base):
     retry_count = Column(Integer, nullable=False, default=0, server_default='0')
     receipt_uuid = Column(String(255), nullable=True, index=True)
     receipt_created_at = Column(AwareDateTime(), nullable=True)
-    referrer = Column(String(500), nullable=True)
 
     landing = relationship('LandingPage', back_populates='guest_purchases', lazy='selectin')
     tariff = relationship('Tariff', lazy='selectin')
@@ -3413,3 +3410,16 @@ class NewsTag(Base):
 
     def __repr__(self) -> str:
         return f"<NewsTag id={self.id} name='{self.name}'>"
+
+class YandexClientIdMap(Base):
+    __tablename__ = 'yandex_client_id_map'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False)
+    yandex_cid = Column(String(128), nullable=False)
+    source = Column(String(10), nullable=False, default='web')
+    counter_id = Column(String(32), nullable=True)
+    registration_sent = Column(Boolean, default=False, nullable=False)
+    trial_sent = Column(Boolean, default=False, nullable=False)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+    user = relationship('User', foreign_keys=[user_id])

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3325,6 +3325,7 @@ class GuestPurchase(Base):
     retry_count = Column(Integer, nullable=False, default=0, server_default='0')
     receipt_uuid = Column(String(255), nullable=True, index=True)
     receipt_created_at = Column(AwareDateTime(), nullable=True)
+    referrer = Column(String(500), nullable=True)
 
     landing = relationship('LandingPage', back_populates='guest_purchases', lazy='selectin')
     tariff = relationship('Tariff', lazy='selectin')

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3260,10 +3260,11 @@ class LandingPage(Base):
     discount_starts_at = Column(AwareDateTime(), nullable=True)
     discount_ends_at = Column(AwareDateTime(), nullable=True)
     discount_badge_text = Column(JSON, nullable=True)  # LocaleDict {"ru": "...", "en": "..."}
-    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
-    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
+    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
+    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
     analytics_view_goal = Column(String(100), nullable=True)
     analytics_click_goal = Column(String(100), nullable=True)
+    sticky_pay_button = Column(Boolean, default=False, server_default="false")
     background_config = Column(
         JSON, nullable=True
     )  # AnimationConfig: {enabled, type, settings, opacity, blur, reducedOnMobile}
@@ -3410,7 +3411,6 @@ class NewsTag(Base):
 
     def __repr__(self) -> str:
         return f"<NewsTag id={self.id} name='{self.name}'>"
-
 
 class YandexClientIdMap(Base):
     __tablename__ = 'yandex_client_id_map'

--- a/migrations/alembic/versions/0053_add_guest_purchase_referrer.py
+++ b/migrations/alembic/versions/0053_add_guest_purchase_referrer.py
@@ -1,0 +1,21 @@
+"""Add referrer column to guest_purchases.
+
+Revision ID: 0053
+Revises: 0052
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0053'
+down_revision = '0052'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('guest_purchases', sa.Column('referrer', sa.String(500), nullable=True))
+
+
+def downgrade():
+    op.drop_column('guest_purchases', 'referrer')

--- a/migrations/alembic/versions/0054_add_analytics_goals_to_landing_pages.py
+++ b/migrations/alembic/versions/0054_add_analytics_goals_to_landing_pages.py
@@ -1,0 +1,35 @@
+"""Add analytics goal fields to landing_pages.
+
+Revision ID: 0054
+Revises: 0053
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0054'
+down_revision = '0053'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'landing_pages', sa.Column('analytics_view_enabled', sa.Boolean(), server_default='false', nullable=True)
+    )
+    op.add_column(
+        'landing_pages', sa.Column('analytics_view_goal', sa.String(100), server_default='landing_view', nullable=True)
+    )
+    op.add_column(
+        'landing_pages', sa.Column('analytics_click_enabled', sa.Boolean(), server_default='false', nullable=True)
+    )
+    op.add_column(
+        'landing_pages', sa.Column('analytics_click_goal', sa.String(100), server_default='landing_pay', nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('landing_pages', 'analytics_click_goal')
+    op.drop_column('landing_pages', 'analytics_click_enabled')
+    op.drop_column('landing_pages', 'analytics_view_goal')
+    op.drop_column('landing_pages', 'analytics_view_enabled')


### PR DESCRIPTION
## Описание

Улучшения статистики лендингов + аналитические цели per-landing.

### Статистика
- Реферер в покупках (HTTP Referer → колонка referrer)
- Часовой пояс в группировке по дням (параметр tz)
- Валидация timezone через zoneinfo

### Аналитические цели
- 4 новых поля в LandingPage: analytics_view_enabled/goal, analytics_click_enabled/goal
- Каждый лендинг может иметь свои JS-цели Яндекс.Метрики
- Дефолт: landing_view / landing_pay
- Отдаётся в публичном API для фронта

### Файлы
- models.py — 4 поля + referrer
- admin_landings.py — API + timezone + referrer
- landing.py — публичный конфиг + referrer capture
- Миграции 0053 (referrer) + 0054 (analytics goals)

### Связанный PR
- Кабинет: #373