### PR TITLE
fix: handle None values in email template substitution

### DIFF
--- a/app/cabinet/services/email_template_overrides.py
+++ b/app/cabinet/services/email_template_overrides.py
@@ -196,7 +196,7 @@ async def get_rendered_override(
     # Simple variable substitution for context vars like {username}, {verification_url}, etc.
     if context:
         for key, value in context.items():
-            body_html = body_html.replace(f'{{{key}}}', html.escape(str(value)))
+            body_html = body_html.replace(f'{{{key}}}', html.escape(str(value)) if value is not None else '')
 
     rendered = templates._wrap_override_template(body_html, language)
     subject = override['subject']
@@ -204,7 +204,7 @@ async def get_rendered_override(
     # Also substitute in subject
     if context:
         for key, value in context.items():
-            safe_value = str(value).replace('\r', '').replace('\n', '')
+            safe_value = str(value).replace('\r', '').replace('\n', '') if value is not None else ''
             subject = subject.replace(f'{{{key}}}', safe_value)
 
     return (subject, rendered)


### PR DESCRIPTION
## Summary
- When email template context variables (like `cabinet_password`) are `None`, `str(None)` produces the literal string `"None"` in rendered emails
- This fix treats `None` values as empty strings in both body and subject substitution

## Problem
Users receive emails with literal "None" text instead of empty/hidden fields. For example, guest_cabinet_credentials and guest_subscription_delivered templates show "Пароль: None" for existing users who already have a password.

## Fix
Two lines in `app/cabinet/services/email_template_overrides.py`:
- `html.escape(str(value))` → `html.escape(str(value)) if value is not None else ''`
- Same for subject substitution