### PR TITLE
fix: доход за сегодня включает гостевые покупки

### DIFF
--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -810,6 +810,7 @@ _STATS_PERIOD_DAYS = 30
 @router.get('/{landing_id}/stats', response_model=LandingStatsResponse)
 async def get_landing_stats(
     landing_id: int,
+    tz: str = 'UTC',
     admin: User = Depends(require_permission('landings:read')),
     db: AsyncSession = Depends(get_cabinet_db),
 ) -> LandingStatsResponse:
@@ -845,9 +846,18 @@ async def get_landing_stats(
     conversion_rate = round(total_successful / total_created * 100, 1) if total_created > 0 else 0.0
 
     # -- Daily stats for last N days --
-    now = datetime.now(UTC)
+    # Validate timezone
+    _tz = tz if tz and len(tz) < 50 else 'UTC'
+    try:
+        import zoneinfo
+
+        _tzi = zoneinfo.ZoneInfo(_tz)
+        now = datetime.now(_tzi)
+    except Exception:
+        _tz = 'UTC'
+        now = datetime.now(UTC)
     cutoff = now - timedelta(days=_STATS_PERIOD_DAYS)
-    day_at_utc = func.date(func.timezone('UTC', GuestPurchase.paid_at))
+    day_at_utc = func.date(func.timezone(_tz, GuestPurchase.paid_at))
     daily_result = await db.execute(
         select(
             day_at_utc.label('day'),
@@ -866,7 +876,7 @@ async def get_landing_stats(
     daily_rows = {str(r.day): r for r in daily_result.all()}
 
     # Created per day (all statuses, by created_at)
-    day_created_utc = func.date(func.timezone('UTC', GuestPurchase.created_at))
+    day_created_utc = func.date(func.timezone(_tz, GuestPurchase.created_at))
     created_result = await db.execute(
         select(
             day_created_utc.label('day'),

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -1,0 +1,1094 @@
+"""Admin routes for landing page management in cabinet."""
+
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, field_validator, model_validator
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cabinet.utils.locale import (
+    ensure_locale_dict,
+    validate_locale_dict,
+)
+from app.database.crud.landing import (
+    create_landing,
+    delete_landing,
+    get_all_landing_purchase_stats,
+    get_all_landings,
+    get_landing_by_id,
+    get_landing_by_slug,
+    update_landing,
+    update_landing_order,
+)
+from app.database.models import GuestPurchase, GuestPurchaseStatus, LandingPage, Tariff, User
+
+from ..dependencies import get_cabinet_db, require_permission
+from .branding import ALLOWED_BG_TYPES, _validate_settings
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/admin/landings', tags=['Cabinet Admin Landings'])
+
+# Slugs that conflict with public landing router path segments
+_RESERVED_SLUGS = frozenset(
+    {
+        'purchase',
+        'admin',
+        'api',
+        'health',
+        'static',
+        'assets',
+        'favicon',
+        'robots',
+        'sitemap',
+        'well-known',
+    }
+)
+
+
+_ALLOWED_BG_CONFIG_KEYS = frozenset({'enabled', 'type', 'settings', 'opacity', 'blur', 'reducedOnMobile'})
+
+
+def _validate_background_config(v: dict | None) -> dict | None:
+    """Validate and sanitize background_config, reusing branding constraints."""
+    if v is None:
+        return None
+    if not isinstance(v.get('enabled'), bool):
+        raise ValueError('background_config.enabled must be a boolean')
+    bg_type = v.get('type')
+    if not isinstance(bg_type, str) or bg_type not in ALLOWED_BG_TYPES:
+        raise ValueError(f'background_config.type must be one of: {", ".join(ALLOWED_BG_TYPES)}')
+    if 'settings' in v:
+        if not isinstance(v['settings'], dict):
+            raise ValueError('background_config.settings must be a dict')
+        _validate_settings(v['settings'])
+    if 'opacity' in v:
+        opacity = v['opacity']
+        if not isinstance(opacity, int | float) or not (0 <= opacity <= 1):
+            raise ValueError('background_config.opacity must be 0-1')
+    if 'blur' in v:
+        blur = v['blur']
+        if not isinstance(blur, int | float) or not (0 <= blur <= 100):
+            raise ValueError('background_config.blur must be 0-100')
+    if 'reducedOnMobile' in v and not isinstance(v['reducedOnMobile'], bool):
+        raise ValueError('background_config.reducedOnMobile must be a boolean')
+    # Strip unknown keys
+    return {k: val for k, val in v.items() if k in _ALLOWED_BG_CONFIG_KEYS}
+
+
+# ============ Schemas ============
+
+
+class LandingFeatureInput(BaseModel):
+    icon: str = Field(default='', max_length=100)
+    title: dict[str, str] = Field(default_factory=dict)
+    description: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator('title', 'description', mode='before')
+    @classmethod
+    def coerce_to_dict(cls, v: dict[str, str] | str | None) -> dict[str, str]:
+        return ensure_locale_dict(v)
+
+    @field_validator('title')
+    @classmethod
+    def validate_title_length(cls, v: dict[str, str]) -> dict[str, str]:
+        return validate_locale_dict(v, max_length=200, field_name='feature.title')
+
+    @field_validator('description')
+    @classmethod
+    def validate_description_length(cls, v: dict[str, str]) -> dict[str, str]:
+        return validate_locale_dict(v, max_length=500, field_name='feature.description')
+
+
+class LandingPaymentMethodInput(BaseModel):
+    method_id: str = Field(max_length=50)
+    display_name: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=500)
+    icon_url: str | None = Field(default=None, max_length=500)
+    sort_order: int = 0
+    min_amount_kopeks: int | None = None
+    max_amount_kopeks: int | None = None
+    currency: str | None = Field(default=None, max_length=10)
+    return_url: str | None = Field(default=None, max_length=500)
+    sub_options: dict[str, bool] | None = None
+
+    @field_validator('sub_options', mode='before')
+    @classmethod
+    def validate_sub_options(cls, v: dict[str, bool] | None) -> dict[str, bool] | None:
+        if not v:
+            return None
+        if len(v) > 20:
+            raise ValueError('sub_options cannot have more than 20 keys')
+        for key in v:
+            if not isinstance(key, str) or len(key) > 50:
+                raise ValueError('sub_options keys must be strings of at most 50 characters')
+        return v
+
+    @field_validator('icon_url', mode='before')
+    @classmethod
+    def validate_icon_url(cls, v: str | None) -> str | None:
+        if not v:
+            return None
+        if not v.startswith(('https://', '/')):
+            raise ValueError('icon_url must use HTTPS or be a relative path')
+        return v
+
+    @field_validator('return_url', mode='before')
+    @classmethod
+    def validate_return_url(cls, v: str | None) -> str | None:
+        if not v:
+            return None
+        if not v.startswith('https://'):
+            raise ValueError('return_url must use HTTPS')
+        parsed = urlparse(v)
+        if not parsed.hostname or parsed.username or parsed.password:
+            raise ValueError('return_url must be a valid HTTPS URL without credentials')
+        return v
+
+    @field_validator('currency', mode='before')
+    @classmethod
+    def validate_currency(cls, v: str | None) -> str | None:
+        if not v:
+            return None
+        return v.strip().upper()
+
+    @field_validator('min_amount_kopeks', 'max_amount_kopeks')
+    @classmethod
+    def validate_amounts(cls, v: int | None) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError('Amount cannot be negative')
+        return v
+
+    @model_validator(mode='after')
+    def validate_amount_range(self) -> 'LandingPaymentMethodInput':
+        if (
+            self.min_amount_kopeks is not None
+            and self.max_amount_kopeks is not None
+            and self.min_amount_kopeks > self.max_amount_kopeks
+        ):
+            raise ValueError('min_amount_kopeks cannot be greater than max_amount_kopeks')
+        return self
+
+
+class LandingCreateRequest(BaseModel):
+    slug: str = Field(pattern=r'^[a-z0-9\-]+$', min_length=1, max_length=100)
+    title: dict[str, str] = Field(default_factory=lambda: {'ru': ''})
+    subtitle: dict[str, str] | None = None
+    is_active: bool = True
+    features: list[LandingFeatureInput] = Field(default_factory=list, max_length=20)
+    footer_text: dict[str, str] | None = None
+    allowed_tariff_ids: list[int] = Field(default_factory=list, max_length=50)
+    allowed_periods: dict[str, list[int]] = Field(default_factory=dict)
+    payment_methods: list[LandingPaymentMethodInput] = Field(default_factory=list, max_length=10)
+
+    @field_validator('allowed_periods')
+    @classmethod
+    def validate_allowed_periods_size(cls, v: dict[str, list[int]]) -> dict[str, list[int]]:
+        if len(v) > 50:
+            raise ValueError('allowed_periods cannot have more than 50 entries')
+        for key, periods in v.items():
+            if len(periods) > 20:
+                raise ValueError(f'allowed_periods[{key}] cannot have more than 20 periods')
+        return v
+
+    gift_enabled: bool = True
+    custom_css: str | None = Field(default=None, max_length=10000)
+    meta_title: dict[str, str] | None = None
+    meta_description: dict[str, str] | None = None
+    discount_percent: int | None = Field(default=None, ge=1, le=99)
+    discount_overrides: dict[str, int] | None = None  # {"tariff_id": percent}
+    discount_starts_at: datetime | None = None
+    discount_ends_at: datetime | None = None
+    discount_badge_text: dict[str, str] | None = None
+    background_config: dict | None = None
+    analytics_view_enabled: bool | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
+    sticky_pay_button: bool | None = False
+
+    @field_validator('background_config')
+    @classmethod
+    def validate_background_config(cls, v: dict | None) -> dict | None:
+        return _validate_background_config(v)
+
+    @field_validator(
+        'title', 'subtitle', 'footer_text', 'meta_title', 'meta_description', 'discount_badge_text', mode='before'
+    )
+    @classmethod
+    def coerce_text_to_dict(cls, v: dict[str, str] | str | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return ensure_locale_dict(v)
+
+    @field_validator('title')
+    @classmethod
+    def validate_title(cls, v: dict[str, str]) -> dict[str, str]:
+        return validate_locale_dict(v, max_length=500, field_name='title')
+
+    @field_validator('subtitle')
+    @classmethod
+    def validate_subtitle(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=1000, field_name='subtitle')
+
+    @field_validator('footer_text')
+    @classmethod
+    def validate_footer_text(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=5000, field_name='footer_text')
+
+    @field_validator('meta_title')
+    @classmethod
+    def validate_meta_title(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=200, field_name='meta_title')
+
+    @field_validator('meta_description')
+    @classmethod
+    def validate_meta_description(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=500, field_name='meta_description')
+
+    @field_validator('discount_badge_text')
+    @classmethod
+    def validate_discount_badge_text(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=200, field_name='discount_badge_text')
+
+    @field_validator('discount_starts_at', 'discount_ends_at', mode='after')
+    @classmethod
+    def ensure_aware_datetime(cls, v: datetime | None) -> datetime | None:
+        if v is not None and v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v
+
+    @model_validator(mode='after')
+    def validate_discount(self) -> 'LandingCreateRequest':
+        has_discount = self.discount_percent is not None
+        has_dates = self.discount_starts_at is not None or self.discount_ends_at is not None
+        if has_dates and not has_discount:
+            raise ValueError('discount_percent is required when discount dates are set')
+        if has_discount and not (self.discount_starts_at and self.discount_ends_at):
+            raise ValueError('discount_starts_at and discount_ends_at are required when discount_percent is set')
+        if self.discount_starts_at and self.discount_ends_at:
+            if self.discount_starts_at >= self.discount_ends_at:
+                raise ValueError('discount_starts_at must be before discount_ends_at')
+        if self.discount_overrides:
+            if len(self.discount_overrides) > 100:
+                raise ValueError('discount_overrides cannot have more than 100 entries')
+            for key, val in self.discount_overrides.items():
+                if not key.isdigit():
+                    raise ValueError('discount_overrides keys must be tariff ID strings')
+                if not (1 <= val <= 99):
+                    raise ValueError('discount_overrides values must be 1-99')
+            if self.allowed_tariff_ids:
+                allowed_set = {str(tid) for tid in self.allowed_tariff_ids}
+                invalid = set(self.discount_overrides.keys()) - allowed_set
+                if invalid:
+                    raise ValueError(f'discount_overrides contains tariff IDs not in allowed_tariff_ids: {invalid}')
+        return self
+
+
+class LandingUpdateRequest(BaseModel):
+    slug: str | None = Field(default=None, pattern=r'^[a-z0-9\-]+$', min_length=1, max_length=100)
+    title: dict[str, str] | None = None
+    subtitle: dict[str, str] | None = None
+    is_active: bool | None = None
+    features: list[LandingFeatureInput] | None = Field(default=None, max_length=20)
+    footer_text: dict[str, str] | None = None
+    allowed_tariff_ids: list[int] | None = Field(default=None, max_length=50)
+    allowed_periods: dict[str, list[int]] | None = None
+    payment_methods: list[LandingPaymentMethodInput] | None = Field(default=None, max_length=10)
+    gift_enabled: bool | None = None
+    custom_css: str | None = Field(default=None, max_length=10000)
+    meta_title: dict[str, str] | None = None
+    meta_description: dict[str, str] | None = None
+    discount_percent: int | None = Field(default=None, ge=1, le=99)
+    discount_overrides: dict[str, int] | None = None
+    discount_starts_at: datetime | None = None
+    discount_ends_at: datetime | None = None
+    discount_badge_text: dict[str, str] | None = None
+    background_config: dict | None = None
+    analytics_view_enabled: bool | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
+
+    @field_validator('background_config')
+    @classmethod
+    def validate_background_config(cls, v: dict | None) -> dict | None:
+        return _validate_background_config(v)
+
+    @field_validator('allowed_periods')
+    @classmethod
+    def validate_allowed_periods_size(cls, v: dict[str, list[int]] | None) -> dict[str, list[int]] | None:
+        if v is None:
+            return None
+        if len(v) > 50:
+            raise ValueError('allowed_periods cannot have more than 50 entries')
+        for key, periods in v.items():
+            if len(periods) > 20:
+                raise ValueError(f'allowed_periods[{key}] cannot have more than 20 periods')
+        return v
+
+    @field_validator(
+        'title', 'subtitle', 'footer_text', 'meta_title', 'meta_description', 'discount_badge_text', mode='before'
+    )
+    @classmethod
+    def coerce_text_to_dict(cls, v: dict[str, str] | str | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return ensure_locale_dict(v)
+
+    @field_validator('title')
+    @classmethod
+    def validate_title(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=500, field_name='title')
+
+    @field_validator('subtitle')
+    @classmethod
+    def validate_subtitle(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=1000, field_name='subtitle')
+
+    @field_validator('footer_text')
+    @classmethod
+    def validate_footer_text(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=5000, field_name='footer_text')
+
+    @field_validator('meta_title')
+    @classmethod
+    def validate_meta_title(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=200, field_name='meta_title')
+
+    @field_validator('meta_description')
+    @classmethod
+    def validate_meta_description(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=500, field_name='meta_description')
+
+    @field_validator('discount_badge_text')
+    @classmethod
+    def validate_discount_badge_text(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return validate_locale_dict(v, max_length=200, field_name='discount_badge_text')
+
+    @field_validator('discount_starts_at', 'discount_ends_at', mode='after')
+    @classmethod
+    def ensure_aware_datetime(cls, v: datetime | None) -> datetime | None:
+        if v is not None and v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v
+
+    @model_validator(mode='after')
+    def validate_discount(self) -> 'LandingUpdateRequest':
+        if self.discount_starts_at is not None and self.discount_ends_at is not None:
+            if self.discount_starts_at >= self.discount_ends_at:
+                raise ValueError('discount_starts_at must be before discount_ends_at')
+        if self.discount_overrides:
+            if len(self.discount_overrides) > 100:
+                raise ValueError('discount_overrides cannot have more than 100 entries')
+            for key, val in self.discount_overrides.items():
+                if not key.isdigit():
+                    raise ValueError('discount_overrides keys must be tariff ID strings')
+                if not (1 <= val <= 99):
+                    raise ValueError('discount_overrides values must be 1-99')
+        return self
+
+
+class PurchaseStats(BaseModel):
+    total: int = 0
+    pending: int = 0
+    paid: int = 0
+    delivered: int = 0
+    pending_activation: int = 0
+    failed: int = 0
+    expired: int = 0
+
+
+class LandingListItem(BaseModel):
+    id: int
+    slug: str
+    title: dict[str, str]
+    is_active: bool
+    display_order: int
+    gift_enabled: bool
+    tariff_count: int
+    method_count: int
+    purchase_stats: PurchaseStats
+    has_active_discount: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @field_validator('title', mode='before')
+    @classmethod
+    def coerce_title(cls, v: dict[str, str] | str | None) -> dict[str, str]:
+        return ensure_locale_dict(v)
+
+    class Config:
+        from_attributes = True
+
+
+class LandingDetailResponse(BaseModel):
+    id: int
+    slug: str
+    title: dict[str, str]
+    subtitle: dict[str, str] | None = None
+    is_active: bool
+    display_order: int
+    features: list[LandingFeatureInput]
+    footer_text: dict[str, str] | None = None
+    allowed_tariff_ids: list[int]
+    allowed_periods: dict[str, list[int]]
+    payment_methods: list[LandingPaymentMethodInput]
+    gift_enabled: bool
+    custom_css: str | None = None
+    meta_title: dict[str, str] | None = None
+    meta_description: dict[str, str] | None = None
+    discount_percent: int | None = None
+    discount_overrides: dict[str, int] | None = None
+    discount_starts_at: datetime | None = None
+    discount_ends_at: datetime | None = None
+    discount_badge_text: dict[str, str] | None = None
+    background_config: dict | None = None
+    analytics_view_enabled: bool | None = None
+    analytics_click_enabled: bool | None = None
+    analytics_view_goal: str | None = Field(default=None, max_length=100)
+    analytics_click_goal: str | None = Field(default=None, max_length=100)
+    sticky_pay_button: bool | None = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @field_validator(
+        'title', 'subtitle', 'footer_text', 'meta_title', 'meta_description', 'discount_badge_text', mode='before'
+    )
+    @classmethod
+    def coerce_to_dict(cls, v: dict[str, str] | str | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        return ensure_locale_dict(v)
+
+    class Config:
+        from_attributes = True
+
+
+class OrderRequest(BaseModel):
+    landing_ids: list[int]
+
+
+class LandingDailyStat(BaseModel):
+    date: str  # YYYY-MM-DD
+    created: int = 0
+    purchases: int
+    revenue_kopeks: int
+    gifts: int
+
+
+class LandingTariffStat(BaseModel):
+    tariff_id: int | None
+    tariff_name: str
+    purchases: int
+    revenue_kopeks: int
+
+
+class LandingStatsResponse(BaseModel):
+    # Summary
+    total_purchases: int
+    total_revenue_kopeks: int
+    total_gifts: int
+    total_regular: int
+    avg_purchase_kopeks: int
+    # Conversion: created -> paid/delivered
+    total_created: int
+    total_successful: int  # paid + delivered + pending_activation
+    conversion_rate: float  # percent
+    # Daily chart data (last 30 days)
+    daily_stats: list[LandingDailyStat]
+    # Tariff breakdown
+    tariff_stats: list[LandingTariffStat]
+
+
+class LandingPurchaseItem(BaseModel):
+    id: int
+    token: str
+    contact_type: str
+    contact_value: str
+    is_gift: bool
+    gift_recipient_type: str | None = None
+    gift_recipient_value: str | None = None
+    tariff_name: str | None = None
+    period_days: int
+    amount_kopeks: int
+    currency: str
+    payment_method: str | None = None
+    status: str
+    created_at: datetime | None = None
+    paid_at: datetime | None = None
+
+
+class LandingPurchaseListResponse(BaseModel):
+    items: list[LandingPurchaseItem]
+    total: int
+
+
+# ============ Routes ============
+
+# IMPORTANT: /order MUST come before /{landing_id} to avoid "order" being
+# parsed as a landing_id path parameter.
+
+
+@router.get('', response_model=list[LandingListItem])
+async def list_landings(
+    admin: User = Depends(require_permission('landings:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """List all landing pages with purchase stats."""
+    landings = await get_all_landings(db)
+    all_stats = await get_all_landing_purchase_stats(db)
+    empty_stats = {
+        'total': 0,
+        'pending': 0,
+        'paid': 0,
+        'delivered': 0,
+        'pending_activation': 0,
+        'failed': 0,
+        'expired': 0,
+    }
+
+    now = datetime.now(UTC)
+    items = []
+    for landing in landings:
+        stats = all_stats.get(landing.id, empty_stats)
+        discount_active = bool(
+            landing.discount_percent
+            and landing.discount_starts_at
+            and landing.discount_ends_at
+            and landing.discount_starts_at <= now < landing.discount_ends_at
+        )
+        items.append(
+            LandingListItem(
+                id=landing.id,
+                slug=landing.slug,
+                title=landing.title,
+                is_active=landing.is_active,
+                display_order=landing.display_order,
+                gift_enabled=landing.gift_enabled,
+                tariff_count=len(landing.allowed_tariff_ids or []),
+                method_count=len(landing.payment_methods or []),
+                purchase_stats=PurchaseStats(
+                    total=stats.get('total', 0),
+                    pending=stats.get('pending', 0),
+                    paid=stats.get('paid', 0),
+                    delivered=stats.get('delivered', 0),
+                    pending_activation=stats.get('pending_activation', 0),
+                    failed=stats.get('failed', 0),
+                    expired=stats.get('expired', 0),
+                ),
+                has_active_discount=discount_active,
+                created_at=landing.created_at,
+                updated_at=landing.updated_at,
+            )
+        )
+    return items
+
+
+@router.post('', response_model=LandingDetailResponse, status_code=status.HTTP_201_CREATED)
+async def create_landing_page(
+    request: LandingCreateRequest,
+    admin: User = Depends(require_permission('landings:create')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Create a new landing page."""
+    if request.slug in _RESERVED_SLUGS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Slug "{request.slug}" is reserved and cannot be used',
+        )
+
+    existing = await get_landing_by_slug(db, request.slug)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f'Landing page with slug "{request.slug}" already exists',
+        )
+
+    landing = await create_landing(
+        db,
+        slug=request.slug,
+        title=request.title,
+        subtitle=request.subtitle,
+        is_active=request.is_active,
+        features=[f.model_dump() for f in request.features],
+        footer_text=request.footer_text,
+        allowed_tariff_ids=request.allowed_tariff_ids,
+        allowed_periods=request.allowed_periods,
+        payment_methods=[m.model_dump() for m in request.payment_methods],
+        gift_enabled=request.gift_enabled,
+        custom_css=request.custom_css,
+        meta_title=request.meta_title,
+        meta_description=request.meta_description,
+        discount_percent=request.discount_percent,
+        discount_overrides=request.discount_overrides,
+        discount_starts_at=request.discount_starts_at,
+        discount_ends_at=request.discount_ends_at,
+        discount_badge_text=request.discount_badge_text,
+        background_config=request.background_config,
+    )
+
+    logger.info('Admin created landing page', admin_id=admin.id, slug=landing.slug, landing_id=landing.id)
+
+    return _landing_to_detail(landing)
+
+
+@router.put('/order')
+async def update_landings_order(
+    request: OrderRequest,
+    admin: User = Depends(require_permission('landings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Batch update display order for landing pages."""
+    await update_landing_order(db, request.landing_ids)
+    logger.info('Admin updated landing page order', admin_id=admin.id, landing_ids=request.landing_ids)
+    return {'success': True}
+
+
+@router.get('/{landing_id}', response_model=LandingDetailResponse)
+async def get_landing_detail(
+    landing_id: int,
+    admin: User = Depends(require_permission('landings:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Get a single landing page with full details."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+    return _landing_to_detail(landing)
+
+
+@router.put('/{landing_id}', response_model=LandingDetailResponse)
+async def update_landing_page(
+    landing_id: int,
+    request: LandingUpdateRequest,
+    admin: User = Depends(require_permission('landings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Update a landing page."""
+    data = request.model_dump(exclude_unset=True)
+
+    # If slug is being changed, check reserved and uniqueness
+    if 'slug' in data:
+        if data['slug'] in _RESERVED_SLUGS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'Slug "{data["slug"]}" is reserved and cannot be used',
+            )
+        existing = await get_landing_by_slug(db, data['slug'])
+        if existing is not None and existing.id != landing_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f'Landing page with slug "{data["slug"]}" already exists',
+            )
+
+    # Serialize nested Pydantic models to dicts for JSON storage
+    if 'features' in data and data['features'] is not None:
+        data['features'] = [f.model_dump() if hasattr(f, 'model_dump') else f for f in data['features']]
+    if 'payment_methods' in data and data['payment_methods'] is not None:
+        data['payment_methods'] = [m.model_dump() if hasattr(m, 'model_dump') else m for m in data['payment_methods']]
+
+    # Cascade-clear all discount fields when discount_percent is explicitly set to None
+    if 'discount_percent' in data and data['discount_percent'] is None:
+        data['discount_overrides'] = None
+        data['discount_starts_at'] = None
+        data['discount_ends_at'] = None
+        data['discount_badge_text'] = None
+
+    # Validate merged discount dates on partial update
+    if 'discount_starts_at' in data or 'discount_ends_at' in data:
+        existing_landing = await get_landing_by_id(db, landing_id)
+        if existing_landing is not None:
+            effective_starts = data.get('discount_starts_at', existing_landing.discount_starts_at)
+            effective_ends = data.get('discount_ends_at', existing_landing.discount_ends_at)
+            if effective_starts and effective_ends and effective_starts >= effective_ends:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail='discount_starts_at must be before discount_ends_at',
+                )
+
+    landing = await update_landing(db, landing_id, data)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    logger.info('Admin updated landing page', admin_id=admin.id, slug=landing.slug, landing_id=landing.id)
+
+    return _landing_to_detail(landing)
+
+
+@router.delete('/{landing_id}')
+async def delete_landing_page(
+    landing_id: int,
+    admin: User = Depends(require_permission('landings:delete')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Delete a landing page."""
+    deleted = await delete_landing(db, landing_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+    logger.info('Admin deleted landing page', admin_id=admin.id, landing_id=landing_id)
+    return {'success': True}
+
+
+@router.post('/{landing_id}/toggle', response_model=LandingDetailResponse)
+async def toggle_landing_active(
+    landing_id: int,
+    admin: User = Depends(require_permission('landings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Toggle active/inactive state of a landing page."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    new_active = not landing.is_active
+    landing = await update_landing(db, landing_id, {'is_active': new_active})
+
+    logger.info(
+        'Admin toggled landing page',
+        admin_id=admin.id,
+        landing_id=landing_id,
+        is_active=new_active,
+    )
+
+    return _landing_to_detail(landing)
+
+
+_SUCCESSFUL_STATUSES = (
+    GuestPurchaseStatus.PAID.value,
+    GuestPurchaseStatus.DELIVERED.value,
+    GuestPurchaseStatus.PENDING_ACTIVATION.value,
+)
+
+_STATS_PERIOD_DAYS = 30
+
+
+@router.get('/{landing_id}/stats', response_model=LandingStatsResponse)
+async def get_landing_stats(
+    landing_id: int,
+    admin: User = Depends(require_permission('landings:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> LandingStatsResponse:
+    """Get daily statistics and tariff breakdown for a landing page."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    # -- Summary stats (single query) --
+    is_successful = GuestPurchase.status.in_(_SUCCESSFUL_STATUSES)
+    summary_result = await db.execute(
+        select(
+            func.count(GuestPurchase.id).label('total_created'),
+            func.count(case((is_successful, GuestPurchase.id))).label('total_successful'),
+            func.coalesce(func.sum(case((is_successful, GuestPurchase.amount_kopeks))), 0).label(
+                'total_revenue_kopeks'
+            ),
+            func.count(case((and_(is_successful, GuestPurchase.is_gift.is_(True)), GuestPurchase.id))).label(
+                'total_gifts'
+            ),
+        ).where(GuestPurchase.landing_id == landing_id)
+    )
+    row = summary_result.one()
+    total_created: int = row.total_created
+    total_successful: int = row.total_successful
+    total_revenue_kopeks: int = row.total_revenue_kopeks
+    total_gifts: int = row.total_gifts
+    total_regular = total_successful - total_gifts
+    avg_purchase_kopeks = total_revenue_kopeks // total_successful if total_successful > 0 else 0
+    conversion_rate = round(total_successful / total_created * 100, 1) if total_created > 0 else 0.0
+
+    # -- Daily stats for last N days --
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=_STATS_PERIOD_DAYS)
+    day_at_utc = func.date(func.timezone('UTC', GuestPurchase.paid_at))
+    daily_result = await db.execute(
+        select(
+            day_at_utc.label('day'),
+            func.count(GuestPurchase.id).label('purchases'),
+            func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0).label('revenue_kopeks'),
+            func.count(case((GuestPurchase.is_gift.is_(True), GuestPurchase.id))).label('gifts'),
+        )
+        .where(
+            GuestPurchase.landing_id == landing_id,
+            is_successful,
+            GuestPurchase.paid_at >= cutoff,
+        )
+        .group_by(day_at_utc)
+        .order_by(day_at_utc)
+    )
+    daily_rows = {str(r.day): r for r in daily_result.all()}
+
+    # Created per day (all statuses, by created_at)
+    day_created_utc = func.date(func.timezone('UTC', GuestPurchase.created_at))
+    created_result = await db.execute(
+        select(
+            day_created_utc.label('day'),
+            func.count(GuestPurchase.id).label('created'),
+        )
+        .where(
+            GuestPurchase.landing_id == landing_id,
+            GuestPurchase.created_at >= cutoff,
+        )
+        .group_by(day_created_utc)
+        .order_by(day_created_utc)
+    )
+    created_rows = {str(r.day): r.created for r in created_result.all()}
+
+    # Fill missing days with zeros
+    today = now.date()
+    daily_stats: list[LandingDailyStat] = []
+    for i in range(_STATS_PERIOD_DAYS, -1, -1):
+        day = today - timedelta(days=i)
+        day_str = day.isoformat()
+        day_created = created_rows.get(day_str, 0)
+        if day_str in daily_rows:
+            r = daily_rows[day_str]
+            daily_stats.append(
+                LandingDailyStat(
+                    date=day_str,
+                    created=day_created,
+                    purchases=r.purchases,
+                    revenue_kopeks=r.revenue_kopeks,
+                    gifts=r.gifts,
+                )
+            )
+        else:
+            daily_stats.append(
+                LandingDailyStat(
+                    date=day_str,
+                    created=day_created,
+                    purchases=0,
+                    revenue_kopeks=0,
+                    gifts=0,
+                )
+            )
+
+    # -- Tariff breakdown --
+    tariff_result = await db.execute(
+        select(
+            GuestPurchase.tariff_id,
+            func.coalesce(Tariff.name, 'Unknown').label('tariff_name'),
+            func.count(GuestPurchase.id).label('purchases'),
+            func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0).label('revenue_kopeks'),
+        )
+        .outerjoin(Tariff, GuestPurchase.tariff_id == Tariff.id)
+        .where(
+            GuestPurchase.landing_id == landing_id,
+            is_successful,
+        )
+        .group_by(GuestPurchase.tariff_id, Tariff.name)
+        .order_by(func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0).desc())
+    )
+    tariff_stats = [
+        LandingTariffStat(
+            tariff_id=r.tariff_id,
+            tariff_name=r.tariff_name,
+            purchases=r.purchases,
+            revenue_kopeks=r.revenue_kopeks,
+        )
+        for r in tariff_result.all()
+    ]
+
+    return LandingStatsResponse(
+        total_purchases=total_created,
+        total_revenue_kopeks=total_revenue_kopeks,
+        total_gifts=total_gifts,
+        total_regular=total_regular,
+        avg_purchase_kopeks=avg_purchase_kopeks,
+        total_created=total_created,
+        total_successful=total_successful,
+        conversion_rate=conversion_rate,
+        daily_stats=daily_stats,
+        tariff_stats=tariff_stats,
+    )
+
+
+_PURCHASE_LIST_MAX_LIMIT = 100
+_PURCHASE_LIST_DEFAULT_LIMIT = 20
+_PURCHASE_TOKEN_VISIBLE_CHARS = 8
+
+
+@router.get('/{landing_id}/purchases', response_model=LandingPurchaseListResponse)
+async def get_landing_purchases(
+    landing_id: int,
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=_PURCHASE_LIST_DEFAULT_LIMIT, ge=1, le=_PURCHASE_LIST_MAX_LIMIT),
+    status_filter: GuestPurchaseStatus | None = Query(default=None, alias='status'),
+    admin: User = Depends(require_permission('landings:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> LandingPurchaseListResponse:
+    """Get paginated list of purchases for a landing page."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    # Base filter conditions
+    conditions = [GuestPurchase.landing_id == landing_id]
+    if status_filter is not None:
+        conditions.append(GuestPurchase.status == status_filter.value)
+
+    where_clause = and_(*conditions)
+
+    # Total count
+    count_result = await db.execute(select(func.count(GuestPurchase.id)).select_from(GuestPurchase).where(where_clause))
+    total: int = count_result.scalar_one()
+
+    # Fetch page with tariff name join
+    items_result = await db.execute(
+        select(
+            GuestPurchase.id,
+            GuestPurchase.token,
+            GuestPurchase.contact_type,
+            GuestPurchase.contact_value,
+            GuestPurchase.is_gift,
+            GuestPurchase.gift_recipient_type,
+            GuestPurchase.gift_recipient_value,
+            func.coalesce(Tariff.name, 'Unknown').label('tariff_name'),
+            GuestPurchase.period_days,
+            GuestPurchase.amount_kopeks,
+            GuestPurchase.currency,
+            GuestPurchase.payment_method,
+            GuestPurchase.status,
+            GuestPurchase.created_at,
+            GuestPurchase.paid_at,
+        )
+        .outerjoin(Tariff, GuestPurchase.tariff_id == Tariff.id)
+        .where(where_clause)
+        .order_by(GuestPurchase.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    items = [
+        LandingPurchaseItem(
+            id=row.id,
+            token=(row.token[:_PURCHASE_TOKEN_VISIBLE_CHARS] + '...') if row.token else '???',
+            contact_type=row.contact_type,
+            contact_value=row.contact_value,
+            is_gift=row.is_gift,
+            gift_recipient_type=row.gift_recipient_type,
+            gift_recipient_value=row.gift_recipient_value,
+            tariff_name=row.tariff_name,
+            period_days=row.period_days,
+            amount_kopeks=row.amount_kopeks,
+            currency=row.currency,
+            payment_method=row.payment_method,
+            status=row.status,
+            created_at=row.created_at,
+            paid_at=row.paid_at,
+        )
+        for row in items_result.all()
+    ]
+
+    return LandingPurchaseListResponse(items=items, total=total)
+
+
+# ============ Helpers ============
+
+
+def _landing_to_detail(landing: LandingPage) -> LandingDetailResponse:
+    """Convert a LandingPage model to LandingDetailResponse.
+
+    Admin detail view returns full locale dicts for all text fields.
+    """
+    features = [
+        LandingFeatureInput(
+            icon=f.get('icon', ''),
+            title=f.get('title', {}),
+            description=f.get('description', {}),
+        )
+        for f in (landing.features or [])
+    ]
+
+    payment_methods = [
+        LandingPaymentMethodInput(
+            method_id=m.get('method_id', ''),
+            display_name=m.get('display_name', ''),
+            description=m.get('description'),
+            icon_url=m.get('icon_url'),
+            sort_order=m.get('sort_order', 0),
+            min_amount_kopeks=m.get('min_amount_kopeks'),
+            max_amount_kopeks=m.get('max_amount_kopeks'),
+            currency=m.get('currency'),
+            return_url=m.get('return_url'),
+            sub_options=m.get('sub_options'),
+        )
+        for m in (landing.payment_methods or [])
+    ]
+
+    return LandingDetailResponse(
+        id=landing.id,
+        slug=landing.slug,
+        title=landing.title or {},
+        subtitle=landing.subtitle,
+        is_active=landing.is_active,
+        display_order=landing.display_order,
+        features=features,
+        footer_text=landing.footer_text,
+        allowed_tariff_ids=landing.allowed_tariff_ids or [],
+        allowed_periods=landing.allowed_periods or {},
+        payment_methods=payment_methods,
+        gift_enabled=landing.gift_enabled,
+        custom_css=landing.custom_css,
+        meta_title=landing.meta_title,
+        meta_description=landing.meta_description,
+        discount_percent=landing.discount_percent,
+        discount_overrides=landing.discount_overrides,
+        discount_starts_at=landing.discount_starts_at,
+        discount_ends_at=landing.discount_ends_at,
+        discount_badge_text=landing.discount_badge_text,
+        background_config=landing.background_config,
+        analytics_view_enabled=landing.analytics_view_enabled,
+        analytics_click_enabled=landing.analytics_click_enabled,
+        analytics_view_goal=landing.analytics_view_goal,
+        analytics_click_goal=landing.analytics_click_goal,
+        sticky_pay_button=getattr(landing, 'sticky_pay_button', False) or False,
+        created_at=landing.created_at,
+        updated_at=landing.updated_at,
+    )

--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -210,7 +210,6 @@ class LandingCreateRequest(BaseModel):
     analytics_view_goal: str | None = Field(default=None, max_length=100)
     analytics_click_goal: str | None = Field(default=None, max_length=100)
     sticky_pay_button: bool | None = False
-    sticky_pay_button: bool | None = False
 
     @field_validator('background_config')
     @classmethod
@@ -654,6 +653,11 @@ async def create_landing_page(
         discount_ends_at=request.discount_ends_at,
         discount_badge_text=request.discount_badge_text,
         background_config=request.background_config,
+        analytics_view_enabled=request.analytics_view_enabled or False,
+        analytics_click_enabled=request.analytics_click_enabled or False,
+        analytics_view_goal=request.analytics_view_goal,
+        analytics_click_goal=request.analytics_click_goal,
+        sticky_pay_button=request.sticky_pay_button or False,
     )
 
     logger.info('Admin created landing page', admin_id=admin.id, slug=landing.slug, landing_id=landing.id)

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -1,0 +1,711 @@
+"""Public landing page routes for guest quick-purchase flow."""
+
+import re
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+from pydantic import BaseModel, Field, model_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cabinet.dependencies import get_cabinet_db
+from app.cabinet.ip_utils import get_client_ip
+from app.cabinet.utils.locale import DEFAULT_LOCALE, resolve_locale_text
+from app.config import settings
+from app.database.crud.landing import get_active_landing_by_slug, get_purchase_by_token
+from app.database.models import GuestPurchase, GuestPurchaseStatus, LandingPage, Tariff
+from app.services.guest_purchase_service import (
+    GuestPurchaseError,
+    activate_purchase as activate_guest_purchase,
+    create_purchase,
+    validate_and_calculate,
+)
+from app.services.payment_method_config_service import _get_method_defaults
+from app.services.payment_service import PaymentService
+from app.utils.cache import RateLimitCache, cache
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/landing', tags=['Landing Pages'])
+
+
+class LandingFeature(BaseModel):
+    icon: str = ''
+    title: str = ''
+    description: str = ''
+
+
+class LandingTariffPeriod(BaseModel):
+    days: int
+    label: str
+    price_kopeks: int
+    price_label: str
+    original_price_kopeks: int | None = None  # set if discount active
+    original_price_label: str | None = None
+    discount_percent: int | None = None  # effective discount for this tariff
+
+
+class LandingTariff(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    traffic_limit_gb: int
+    device_limit: int
+    tier_level: int
+    periods: list[LandingTariffPeriod]
+
+
+class LandingPaymentMethodSubOption(BaseModel):
+    id: str
+    name: str
+
+
+class LandingPaymentMethod(BaseModel):
+    method_id: str
+    display_name: str
+    description: str | None = None
+    icon_url: str | None = None
+    sort_order: int = 0
+    min_amount_kopeks: int | None = None
+    max_amount_kopeks: int | None = None
+    currency: str | None = None
+    # Enabled sub-options with display labels (e.g. СБП, Карта).
+    # None or empty means no sub-option selection needed.
+    sub_options: list[LandingPaymentMethodSubOption] | None = None
+
+
+class LandingDiscountInfo(BaseModel):
+    percent: int  # default discount
+    ends_at: str  # ISO datetime
+    badge_text: str | None = None  # resolved locale text
+
+
+class LandingConfigResponse(BaseModel):
+    slug: str
+    title: str
+    subtitle: str | None = None
+    features: list[LandingFeature]
+    footer_text: str | None = None
+    tariffs: list[LandingTariff]
+    payment_methods: list[LandingPaymentMethod]
+    gift_enabled: bool
+    custom_css: str | None = None
+    meta_title: str | None = None
+    meta_description: str | None = None
+    discount: LandingDiscountInfo | None = None  # null if no active discount
+    background_config: dict | None = None
+    analytics_view_enabled: bool = False
+    analytics_click_enabled: bool = False
+    analytics_view_goal: str | None = None
+    analytics_click_goal: str | None = None
+    sticky_pay_button: bool = False
+
+
+_EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
+_TELEGRAM_RE = re.compile(r'^@?[a-zA-Z][a-zA-Z0-9_]{4,31}$')
+
+
+def _validate_contact(contact_type: str, contact_value: str) -> None:
+    """Validate contact value matches the declared type format."""
+    if contact_type == 'email' and not _EMAIL_RE.match(contact_value):
+        raise ValueError('Invalid email format')
+    if contact_type == 'telegram' and not _TELEGRAM_RE.match(contact_value):
+        raise ValueError('Invalid Telegram username format')
+
+
+class PurchaseRequest(BaseModel):
+    tariff_id: int
+    period_days: int
+    contact_type: str = Field(pattern=r'^(email|telegram)$')
+    contact_value: str = Field(min_length=1, max_length=255)
+    payment_method: str = Field(min_length=1, max_length=50, pattern=r'^[a-z0-9_]+$')
+    is_gift: bool = False
+    gift_recipient_type: str | None = Field(default=None, pattern=r'^(email|telegram)$')
+    gift_recipient_value: str | None = Field(default=None, max_length=255)
+    gift_message: str | None = Field(default=None, max_length=1000)
+    yandex_cid: str | None = Field(default=None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$')
+    referrer: str | None = Field(default=None, max_length=500)
+
+    @model_validator(mode='after')
+    def validate_contacts(self) -> 'PurchaseRequest':
+        _validate_contact(self.contact_type, self.contact_value)
+        if self.is_gift:
+            if not self.gift_recipient_type or not self.gift_recipient_value:
+                raise ValueError('Gift recipient type and value are required for gift purchases')
+            _validate_contact(self.gift_recipient_type, self.gift_recipient_value)
+        return self
+
+
+class PurchaseResponse(BaseModel):
+    purchase_token: str
+    payment_url: str
+
+
+class PurchaseStatusResponse(BaseModel):
+    status: str
+    subscription_url: str | None = None
+    subscription_crypto_link: str | None = None
+    is_gift: bool = False
+    contact_value: str | None = None
+    recipient_contact_value: str | None = None
+    period_days: int | None = None
+    tariff_name: str | None = None
+    gift_message: str | None = None
+    contact_type: str | None = None
+    cabinet_email: str | None = None
+    cabinet_password: str | None = None
+    auto_login_token: str | None = None
+    recipient_in_bot: bool | None = None
+    bot_link: str | None = None
+
+
+def _mask_contact(value: str) -> str:
+    """Mask contact value to avoid leaking PII in API responses."""
+    if '@' in value and not value.startswith('@'):
+        # Email: show first 2 chars + mask + domain
+        local, domain = value.rsplit('@', 1)
+        return f'{local[:2]}***@{domain}'
+    if value.startswith('@'):
+        # Telegram: show first 3 chars + mask
+        return f'{value[:3]}***'
+    return value[:3] + '***'
+
+
+_SUBSCRIPTION_URL_EXPIRY_HOURS = 24
+
+
+def _build_purchase_status_response(purchase: GuestPurchase) -> PurchaseStatusResponse:
+    """Build a PurchaseStatusResponse from a GuestPurchase record."""
+    tariff_name = purchase.tariff.name if purchase.tariff else None
+
+    within_ttl = False
+    subscription_url = None
+    subscription_crypto_link = None
+    if purchase.delivered_at and purchase.subscription_url and not purchase.is_gift:
+        age = datetime.now(UTC) - purchase.delivered_at
+        if age < timedelta(hours=_SUBSCRIPTION_URL_EXPIRY_HOURS):
+            within_ttl = True
+            subscription_url = purchase.subscription_url
+            subscription_crypto_link = purchase.subscription_crypto_link
+
+    masked_contact = _mask_contact(purchase.contact_value) if purchase.contact_value else None
+
+    recipient_contact_value = None
+    gift_message = None
+    if purchase.is_gift:
+        if purchase.gift_recipient_value:
+            recipient_contact_value = _mask_contact(purchase.gift_recipient_value)
+        gift_message = purchase.gift_message
+
+    # Determine effective contact type for the recipient
+    if purchase.is_gift and purchase.gift_recipient_type:
+        effective_contact_type = purchase.gift_recipient_type
+    else:
+        effective_contact_type = purchase.contact_type
+
+    # Cabinet credentials for email self-purchases (not gifts)
+    cabinet_email = None
+    cabinet_password = None
+    auto_login_token = None
+    is_terminal = purchase.status in (GuestPurchaseStatus.DELIVERED.value, GuestPurchaseStatus.PENDING_ACTIVATION.value)
+    is_email_self_purchase = effective_contact_type == 'email' and not purchase.is_gift
+
+    if is_terminal and is_email_self_purchase:
+        cabinet_email = purchase.contact_value
+        # For PENDING_ACTIVATION: cap credential exposure at 72h from paid_at
+        pending_within_ttl = (
+            purchase.status == GuestPurchaseStatus.PENDING_ACTIVATION.value
+            and purchase.paid_at
+            and (datetime.now(UTC) - purchase.paid_at) < timedelta(hours=72)
+        )
+        if within_ttl or pending_within_ttl:
+            cabinet_password = purchase.cabinet_password
+            auto_login_token = purchase.auto_login_token
+
+    # For telegram gifts: indicate whether recipient is known to the bot
+    recipient_in_bot: bool | None = None
+    bot_link: str | None = None
+    if purchase.is_gift and effective_contact_type == 'telegram':
+        recipient_in_bot = purchase.user is not None and purchase.user.telegram_id is not None
+        if not recipient_in_bot:
+            bot_username = settings.get_bot_username()
+            if bot_username:
+                bot_link = f'https://t.me/{bot_username}'
+
+    return PurchaseStatusResponse(
+        status=purchase.status,
+        subscription_url=subscription_url,
+        subscription_crypto_link=subscription_crypto_link,
+        is_gift=purchase.is_gift,
+        contact_value=masked_contact,
+        recipient_contact_value=recipient_contact_value,
+        period_days=purchase.period_days,
+        tariff_name=tariff_name,
+        gift_message=gift_message,
+        contact_type=effective_contact_type,
+        cabinet_email=cabinet_email,
+        cabinet_password=cabinet_password,
+        auto_login_token=auto_login_token,
+        recipient_in_bot=recipient_in_bot,
+        bot_link=bot_link,
+    )
+
+
+def _period_label(days: int) -> str:
+    """Human-readable label for a period in days."""
+    if days == 1:
+        return '1 day'
+    if days <= 6:
+        return f'{days} days'
+    if days == 7:
+        return '1 week'
+    if days == 14:
+        return '2 weeks'
+    if days == 30:
+        return '1 month'
+    if days == 60:
+        return '2 months'
+    if days == 90:
+        return '3 months'
+    if days == 180:
+        return '6 months'
+    if days == 365:
+        return '1 year'
+    if days == 456:
+        return '1 year + 3 mo.'
+
+    months = days // 30
+    remainder = days % 30
+    if months > 0 and remainder == 0:
+        return f'{months} mo.'
+    if months > 0:
+        return f'{months} mo. + {remainder} d.'
+    return f'{days} days'
+
+
+def _get_active_discount(landing: LandingPage, lang: str) -> LandingDiscountInfo | None:
+    """Return discount info if currently active, else None."""
+    if not landing.discount_percent or not landing.discount_starts_at or not landing.discount_ends_at:
+        return None
+    now = datetime.now(UTC)
+    if not (landing.discount_starts_at <= now < landing.discount_ends_at):
+        return None
+    badge = resolve_locale_text(landing.discount_badge_text, lang) if landing.discount_badge_text else None
+    return LandingDiscountInfo(
+        percent=landing.discount_percent,
+        ends_at=landing.discount_ends_at.isoformat(),
+        badge_text=badge or None,
+    )
+
+
+async def _load_landing_tariffs(
+    db: AsyncSession, landing: LandingPage, discount: LandingDiscountInfo | None = None
+) -> list[LandingTariff]:
+    """Load tariffs for a landing page, filtered by allowed IDs and periods."""
+    allowed_ids = landing.allowed_tariff_ids or []
+    if not allowed_ids:
+        return []
+
+    result = await db.execute(
+        select(Tariff)
+        .where(Tariff.id.in_(allowed_ids), Tariff.is_active.is_(True))
+        .order_by(Tariff.display_order, Tariff.id)
+    )
+    tariffs = result.scalars().all()
+
+    allowed_periods = landing.allowed_periods or {}
+    landing_tariffs = []
+
+    for tariff in tariffs:
+        # Determine which periods to show
+        tariff_period_override = allowed_periods.get(str(tariff.id))
+        if tariff_period_override is not None:
+            period_days_list = sorted(tariff_period_override)
+        else:
+            period_days_list = tariff.get_available_periods()
+
+        periods = []
+        for days in period_days_list:
+            price = tariff.get_price_for_period(days)
+            if price is None:
+                continue
+
+            original_price_kopeks = None
+            original_price_label = None
+            effective_discount = None
+
+            if discount:
+                # Per-tariff override takes priority (read from landing model, not response DTO)
+                overrides = landing.discount_overrides or {}
+                tariff_override = overrides.get(str(tariff.id))
+                effective_discount = tariff_override if tariff_override is not None else discount.percent
+                original_price_kopeks = price
+                original_price_label = settings.format_price(price)
+                from app.services.pricing_engine import PricingEngine
+
+                price = max(1, PricingEngine.apply_discount(price, effective_discount))
+
+            periods.append(
+                LandingTariffPeriod(
+                    days=days,
+                    label=_period_label(days),
+                    price_kopeks=price,
+                    price_label=settings.format_price(price),
+                    original_price_kopeks=original_price_kopeks,
+                    original_price_label=original_price_label,
+                    discount_percent=effective_discount,
+                )
+            )
+
+        if not periods:
+            continue
+
+        landing_tariffs.append(
+            LandingTariff(
+                id=tariff.id,
+                name=tariff.name,
+                description=tariff.description,
+                traffic_limit_gb=tariff.traffic_limit_gb,
+                device_limit=tariff.device_limit,
+                tier_level=tariff.tier_level,
+                periods=periods,
+            )
+        )
+
+    return landing_tariffs
+
+
+# IMPORTANT: /purchase/{token} must come BEFORE /{slug} to avoid shadowing
+# (FastAPI checks routes in definition order; "purchase" would match {slug})
+
+
+@router.get('/purchase/{token}', response_model=PurchaseStatusResponse)
+async def get_purchase_status(
+    token: str,
+    raw_request: Request,
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Get the status of a guest purchase by token.
+
+    No authentication required.
+    """
+    client_ip = get_client_ip(raw_request)
+    if await RateLimitCache.is_ip_rate_limited(client_ip, 'purchase_status', limit=30, window=60, fail_closed=True):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail='Too many requests')
+
+    purchase = await get_purchase_by_token(db, token)
+    if purchase is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Purchase not found',
+        )
+
+    response = _build_purchase_status_response(purchase)
+
+    # Cleanup: null expired credentials from DB
+    needs_cleanup = False
+    if purchase.delivered_at and (purchase.cabinet_password or purchase.auto_login_token):
+        age = datetime.now(UTC) - purchase.delivered_at
+        if age >= timedelta(hours=_SUBSCRIPTION_URL_EXPIRY_HOURS):
+            needs_cleanup = True
+    elif (
+        purchase.status == GuestPurchaseStatus.PENDING_ACTIVATION.value
+        and purchase.paid_at
+        and (purchase.cabinet_password or purchase.auto_login_token)
+        and (datetime.now(UTC) - purchase.paid_at) >= timedelta(hours=72)
+    ):
+        needs_cleanup = True
+
+    if needs_cleanup:
+        purchase.cabinet_password = None
+        purchase.auto_login_token = None
+        await db.commit()
+
+    return response
+
+
+@router.post('/activate/{token}', response_model=PurchaseStatusResponse)
+async def activate_purchase(
+    token: str,
+    raw_request: Request,
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Activate a pending guest purchase, replacing the user's current subscription.
+
+    No authentication required (token is the secret).
+    """
+    client_ip = get_client_ip(raw_request)
+    if await RateLimitCache.is_ip_rate_limited(client_ip, 'activate_purchase', limit=5, window=60, fail_closed=True):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail='Too many requests')
+
+    try:
+        purchase = await activate_guest_purchase(db, token)
+    except GuestPurchaseError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    return _build_purchase_status_response(purchase)
+
+
+@router.get('/{slug}', response_model=LandingConfigResponse)
+async def get_landing_config(
+    raw_request: Request,
+    slug: str = Path(max_length=100),
+    lang: str = Query(DEFAULT_LOCALE, max_length=5, description='Locale: ru, en, zh, fa'),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Get public landing page configuration with tariffs and payment methods.
+
+    No authentication required. Pass ``?lang=en`` to get localized text.
+    """
+    client_ip = get_client_ip(raw_request)
+    if await RateLimitCache.is_ip_rate_limited(client_ip, 'landing_config', limit=60, window=60, fail_closed=True):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail='Too many requests')
+
+    landing = await get_active_landing_by_slug(db, slug)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    discount = _get_active_discount(landing, lang)
+    tariffs = await _load_landing_tariffs(db, landing, discount)
+
+    # Build payment methods from landing config
+    raw_methods = landing.payment_methods or []
+    method_defaults = _get_method_defaults()
+
+    payment_methods: list[LandingPaymentMethod] = []
+    for m in raw_methods:
+        method_id = m.get('method_id', '')
+        raw_sub_options = m.get('sub_options')  # dict[str, bool] | None
+
+        # Resolve sub-options: filter enabled ones and attach display names
+        resolved_sub_options: list[LandingPaymentMethodSubOption] | None = None
+        method_def = method_defaults.get(method_id)
+        available = method_def.get('available_sub_options') if method_def else None
+        if available:
+            resolved = []
+            for opt in available:
+                opt_id = opt['id']
+                # If landing has explicit sub_options config, respect it; otherwise all enabled
+                if raw_sub_options is None or raw_sub_options.get(opt_id, True):
+                    resolved.append(LandingPaymentMethodSubOption(id=opt_id, name=opt['name']))
+            if resolved:
+                resolved_sub_options = resolved
+
+        payment_methods.append(
+            LandingPaymentMethod(
+                method_id=method_id,
+                display_name=m.get('display_name', ''),
+                description=m.get('description'),
+                icon_url=m.get('icon_url'),
+                sort_order=m.get('sort_order', 0),
+                min_amount_kopeks=m.get('min_amount_kopeks'),
+                max_amount_kopeks=m.get('max_amount_kopeks'),
+                currency=m.get('currency'),
+                sub_options=resolved_sub_options,
+            )
+        )
+
+    # Resolve locale dicts to flat strings for the requested language
+    features = [
+        LandingFeature(
+            icon=f.get('icon', ''),
+            title=resolve_locale_text(f.get('title'), lang),
+            description=resolve_locale_text(f.get('description'), lang),
+        )
+        for f in (landing.features or [])
+    ]
+
+    return LandingConfigResponse(
+        slug=landing.slug,
+        title=resolve_locale_text(landing.title, lang),
+        subtitle=resolve_locale_text(landing.subtitle, lang) or None,
+        features=features,
+        footer_text=resolve_locale_text(landing.footer_text, lang) or None,
+        tariffs=tariffs,
+        payment_methods=payment_methods,
+        gift_enabled=landing.gift_enabled,
+        custom_css=landing.custom_css,
+        meta_title=resolve_locale_text(landing.meta_title, lang) or None,
+        meta_description=resolve_locale_text(landing.meta_description, lang) or None,
+        discount=discount,
+        background_config=landing.background_config,
+        analytics_view_enabled=landing.analytics_view_enabled,
+        analytics_click_enabled=landing.analytics_click_enabled,
+        analytics_view_goal=landing.analytics_view_goal,
+        analytics_click_goal=landing.analytics_click_goal,
+        sticky_pay_button=getattr(landing, 'sticky_pay_button', False) or False,
+    )
+
+
+@router.post('/{slug}/purchase', response_model=PurchaseResponse)
+async def create_landing_purchase(
+    slug: str,
+    body: PurchaseRequest,
+    raw_request: Request,
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Create a guest purchase on a landing page.
+
+    No authentication required.
+    """
+    client_ip = get_client_ip(raw_request)
+    if await RateLimitCache.is_ip_rate_limited(client_ip, 'landing_purchase', limit=30, window=60, fail_closed=True):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail='Too many purchase attempts, please try again later',
+        )
+
+    landing = await get_active_landing_by_slug(db, slug)
+    if landing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Landing page not found',
+        )
+
+    if body.is_gift and not landing.gift_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Gift purchases are not enabled for this landing page',
+        )
+
+    # Validate payment method is available on this landing.
+    # The frontend may send a suffixed method ID (e.g. "platega_2", "yookassa_sbp")
+    # to select a specific sub-option. We match against the base method_id and
+    # validate the suffix against known & enabled sub-options.
+    raw_methods = landing.payment_methods or []
+    method_defaults = _get_method_defaults()
+
+    method_config = next((m for m in raw_methods if m.get('method_id') == body.payment_method), None)
+    if method_config is None:
+        # Try matching by prefix: "platega_2" → base "platega"
+        # Sort by length descending so "freekassa_sbp" is checked before "freekassa"
+        sorted_methods = sorted(raw_methods, key=lambda m: len(m.get('method_id', '')), reverse=True)
+        for m in sorted_methods:
+            mid = m.get('method_id', '')
+            if body.payment_method.startswith(mid + '_'):
+                suffix = body.payment_method[len(mid) + 1 :]
+                # Validate suffix is a known sub-option
+                method_def = method_defaults.get(mid)
+                available = (method_def.get('available_sub_options') if method_def else None) or []
+                valid_ids = {opt['id'] for opt in available}
+                if suffix not in valid_ids:
+                    break  # invalid suffix → reject
+                # Validate suffix is enabled on this landing
+                raw_sub_options = m.get('sub_options')  # dict[str, bool] | None
+                if raw_sub_options is not None and not raw_sub_options.get(suffix, True):
+                    break  # disabled sub-option → reject
+                method_config = m
+                break
+    if method_config is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Payment method is not available on this landing page',
+        )
+
+    # Validate tariff + period + calculate price
+    try:
+        tariff, amount_kopeks = await validate_and_calculate(db, landing, body.tariff_id, body.period_days)
+    except GuestPurchaseError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    # Gift purchases require the tariff to be visible in the gift section
+    if body.is_gift and not tariff.show_in_gift:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='This tariff is not available for gift purchases',
+        )
+
+    # Validate amount against per-method min/max limits (before creating purchase record)
+    min_amount = method_config.get('min_amount_kopeks')
+    max_amount = method_config.get('max_amount_kopeks')
+    if min_amount is not None and amount_kopeks < min_amount:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Amount is below the minimum ({settings.format_price(min_amount)}) for this payment method',
+        )
+    if max_amount is not None and amount_kopeks > max_amount:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Amount exceeds the maximum ({settings.format_price(max_amount)}) for this payment method',
+        )
+
+    # Create purchase record (no commit yet — wait for payment creation)
+    purchase = await create_purchase(
+        db,
+        landing=landing,
+        tariff=tariff,
+        period_days=body.period_days,
+        amount_kopeks=amount_kopeks,
+        contact_type=body.contact_type,
+        contact_value=body.contact_value,
+        payment_method=body.payment_method,
+        is_gift=body.is_gift,
+        gift_recipient_type=body.gift_recipient_type,
+        gift_recipient_value=body.gift_recipient_value,
+        gift_message=body.gift_message,
+        commit=False,
+    )
+
+    # Save referrer from request body (document.referrer captured on page load)
+    if body.referrer:
+        purchase.referrer = body.referrer
+
+    # Determine return URL: per-method override → default cabinet URL
+    cabinet_base = (settings.CABINET_URL or '').rstrip('/')
+    default_return_url = f'{cabinet_base}/buy/success/{purchase.token}'
+    method_return_url = method_config.get('return_url')
+    if method_return_url:
+        # Allow {token} placeholder in custom return URLs
+        return_url = method_return_url.replace('{token}', purchase.token)
+    else:
+        return_url = default_return_url
+
+    payment_service = PaymentService()
+    payment_result = await payment_service.create_guest_payment(
+        db=db,
+        amount_kopeks=amount_kopeks,
+        payment_method=body.payment_method,
+        description=f'{tariff.name} — {body.period_days}d',
+        purchase_token=purchase.token,
+        return_url=return_url,
+    )
+
+    if payment_result is None:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Payment provider is unavailable, please try again later',
+        )
+
+    payment_url = payment_result.get('payment_url')
+    if not payment_url:
+        await db.rollback()
+        logger.error(
+            'Payment created but no payment_url returned',
+            purchase_token=purchase.token[:5],
+            provider=payment_result.get('provider'),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Payment provider returned an invalid response',
+        )
+
+    await db.commit()
+    await db.refresh(purchase)
+
+    # Persist Yandex CID in cache so fulfill_purchase can link it to the user later
+    if body.yandex_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+        try:
+            await cache.set(f'yacid:purchase:{purchase.token}', body.yandex_cid, expire=86400)
+        except Exception:
+            pass
+
+    return PurchaseResponse(
+        purchase_token=purchase.token,
+        payment_url=payment_url,
+    )

--- a/app/database/crud/landing.py
+++ b/app/database/crud/landing.py
@@ -1,0 +1,261 @@
+import secrets
+
+import structlog
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import GuestPurchase, GuestPurchaseStatus, LandingPage
+
+
+logger = structlog.get_logger(__name__)
+
+
+async def get_landing_by_slug(db: AsyncSession, slug: str) -> LandingPage | None:
+    """Get a landing page by its slug."""
+    result = await db.execute(select(LandingPage).where(LandingPage.slug == slug))
+    return result.scalars().first()
+
+
+async def get_landing_by_id(db: AsyncSession, landing_id: int) -> LandingPage | None:
+    """Get a landing page by its ID."""
+    result = await db.execute(select(LandingPage).where(LandingPage.id == landing_id))
+    return result.scalars().first()
+
+
+async def get_active_landing_by_slug(db: AsyncSession, slug: str) -> LandingPage | None:
+    """Get an active landing page by its slug."""
+    result = await db.execute(
+        select(LandingPage).where(
+            LandingPage.slug == slug,
+            LandingPage.is_active.is_(True),
+        )
+    )
+    return result.scalars().first()
+
+
+async def get_all_landings(db: AsyncSession) -> list[LandingPage]:
+    """Get all landing pages ordered by display_order."""
+    result = await db.execute(select(LandingPage).order_by(LandingPage.display_order, LandingPage.id))
+    return list(result.scalars().all())
+
+
+async def create_landing(db: AsyncSession, **kwargs) -> LandingPage:
+    """Create a new landing page."""
+    landing = LandingPage(**kwargs)
+    db.add(landing)
+    await db.flush()
+    await db.commit()
+    await db.refresh(landing)
+    logger.info(
+        'Created landing page',
+        slug=landing.slug,
+        landing_id=landing.id,
+    )
+    return landing
+
+
+_LANDING_UPDATABLE_FIELDS = frozenset(
+    {
+        'slug',
+        'title',
+        'subtitle',
+        'is_active',
+        'features',
+        'footer_text',
+        'allowed_tariff_ids',
+        'allowed_periods',
+        'payment_methods',
+        'gift_enabled',
+        'custom_css',
+        'meta_title',
+        'meta_description',
+        'display_order',
+        'discount_percent',
+        'discount_overrides',
+        'discount_starts_at',
+        'discount_ends_at',
+        'discount_badge_text',
+        'background_config',
+        'analytics_view_enabled',
+        'analytics_click_enabled',
+        'analytics_view_goal',
+        'analytics_click_goal',
+        'sticky_pay_button',
+    }
+)
+
+
+async def update_landing(db: AsyncSession, landing_id: int, data: dict) -> LandingPage | None:
+    """Update a landing page by ID. Returns None if not found."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        return None
+
+    for key, value in data.items():
+        if key in _LANDING_UPDATABLE_FIELDS:
+            setattr(landing, key, value)
+
+    await db.commit()
+    await db.refresh(landing)
+    logger.info(
+        'Updated landing page',
+        landing_id=landing.id,
+        slug=landing.slug,
+        updated_fields=list(data.keys()),
+    )
+    return landing
+
+
+async def delete_landing(db: AsyncSession, landing_id: int) -> bool:
+    """Delete a landing page by ID. Returns True if deleted."""
+    landing = await get_landing_by_id(db, landing_id)
+    if landing is None:
+        return False
+
+    await db.delete(landing)
+    await db.commit()
+    logger.info(
+        'Deleted landing page',
+        landing_id=landing_id,
+        slug=landing.slug,
+    )
+    return True
+
+
+async def update_landing_order(db: AsyncSession, landing_ids: list[int]) -> None:
+    """Set display_order for landing pages based on position in list."""
+    for order, landing_id in enumerate(landing_ids):
+        await db.execute(update(LandingPage).where(LandingPage.id == landing_id).values(display_order=order))
+    await db.commit()
+    logger.info('Updated landing page order', landing_ids=landing_ids)
+
+
+def generate_purchase_token() -> str:
+    """Generate a cryptographically secure purchase token."""
+    return secrets.token_urlsafe(48)
+
+
+async def create_guest_purchase(db: AsyncSession, *, commit: bool = True, **kwargs) -> GuestPurchase:
+    """Create a new guest purchase with an auto-generated token."""
+    if 'token' not in kwargs:
+        kwargs['token'] = generate_purchase_token()
+
+    purchase = GuestPurchase(**kwargs)
+    db.add(purchase)
+    await db.flush()
+    if commit:
+        await db.commit()
+    await db.refresh(purchase)
+    logger.info(
+        'Created guest purchase',
+        purchase_id=purchase.id,
+        token_prefix=purchase.token[:5],
+        status=purchase.status,
+        landing_id=purchase.landing_id,
+    )
+    return purchase
+
+
+async def get_purchase_by_token(db: AsyncSession, token: str) -> GuestPurchase | None:
+    """Get a guest purchase by its token."""
+    result = await db.execute(select(GuestPurchase).where(GuestPurchase.token == token))
+    return result.scalars().first()
+
+
+_PURCHASE_UPDATABLE_FIELDS = frozenset(
+    {
+        'payment_id',
+        'paid_at',
+        'delivered_at',
+        'subscription_url',
+        'subscription_crypto_link',
+        'user_id',
+    }
+)
+
+
+async def update_purchase_status(
+    db: AsyncSession,
+    token: str,
+    status: GuestPurchaseStatus | str,
+    *,
+    commit: bool = True,
+    **extra_fields,
+) -> GuestPurchase | None:
+    """Update the status of a guest purchase and optional extra fields."""
+    purchase = await get_purchase_by_token(db, token)
+    if purchase is None:
+        return None
+
+    old_status = purchase.status
+    purchase.status = status.value if isinstance(status, GuestPurchaseStatus) else status
+
+    for key, value in extra_fields.items():
+        if key not in _PURCHASE_UPDATABLE_FIELDS:
+            logger.warning('Ignoring disallowed field in purchase update', field=key)
+            continue
+        setattr(purchase, key, value)
+
+    if commit:
+        await db.commit()
+        await db.refresh(purchase)
+    else:
+        await db.flush()
+
+    logger.info(
+        'Updated guest purchase status',
+        purchase_id=purchase.id,
+        token_prefix=token[:5],
+        old_status=old_status,
+        new_status=purchase.status,
+    )
+    return purchase
+
+
+async def get_landing_purchase_stats(db: AsyncSession, landing_id: int) -> dict:
+    """Get purchase counts grouped by status for a landing page."""
+    result = await db.execute(
+        select(
+            GuestPurchase.status,
+            func.count(GuestPurchase.id),
+        )
+        .where(GuestPurchase.landing_id == landing_id)
+        .group_by(GuestPurchase.status)
+    )
+    rows = result.all()
+
+    stats = {s.value: 0 for s in GuestPurchaseStatus}
+    stats['total'] = 0
+    for status_value, count in rows:
+        stats[status_value] = count
+        stats['total'] += count
+
+    return stats
+
+
+async def get_all_landing_purchase_stats(db: AsyncSession) -> dict[int, dict]:
+    """Get purchase counts grouped by landing_id and status in a single query.
+
+    Returns a dict mapping landing_id -> {status: count, 'total': count}.
+    """
+    result = await db.execute(
+        select(
+            GuestPurchase.landing_id,
+            GuestPurchase.status,
+            func.count(GuestPurchase.id),
+        )
+        .where(GuestPurchase.landing_id.is_not(None))
+        .group_by(GuestPurchase.landing_id, GuestPurchase.status)
+    )
+    rows = result.all()
+
+    all_stats: dict[int, dict] = {}
+    for landing_id, status_value, count in rows:
+        if landing_id not in all_stats:
+            stats = {s.value: 0 for s in GuestPurchaseStatus}
+            stats['total'] = 0
+            all_stats[landing_id] = stats
+        all_stats[landing_id][status_value] = count
+        all_stats[landing_id]['total'] += count
+
+    return all_stats

--- a/app/database/crud/transaction.py
+++ b/app/database/crud/transaction.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import structlog
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, case, func, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -297,6 +297,18 @@ async def get_transactions_statistics(
     )
     total_income = income_result.scalar()
 
+    # Guest purchases (landing/cabinet)
+    gp_income_result = await db.execute(
+        select(func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0)).where(
+            and_(
+                GuestPurchase.status == GuestPurchaseStatus.DELIVERED.value,
+                GuestPurchase.paid_at >= start_date,
+                GuestPurchase.paid_at <= end_date,
+            )
+        )
+    )
+    total_income += gp_income_result.scalar()
+
     expenses_result = await db.execute(
         select(func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)).where(
             and_(
@@ -380,6 +392,17 @@ async def get_transactions_statistics(
         )
     )
     income_today = today_income_result.scalar()
+
+    # Guest purchases today
+    gp_today_result = await db.execute(
+        select(func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0)).where(
+            and_(
+                GuestPurchase.status == GuestPurchaseStatus.DELIVERED.value,
+                GuestPurchase.paid_at >= today,
+            )
+        )
+    )
+    income_today += gp_today_result.scalar()
 
     return {
         'period': {'start_date': start_date, 'end_date': end_date},

--- a/app/database/crud/transaction.py
+++ b/app/database/crud/transaction.py
@@ -5,7 +5,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.database.models import PaymentMethod, Transaction, TransactionType, User
+from app.database.models import GuestPurchase, GuestPurchaseStatus, PaymentMethod, Transaction, TransactionType, User
 
 
 logger = structlog.get_logger(__name__)
@@ -25,6 +25,8 @@ REAL_PAYMENT_METHODS = [
     PaymentMethod.CLOUDPAYMENTS.value,
     PaymentMethod.FREEKASSA.value,
     PaymentMethod.KASSA_AI.value,
+    PaymentMethod.RIOPAY.value,
+    PaymentMethod.SEVERPAY.value,
 ]
 
 
@@ -38,11 +40,26 @@ async def create_transaction(
     external_id: str | None = None,
     is_completed: bool = True,
     created_at: datetime | None = None,
+    *,
+    commit: bool = True,
 ) -> Transaction:
+    # SUBSCRIPTION_PAYMENT / GIFT_PAYMENT — always store as negative (debit from user balance)
+    # Keep original for downstream consumers (events, contests)
+    stored_amount = (
+        -amount_kopeks
+        if type in (TransactionType.SUBSCRIPTION_PAYMENT, TransactionType.GIFT_PAYMENT) and amount_kopeks > 0
+        else amount_kopeks
+    )
+
+    # Default payment_method to BALANCE for subscription/gift payments from bot (not landing)
+    # to avoid double-counting with DEPOSIT in revenue calculations
+    if payment_method is None and type in (TransactionType.SUBSCRIPTION_PAYMENT, TransactionType.GIFT_PAYMENT):
+        payment_method = PaymentMethod.BALANCE
+
     transaction = Transaction(
         user_id=user_id,
         type=type.value,
-        amount_kopeks=amount_kopeks,
+        amount_kopeks=stored_amount,
         description=description,
         payment_method=payment_method.value if payment_method else None,
         external_id=external_id,
@@ -52,17 +69,82 @@ async def create_transaction(
     )
 
     db.add(transaction)
-    await db.commit()
+    if commit:
+        await db.commit()
+    else:
+        await db.flush()
     await db.refresh(transaction)
 
     logger.info(
         '💳 Создана транзакция: на ₽ для пользователя',
         type_value=type.value,
-        amount_kopeks=amount_kopeks / 100,
+        amount_kopeks=stored_amount / 100,
         user_id=user_id,
     )
 
-    # Отправляем событие о транзакции
+    # Side-effects skipped when commit=False to preserve caller's transaction atomicity.
+    # Callers using commit=False should call emit_transaction_side_effects() after their own db.commit().
+    if commit:
+        try:
+            from app.services.event_emitter import event_emitter
+
+            await event_emitter.emit(
+                'payment.completed' if type == TransactionType.DEPOSIT else 'transaction.created',
+                {
+                    'transaction_id': transaction.id,
+                    'user_id': user_id,
+                    'type': type.value,
+                    'amount_kopeks': abs(amount_kopeks),
+                    'amount_rubles': abs(amount_kopeks) / 100,
+                    'payment_method': payment_method.value if payment_method else None,
+                    'external_id': external_id,
+                    'is_completed': is_completed,
+                    'description': description,
+                },
+                db=db,
+            )
+        except Exception as error:
+            logger.warning('Failed to emit transaction event', error=error)
+
+        try:
+            from app.services.promo_group_assignment import (
+                maybe_assign_promo_group_by_total_spent,
+            )
+
+            await maybe_assign_promo_group_by_total_spent(db, user_id)
+        except Exception as exc:
+            logger.warning('Не удалось проверить автовыдачу промогруппы для пользователя', user_id=user_id, exc=exc)
+        if type == TransactionType.SUBSCRIPTION_PAYMENT and is_completed:
+            try:
+                from app.services.referral_contest_service import referral_contest_service
+
+                await referral_contest_service.on_subscription_payment(
+                    db,
+                    user_id,
+                    abs(amount_kopeks),
+                )
+            except Exception as exc:
+                logger.debug('Не удалось записать событие конкурса для пользователя', user_id=user_id, exc=exc)
+
+    return transaction
+
+
+async def emit_transaction_side_effects(
+    db: AsyncSession,
+    transaction: Transaction,
+    *,
+    amount_kopeks: int,
+    user_id: int,
+    type: TransactionType,
+    payment_method: PaymentMethod | None = None,
+    external_id: str | None = None,
+    is_completed: bool = True,
+    description: str = '',
+) -> None:
+    """Fire side-effects that were deferred when create_transaction(commit=False) was used.
+
+    Call this AFTER db.commit() to emit events and run promo checks.
+    """
     try:
         from app.services.event_emitter import event_emitter
 
@@ -72,8 +154,8 @@ async def create_transaction(
                 'transaction_id': transaction.id,
                 'user_id': user_id,
                 'type': type.value,
-                'amount_kopeks': amount_kopeks,
-                'amount_rubles': amount_kopeks / 100,
+                'amount_kopeks': abs(amount_kopeks),
+                'amount_rubles': abs(amount_kopeks) / 100,
                 'payment_method': payment_method.value if payment_method else None,
                 'external_id': external_id,
                 'is_completed': is_completed,
@@ -82,7 +164,7 @@ async def create_transaction(
             db=db,
         )
     except Exception as error:
-        logger.warning('Failed to emit transaction event', error=error)
+        logger.warning('Failed to emit deferred transaction event', error=error)
 
     try:
         from app.services.promo_group_assignment import (
@@ -91,20 +173,19 @@ async def create_transaction(
 
         await maybe_assign_promo_group_by_total_spent(db, user_id)
     except Exception as exc:
-        logger.debug('Не удалось проверить автовыдачу промогруппы для пользователя', user_id=user_id, exc=exc)
-    if type == TransactionType.SUBSCRIPTION_PAYMENT:
+        logger.warning('Не удалось проверить автовыдачу промогруппы для пользователя', user_id=user_id, exc=exc)
+
+    if type == TransactionType.SUBSCRIPTION_PAYMENT and is_completed:
         try:
             from app.services.referral_contest_service import referral_contest_service
 
             await referral_contest_service.on_subscription_payment(
                 db,
                 user_id,
-                amount_kopeks,
+                abs(amount_kopeks),
             )
         except Exception as exc:
             logger.debug('Не удалось записать событие конкурса для пользователя', user_id=user_id, exc=exc)
-
-    return transaction
 
 
 async def get_transaction_by_id(db: AsyncSession, transaction_id: int) -> Transaction | None:
@@ -177,7 +258,7 @@ async def complete_transaction(db: AsyncSession, transaction: Transaction) -> Tr
 
         await maybe_assign_promo_group_by_total_spent(db, transaction.user_id)
     except Exception as exc:
-        logger.debug(
+        logger.warning(
             'Не удалось проверить автовыдачу промогруппы для пользователя', user_id=transaction.user_id, exc=exc
         )
 
@@ -202,11 +283,11 @@ async def get_transactions_statistics(
     if not end_date:
         end_date = datetime.now(UTC)
 
-    # Доход считаем только по реальным платежам (исключаем колесо, промокоды, админские пополнения)
+    # Доход считаем по реальным платежам + прямые покупки подписок (лендинги)
     income_result = await db.execute(
-        select(func.coalesce(func.sum(Transaction.amount_kopeks), 0)).where(
+        select(func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)).where(
             and_(
-                Transaction.type == TransactionType.DEPOSIT.value,
+                Transaction.type.in_([TransactionType.DEPOSIT.value, TransactionType.SUBSCRIPTION_PAYMENT.value]),
                 Transaction.is_completed == True,
                 Transaction.created_at >= start_date,
                 Transaction.created_at <= end_date,
@@ -217,7 +298,7 @@ async def get_transactions_statistics(
     total_income = income_result.scalar()
 
     expenses_result = await db.execute(
-        select(func.coalesce(func.sum(Transaction.amount_kopeks), 0)).where(
+        select(func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)).where(
             and_(
                 Transaction.type == TransactionType.WITHDRAWAL.value,
                 Transaction.is_completed == True,
@@ -244,7 +325,7 @@ async def get_transactions_statistics(
         select(
             Transaction.type,
             func.count(Transaction.id).label('count'),
-            func.coalesce(func.sum(Transaction.amount_kopeks), 0).label('total_amount'),
+            func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0).label('total_amount'),
         )
         .where(
             and_(
@@ -263,11 +344,11 @@ async def get_transactions_statistics(
         select(
             Transaction.payment_method,
             func.count(Transaction.id).label('count'),
-            func.coalesce(func.sum(Transaction.amount_kopeks), 0).label('total_amount'),
+            func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0).label('total_amount'),
         )
         .where(
             and_(
-                Transaction.type == TransactionType.DEPOSIT.value,
+                Transaction.type.in_([TransactionType.DEPOSIT.value, TransactionType.SUBSCRIPTION_PAYMENT.value]),
                 Transaction.is_completed == True,
                 Transaction.created_at >= start_date,
                 Transaction.created_at <= end_date,
@@ -287,11 +368,11 @@ async def get_transactions_statistics(
     )
     transactions_today = today_result.scalar()
 
-    # Доход за сегодня - только реальные платежи
+    # Доход за сегодня — реальные платежи + прямые покупки подписок (лендинги)
     today_income_result = await db.execute(
-        select(func.coalesce(func.sum(Transaction.amount_kopeks), 0)).where(
+        select(func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)).where(
             and_(
-                Transaction.type == TransactionType.DEPOSIT.value,
+                Transaction.type.in_([TransactionType.DEPOSIT.value, TransactionType.SUBSCRIPTION_PAYMENT.value]),
                 Transaction.is_completed == True,
                 Transaction.created_at >= today,
                 Transaction.payment_method.in_(REAL_PAYMENT_METHODS),
@@ -315,24 +396,50 @@ async def get_transactions_statistics(
 
 
 async def get_revenue_by_period(db: AsyncSession, days: int = 30) -> list[dict]:
-    """Доход по дням - только реальные платежи."""
+    """Доход по дням — реальные платежи + гостевые покупки (лендинг/кабинет)."""
     start_date = datetime.now(UTC) - timedelta(days=days)
 
-    result = await db.execute(
+    # Transactions: deposits + subscription payments via real payment methods
+    tx_query = (
         select(
             func.date(Transaction.created_at).label('date'),
-            func.coalesce(func.sum(Transaction.amount_kopeks), 0).label('amount'),
+            func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0).label('amount'),
         )
         .where(
             and_(
-                Transaction.type == TransactionType.DEPOSIT.value,
+                Transaction.type.in_([TransactionType.DEPOSIT.value, TransactionType.SUBSCRIPTION_PAYMENT.value]),
                 Transaction.is_completed == True,
                 Transaction.created_at >= start_date,
                 Transaction.payment_method.in_(REAL_PAYMENT_METHODS),
             )
         )
         .group_by(func.date(Transaction.created_at))
-        .order_by(func.date(Transaction.created_at))
+    )
+
+    # Guest purchases: delivered (landing/cabinet direct purchases)
+    gp_query = (
+        select(
+            func.date(GuestPurchase.paid_at).label('date'),
+            func.coalesce(func.sum(GuestPurchase.amount_kopeks), 0).label('amount'),
+        )
+        .where(
+            and_(
+                GuestPurchase.status == GuestPurchaseStatus.DELIVERED.value,
+                GuestPurchase.paid_at >= start_date,
+            )
+        )
+        .group_by(func.date(GuestPurchase.paid_at))
+    )
+
+    # Union and aggregate
+    combined = union_all(tx_query, gp_query).subquery()
+    result = await db.execute(
+        select(
+            combined.c.date,
+            func.sum(combined.c.amount).label('amount'),
+        )
+        .group_by(combined.c.date)
+        .order_by(combined.c.date)
     )
 
     return [{'date': row.date, 'amount_kopeks': row.amount} for row in result]

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -8,12 +8,13 @@ def _aware(dt: datetime | None) -> datetime | None:
     return dt
 
 
-from enum import Enum
+from enum import Enum, StrEnum
 
 from sqlalchemy import (
     JSON,
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     Date,
     DateTime,
@@ -27,6 +28,7 @@ from sqlalchemy import (
     Time,
     TypeDecorator,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
@@ -122,6 +124,7 @@ class SubscriptionStatus(Enum):
     ACTIVE = 'active'
     EXPIRED = 'expired'
     DISABLED = 'disabled'
+    LIMITED = 'limited'
     PENDING = 'pending'
 
 
@@ -130,8 +133,10 @@ class TransactionType(Enum):
     WITHDRAWAL = 'withdrawal'
     SUBSCRIPTION_PAYMENT = 'subscription_payment'
     REFUND = 'refund'
+    FAILED_REFUND = 'failed_refund'
     REFERRAL_REWARD = 'referral_reward'
     POLL_REWARD = 'poll_reward'
+    GIFT_PAYMENT = 'gift_payment'
 
 
 class PromoCodeType(Enum):
@@ -155,6 +160,8 @@ class PaymentMethod(Enum):
     CLOUDPAYMENTS = 'cloudpayments'
     FREEKASSA = 'freekassa'
     KASSA_AI = 'kassa_ai'
+    RIOPAY = 'riopay'
+    SEVERPAY = 'severpay'
     MANUAL = 'manual'
     BALANCE = 'balance'
 
@@ -191,7 +198,7 @@ class YooKassaPayment(Base):
     __tablename__ = 'yookassa_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
     yookassa_payment_id = Column(String(255), unique=True, nullable=False, index=True)
     amount_kopeks = Column(Integer, nullable=False)
     currency = Column(String(3), default='RUB', nullable=False)
@@ -236,11 +243,43 @@ class YooKassaPayment(Base):
         return f'<YooKassaPayment(id={self.id}, yookassa_id={self.yookassa_payment_id}, amount={self.amount_rubles}₽, status={self.status})>'
 
 
+class SavedPaymentMethod(Base):
+    __tablename__ = 'saved_payment_methods'
+    __table_args__ = (Index('ix_saved_payment_methods_user_active', 'user_id', 'is_active'),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
+
+    # YooKassa payment_method.id — ключ для рекуррентных списаний
+    yookassa_payment_method_id = Column(String(255), unique=True, nullable=False, index=True)
+
+    # Тип метода: bank_card, yoo_money, sberbank, tinkoff_bank, sbp, mir_pay
+    method_type = Column(String(50), nullable=False, default='bank_card')
+
+    # Отображаемые данные карты (маскированные)
+    card_first6 = Column(String(6), nullable=True)
+    card_last4 = Column(String(4), nullable=True)
+    card_type = Column(String(50), nullable=True)  # Visa, MasterCard, Mir
+    card_expiry_month = Column(String(2), nullable=True)
+    card_expiry_year = Column(String(4), nullable=True)
+    title = Column(String(255), nullable=True)  # "Bank card *4444"
+
+    is_active = Column(Boolean, default=True)
+
+    created_at = Column(AwareDateTime(), nullable=False, server_default=func.now())
+    updated_at = Column(AwareDateTime(), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    user = relationship('User', backref='saved_payment_methods')
+
+    def __repr__(self):
+        return f'<SavedPaymentMethod(id={self.id}, user_id={self.user_id}, type={self.method_type}, last4={self.card_last4})>'
+
+
 class CryptoBotPayment(Base):
     __tablename__ = 'cryptobot_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     invoice_id = Column(String(255), unique=True, nullable=False, index=True)
     amount = Column(String(50), nullable=False)
@@ -290,7 +329,7 @@ class HeleketPayment(Base):
     __tablename__ = 'heleket_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     uuid = Column(String(255), unique=True, nullable=False, index=True)
     order_id = Column(String(128), unique=True, nullable=False, index=True)
@@ -349,7 +388,7 @@ class MulenPayPayment(Base):
     __tablename__ = 'mulenpay_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     mulen_payment_id = Column(Integer, nullable=True, index=True)
     uuid = Column(String(255), unique=True, nullable=False, index=True)
@@ -385,7 +424,7 @@ class Pal24Payment(Base):
     __tablename__ = 'pal24_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     bill_id = Column(String(255), unique=True, nullable=False, index=True)
     order_id = Column(String(255), nullable=True, index=True)
@@ -442,7 +481,7 @@ class WataPayment(Base):
     __tablename__ = 'wata_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     payment_link_id = Column(String(64), unique=True, nullable=False, index=True)
     order_id = Column(String(255), nullable=True, index=True)
@@ -485,7 +524,7 @@ class PlategaPayment(Base):
     __tablename__ = 'platega_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     platega_transaction_id = Column(String(255), unique=True, nullable=True, index=True)
     correlation_id = Column(String(64), unique=True, nullable=False, index=True)
@@ -527,7 +566,7 @@ class CloudPaymentsPayment(Base):
     __tablename__ = 'cloudpayments_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     # CloudPayments идентификаторы
     transaction_id_cp = Column(BigInteger, unique=True, nullable=True, index=True)  # TransactionId от CloudPayments
@@ -596,7 +635,7 @@ class FreekassaPayment(Base):
     __tablename__ = 'freekassa_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     # Идентификаторы
     order_id = Column(String(64), unique=True, nullable=False, index=True)  # Наш ID заказа
@@ -658,7 +697,7 @@ class KassaAiPayment(Base):
     __tablename__ = 'kassa_ai_payments'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
 
     # Идентификаторы
     order_id = Column(String(64), unique=True, nullable=False, index=True)  # Наш ID заказа
@@ -712,6 +751,131 @@ class KassaAiPayment(Base):
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return f'<KassaAiPayment(id={self.id}, order_id={self.order_id}, amount={self.amount_rubles}₽, status={self.status})>'
+
+
+class RioPayPayment(Base):
+    """Платежи через RioPay (api.riopay.online)."""
+
+    __tablename__ = 'riopay_payments'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
+
+    # Идентификаторы
+    order_id = Column(String(64), unique=True, nullable=False, index=True)  # Наш internal ID
+    riopay_order_id = Column(String(64), unique=True, nullable=True, index=True)  # UUID от RioPay
+
+    # Суммы
+    amount_kopeks = Column(Integer, nullable=False)
+    currency = Column(String(10), nullable=False, default='RUB')
+    description = Column(Text, nullable=True)
+
+    # Статусы
+    status = Column(String(32), nullable=False, default='pending')  # pending, success, failed, expired, canceled
+    is_paid = Column(Boolean, default=False)
+
+    # Данные платежа
+    payment_url = Column(Text, nullable=True)
+    payment_method = Column(String(32), nullable=True)  # CARD, SBP
+
+    # Метаданные
+    metadata_json = Column(JSON, nullable=True)
+    callback_payload = Column(JSON, nullable=True)
+
+    # Временные метки
+    paid_at = Column(AwareDateTime(), nullable=True)
+    expires_at = Column(AwareDateTime(), nullable=True)
+    created_at = Column(AwareDateTime(), default=func.now())
+    updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
+
+    # Связь с транзакцией
+    transaction_id = Column(Integer, ForeignKey('transactions.id'), nullable=True)
+
+    # Relationships
+    user = relationship('User', backref='riopay_payments')
+    transaction = relationship('Transaction', backref='riopay_payment')
+
+    @property
+    def amount_rubles(self) -> float:
+        return self.amount_kopeks / 100
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == 'pending'
+
+    @property
+    def is_success(self) -> bool:
+        return self.status == 'success' and self.is_paid
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status in ['failed', 'expired', 'canceled']
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f'<RioPayPayment(id={self.id}, order_id={self.order_id}, amount={self.amount_rubles}₽, status={self.status})>'
+
+
+class SeverPayPayment(Base):
+    """Платежи через SeverPay (severpay.io)."""
+
+    __tablename__ = 'severpay_payments'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
+
+    # Идентификаторы
+    order_id = Column(String(64), unique=True, nullable=False, index=True)  # Наш internal ID
+    severpay_id = Column(String(64), unique=True, nullable=True, index=True)  # ID от SeverPay
+    severpay_uid = Column(String(64), unique=True, nullable=True, index=True)  # UID от SeverPay
+
+    # Суммы
+    amount_kopeks = Column(Integer, nullable=False)
+    currency = Column(String(10), nullable=False, default='RUB')
+    description = Column(Text, nullable=True)
+
+    # Статусы
+    status = Column(String(32), nullable=False, default='pending')
+    is_paid = Column(Boolean, default=False)
+
+    # Данные платежа
+    payment_url = Column(Text, nullable=True)
+    payment_method = Column(String(32), nullable=True)
+
+    # Метаданные
+    metadata_json = Column(JSON, nullable=True)
+    callback_payload = Column(JSON, nullable=True)
+
+    # Временные метки
+    paid_at = Column(AwareDateTime(), nullable=True)
+    expires_at = Column(AwareDateTime(), nullable=True)
+    created_at = Column(AwareDateTime(), default=func.now())
+    updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
+
+    # Связь с транзакцией
+    transaction_id = Column(Integer, ForeignKey('transactions.id'), nullable=True)
+
+    # Relationships
+    user = relationship('User', backref='severpay_payments')
+    transaction = relationship('Transaction', backref='severpay_payment')
+
+    @property
+    def amount_rubles(self) -> float:
+        return self.amount_kopeks / 100
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == 'pending'
+
+    @property
+    def is_success(self) -> bool:
+        return self.status == 'success' and self.is_paid
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status in ['failed', 'expired', 'declined', 'amount_mismatch']
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f'<SeverPayPayment(id={self.id}, order_id={self.order_id}, amount={self.amount_rubles}₽, status={self.status})>'
 
 
 class PromoGroup(Base):
@@ -877,8 +1041,14 @@ class Tariff(Base):
     min_traffic_gb = Column(Integer, default=1, nullable=False)  # Минимальный трафик в ГБ
     max_traffic_gb = Column(Integer, default=1000, nullable=False)  # Максимальный трафик в ГБ
 
-    # Режим сброса трафика: DAY, WEEK, MONTH, NO_RESET (по умолчанию берётся из конфига)
+    # Видимость в разделе подарков
+    show_in_gift = Column(Boolean, default=True, server_default='true', nullable=False)
+
+    # Режим сброса трафика: DAY, WEEK, MONTH, MONTH_ROLLING, NO_RESET (по умолчанию берётся из конфига)
     traffic_reset_mode = Column(String(20), nullable=True, default=None)  # None = использовать глобальную настройку
+
+    # Внешний сквад RemnaWave (UUID) — назначается пользователю при создании подписки
+    external_squad_uuid = Column(String(255), nullable=True, default=None)
 
     created_at = Column(AwareDateTime(), default=func.now())
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
@@ -1017,7 +1187,7 @@ class User(Base):
     balance_kopeks = Column(Integer, default=0)
     used_promocodes = Column(Integer, default=0)
     has_had_paid_subscription = Column(Boolean, default=False, nullable=False)
-    referred_by_id = Column(Integer, ForeignKey('users.id'), nullable=True, index=True)
+    referred_by_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
     referral_code = Column(String(20), unique=True, nullable=True)
     created_at = Column(AwareDateTime(), default=func.now())
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
@@ -1044,8 +1214,26 @@ class User(Base):
     discord_id = Column(String(255), unique=True, nullable=True, index=True)
     vk_id = Column(BigInteger, unique=True, nullable=True, index=True)
     broadcasts = relationship('BroadcastHistory', back_populates='admin')
-    referrals = relationship('User', backref='referrer', remote_side=[id], foreign_keys='User.referred_by_id')
-    subscription = relationship('Subscription', back_populates='user', uselist=False)
+    referrals = relationship(
+        'User', backref='referrer', remote_side=[id], foreign_keys='User.referred_by_id', post_update=True
+    )
+    subscriptions = relationship('Subscription', back_populates='user', order_by='Subscription.created_at.desc()')
+
+    @property
+    def subscription(self) -> 'Subscription | None':
+        """Deprecated: returns the first active subscription or most recent one.
+
+        Use user.subscriptions directly for multi-tariff support.
+        """
+        if not self.subscriptions:
+            return None
+        # Prefer active/trial subscription
+        for sub in self.subscriptions:
+            if sub.status in (SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIAL.value):
+                return sub
+        # Fallback to most recent (already ordered by created_at desc)
+        return self.subscriptions[0]
+
     transactions = relationship('Transaction', back_populates='user')
     referral_earnings = relationship('ReferralEarning', foreign_keys='ReferralEarning.user_id', back_populates='user')
     discount_offers = relationship('DiscountOffer', back_populates='user')
@@ -1119,10 +1307,10 @@ class User(Base):
 
     def get_primary_promo_group(self):
         """Возвращает промогруппу с максимальным приоритетом."""
-        if not self.user_promo_groups:
-            return getattr(self, 'promo_group', None)
-
         try:
+            if not self.user_promo_groups:
+                return getattr(self, 'promo_group', None)
+
             # Сортируем по приоритету группы (убывание), затем по ID группы
             # Используем getattr для защиты от ленивой загрузки
             sorted_groups = sorted(
@@ -1134,7 +1322,7 @@ class User(Base):
             if sorted_groups and sorted_groups[0].promo_group:
                 return sorted_groups[0].promo_group
         except Exception:
-            # Если возникла ошибка (например, ленивая загрузка), fallback на старую связь
+            # Если возникла ошибка (например, ленивая загрузка в async), fallback на старую связь
             pass
 
         # Fallback на старую связь если новая пустая или возникла ошибка
@@ -1161,10 +1349,20 @@ class Subscription(Base):
     __table_args__ = (
         Index('ix_subscriptions_status_trial', 'status', 'is_trial'),
         Index('ix_subscriptions_trial_created', 'is_trial', 'created_at'),
+        Index('ix_subscriptions_user_id', 'user_id'),
+        Index('ix_subscriptions_user_status', 'user_id', 'status'),
+        Index('ix_subscriptions_user_tariff_status', 'user_id', 'tariff_id', 'status'),
+        Index(
+            'uq_subscriptions_user_tariff_active',
+            'user_id',
+            'tariff_id',
+            unique=True,
+            postgresql_where=text("tariff_id IS NOT NULL AND status IN ('active', 'trial')"),
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False, unique=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
 
     status = Column(String(20), default=SubscriptionStatus.TRIAL.value)
     is_trial = Column(Boolean, default=True)
@@ -1196,9 +1394,13 @@ class Subscription(Base):
     last_webhook_update_at = Column(AwareDateTime(), nullable=True)
 
     remnawave_short_uuid = Column(String(255), nullable=True)
+    remnawave_uuid = Column(String(255), nullable=True)
+    remnawave_short_id = Column(
+        String(16), nullable=False, unique=True, server_default=''
+    )  # Permanent short ID for username suffix
 
     # Тариф (для режима продаж "Тарифы")
-    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='SET NULL'), nullable=True, index=True)
+    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='RESTRICT'), nullable=True, index=True)
 
     # Суточная подписка
     is_daily_paused = Column(
@@ -1206,7 +1408,7 @@ class Subscription(Base):
     )  # Приостановлена ли суточная подписка пользователем
     last_daily_charge_at = Column(AwareDateTime(), nullable=True)  # Время последнего суточного списания
 
-    user = relationship('User', back_populates='subscription')
+    user = relationship('User', back_populates='subscriptions')
     tariff = relationship('Tariff', back_populates='subscriptions')
     discount_offers = relationship('DiscountOffer', back_populates='subscription')
     temporary_accesses = relationship(
@@ -1245,6 +1447,9 @@ class Subscription(Base):
         if self.status == SubscriptionStatus.DISABLED.value:
             return 'disabled'
 
+        if self.status == SubscriptionStatus.LIMITED.value:
+            return 'limited'
+
         if self.status == SubscriptionStatus.ACTIVE.value:
             if end is None or end <= current_time:
                 return 'expired'
@@ -1269,6 +1474,8 @@ class Subscription(Base):
             return '🟢 Активна'
         if actual_status == 'disabled':
             return '⚫ Отключена'
+        if actual_status == 'limited':
+            return '⚠️ Трафик исчерпан'
         if actual_status == 'trial':
             return '🎯 Тестовая'
 
@@ -1286,6 +1493,8 @@ class Subscription(Base):
             return '💎'
         if actual_status == 'disabled':
             return '⚫'
+        if actual_status == 'limited':
+            return '⚠️'
         if actual_status == 'trial':
             return '🎁'
 
@@ -1334,7 +1543,7 @@ class Subscription(Base):
         else:
             self.end_date = datetime.now(UTC) + timedelta(days=days)
 
-        if self.status == SubscriptionStatus.EXPIRED.value:
+        if self.status in (SubscriptionStatus.EXPIRED.value, SubscriptionStatus.LIMITED.value):
             self.status = SubscriptionStatus.ACTIVE.value
 
     def add_traffic(self, gb: int):
@@ -1393,13 +1602,15 @@ class TrafficPurchase(Base):
 class Transaction(Base):
     __tablename__ = 'transactions'
     __table_args__ = (
+        UniqueConstraint('external_id', 'payment_method', name='uq_transaction_external_id_method'),
         Index('ix_transactions_type_created_completed', 'type', 'created_at', 'is_completed'),
         Index('ix_transactions_user_created', 'user_id', 'created_at'),
         Index('ix_transactions_type_method_created', 'type', 'payment_method', 'created_at'),
+        Index('ix_transactions_user_type_completed_amount', 'user_id', 'type', 'is_completed', 'amount_kopeks'),
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
 
     type = Column(String(50), nullable=False)
     amount_kopeks = Column(Integer, nullable=False)
@@ -1432,7 +1643,7 @@ class SubscriptionConversion(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
 
     converted_at = Column(AwareDateTime(), default=func.now())
 
@@ -1476,7 +1687,9 @@ class PromoCode(Base):
     is_active = Column(Boolean, default=True)
     first_purchase_only = Column(Boolean, default=False)  # Только для первой покупки
 
-    created_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='SET NULL'), nullable=True, index=True)
+
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     promo_group_id = Column(Integer, ForeignKey('promo_groups.id', ondelete='SET NULL'), nullable=True, index=True)
 
     created_at = Column(AwareDateTime(), default=func.now())
@@ -1484,6 +1697,7 @@ class PromoCode(Base):
 
     uses = relationship('PromoCodeUse', back_populates='promocode')
     promo_group = relationship('PromoGroup')
+    tariff = relationship('Tariff', foreign_keys=[tariff_id])
 
     @property
     def is_valid(self) -> bool:
@@ -1502,10 +1716,11 @@ class PromoCode(Base):
 
 class PromoCodeUse(Base):
     __tablename__ = 'promocode_uses'
+    __table_args__ = (UniqueConstraint('user_id', 'promocode_id', name='uq_promocode_uses_user_promo'),)
 
     id = Column(Integer, primary_key=True, index=True)
     promocode_id = Column(Integer, ForeignKey('promocodes.id'), nullable=False)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
 
     used_at = Column(AwareDateTime(), default=func.now())
 
@@ -1517,8 +1732,8 @@ class ReferralEarning(Base):
     __tablename__ = 'referral_earnings'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
-    referral_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
+    referral_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
 
     amount_kopeks = Column(Integer, nullable=False)
     reason = Column(String(100), nullable=False)
@@ -1556,7 +1771,7 @@ class WithdrawalRequest(Base):
     __tablename__ = 'withdrawal_requests'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
 
     amount_kopeks = Column(Integer, nullable=False)  # Сумма к выводу
     status = Column(String(50), default=WithdrawalRequestStatus.PENDING.value, nullable=False, index=True)
@@ -1569,7 +1784,7 @@ class WithdrawalRequest(Base):
     risk_analysis = Column(Text, nullable=True)  # JSON с деталями анализа
 
     # Обработка админом
-    processed_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    processed_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     processed_at = Column(AwareDateTime(), nullable=True)
     admin_comment = Column(Text, nullable=True)
 
@@ -1855,6 +2070,25 @@ class SystemSetting(Base):
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
 
 
+class EmailTemplate(Base):
+    """Custom email template overrides (accessed via raw SQL in cabinet services)."""
+
+    __tablename__ = 'email_templates'
+    __table_args__ = (
+        UniqueConstraint('notification_type', 'language', name='uq_email_templates_type_lang'),
+        Index('ix_email_templates_notification_type', 'notification_type'),
+    )
+
+    id = Column(Integer, primary_key=True)
+    notification_type = Column(String(100), nullable=False)
+    language = Column(String(10), nullable=False)
+    subject = Column(String(500), nullable=False)
+    body_html = Column(Text, nullable=False)
+    is_active = Column(Boolean, nullable=False, server_default='true')
+    created_at = Column(AwareDateTime(), nullable=False, server_default=func.now())
+    updated_at = Column(AwareDateTime(), nullable=False, server_default=func.now())
+
+
 class MonitoringLog(Base):
     __tablename__ = 'monitoring_logs'
 
@@ -1999,7 +2233,7 @@ class BroadcastHistory(Base):
     failed_count = Column(Integer, default=0)
     blocked_count = Column(Integer, default=0)
     status = Column(String(50), default='in_progress')
-    admin_id = Column(Integer, ForeignKey('users.id'))
+    admin_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     admin_name = Column(String(255))
     created_at = Column(AwareDateTime(), server_default=func.now())
     completed_at = Column(AwareDateTime(), nullable=True)
@@ -2165,7 +2399,7 @@ class SubscriptionServer(Base):
     __tablename__ = 'subscription_servers'
 
     id = Column(Integer, primary_key=True, index=True)
-    subscription_id = Column(Integer, ForeignKey('subscriptions.id'), nullable=False)
+    subscription_id = Column(Integer, ForeignKey('subscriptions.id', ondelete='CASCADE'), nullable=False, index=True)
     server_squad_id = Column(Integer, ForeignKey('server_squads.id'), nullable=False)
 
     connected_at = Column(AwareDateTime(), default=func.now())
@@ -2215,7 +2449,7 @@ class WelcomeText(Base):
     text_content = Column(Text, nullable=False)
     is_active = Column(Boolean, default=True)
     is_enabled = Column(Boolean, default=True)
-    created_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     created_at = Column(AwareDateTime(), default=func.now())
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
 
@@ -2263,7 +2497,7 @@ class AdvertisingCampaign(Base):
     # Привязка к партнёру
     partner_user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
 
-    created_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     created_at = Column(AwareDateTime(), default=func.now())
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())
 
@@ -2292,7 +2526,10 @@ class AdvertisingCampaign(Base):
 
 class AdvertisingCampaignRegistration(Base):
     __tablename__ = 'advertising_campaign_registrations'
-    __table_args__ = (UniqueConstraint('campaign_id', 'user_id', name='uq_campaign_user'),)
+    __table_args__ = (
+        UniqueConstraint('campaign_id', 'user_id', name='uq_campaign_user'),
+        Index('ix_campaign_reg_user_created', 'user_id', 'created_at'),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     campaign_id = Column(Integer, ForeignKey('advertising_campaigns.id', ondelete='CASCADE'), nullable=False)
@@ -2898,7 +3135,7 @@ class AdminRole(Base):
     icon = Column(String(50), nullable=True)
     is_system = Column(Boolean, default=False, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
-    created_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     created_at = Column(AwareDateTime(), server_default=func.now())
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
 
@@ -2917,7 +3154,7 @@ class UserRole(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
     role_id = Column(Integer, ForeignKey('admin_roles.id', ondelete='CASCADE'), nullable=False)
-    assigned_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    assigned_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     assigned_at = Column(AwareDateTime(), server_default=func.now())
     expires_at = Column(AwareDateTime(), nullable=True)
     is_active = Column(Boolean, default=True, nullable=False)
@@ -2947,7 +3184,7 @@ class AccessPolicy(Base):
     resource = Column(String(100), nullable=False)
     actions = Column(JSONB, default=list, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
-    created_by = Column(Integer, ForeignKey('users.id'), nullable=True)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
     created_at = Column(AwareDateTime(), server_default=func.now())
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
 
@@ -2964,7 +3201,7 @@ class AdminAuditLog(Base):
     __tablename__ = 'admin_audit_log'
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
     action = Column(String(100), nullable=False)
     resource_type = Column(String(50), nullable=True)
     resource_id = Column(String(100), nullable=True)
@@ -2986,3 +3223,205 @@ class AdminAuditLog(Base):
 
     def __repr__(self) -> str:
         return f'<AdminAuditLog id={self.id} action={self.action!r} status={self.status!r}>'
+
+
+class LandingPage(Base):
+    """Public quick-purchase landing page configuration."""
+
+    __tablename__ = 'landing_pages'
+    __table_args__ = (
+        CheckConstraint(
+            'discount_percent IS NULL OR (discount_percent >= 1 AND discount_percent <= 99)',
+            name='chk_landing_discount_percent_range',
+        ),
+        CheckConstraint(
+            'discount_starts_at IS NULL OR discount_ends_at IS NULL OR discount_starts_at < discount_ends_at',
+            name='chk_landing_discount_dates_order',
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    slug = Column(String(100), unique=True, nullable=False, index=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    title = Column(JSON, nullable=False, default=dict)
+    subtitle = Column(JSON, nullable=True)
+    features = Column(JSON, nullable=False, default=list)
+    footer_text = Column(JSON, nullable=True)
+    allowed_tariff_ids = Column(JSON, nullable=False, default=list)
+    allowed_periods = Column(JSON, nullable=False, default=dict)
+    payment_methods = Column(JSON, nullable=False, default=list)
+    gift_enabled = Column(Boolean, nullable=False, default=True)
+    custom_css = Column(Text, nullable=True)
+    meta_title = Column(JSON, nullable=True)
+    meta_description = Column(JSON, nullable=True)
+    display_order = Column(Integer, nullable=False, default=0)
+    discount_percent = Column(Integer, nullable=True)  # 1-99, global discount for all tariffs
+    discount_overrides = Column(JSON, nullable=True)  # {"tariff_id": percent} per-tariff override
+    discount_starts_at = Column(AwareDateTime(), nullable=True)
+    discount_ends_at = Column(AwareDateTime(), nullable=True)
+    discount_badge_text = Column(JSON, nullable=True)  # LocaleDict {"ru": "...", "en": "..."}
+    analytics_view_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
+    analytics_click_enabled = Column(Boolean, nullable=False, default=False, server_default='false')
+    analytics_view_goal = Column(String(100), nullable=True)
+    analytics_click_goal = Column(String(100), nullable=True)
+    sticky_pay_button = Column(Boolean, default=False, server_default='false')
+    background_config = Column(
+        JSON, nullable=True
+    )  # AnimationConfig: {enabled, type, settings, opacity, blur, reducedOnMobile}
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+
+    guest_purchases = relationship('GuestPurchase', back_populates='landing', lazy='noload')
+
+    def __repr__(self) -> str:
+        return f"<LandingPage slug='{self.slug}' active={self.is_active}>"
+
+
+class GuestPurchaseStatus(StrEnum):
+    PENDING = 'pending'
+    PAID = 'paid'
+    DELIVERED = 'delivered'
+    PENDING_ACTIVATION = 'pending_activation'
+    FAILED = 'failed'
+    EXPIRED = 'expired'
+
+
+class GuestPurchase(Base):
+    """Guest (unauthenticated) purchase record."""
+
+    __tablename__ = 'guest_purchases'
+    __table_args__ = (
+        Index('ix_guest_purchases_status', 'status'),
+        Index('ix_guest_purchases_contact', 'contact_type', 'contact_value'),
+        Index('ix_guest_purchases_landing_status_paid', 'landing_id', 'status', 'paid_at'),
+        Index('ix_guest_purchases_source', 'source'),
+        Index('ix_guest_purchases_user_gift_status', 'user_id', 'is_gift', 'status'),
+        Index('ix_guest_purchases_status_paid_at', 'status', 'paid_at'),
+        Index('ix_guest_purchases_buyer_user_id', 'buyer_user_id'),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String(64), unique=True, nullable=False, index=True)
+    landing_id = Column(Integer, ForeignKey('landing_pages.id', ondelete='SET NULL'), nullable=True)
+    contact_type = Column(String(20), nullable=False)  # 'email' or 'telegram'
+    contact_value = Column(String(255), nullable=False)
+    is_gift = Column(Boolean, nullable=False, default=False)
+    source = Column(String(20), nullable=False, default='landing', server_default='landing')  # 'landing' or 'cabinet'
+    buyer_user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    gift_recipient_type = Column(String(20), nullable=True)
+    gift_recipient_value = Column(String(255), nullable=True)
+    gift_message = Column(Text, nullable=True)
+    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='SET NULL'), nullable=True)
+    period_days = Column(Integer, nullable=False)
+    amount_kopeks = Column(Integer, nullable=False)
+    currency = Column(String(3), nullable=False, default='RUB')
+    payment_method = Column(String(50), nullable=True)
+    payment_id = Column(String(255), nullable=True)
+    status = Column(String(20), nullable=False, default=GuestPurchaseStatus.PENDING.value)
+    subscription_url = Column(Text, nullable=True)
+    subscription_crypto_link = Column(Text, nullable=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    paid_at = Column(AwareDateTime(), nullable=True)
+    delivered_at = Column(AwareDateTime(), nullable=True)
+    cabinet_password = Column(Text, nullable=True)
+    auto_login_token = Column(Text, nullable=True)
+    recipient_warning = Column(String(50), nullable=True)
+    retry_count = Column(Integer, nullable=False, default=0, server_default='0')
+    receipt_uuid = Column(String(255), nullable=True, index=True)
+    receipt_created_at = Column(AwareDateTime(), nullable=True)
+
+    landing = relationship('LandingPage', back_populates='guest_purchases', lazy='selectin')
+    tariff = relationship('Tariff', lazy='selectin')
+    user = relationship('User', foreign_keys=[user_id], lazy='selectin')
+    buyer = relationship('User', foreign_keys=[buyer_user_id], lazy='selectin')
+
+    def __repr__(self) -> str:
+        token_prefix = self.token[:5] if self.token else '?'
+        return f"<GuestPurchase token='{token_prefix}...' status='{self.status}'>"
+
+
+class NewsArticle(Base):
+    """News article for the cabinet news section."""
+
+    __tablename__ = 'news_articles'
+    __table_args__ = (
+        # Covers the main public list query: WHERE is_published = true ORDER BY published_at DESC
+        Index('ix_news_articles_published_at_published', 'is_published', 'published_at'),
+        # Covers the category-filtered public list: WHERE is_published = true AND category = ?
+        Index('ix_news_articles_published_category', 'is_published', 'category'),
+        # Covers the admin list query: ORDER BY created_at DESC
+        Index('ix_news_articles_created_at', 'created_at'),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(500), nullable=False)
+    slug = Column(String(500), unique=True, nullable=False, index=True)
+    content = Column(Text, nullable=False, default='', server_default='')
+    excerpt = Column(Text, nullable=True)
+    category = Column(String(100), nullable=False, default='', server_default='')
+    category_color = Column(String(20), nullable=False, default='#00e5a0', server_default='#00e5a0')
+    tag = Column(String(50), nullable=True)
+    featured_image_url = Column(Text, nullable=True)
+    is_published = Column(Boolean, nullable=False, default=False, server_default='false')
+    is_featured = Column(Boolean, nullable=False, default=False, server_default='false')
+    published_at = Column(AwareDateTime(), nullable=True)
+    read_time_minutes = Column(Integer, nullable=False, default=1, server_default='1')
+    views_count = Column(Integer, nullable=False, default=0, server_default='0')
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+
+    category_id = Column(Integer, ForeignKey('news_categories.id', ondelete='SET NULL'), nullable=True)
+    tag_id = Column(Integer, ForeignKey('news_tags.id', ondelete='SET NULL'), nullable=True)
+
+    author = relationship('User', backref='created_news_articles', foreign_keys=[created_by])
+    category_obj = relationship('NewsCategory', foreign_keys=[category_id], lazy='noload')
+    tag_obj = relationship('NewsTag', foreign_keys=[tag_id], lazy='noload')
+
+    def __repr__(self) -> str:
+        return f"<NewsArticle id={self.id} slug='{self.slug}' published={self.is_published}>"
+
+
+class NewsCategory(Base):
+    """Managed news category with a display color."""
+
+    __tablename__ = 'news_categories'
+    __table_args__ = (Index('ix_news_categories_name_lower', text('lower(name)'), unique=True),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(100), nullable=False)
+    color = Column(String(20), nullable=False, server_default='#00e5a0')
+    created_at = Column(AwareDateTime(), server_default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<NewsCategory id={self.id} name='{self.name}'>"
+
+
+class NewsTag(Base):
+    """Managed news tag with a display color."""
+
+    __tablename__ = 'news_tags'
+    __table_args__ = (Index('ix_news_tags_name_lower', text('lower(name)'), unique=True),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(50), nullable=False)
+    color = Column(String(20), nullable=False, server_default='#94a3b8')
+    created_at = Column(AwareDateTime(), server_default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<NewsTag id={self.id} name='{self.name}'>"
+
+
+class YandexClientIdMap(Base):
+    __tablename__ = 'yandex_client_id_map'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False)
+    yandex_cid = Column(String(128), nullable=False)
+    source = Column(String(10), nullable=False, default='web')
+    counter_id = Column(String(32), nullable=True)
+    registration_sent = Column(Boolean, default=False, nullable=False)
+    trial_sent = Column(Boolean, default=False, nullable=False)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+    user = relationship('User', foreign_keys=[user_id])

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3328,6 +3328,7 @@ class GuestPurchase(Base):
     auto_login_token = Column(Text, nullable=True)
     recipient_warning = Column(String(50), nullable=True)
     retry_count = Column(Integer, nullable=False, default=0, server_default='0')
+    referrer = Column(Text, nullable=True)
     receipt_uuid = Column(String(255), nullable=True, index=True)
     receipt_created_at = Column(AwareDateTime(), nullable=True)
 


### PR DESCRIPTION
## Проблема

«Доход за сегодня» и «Доход за месяц» в панели администратора не учитывали гостевые покупки (лендинг/кабинет). Функция `get_revenue_by_period` считала только `transactions`, игнорируя `guest_purchases`.

## Решение

`get_revenue_by_period` теперь использует `UNION ALL` из:
- `transactions` (deposits + subscription_payments через реальные платёжные методы)
- `guest_purchases` (со статусом `delivered`)

Результат агрегируется по дням.

## Файлы
- `app/database/crud/transaction.py` — добавлен UNION ALL с guest_purchases