### PR TITLE
feat: expose user_agent in cabinet devices API

### DIFF
--- a/app/cabinet/routes/subscription_modules/devices.py
+++ b/app/cabinet/routes/subscription_modules/devices.py
@@ -778,6 +778,7 @@ async def get_devices(
                 hwid = device.get('hwid') or device.get('deviceId') or device.get('id')
                 platform = device.get('platform') or device.get('platformType') or 'Unknown'
                 model = device.get('deviceModel') or device.get('model') or device.get('name') or 'Unknown'
+                user_agent = device.get('userAgent') or ''
                 created_at = device.get('updatedAt') or device.get('lastSeen') or device.get('createdAt')
 
                 formatted_devices.append(
@@ -785,6 +786,7 @@ async def get_devices(
                         'hwid': hwid,
                         'platform': platform,
                         'device_model': model,
+                        'user_agent': user_agent,
                         'created_at': created_at,
                     }
                 )

--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -430,6 +430,7 @@ class DeviceInfo(BaseModel):
     hwid: str
     platform: str = ''
     device_model: str = ''
+    user_agent: str = ''
     created_at: str | None = None
 
 


### PR DESCRIPTION
## Summary

- Forward `userAgent` from Remnawave device response to cabinet frontend
- Remnawave already stores and returns `userAgent` per device — this change just maps it through

## Changes

1. `app/cabinet/schemas/users.py` — added `user_agent: str = ''` to `DeviceInfo`
2. `app/cabinet/routes/subscription_modules/devices.py` — extract `device.get('userAgent')` and include in response

## Why

Cabinet users want to see which VPN client app is connected (Hiddify, V2RayNG, Happ, etc.) — not just the device model. The data is already available from Remnawave but wasn't being forwarded.