### PR TITLE
fix(ci): read Docker image version from release-please manifest instead of hardcoding

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -26,36 +26,38 @@ jobs:
     - name: Get version info
       id: version
       run: |
-        echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        
+        SHORT_SHA=$(git rev-parse --short HEAD)
+        echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
         echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-        
-        # Определяем версию и теги
+
+        # Read base version from release-please manifest (single source of truth)
+        BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
+
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🏷️ Собираем релизную версию: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/main ]]; then
-          VERSION="v3.7.0-$(git rev-parse --short HEAD)" # x-release-please-version
+          VERSION="v${BASE_VERSION}-${SHORT_SHA}"
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🚀 Собираем версию из main: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-          VERSION="v3.7.0-dev-$(git rev-parse --short HEAD)" # x-release-please-version
+          VERSION="v${BASE_VERSION}-dev-${SHORT_SHA}"
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:dev,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🧪 Собираем dev версию: $VERSION"
         else
-          VERSION="v3.7.0-pr-$(git rev-parse --short HEAD)" # x-release-please-version
-          TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:pr-$(git rev-parse --short HEAD)"
+          VERSION="v${BASE_VERSION}-pr-${SHORT_SHA}"
+          TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:pr-${SHORT_SHA}"
           echo "🔀 Собираем PR версию: $VERSION"
         fi
-        
+
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tags=$TAGS" >> $GITHUB_OUTPUT
         echo "should_push=${{ github.event_name != 'pull_request' }}" >> $GITHUB_OUTPUT
-        
+
         echo "=== Информация о сборке ==="
         echo "Версия: $VERSION"
-        echo "Коммит: $(git rev-parse --short HEAD)"
+        echo "Коммит: $SHORT_SHA"
         echo "Теги: $TAGS"
         echo "Push: ${{ github.event_name != 'pull_request' }}"
         echo "==========================="

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -42,25 +42,28 @@ jobs:
       - name: Get version info
         id: version
         run: |
-          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          
+
+          # Read base version from release-please manifest (single source of truth)
+          BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
+
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             echo "🏷️ Building release version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION="v3.7.0-$(git rev-parse --short HEAD)" # x-release-please-version
+            VERSION="v${BASE_VERSION}-${SHORT_SHA}"
             echo "🚀 Building main version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-            VERSION="v3.7.0-dev-$(git rev-parse --short HEAD)" # x-release-please-version
+            VERSION="v${BASE_VERSION}-dev-${SHORT_SHA}"
             echo "🧪 Building dev version: $VERSION"
           else
-            VERSION="v3.7.0-pr-$(git rev-parse --short HEAD)" # x-release-please-version
+            VERSION="v${BASE_VERSION}-pr-${SHORT_SHA}"
             echo "🔀 Building PR version: $VERSION"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
-          # Определяем, нужно ли пушить образ
+
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "should_push=false" >> $GITHUB_OUTPUT
             echo "⚠️ PR - only build without push"


### PR DESCRIPTION
Fixes #2858

## Summary / Описание

Replaces hardcoded `v3.7.0` version strings in Docker workflow files with a runtime read from `.release-please-manifest.json`.

Заменяет захардкоженные строки `v3.7.0` в Docker workflow-файлах на чтение из `.release-please-manifest.json` во время сборки.

## What changed / Что изменилось

- `docker-hub.yml` and `docker-registry.yml`: read `BASE_VERSION` from `.release-please-manifest.json` via `jq` instead of using stale `x-release-please-version` markers
- Removed the `x-release-please-version` comments (no longer needed)
- No changes to `release-please-config.json` (re-adding workflow files to `extra-files` would hit the same 403)

---

- `docker-hub.yml` и `docker-registry.yml`: чтение `BASE_VERSION` из `.release-please-manifest.json` через `jq` вместо устаревших маркеров `x-release-please-version`
- Удалены комментарии `x-release-please-version` (больше не нужны)
- `release-please-config.json` не изменён (добавление workflow-файлов обратно в `extra-files` вызовет ту же ошибку 403)

## Tested / Проверено

Tested on fork (ghcr.io workflow): images correctly tagged as `v3.45.1-<sha>` instead of `v3.7.0-<sha>`.

Проверено на форке (ghcr.io workflow): образы корректно тегируются как `v3.45.1-<sha>` вместо `v3.7.0-<sha>`.