### PR TITLE
feat(config): add TELEGRAM_API_URL for custom Telegram API server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,14 @@ SUPPORT_USERNAME=@support
 # Имя пользователя бота (опционально, автоопределяется)
 # BOT_USERNAME=
 
-# ===== SOCKS5 ПРОКСИ =====
+# ===== СЕТЬ И ПРОКСИ =====
 # URL SOCKS5 прокси-сервера для маршрутизации трафика бота к Telegram API
 # Формат: socks5://user:password@host:port или socks5://host:port
 # PROXY_URL=socks5://127.0.0.1:1080
+
+# Альтернативный URL сервера Telegram Bot API (для регионов где api.telegram.org заблокирован)
+# Примеры: Cloudflare Worker, self-hosted telegram-bot-api (tdlib), любой совместимый прокси
+# TELEGRAM_API_URL=https://your-telegram-proxy.workers.dev
 
 # ===== СИСТЕМА ПОДДЕРЖКИ =====
 # Включить меню поддержки в интерфейсе

--- a/app/bot_factory.py
+++ b/app/bot_factory.py
@@ -1,4 +1,4 @@
-"""Factory for creating Bot instances with proxy support."""
+"""Factory for creating Bot instances with proxy and custom API server support."""
 
 from aiogram import Bot
 from aiogram.client.default import DefaultBotProperties
@@ -8,13 +8,21 @@ from app.config import settings
 
 
 def create_bot(token: str | None = None, **kwargs) -> Bot:
-    """Create a Bot instance with SOCKS5 proxy session if PROXY_URL is configured."""
+    """Create a Bot instance with SOCKS5 proxy and/or custom Telegram API server."""
     proxy_url = settings.get_proxy_url()
+    telegram_api_url = settings.get_telegram_api_url()
     session = None
-    if proxy_url:
+    if proxy_url or telegram_api_url:
         from aiogram.client.session.aiohttp import AiohttpSession
+        from aiogram.client.telegram import TelegramAPIServer
 
-        session = AiohttpSession(proxy=proxy_url)
+        session_kwargs: dict = {}
+        if proxy_url:
+            session_kwargs["proxy"] = proxy_url
+        if telegram_api_url:
+            session_kwargs["api"] = TelegramAPIServer.from_base(telegram_api_url)
 
-    kwargs.setdefault('default', DefaultBotProperties(parse_mode=ParseMode.HTML))
+        session = AiohttpSession(**session_kwargs)
+
+    kwargs.setdefault("default", DefaultBotProperties(parse_mode=ParseMode.HTML))
     return Bot(token=token or settings.BOT_TOKEN, session=session, **kwargs)

--- a/app/config.py
+++ b/app/config.py
@@ -20,7 +20,7 @@ DEFAULT_DISPLAY_NAME_BANNED_KEYWORDS: list[str] = [
     # Примеры: "tme", "joingroup", "support", "admin"
 ]
 
-USER_TAG_PATTERN = re.compile(r'^[A-Z0-9_]{1,16}$')
+USER_TAG_PATTERN = re.compile(r"^[A-Z0-9_]{1,16}$")
 
 
 logger = structlog.get_logger(__name__)
@@ -29,16 +29,16 @@ logger = structlog.get_logger(__name__)
 class Settings(BaseSettings):
     BOT_TOKEN: str
     BOT_USERNAME: str | None = None
-    ADMIN_IDS: str = ''
-    ADMIN_EMAILS: str = ''  # Comma-separated admin emails for email-only users
+    ADMIN_IDS: str = ""
+    ADMIN_EMAILS: str = ""  # Comma-separated admin emails for email-only users
 
     # Test email account for development/testing (bypasses email verification and SMTP)
-    TEST_EMAIL: str = ''  # e.g., test@example.com
-    TEST_EMAIL_PASSWORD: str = ''  # Password for test account
+    TEST_EMAIL: str = ""  # e.g., test@example.com
+    TEST_EMAIL_PASSWORD: str = ""  # Password for test account
 
-    SUPPORT_USERNAME: str = '@support'
+    SUPPORT_USERNAME: str = "@support"
     SUPPORT_MENU_ENABLED: bool = True
-    SUPPORT_SYSTEM_MODE: str = 'both'  # one of: tickets, contact, both
+    SUPPORT_SYSTEM_MODE: str = "both"  # one of: tickets, contact, both
     # SLA for support tickets
     SUPPORT_TICKET_SLA_ENABLED: bool = True
     SUPPORT_TICKET_SLA_MINUTES: int = 5
@@ -47,8 +47,10 @@ class Settings(BaseSettings):
 
     # MiniApp tickets settings
     MINIAPP_TICKETS_ENABLED: bool = True  # Enable/disable tickets section in miniapp
-    MINIAPP_SUPPORT_TYPE: str = 'tickets'  # one of: tickets, profile, url
-    MINIAPP_SUPPORT_URL: str = ''  # Custom URL to redirect when tickets disabled (only for url type)
+    MINIAPP_SUPPORT_TYPE: str = "tickets"  # one of: tickets, profile, url
+    MINIAPP_SUPPORT_URL: str = (
+        ""  # Custom URL to redirect when tickets disabled (only for url type)
+    )
 
     ADMIN_NOTIFICATIONS_ENABLED: bool = False
     ADMIN_NOTIFICATIONS_CHAT_ID: str | None = None
@@ -61,11 +63,19 @@ class Settings(BaseSettings):
     ADMIN_NOTIFICATIONS_RENEWALS_TOPIC_ID: int | None = None  # Продления
     ADMIN_NOTIFICATIONS_TRIALS_TOPIC_ID: int | None = None  # Триалы
     ADMIN_NOTIFICATIONS_BALANCE_TOPIC_ID: int | None = None  # Пополнение баланса
-    ADMIN_NOTIFICATIONS_ADDONS_TOPIC_ID: int | None = None  # Докупка трафика/устройств/серверов
-    ADMIN_NOTIFICATIONS_INFRASTRUCTURE_TOPIC_ID: int | None = None  # Ноды, техработы, статус панели
+    ADMIN_NOTIFICATIONS_ADDONS_TOPIC_ID: int | None = (
+        None  # Докупка трафика/устройств/серверов
+    )
+    ADMIN_NOTIFICATIONS_INFRASTRUCTURE_TOPIC_ID: int | None = (
+        None  # Ноды, техработы, статус панели
+    )
     ADMIN_NOTIFICATIONS_ERRORS_TOPIC_ID: int | None = None  # Ошибки бота
-    ADMIN_NOTIFICATIONS_PROMO_TOPIC_ID: int | None = None  # Промокоды, кампании, промогруппы
-    ADMIN_NOTIFICATIONS_PARTNERS_TOPIC_ID: int | None = None  # Партнёрки, выводы, админ-действия
+    ADMIN_NOTIFICATIONS_PROMO_TOPIC_ID: int | None = (
+        None  # Промокоды, кампании, промогруппы
+    )
+    ADMIN_NOTIFICATIONS_PARTNERS_TOPIC_ID: int | None = (
+        None  # Партнёрки, выводы, админ-действия
+    )
 
     # Настройки очереди чеков NaloGO
     NALOGO_QUEUE_CHECK_INTERVAL: int = 300  # Интервал проверки очереди (секунды)
@@ -83,20 +93,20 @@ class Settings(BaseSettings):
 
     DATABASE_URL: str | None = None
 
-    POSTGRES_HOST: str = 'postgres'
+    POSTGRES_HOST: str = "postgres"
     POSTGRES_PORT: int = 5432
-    POSTGRES_DB: str = 'remnawave_bot'
-    POSTGRES_USER: str = 'remnawave_user'
-    POSTGRES_PASSWORD: str = 'secure_password_123'
+    POSTGRES_DB: str = "remnawave_bot"
+    POSTGRES_USER: str = "remnawave_user"
+    POSTGRES_PASSWORD: str = "secure_password_123"
 
-    SQLITE_PATH: str = './data/bot.db'
-    LOCALES_PATH: str = './locales'
+    SQLITE_PATH: str = "./data/bot.db"
+    LOCALES_PATH: str = "./locales"
 
-    TIMEZONE: str = Field(default_factory=lambda: os.getenv('TZ', 'UTC'))
+    TIMEZONE: str = Field(default_factory=lambda: os.getenv("TZ", "UTC"))
 
-    DATABASE_MODE: str = 'auto'
+    DATABASE_MODE: str = "auto"
 
-    REDIS_URL: str = 'redis://localhost:6379/0'
+    REDIS_URL: str = "redis://localhost:6379/0"
     CART_TTL_SECONDS: int = 3600  # Время жизни корзины пользователя в Redis (1 час)
 
     REMNAWAVE_API_URL: str | None = None
@@ -106,18 +116,22 @@ class Settings(BaseSettings):
     REMNAWAVE_USERNAME: str | None = None
     REMNAWAVE_PASSWORD: str | None = None
     REMNAWAVE_CADDY_TOKEN: str | None = None
-    REMNAWAVE_AUTH_TYPE: str = 'api_key'  # api_key, basic, bearer, cookies, caddy
-    REMNAWAVE_USER_DESCRIPTION_TEMPLATE: str = 'Bot user: {full_name} {username}'
-    REMNAWAVE_USER_USERNAME_TEMPLATE: str = 'user_{telegram_id}'
-    REMNAWAVE_USER_DELETE_MODE: str = 'delete'  # "delete" или "disable"
+    REMNAWAVE_AUTH_TYPE: str = "api_key"  # api_key, basic, bearer, cookies, caddy
+    REMNAWAVE_USER_DESCRIPTION_TEMPLATE: str = "Bot user: {full_name} {username}"
+    REMNAWAVE_USER_USERNAME_TEMPLATE: str = "user_{telegram_id}"
+    REMNAWAVE_USER_DELETE_MODE: str = "delete"  # "delete" или "disable"
     REMNAWAVE_AUTO_SYNC_ENABLED: bool = False
-    REMNAWAVE_AUTO_SYNC_TIMES: str = '03:00'
-    CABINET_REMNA_SUB_CONFIG: str | None = None  # UUID конфига страницы подписки из RemnaWave
+    REMNAWAVE_AUTO_SYNC_TIMES: str = "03:00"
+    CABINET_REMNA_SUB_CONFIG: str | None = (
+        None  # UUID конфига страницы подписки из RemnaWave
+    )
 
     # RemnaWave incoming webhooks (real-time event delivery from backend)
     REMNAWAVE_WEBHOOK_ENABLED: bool = False
-    REMNAWAVE_WEBHOOK_PATH: str = '/remnawave-webhook'
-    REMNAWAVE_WEBHOOK_SECRET: str | None = None  # HMAC-SHA256 shared secret (min 32 chars)
+    REMNAWAVE_WEBHOOK_PATH: str = "/remnawave-webhook"
+    REMNAWAVE_WEBHOOK_SECRET: str | None = (
+        None  # HMAC-SHA256 shared secret (min 32 chars)
+    )
     REMNAWAVE_WEBHOOK_NOTIFY_NODE_CONNECTION_STATUS: bool = True
 
     # Webhook user notification toggles (what Telegram messages users receive from webhook events)
@@ -142,10 +156,10 @@ class Settings(BaseSettings):
     TRIAL_PAYMENT_ENABLED: bool = False
     TRIAL_ACTIVATION_PRICE: int = 0
     TRIAL_USER_TAG: str | None = None
-    TRIAL_DISABLED_FOR: str = 'none'  # none, email, telegram, all
+    TRIAL_DISABLED_FOR: str = "none"  # none, email, telegram, all
     DEFAULT_TRAFFIC_LIMIT_GB: int = 100
     DEFAULT_DEVICE_LIMIT: int = 1
-    DEFAULT_TRAFFIC_RESET_STRATEGY: str = 'MONTH'
+    DEFAULT_TRAFFIC_RESET_STRATEGY: str = "MONTH"
     RESET_TRAFFIC_ON_PAYMENT: bool = False
     RESET_TRAFFIC_ON_TARIFF_SWITCH: bool = True
     MAX_DEVICES_LIMIT: int = 20
@@ -157,7 +171,7 @@ class Settings(BaseSettings):
     MONITORING_LOGS_RETENTION_DAYS: int = 30
     NOTIFICATION_CACHE_HOURS: int = 24
 
-    SERVER_STATUS_MODE: str = 'disabled'
+    SERVER_STATUS_MODE: str = "disabled"
     SERVER_STATUS_EXTERNAL_URL: str | None = None
     SERVER_STATUS_METRICS_URL: str | None = None
     SERVER_STATUS_METRICS_USERNAME: str | None = None
@@ -167,8 +181,8 @@ class Settings(BaseSettings):
     SERVER_STATUS_ITEMS_PER_PAGE: int = 10
 
     BASE_SUBSCRIPTION_PRICE: int = 50000
-    AVAILABLE_SUBSCRIPTION_PERIODS: str = '14,30,60,90,180,360'
-    AVAILABLE_RENEWAL_PERIODS: str = '30,90,180'
+    AVAILABLE_SUBSCRIPTION_PERIODS: str = "14,30,60,90,180,360"
+    AVAILABLE_RENEWAL_PERIODS: str = "30,90,180"
     PRICE_14_DAYS: int = 50000
     PRICE_30_DAYS: int = 99000
     PRICE_60_DAYS: int = 189000
@@ -187,27 +201,27 @@ class Settings(BaseSettings):
     PRICE_TRAFFIC_1000GB: int = 19500
     PRICE_TRAFFIC_UNLIMITED: int = 20000
 
-    TRAFFIC_PACKAGES_CONFIG: str = ''
+    TRAFFIC_PACKAGES_CONFIG: str = ""
 
     PRICE_PER_DEVICE: int = 5000
     DEVICES_SELECTION_ENABLED: bool = True
     DEVICES_SELECTION_DISABLED_AMOUNT: int | None = None
 
     BASE_PROMO_GROUP_PERIOD_DISCOUNTS_ENABLED: bool = False
-    BASE_PROMO_GROUP_PERIOD_DISCOUNTS: str = ''
+    BASE_PROMO_GROUP_PERIOD_DISCOUNTS: str = ""
 
     # Режим выбора трафика:
     # - selectable: пользователь выбирает трафик при покупке и может докупать
     # - fixed: фиксированный лимит, без выбора и без докупки
     # - fixed_with_topup: фиксированный лимит при покупке, но докупка разрешена (при продлении сброс до лимита)
-    TRAFFIC_SELECTION_MODE: str = 'selectable'
+    TRAFFIC_SELECTION_MODE: str = "selectable"
     FIXED_TRAFFIC_LIMIT_GB: int = 100
     BUY_TRAFFIC_BUTTON_VISIBLE: bool = True
 
     # Режим продаж подписок:
     # - classic: классический режим (выбор серверов, трафика, устройств, периода отдельно)
     # - tariffs: режим тарифов (готовые пакеты с фиксированными параметрами)
-    SALES_MODE: str = 'tariffs'
+    SALES_MODE: str = "tariffs"
 
     # Multi-tariff mode: allows users to purchase multiple tariffs simultaneously
     # Only works when SALES_MODE='tariffs'
@@ -222,14 +236,14 @@ class Settings(BaseSettings):
     # Настройки докупки трафика
     TRAFFIC_TOPUP_ENABLED: bool = True  # Включить/выключить функцию докупки трафика
     # Пакеты для докупки трафика (формат: "гб:цена:enabled", пустая строка = использовать TRAFFIC_PACKAGES_CONFIG)
-    TRAFFIC_TOPUP_PACKAGES_CONFIG: str = ''
+    TRAFFIC_TOPUP_PACKAGES_CONFIG: str = ""
 
     # Настройки сброса трафика
     # Режимы расчета цены сброса:
     # "period" - фиксированная цена = стоимость периода 30 дней (старое поведение)
     # "traffic" - цена зависит от текущего лимита трафика (цена пакета трафика)
     # "traffic_with_purchased" - цена = базовый трафик + докупленный трафик (рекомендуется)
-    TRAFFIC_RESET_PRICE_MODE: str = 'traffic_with_purchased'
+    TRAFFIC_RESET_PRICE_MODE: str = "traffic_with_purchased"
     # Базовая цена сброса в копейках (используется если режим "period" или как минимальная цена)
     TRAFFIC_RESET_BASE_PRICE: int = 0  # 0 = использовать PERIOD_PRICES[30]
 
@@ -237,7 +251,9 @@ class Settings(BaseSettings):
     REFERRAL_FIRST_TOPUP_BONUS_KOPEKS: int = 10000
     REFERRAL_INVITER_BONUS_KOPEKS: int = 10000
     REFERRAL_COMMISSION_PERCENT: int = 25
-    REFERRAL_MAX_COMMISSION_PAYMENTS: int = 0  # Макс. кол-во платежей реферала с комиссией (0 = без лимита)
+    REFERRAL_MAX_COMMISSION_PAYMENTS: int = (
+        0  # Макс. кол-во платежей реферала с комиссией (0 = без лимита)
+    )
 
     REFERRAL_PROGRAM_ENABLED: bool = True
     REFERRAL_NOTIFICATIONS_ENABLED: bool = True
@@ -247,15 +263,29 @@ class Settings(BaseSettings):
     REFERRAL_WITHDRAWAL_ENABLED: bool = False  # Включить возможность вывода
     REFERRAL_WITHDRAWAL_MIN_AMOUNT_KOPEKS: int = 100000  # Мин. сумма вывода (1000₽)
     REFERRAL_WITHDRAWAL_COOLDOWN_DAYS: int = 30  # Частота запросов на вывод
-    REFERRAL_WITHDRAWAL_ONLY_REFERRAL_BALANCE: bool = True  # Только реф. баланс (False = реф + свой)
-    REFERRAL_WITHDRAWAL_REQUISITES_TEXT: str = ''  # Текст-подсказка для реквизитов при выводе
-    REFERRAL_WITHDRAWAL_NOTIFICATIONS_TOPIC_ID: int | None = None  # Топик для уведомлений
-    REFERRAL_PARTNER_SECTION_VISIBLE: bool = True  # Показывать раздел партнёрки в кабинете
+    REFERRAL_WITHDRAWAL_ONLY_REFERRAL_BALANCE: bool = (
+        True  # Только реф. баланс (False = реф + свой)
+    )
+    REFERRAL_WITHDRAWAL_REQUISITES_TEXT: str = (
+        ""  # Текст-подсказка для реквизитов при выводе
+    )
+    REFERRAL_WITHDRAWAL_NOTIFICATIONS_TOPIC_ID: int | None = (
+        None  # Топик для уведомлений
+    )
+    REFERRAL_PARTNER_SECTION_VISIBLE: bool = (
+        True  # Показывать раздел партнёрки в кабинете
+    )
 
     # Настройки анализа на подозрительность
-    REFERRAL_WITHDRAWAL_SUSPICIOUS_MIN_DEPOSIT_KOPEKS: int = 50000  # Мин. сумма от 1 реферала (500₽)
-    REFERRAL_WITHDRAWAL_SUSPICIOUS_MAX_DEPOSITS_PER_MONTH: int = 10  # Макс. пополнений от 1 реферала/мес
-    REFERRAL_WITHDRAWAL_SUSPICIOUS_NO_PURCHASES_RATIO: float = 2.0  # Пополнил в X раз больше чем потратил
+    REFERRAL_WITHDRAWAL_SUSPICIOUS_MIN_DEPOSIT_KOPEKS: int = (
+        50000  # Мин. сумма от 1 реферала (500₽)
+    )
+    REFERRAL_WITHDRAWAL_SUSPICIOUS_MAX_DEPOSITS_PER_MONTH: int = (
+        10  # Макс. пополнений от 1 реферала/мес
+    )
+    REFERRAL_WITHDRAWAL_SUSPICIOUS_NO_PURCHASES_RATIO: float = (
+        2.0  # Пополнил в X раз больше чем потратил
+    )
 
     # Тестовый режим для вывода (позволяет админам вручную начислять реф. доход)
     REFERRAL_WITHDRAWAL_TEST_MODE: bool = False
@@ -284,9 +314,15 @@ class Settings(BaseSettings):
     MENU_LAYOUT_ENABLED: bool = False  # Включить управление меню через API
 
     # Настройки мониторинга трафика
-    TRAFFIC_MONITORING_ENABLED: bool = False  # Глобальный переключатель (для обратной совместимости)
-    TRAFFIC_THRESHOLD_GB_PER_DAY: float = 10.0  # Порог трафика в ГБ за сутки (для обратной совместимости)
-    TRAFFIC_MONITORING_INTERVAL_HOURS: int = 24  # Интервал проверки в часах (для обратной совместимости)
+    TRAFFIC_MONITORING_ENABLED: bool = (
+        False  # Глобальный переключатель (для обратной совместимости)
+    )
+    TRAFFIC_THRESHOLD_GB_PER_DAY: float = (
+        10.0  # Порог трафика в ГБ за сутки (для обратной совместимости)
+    )
+    TRAFFIC_MONITORING_INTERVAL_HOURS: int = (
+        24  # Интервал проверки в часах (для обратной совместимости)
+    )
     SUSPICIOUS_NOTIFICATIONS_TOPIC_ID: int | None = None
 
     # Новый мониторинг трафика v2
@@ -297,13 +333,15 @@ class Settings(BaseSettings):
 
     # Суточная проверка (трафик за 24 часа)
     TRAFFIC_DAILY_CHECK_ENABLED: bool = False
-    TRAFFIC_DAILY_CHECK_TIME: str = '00:00'  # Время суточной проверки (HH:MM)
+    TRAFFIC_DAILY_CHECK_TIME: str = "00:00"  # Время суточной проверки (HH:MM)
     TRAFFIC_DAILY_THRESHOLD_GB: float = 50.0  # Порог суточного трафика в ГБ
 
     # Фильтрация по серверам (UUID нод через запятую)
-    TRAFFIC_MONITORED_NODES: str = ''  # Только эти ноды (пусто = все)
-    TRAFFIC_IGNORED_NODES: str = ''  # Исключить эти ноды
-    TRAFFIC_EXCLUDED_USER_UUIDS: str = ''  # Исключить пользователей (UUID через запятую)
+    TRAFFIC_MONITORED_NODES: str = ""  # Только эти ноды (пусто = все)
+    TRAFFIC_IGNORED_NODES: str = ""  # Исключить эти ноды
+    TRAFFIC_EXCLUDED_USER_UUIDS: str = (
+        ""  # Исключить пользователей (UUID через запятую)
+    )
 
     # Параллельность и кулдаун
     TRAFFIC_CHECK_BATCH_SIZE: int = 1000  # Размер батча для получения пользователей
@@ -311,10 +349,12 @@ class Settings(BaseSettings):
     TRAFFIC_NOTIFICATION_COOLDOWN_MINUTES: int = 60  # Кулдаун уведомлений (минуты)
     TRAFFIC_SNAPSHOT_TTL_HOURS: int = 24  # TTL для snapshot трафика в Redis (часы)
     # Настройки суточных подписок
-    DAILY_SUBSCRIPTIONS_ENABLED: bool = True  # Включить автоматическое списание для суточных тарифов
+    DAILY_SUBSCRIPTIONS_ENABLED: bool = (
+        True  # Включить автоматическое списание для суточных тарифов
+    )
     DAILY_SUBSCRIPTIONS_CHECK_INTERVAL_MINUTES: int = 30  # Интервал проверки в минутах
 
-    AUTOPAY_WARNING_DAYS: str = '3,1'
+    AUTOPAY_WARNING_DAYS: str = "3,1"
 
     ENABLE_AUTOPAY: bool = False
 
@@ -331,44 +371,46 @@ class Settings(BaseSettings):
     MAINTENANCE_AUTO_ENABLE: bool = True
     MAINTENANCE_MONITORING_ENABLED: bool = True
     MAINTENANCE_RETRY_ATTEMPTS: int = 1
-    MAINTENANCE_MESSAGE: str = '🔧 Ведутся технические работы. Сервис временно недоступен. Попробуйте позже.'
+    MAINTENANCE_MESSAGE: str = (
+        "🔧 Ведутся технические работы. Сервис временно недоступен. Попробуйте позже."
+    )
 
     TELEGRAM_STARS_ENABLED: bool = True
     TELEGRAM_STARS_RATE_RUB: float = 1.3
-    TELEGRAM_STARS_DISPLAY_NAME: str = 'Telegram Stars'
+    TELEGRAM_STARS_DISPLAY_NAME: str = "Telegram Stars"
 
     # Telegram Login Widget (cabinet auth page)
-    TELEGRAM_WIDGET_SIZE: Literal['large', 'medium', 'small'] = 'large'
+    TELEGRAM_WIDGET_SIZE: Literal["large", "medium", "small"] = "large"
     TELEGRAM_WIDGET_RADIUS: int = Field(default=8, ge=0, le=20)
     TELEGRAM_WIDGET_USERPIC: bool = True
     TELEGRAM_WIDGET_REQUEST_ACCESS: bool = True
 
     # Telegram Login OIDC (new system via oauth.telegram.org)
     TELEGRAM_OIDC_ENABLED: bool = False
-    TELEGRAM_OIDC_CLIENT_ID: str = ''
-    TELEGRAM_OIDC_CLIENT_SECRET: str = ''
+    TELEGRAM_OIDC_CLIENT_ID: str = ""
+    TELEGRAM_OIDC_CLIENT_SECRET: str = ""
 
     TRIBUTE_ENABLED: bool = False
     TRIBUTE_API_KEY: str | None = None
     TRIBUTE_DONATE_LINK: str | None = None
-    TRIBUTE_WEBHOOK_PATH: str = '/tribute-webhook'
-    TRIBUTE_WEBHOOK_HOST: str = '0.0.0.0'
+    TRIBUTE_WEBHOOK_PATH: str = "/tribute-webhook"
+    TRIBUTE_WEBHOOK_HOST: str = "0.0.0.0"
     TRIBUTE_WEBHOOK_PORT: int = 8081
 
     YOOKASSA_ENABLED: bool = False
-    YOOKASSA_DISPLAY_NAME: str = 'YooKassa'
+    YOOKASSA_DISPLAY_NAME: str = "YooKassa"
     YOOKASSA_SHOP_ID: str | None = None
     YOOKASSA_SECRET_KEY: str | None = None
     YOOKASSA_RETURN_URL: str | None = None
     YOOKASSA_DEFAULT_RECEIPT_EMAIL: str | None = None
     YOOKASSA_VAT_CODE: int = 1
     YOOKASSA_SBP_ENABLED: bool = False
-    YOOKASSA_PAYMENT_MODE: str = 'full_payment'
-    YOOKASSA_PAYMENT_SUBJECT: str = 'service'
-    YOOKASSA_WEBHOOK_PATH: str = '/yookassa-webhook'
-    YOOKASSA_WEBHOOK_HOST: str = '0.0.0.0'
+    YOOKASSA_PAYMENT_MODE: str = "full_payment"
+    YOOKASSA_PAYMENT_SUBJECT: str = "service"
+    YOOKASSA_WEBHOOK_PATH: str = "/yookassa-webhook"
+    YOOKASSA_WEBHOOK_HOST: str = "0.0.0.0"
     YOOKASSA_WEBHOOK_PORT: int = 8082
-    YOOKASSA_TRUSTED_PROXY_NETWORKS: str = ''
+    YOOKASSA_TRUSTED_PROXY_NETWORKS: str = ""
     YOOKASSA_MIN_AMOUNT_KOPEKS: int = 5000
     YOOKASSA_MAX_AMOUNT_KOPEKS: int = 1000000
     YOOKASSA_RECURRENT_ENABLED: bool = False
@@ -382,44 +424,46 @@ class Settings(BaseSettings):
     NALOGO_INN: str | None = None
     NALOGO_PASSWORD: str | None = None
     NALOGO_DEVICE_ID: str | None = None
-    NALOGO_STORAGE_PATH: str = './nalogo_tokens.json'
-    NALOGO_PROXY_URL: str | None = None  # SOCKS proxy for nalog.ru; falls back to PROXY_URL if not set
+    NALOGO_STORAGE_PATH: str = "./nalogo_tokens.json"
+    NALOGO_PROXY_URL: str | None = (
+        None  # SOCKS proxy for nalog.ru; falls back to PROXY_URL if not set
+    )
 
     AUTO_PURCHASE_AFTER_TOPUP_ENABLED: bool = False
 
     # Отключение превью ссылок в сообщениях бота
     DISABLE_WEB_PAGE_PREVIEW: bool = False
     ACTIVATE_BUTTON_VISIBLE: bool = False
-    ACTIVATE_BUTTON_TEXT: str = 'активировать'
-    PAYMENT_BALANCE_DESCRIPTION: str = 'Пополнение баланса'
-    PAYMENT_SUBSCRIPTION_DESCRIPTION: str = 'Оплата подписки'
-    PAYMENT_SERVICE_NAME: str = 'Интернет-сервис'
-    PAYMENT_BALANCE_TEMPLATE: str = '{service_name} - {description}'
-    PAYMENT_SUBSCRIPTION_TEMPLATE: str = '{service_name} - {description}'
+    ACTIVATE_BUTTON_TEXT: str = "активировать"
+    PAYMENT_BALANCE_DESCRIPTION: str = "Пополнение баланса"
+    PAYMENT_SUBSCRIPTION_DESCRIPTION: str = "Оплата подписки"
+    PAYMENT_SERVICE_NAME: str = "Интернет-сервис"
+    PAYMENT_BALANCE_TEMPLATE: str = "{service_name} - {description}"
+    PAYMENT_SUBSCRIPTION_TEMPLATE: str = "{service_name} - {description}"
 
     CRYPTOBOT_ENABLED: bool = False
-    CRYPTOBOT_DISPLAY_NAME: str = 'CryptoBot'
+    CRYPTOBOT_DISPLAY_NAME: str = "CryptoBot"
     CRYPTOBOT_API_TOKEN: str | None = None
     CRYPTOBOT_WEBHOOK_SECRET: str | None = None
-    CRYPTOBOT_BASE_URL: str = 'https://pay.crypt.bot'
+    CRYPTOBOT_BASE_URL: str = "https://pay.crypt.bot"
     CRYPTOBOT_TESTNET: bool = False
-    CRYPTOBOT_WEBHOOK_PATH: str = '/cryptobot-webhook'
+    CRYPTOBOT_WEBHOOK_PATH: str = "/cryptobot-webhook"
     CRYPTOBOT_WEBHOOK_PORT: int = 8083
-    CRYPTOBOT_DEFAULT_ASSET: str = 'USDT'
-    CRYPTOBOT_ASSETS: str = 'USDT,TON,BTC,ETH'
+    CRYPTOBOT_DEFAULT_ASSET: str = "USDT"
+    CRYPTOBOT_ASSETS: str = "USDT,TON,BTC,ETH"
     CRYPTOBOT_INVOICE_EXPIRES_HOURS: int = 24
 
     HELEKET_ENABLED: bool = False
-    HELEKET_DISPLAY_NAME: str = 'Heleket Crypto'
+    HELEKET_DISPLAY_NAME: str = "Heleket Crypto"
     HELEKET_MERCHANT_ID: str | None = None
     HELEKET_API_KEY: str | None = None
-    HELEKET_BASE_URL: str = 'https://api.heleket.com/v1'
-    HELEKET_DEFAULT_CURRENCY: str = 'USDT'
+    HELEKET_BASE_URL: str = "https://api.heleket.com/v1"
+    HELEKET_DEFAULT_CURRENCY: str = "USDT"
     HELEKET_DEFAULT_NETWORK: str | None = None
     HELEKET_INVOICE_LIFETIME: int = 3600
     HELEKET_MARKUP_PERCENT: float = 0.0
-    HELEKET_WEBHOOK_PATH: str = '/heleket-webhook'
-    HELEKET_WEBHOOK_HOST: str = '0.0.0.0'
+    HELEKET_WEBHOOK_PATH: str = "/heleket-webhook"
+    HELEKET_WEBHOOK_HOST: str = "0.0.0.0"
     HELEKET_WEBHOOK_PORT: int = 8086
     HELEKET_CALLBACK_URL: str | None = None
     HELEKET_RETURN_URL: str | None = None
@@ -429,14 +473,14 @@ class Settings(BaseSettings):
     MULENPAY_API_KEY: str | None = None
     MULENPAY_SECRET_KEY: str | None = None
     MULENPAY_SHOP_ID: int | None = None
-    MULENPAY_BASE_URL: str = 'https://mulenpay.ru/api'
-    MULENPAY_WEBHOOK_PATH: str = '/mulenpay-webhook'
-    MULENPAY_DISPLAY_NAME: str = 'Mulen Pay'
-    MULENPAY_DESCRIPTION: str = 'Пополнение баланса'
-    MULENPAY_LANGUAGE: str = 'ru'
+    MULENPAY_BASE_URL: str = "https://mulenpay.ru/api"
+    MULENPAY_WEBHOOK_PATH: str = "/mulenpay-webhook"
+    MULENPAY_DISPLAY_NAME: str = "Mulen Pay"
+    MULENPAY_DESCRIPTION: str = "Пополнение баланса"
+    MULENPAY_LANGUAGE: str = "ru"
     MULENPAY_VAT_CODE: int = 0
 
-    DISPLAY_NAME_BANNED_KEYWORDS: str = '\n'.join(DEFAULT_DISPLAY_NAME_BANNED_KEYWORDS)
+    DISPLAY_NAME_BANNED_KEYWORDS: str = "\n".join(DEFAULT_DISPLAY_NAME_BANNED_KEYWORDS)
     MULENPAY_PAYMENT_SUBJECT: int = 4
     MULENPAY_PAYMENT_MODE: int = 4
     MULENPAY_MIN_AMOUNT_KOPEKS: int = 10000
@@ -445,13 +489,13 @@ class Settings(BaseSettings):
     MULENPAY_WEBSITE_URL: str | None = None
 
     PAL24_ENABLED: bool = False
-    PAL24_DISPLAY_NAME: str = 'PAL24'
+    PAL24_DISPLAY_NAME: str = "PAL24"
     PAL24_API_TOKEN: str | None = None
     PAL24_SHOP_ID: str | None = None
     PAL24_SIGNATURE_TOKEN: str | None = None
-    PAL24_BASE_URL: str = 'https://pal24.pro/api/v1/'
-    PAL24_WEBHOOK_PATH: str = '/pal24-webhook'
-    PAL24_PAYMENT_DESCRIPTION: str = 'Пополнение баланса'
+    PAL24_BASE_URL: str = "https://pal24.pro/api/v1/"
+    PAL24_WEBHOOK_PATH: str = "/pal24-webhook"
+    PAL24_PAYMENT_DESCRIPTION: str = "Пополнение баланса"
     PAL24_MIN_AMOUNT_KOPEKS: int = 10000
     PAL24_MAX_AMOUNT_KOPEKS: int = 100000000
     PAL24_REQUEST_TIMEOUT: int = 30
@@ -463,54 +507,54 @@ class Settings(BaseSettings):
     PLATEGA_ENABLED: bool = False
     PLATEGA_MERCHANT_ID: str | None = None
     PLATEGA_SECRET: str | None = None
-    PLATEGA_DISPLAY_NAME: str = 'Platega'
-    PLATEGA_BASE_URL: str = 'https://app.platega.io'
+    PLATEGA_DISPLAY_NAME: str = "Platega"
+    PLATEGA_BASE_URL: str = "https://app.platega.io"
     PLATEGA_RETURN_URL: str | None = None
     PLATEGA_FAILED_URL: str | None = None
-    PLATEGA_CURRENCY: str = 'RUB'
-    PLATEGA_ACTIVE_METHODS: str = '2,11,12,13'
+    PLATEGA_CURRENCY: str = "RUB"
+    PLATEGA_ACTIVE_METHODS: str = "2,11,12,13"
     PLATEGA_INLINE_METHODS: bool = True
     PLATEGA_MIN_AMOUNT_KOPEKS: int = 10000
     PLATEGA_MAX_AMOUNT_KOPEKS: int = 100000000
-    PLATEGA_WEBHOOK_PATH: str = '/platega-webhook'
-    PLATEGA_WEBHOOK_HOST: str = '0.0.0.0'
+    PLATEGA_WEBHOOK_PATH: str = "/platega-webhook"
+    PLATEGA_WEBHOOK_HOST: str = "0.0.0.0"
     PLATEGA_WEBHOOK_PORT: int = 8086
 
     WATA_ENABLED: bool = False
-    WATA_DISPLAY_NAME: str = 'Wata'
-    WATA_BASE_URL: str = 'https://api.wata.pro/api/h2h'
+    WATA_DISPLAY_NAME: str = "Wata"
+    WATA_BASE_URL: str = "https://api.wata.pro/api/h2h"
     WATA_ACCESS_TOKEN: str | None = None
     WATA_TERMINAL_PUBLIC_ID: str | None = None
-    WATA_PAYMENT_DESCRIPTION: str = 'Пополнение баланса'
-    WATA_PAYMENT_TYPE: str = 'OneTime'
+    WATA_PAYMENT_DESCRIPTION: str = "Пополнение баланса"
+    WATA_PAYMENT_TYPE: str = "OneTime"
     WATA_SUCCESS_REDIRECT_URL: str | None = None
     WATA_FAIL_REDIRECT_URL: str | None = None
     WATA_LINK_TTL_MINUTES: int | None = None
     WATA_MIN_AMOUNT_KOPEKS: int = 10000
     WATA_MAX_AMOUNT_KOPEKS: int = 100000000
     WATA_REQUEST_TIMEOUT: int = 30
-    WATA_WEBHOOK_PATH: str = '/wata-webhook'
-    WATA_WEBHOOK_HOST: str = '0.0.0.0'
+    WATA_WEBHOOK_PATH: str = "/wata-webhook"
+    WATA_WEBHOOK_HOST: str = "0.0.0.0"
     WATA_WEBHOOK_PORT: int = 8085
     WATA_PUBLIC_KEY_URL: str | None = None
     WATA_PUBLIC_KEY_CACHE_SECONDS: int = 3600
 
     # CloudPayments
     CLOUDPAYMENTS_ENABLED: bool = False
-    CLOUDPAYMENTS_DISPLAY_NAME: str = 'CloudPayments'
+    CLOUDPAYMENTS_DISPLAY_NAME: str = "CloudPayments"
     CLOUDPAYMENTS_PUBLIC_ID: str | None = None
     CLOUDPAYMENTS_API_SECRET: str | None = None
-    CLOUDPAYMENTS_API_URL: str = 'https://api.cloudpayments.ru'
-    CLOUDPAYMENTS_WIDGET_URL: str = 'https://widget.cloudpayments.ru/show'
-    CLOUDPAYMENTS_DESCRIPTION: str = 'Пополнение баланса'
-    CLOUDPAYMENTS_CURRENCY: str = 'RUB'
+    CLOUDPAYMENTS_API_URL: str = "https://api.cloudpayments.ru"
+    CLOUDPAYMENTS_WIDGET_URL: str = "https://widget.cloudpayments.ru/show"
+    CLOUDPAYMENTS_DESCRIPTION: str = "Пополнение баланса"
+    CLOUDPAYMENTS_CURRENCY: str = "RUB"
     CLOUDPAYMENTS_MIN_AMOUNT_KOPEKS: int = 5000
     CLOUDPAYMENTS_MAX_AMOUNT_KOPEKS: int = 10000000
-    CLOUDPAYMENTS_WEBHOOK_PATH: str = '/cloudpayments-webhook'
-    CLOUDPAYMENTS_WEBHOOK_HOST: str = '0.0.0.0'
+    CLOUDPAYMENTS_WEBHOOK_PATH: str = "/cloudpayments-webhook"
+    CLOUDPAYMENTS_WEBHOOK_HOST: str = "0.0.0.0"
     CLOUDPAYMENTS_WEBHOOK_PORT: int = 8087
     CLOUDPAYMENTS_RETURN_URL: str | None = None
-    CLOUDPAYMENTS_SKIN: str = 'mini'  # mini, classic, modern
+    CLOUDPAYMENTS_SKIN: str = "mini"  # mini, classic, modern
     CLOUDPAYMENTS_REQUIRE_EMAIL: bool = False
     CLOUDPAYMENTS_TEST_MODE: bool = False
 
@@ -520,13 +564,13 @@ class Settings(BaseSettings):
     FREEKASSA_API_KEY: str | None = None
     FREEKASSA_SECRET_WORD_1: str | None = None  # Для формы оплаты
     FREEKASSA_SECRET_WORD_2: str | None = None  # Для webhook
-    FREEKASSA_DISPLAY_NAME: str = 'Freekassa'
-    FREEKASSA_CURRENCY: str = 'RUB'
+    FREEKASSA_DISPLAY_NAME: str = "Freekassa"
+    FREEKASSA_CURRENCY: str = "RUB"
     FREEKASSA_MIN_AMOUNT_KOPEKS: int = 10000  # 100 руб
     FREEKASSA_MAX_AMOUNT_KOPEKS: int = 100000000  # 1 000 000 руб
     FREEKASSA_PAYMENT_TIMEOUT_SECONDS: int = 3600
-    FREEKASSA_WEBHOOK_PATH: str = '/freekassa-webhook'
-    FREEKASSA_WEBHOOK_HOST: str = '0.0.0.0'
+    FREEKASSA_WEBHOOK_PATH: str = "/freekassa-webhook"
+    FREEKASSA_WEBHOOK_HOST: str = "0.0.0.0"
     FREEKASSA_WEBHOOK_PORT: int = 8088
     # Способ оплаты: None = форма выбора, 42 = обычный СБП, 44 = NSPK СБП
     FREEKASSA_PAYMENT_SYSTEM_ID: int | None = None
@@ -536,41 +580,43 @@ class Settings(BaseSettings):
     SERVER_PUBLIC_IP: str | None = None
     # Раздельные методы оплаты Freekassa (отображаются как отдельные кнопки)
     FREEKASSA_SBP_ENABLED: bool = False  # СБП (QR код) — i=44
-    FREEKASSA_SBP_DISPLAY_NAME: str = 'СБП (QR код)'
+    FREEKASSA_SBP_DISPLAY_NAME: str = "СБП (QR код)"
     FREEKASSA_CARD_ENABLED: bool = False  # Карты РФ — i=36
-    FREEKASSA_CARD_DISPLAY_NAME: str = 'Карта РФ'
+    FREEKASSA_CARD_DISPLAY_NAME: str = "Карта РФ"
 
     # KassaAI (api.fk.life) - отдельная платёжка
     KASSA_AI_ENABLED: bool = False
     KASSA_AI_SHOP_ID: int | None = None
     KASSA_AI_API_KEY: str | None = None
     KASSA_AI_SECRET_WORD_2: str | None = None  # Для webhook
-    KASSA_AI_DISPLAY_NAME: str = 'KassaAI'
-    KASSA_AI_CURRENCY: str = 'RUB'
+    KASSA_AI_DISPLAY_NAME: str = "KassaAI"
+    KASSA_AI_CURRENCY: str = "RUB"
     KASSA_AI_MIN_AMOUNT_KOPEKS: int = 10000  # 100 руб
     KASSA_AI_MAX_AMOUNT_KOPEKS: int = 100000000  # 1 000 000 руб
-    KASSA_AI_WEBHOOK_PATH: str = '/kassa-ai-webhook'
-    KASSA_AI_WEBHOOK_HOST: str = '0.0.0.0'
+    KASSA_AI_WEBHOOK_PATH: str = "/kassa-ai-webhook"
+    KASSA_AI_WEBHOOK_HOST: str = "0.0.0.0"
     KASSA_AI_WEBHOOK_PORT: int = 8089
     # Способ оплаты: 44 = СБП (QR код), 36 = Карты РФ, 43 = SberPay
     KASSA_AI_PAYMENT_SYSTEM_ID: int = 44
     # Раздельные методы оплаты KassaAI (отображаются как отдельные кнопки)
     KASSA_AI_SBP_ENABLED: bool = False  # СБП — payment_system_id=44
-    KASSA_AI_SBP_DISPLAY_NAME: str = 'СБП (KassaAI)'
+    KASSA_AI_SBP_DISPLAY_NAME: str = "СБП (KassaAI)"
     KASSA_AI_CARD_ENABLED: bool = False  # Карты РФ — payment_system_id=36
-    KASSA_AI_CARD_DISPLAY_NAME: str = 'Карта (KassaAI)'
+    KASSA_AI_CARD_DISPLAY_NAME: str = "Карта (KassaAI)"
     KASSA_AI_SBERPAY_ENABLED: bool = False  # SberPay — payment_system_id=43
-    KASSA_AI_SBERPAY_DISPLAY_NAME: str = 'SberPay (KassaAI)'
+    KASSA_AI_SBERPAY_DISPLAY_NAME: str = "SberPay (KassaAI)"
 
     # RioPay (api.riopay.online) v2.0.1
     RIOPAY_ENABLED: bool = False
     RIOPAY_API_TOKEN: str | None = None  # x-api-token header
-    RIOPAY_WEBHOOK_SECRET: str | None = None  # HMAC-SHA512 ключ для вебхуков (по умолчанию = API_TOKEN)
-    RIOPAY_DISPLAY_NAME: str = 'RioPay'
-    RIOPAY_CURRENCY: str = 'RUB'
+    RIOPAY_WEBHOOK_SECRET: str | None = (
+        None  # HMAC-SHA512 ключ для вебхуков (по умолчанию = API_TOKEN)
+    )
+    RIOPAY_DISPLAY_NAME: str = "RioPay"
+    RIOPAY_CURRENCY: str = "RUB"
     RIOPAY_MIN_AMOUNT_KOPEKS: int = 10000  # 100₽
     RIOPAY_MAX_AMOUNT_KOPEKS: int = 100000000  # 1 000 000₽
-    RIOPAY_WEBHOOK_PATH: str = '/riopay-webhook'
+    RIOPAY_WEBHOOK_PATH: str = "/riopay-webhook"
     RIOPAY_SUCCESS_URL: str | None = None
     RIOPAY_FAIL_URL: str | None = None
 
@@ -578,32 +624,32 @@ class Settings(BaseSettings):
     SEVERPAY_ENABLED: bool = False
     SEVERPAY_MID: int | None = None  # Merchant ID
     SEVERPAY_TOKEN: str | None = None  # Secret token for HMAC-SHA256
-    SEVERPAY_DISPLAY_NAME: str = 'SeverPay'
-    SEVERPAY_CURRENCY: str = 'RUB'
+    SEVERPAY_DISPLAY_NAME: str = "SeverPay"
+    SEVERPAY_CURRENCY: str = "RUB"
     SEVERPAY_MIN_AMOUNT_KOPEKS: int = 10000  # 100₽
     SEVERPAY_MAX_AMOUNT_KOPEKS: int = 10000000  # 100 000₽
-    SEVERPAY_WEBHOOK_PATH: str = '/severpay-webhook'
+    SEVERPAY_WEBHOOK_PATH: str = "/severpay-webhook"
     SEVERPAY_RETURN_URL: str | None = None
     SEVERPAY_LIFETIME: int = 1440  # minutes, 30-4320
 
-    MAIN_MENU_MODE: str = 'default'  # 'default' | 'cabinet'
+    MAIN_MENU_MODE: str = "default"  # 'default' | 'cabinet'
     # Стиль кнопок Cabinet: primary (синий), success (зелёный), danger (красный), '' (по умолчанию для каждой секции)
-    CABINET_BUTTON_STYLE: str = ''
-    CONNECT_BUTTON_MODE: str = 'miniapp_subscription'
-    MINIAPP_CUSTOM_URL: str = ''
-    MINIAPP_STATIC_PATH: str = 'miniapp'
+    CABINET_BUTTON_STYLE: str = ""
+    CONNECT_BUTTON_MODE: str = "miniapp_subscription"
+    MINIAPP_CUSTOM_URL: str = ""
+    MINIAPP_STATIC_PATH: str = "miniapp"
 
     # Media upload settings (news article images/videos)
-    MEDIA_UPLOAD_DIR: str = './uploads'
+    MEDIA_UPLOAD_DIR: str = "./uploads"
     MEDIA_MAX_IMAGE_SIZE_MB: int = 10
     MEDIA_MAX_VIDEO_SIZE_MB: int = 50
     MEDIA_IMAGE_MAX_DIMENSION: int = 2048
     MEDIA_JPEG_QUALITY: int = 85
-    MINIAPP_PURCHASE_URL: str = ''
-    MINIAPP_SERVICE_NAME_EN: str = 'Bedolaga VPN'
-    MINIAPP_SERVICE_NAME_RU: str = 'Bedolaga VPN'
-    MINIAPP_SERVICE_DESCRIPTION_EN: str = 'Secure & Fast Connection'
-    MINIAPP_SERVICE_DESCRIPTION_RU: str = 'Безопасное и быстрое подключение'
+    MINIAPP_PURCHASE_URL: str = ""
+    MINIAPP_SERVICE_NAME_EN: str = "Bedolaga VPN"
+    MINIAPP_SERVICE_NAME_RU: str = "Bedolaga VPN"
+    MINIAPP_SERVICE_DESCRIPTION_EN: str = "Secure & Fast Connection"
+    MINIAPP_SERVICE_DESCRIPTION_RU: str = "Безопасное и быстрое подключение"
     CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED: bool = False
     HAPP_CRYPTOLINK_REDIRECT_TEMPLATE: str | None = None
     HAPP_DOWNLOAD_LINK_IOS: str | None = None
@@ -613,24 +659,24 @@ class Settings(BaseSettings):
     HAPP_DOWNLOAD_LINK_PC: str | None = None
     HIDE_SUBSCRIPTION_LINK: bool = False
     ENABLE_LOGO_MODE: bool = True
-    LOGO_FILE: str = 'vpn_logo.png'
+    LOGO_FILE: str = "vpn_logo.png"
     SKIP_RULES_ACCEPT: bool = False
     SKIP_REFERRAL_CODE: bool = False
 
-    DEFAULT_LANGUAGE: str = 'ru'
-    AVAILABLE_LANGUAGES: str = 'ru,en,ua,zh,fa'
+    DEFAULT_LANGUAGE: str = "ru"
+    AVAILABLE_LANGUAGES: str = "ru,en,ua,zh,fa"
     LANGUAGE_SELECTION_ENABLED: bool = True
 
     # Округление цен при отображении (≤50 коп вниз, >50 коп вверх)
     PRICE_ROUNDING_ENABLED: bool = True
 
-    LOG_LEVEL: str = 'INFO'
-    LOG_FILE: str = 'logs/bot.log'
+    LOG_LEVEL: str = "INFO"
+    LOG_FILE: str = "logs/bot.log"
     LOG_COLORS: bool = True  # ANSI-цвета в консоли (false для plain-text вывода)
 
     # === Log Rotation Settings ===
     LOG_ROTATION_ENABLED: bool = False  # По умолчанию старое поведение
-    LOG_ROTATION_TIME: str = '00:00'  # Время ротации (HH:MM)
+    LOG_ROTATION_TIME: str = "00:00"  # Время ротации (HH:MM)
     LOG_ROTATION_KEEP_DAYS: int = 7  # Хранить архивы N дней
     LOG_ROTATION_COMPRESS: bool = True  # Сжимать архивы gzip
     LOG_ROTATION_SEND_TO_TELEGRAM: bool = False  # Отправлять в канал
@@ -638,116 +684,116 @@ class Settings(BaseSettings):
     LOG_ROTATION_TOPIC_ID: int | None = None  # Топик в канале
 
     # Пути к лог-файлам (при LOG_ROTATION_ENABLED=true)
-    LOG_DIR: str = 'logs'
-    LOG_INFO_FILE: str = 'info.log'
-    LOG_WARNING_FILE: str = 'warning.log'
-    LOG_ERROR_FILE: str = 'error.log'
-    LOG_PAYMENTS_FILE: str = 'payments.log'
+    LOG_DIR: str = "logs"
+    LOG_INFO_FILE: str = "info.log"
+    LOG_WARNING_FILE: str = "warning.log"
+    LOG_ERROR_FILE: str = "error.log"
+    LOG_PAYMENTS_FILE: str = "payments.log"
 
     # === Ban Notification Messages ===
 
     # Сообщение о блокировке за превышение лимита устройств
     # Переменные: {ip_count}, {limit}, {ban_minutes}, {node_info}
     BAN_MSG_PUNISHMENT: str = (
-        '🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n\n'
-        '❌ <b>Причина:</b> Превышен лимит устройств\n'
-        '{node_info}\n'
-        '📊 <b>Детали нарушения:</b>\n'
-        '├ 📱 Устройств подключено: <b>{ip_count}</b>\n'
-        '├ 📋 Разрешено по тарифу: <b>{limit}</b>\n'
-        '└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n'
-        '💡 <b>Что делать:</b>\n'
-        '1. Отключите лишние устройства от VPN\n'
-        '2. Дождитесь окончания блокировки\n'
-        '3. Подключитесь заново\n\n'
-        '🔄 Доступ восстановится автоматически'
+        "🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "❌ <b>Причина:</b> Превышен лимит устройств\n"
+        "{node_info}\n"
+        "📊 <b>Детали нарушения:</b>\n"
+        "├ 📱 Устройств подключено: <b>{ip_count}</b>\n"
+        "├ 📋 Разрешено по тарифу: <b>{limit}</b>\n"
+        "└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n"
+        "💡 <b>Что делать:</b>\n"
+        "1. Отключите лишние устройства от VPN\n"
+        "2. Дождитесь окончания блокировки\n"
+        "3. Подключитесь заново\n\n"
+        "🔄 Доступ восстановится автоматически"
     )
 
     # Сообщение о разблокировке
     BAN_MSG_ENABLED: str = (
-        '✅ <b>АККАУНТ РАЗБЛОКИРОВАН</b>\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n\n'
-        '🎉 Ваш аккаунт успешно разблокирован!\n\n'
-        'Теперь вы можете снова пользоваться VPN.\n\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n'
-        '⚠️ <b>Рекомендации:</b>\n'
-        '• Следите за количеством устройств\n'
-        '• Отключайте VPN когда не используете\n'
-        '• Не превышайте лимит по тарифу'
+        "✅ <b>АККАУНТ РАЗБЛОКИРОВАН</b>\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "🎉 Ваш аккаунт успешно разблокирован!\n\n"
+        "Теперь вы можете снова пользоваться VPN.\n\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n"
+        "⚠️ <b>Рекомендации:</b>\n"
+        "• Следите за количеством устройств\n"
+        "• Отключайте VPN когда не используете\n"
+        "• Не превышайте лимит по тарифу"
     )
 
     # Сообщение о блокировке за WiFi
     # Переменные: {ban_minutes}, {network_info}, {node_info}
     BAN_MSG_WIFI: str = (
-        '🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n\n'
-        '❌ <b>Причина:</b> Использование WiFi сети\n'
-        '{node_info}\n'
-        '📊 <b>Детали:</b>\n'
-        '├ 📶 Тип подключения: <b>WiFi</b>\n'
-        '{network_info}'
-        '└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n'
-        '💡 <b>Что делать:</b>\n'
-        '1. Отключитесь от WiFi\n'
-        '2. Используйте мобильный интернет\n'
-        '3. Дождитесь окончания блокировки\n\n'
-        '🔄 Доступ восстановится автоматически'
+        "🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "❌ <b>Причина:</b> Использование WiFi сети\n"
+        "{node_info}\n"
+        "📊 <b>Детали:</b>\n"
+        "├ 📶 Тип подключения: <b>WiFi</b>\n"
+        "{network_info}"
+        "└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n"
+        "💡 <b>Что делать:</b>\n"
+        "1. Отключитесь от WiFi\n"
+        "2. Используйте мобильный интернет\n"
+        "3. Дождитесь окончания блокировки\n\n"
+        "🔄 Доступ восстановится автоматически"
     )
 
     # Сообщение о блокировке за мобильную сеть
     # Переменные: {ban_minutes}, {network_info}, {node_info}
     BAN_MSG_MOBILE: str = (
-        '🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n\n'
-        '❌ <b>Причина:</b> Использование мобильной сети\n'
-        '{node_info}\n'
-        '📊 <b>Детали:</b>\n'
-        '├ 📱 Тип подключения: <b>Мобильная сеть</b>\n'
-        '{network_info}'
-        '└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n'
-        '💡 <b>Что делать:</b>\n'
-        '1. Подключитесь к WiFi\n'
-        '2. Дождитесь окончания блокировки\n'
-        '3. Используйте VPN только через WiFi\n\n'
-        '🔄 Доступ восстановится автоматически'
+        "🚫 <b>АККАУНТ ЗАБЛОКИРОВАН</b>\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "❌ <b>Причина:</b> Использование мобильной сети\n"
+        "{node_info}\n"
+        "📊 <b>Детали:</b>\n"
+        "├ 📱 Тип подключения: <b>Мобильная сеть</b>\n"
+        "{network_info}"
+        "└ ⏱ Время блокировки: <b>{ban_minutes} мин</b>\n\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n"
+        "💡 <b>Что делать:</b>\n"
+        "1. Подключитесь к WiFi\n"
+        "2. Дождитесь окончания блокировки\n"
+        "3. Используйте VPN только через WiFi\n\n"
+        "🔄 Доступ восстановится автоматически"
     )
 
     # Сообщение-предупреждение
     # Переменные: {warning_message}
     BAN_MSG_WARNING: str = (
-        '⚠️ <b>ПРЕДУПРЕЖДЕНИЕ</b>\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n\n'
-        '{warning_message}\n\n'
-        '━━━━━━━━━━━━━━━━━━━━━\n'
-        '❗ При повторном нарушении аккаунт будет заблокирован'
+        "⚠️ <b>ПРЕДУПРЕЖДЕНИЕ</b>\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "{warning_message}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━━\n"
+        "❗ При повторном нарушении аккаунт будет заблокирован"
     )
 
     DEBUG: bool = False
     WEBHOOK_URL: str | None = None
-    WEBHOOK_PATH: str = '/webhook'
+    WEBHOOK_PATH: str = "/webhook"
     WEBHOOK_SECRET_TOKEN: str | None = None
     WEBHOOK_DROP_PENDING_UPDATES: bool = True
     WEBHOOK_MAX_QUEUE_SIZE: int = 1024
     WEBHOOK_WORKERS: int = 4
     WEBHOOK_ENQUEUE_TIMEOUT: float = 0.1
     WEBHOOK_WORKER_SHUTDOWN_TIMEOUT: float = 30.0
-    BOT_RUN_MODE: str = 'polling'
+    BOT_RUN_MODE: str = "polling"
 
     WEB_API_ENABLED: bool = False
-    WEB_API_HOST: str = '0.0.0.0'
+    WEB_API_HOST: str = "0.0.0.0"
     WEB_API_PORT: int = 8080
     WEB_API_WORKERS: int = 1
-    WEB_API_ALLOWED_ORIGINS: str = '*'
+    WEB_API_ALLOWED_ORIGINS: str = "*"
     WEB_API_DOCS_ENABLED: bool = False
-    WEB_API_TITLE: str = 'Remnawave Bot Admin API'
-    WEB_API_VERSION: str = '1.0.0'
+    WEB_API_TITLE: str = "Remnawave Bot Admin API"
+    WEB_API_VERSION: str = "1.0.0"
     WEB_API_DEFAULT_TOKEN: str | None = None
-    WEB_API_DEFAULT_TOKEN_NAME: str = 'Bootstrap Token'
-    WEB_API_TOKEN_HASH_ALGORITHM: str = 'sha256'
+    WEB_API_DEFAULT_TOKEN_NAME: str = "Bootstrap Token"
+    WEB_API_TOKEN_HASH_ALGORITHM: str = "sha256"
     WEB_API_TOKEN_HMAC_SECRET: str | None = None
     WEB_API_REQUEST_LOGGING: bool = True
 
@@ -755,16 +801,16 @@ class Settings(BaseSettings):
     APP_CONFIG_CACHE_TTL: int = 3600
 
     VERSION_CHECK_ENABLED: bool = True
-    VERSION_CHECK_REPO: str = 'fr1ngg/remnawave-bedolaga-telegram-bot'
+    VERSION_CHECK_REPO: str = "fr1ngg/remnawave-bedolaga-telegram-bot"
     VERSION_CHECK_INTERVAL_HOURS: int = 1
 
     BACKUP_AUTO_ENABLED: bool = True
     BACKUP_INTERVAL_HOURS: int = 24
-    BACKUP_TIME: str = '03:00'
+    BACKUP_TIME: str = "03:00"
     BACKUP_MAX_KEEP: int = 7
     BACKUP_COMPRESSION: bool = True
     BACKUP_INCLUDE_LOGS: bool = False
-    BACKUP_LOCATION: str = '/app/data/backups'
+    BACKUP_LOCATION: str = "/app/data/backups"
     BACKUP_SEND_ENABLED: bool = False
     BACKUP_SEND_CHAT_ID: str | None = None
     BACKUP_SEND_TOPIC_ID: int | None = None
@@ -778,32 +824,34 @@ class Settings(BaseSettings):
     CABINET_JWT_SECRET: str | None = None
     CABINET_ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     CABINET_REFRESH_TOKEN_EXPIRE_DAYS: int = 7
-    CABINET_ALLOWED_ORIGINS: str = ''
+    CABINET_ALLOWED_ORIGINS: str = ""
     CABINET_EMAIL_VERIFICATION_ENABLED: bool = True
     CABINET_EMAIL_VERIFICATION_EXPIRE_HOURS: int = 24
     CABINET_PASSWORD_RESET_EXPIRE_HOURS: int = 1
-    CABINET_EMAIL_CHANGE_CODE_EXPIRE_MINUTES: int = 15  # Email change verification code expiration
-    CABINET_EMAIL_AUTH_ENABLED: bool = True  # Enable email registration/login in cabinet
-    CABINET_URL: str = 'https://example.com/cabinet'  # Base URL for cabinet (used in verification emails)
-    CABINET_TRUSTED_PROXIES: str = (
-        ''  # Comma-separated IPs/CIDRs of trusted reverse proxies (e.g. '127.0.0.1,10.0.0.0/8')
+    CABINET_EMAIL_CHANGE_CODE_EXPIRE_MINUTES: int = (
+        15  # Email change verification code expiration
     )
+    CABINET_EMAIL_AUTH_ENABLED: bool = (
+        True  # Enable email registration/login in cabinet
+    )
+    CABINET_URL: str = "https://example.com/cabinet"  # Base URL for cabinet (used in verification emails)
+    CABINET_TRUSTED_PROXIES: str = ""  # Comma-separated IPs/CIDRs of trusted reverse proxies (e.g. '127.0.0.1,10.0.0.0/8')
 
     # OAuth 2.0 provider settings for cabinet
-    OAUTH_GOOGLE_CLIENT_ID: str = ''
-    OAUTH_GOOGLE_CLIENT_SECRET: str = ''
+    OAUTH_GOOGLE_CLIENT_ID: str = ""
+    OAUTH_GOOGLE_CLIENT_SECRET: str = ""
     OAUTH_GOOGLE_ENABLED: bool = False
 
-    OAUTH_YANDEX_CLIENT_ID: str = ''
-    OAUTH_YANDEX_CLIENT_SECRET: str = ''
+    OAUTH_YANDEX_CLIENT_ID: str = ""
+    OAUTH_YANDEX_CLIENT_SECRET: str = ""
     OAUTH_YANDEX_ENABLED: bool = False
 
-    OAUTH_DISCORD_CLIENT_ID: str = ''
-    OAUTH_DISCORD_CLIENT_SECRET: str = ''
+    OAUTH_DISCORD_CLIENT_ID: str = ""
+    OAUTH_DISCORD_CLIENT_SECRET: str = ""
     OAUTH_DISCORD_ENABLED: bool = False
 
-    OAUTH_VK_CLIENT_ID: str = ''
-    OAUTH_VK_CLIENT_SECRET: str = ''
+    OAUTH_VK_CLIENT_ID: str = ""
+    OAUTH_VK_CLIENT_SECRET: str = ""
     OAUTH_VK_ENABLED: bool = False
 
     # SMTP settings for cabinet email
@@ -812,7 +860,7 @@ class Settings(BaseSettings):
     SMTP_USER: str | None = None
     SMTP_PASSWORD: str | None = None
     SMTP_FROM_EMAIL: str | None = None
-    SMTP_FROM_NAME: str = 'VPN Service'
+    SMTP_FROM_NAME: str = "VPN Service"
     SMTP_USE_TLS: bool = True
 
     # Ban System Integration (BedolagaBan monitoring)
@@ -825,7 +873,12 @@ class Settings(BaseSettings):
     # Format: socks5://user:password@host:port or socks5://host:port
     PROXY_URL: str | None = None
 
-    @field_validator('PROXY_URL', 'NALOGO_PROXY_URL', mode='before')
+    # Custom Telegram Bot API server URL (for regions where api.telegram.org is blocked)
+    # Example: https://your-proxy.workers.dev or http://localhost:8081
+    # Default: https://api.telegram.org
+    TELEGRAM_API_URL: str | None = None
+
+    @field_validator("PROXY_URL", "NALOGO_PROXY_URL", mode="before")
     @classmethod
     def validate_proxy_url(cls, value: str | None) -> str | None:
         if not value:
@@ -833,73 +886,75 @@ class Settings(BaseSettings):
         from urllib.parse import urlparse
 
         parsed = urlparse(value)
-        if parsed.scheme not in ('socks5', 'socks5h', 'socks4'):
+        if parsed.scheme not in ("socks5", "socks5h", "socks4"):
             raise ValueError(
-                f'Proxy URL must use socks5://, socks5h://, or socks4:// scheme, got: {parsed.scheme!r}. '
-                'HTTP proxies are not supported for security reasons.'
+                f"Proxy URL must use socks5://, socks5h://, or socks4:// scheme, got: {parsed.scheme!r}. "
+                "HTTP proxies are not supported for security reasons."
             )
         if not parsed.hostname:
-            raise ValueError('Proxy URL must contain a hostname')
+            raise ValueError("Proxy URL must contain a hostname")
         return value
 
-    @field_validator('MAIN_MENU_MODE', mode='before')
+    @field_validator("MAIN_MENU_MODE", mode="before")
     @classmethod
     def normalize_main_menu_mode(cls, value: str | None) -> str:
         if not value:
-            return 'default'
+            return "default"
 
         normalized = str(value).strip().lower()
         aliases = {
-            'classic': 'default',
-            'default': 'default',
-            'full': 'default',
-            'standard': 'default',
-            'cabinet': 'cabinet',
-            'text': 'cabinet',
-            'text_only': 'cabinet',
-            'textual': 'cabinet',
-            'minimal': 'cabinet',
+            "classic": "default",
+            "default": "default",
+            "full": "default",
+            "standard": "default",
+            "cabinet": "cabinet",
+            "text": "cabinet",
+            "text_only": "cabinet",
+            "textual": "cabinet",
+            "minimal": "cabinet",
         }
 
         mode = aliases.get(normalized, normalized)
-        if mode not in {'default', 'cabinet'}:
-            raise ValueError('MAIN_MENU_MODE must be one of: default, cabinet')
+        if mode not in {"default", "cabinet"}:
+            raise ValueError("MAIN_MENU_MODE must be one of: default, cabinet")
         return mode
 
-    @field_validator('SERVER_STATUS_MODE', mode='before')
+    @field_validator("SERVER_STATUS_MODE", mode="before")
     @classmethod
     def normalize_server_status_mode(cls, value: str | None) -> str:
         if not value:
-            return 'disabled'
+            return "disabled"
 
         normalized = str(value).strip().lower()
         aliases = {
-            'off': 'disabled',
-            'none': 'disabled',
-            'disabled': 'disabled',
-            'external': 'external_link',
-            'link': 'external_link',
-            'url': 'external_link',
-            'external_link': 'external_link',
-            'miniapp': 'external_link_miniapp',
-            'mini_app': 'external_link_miniapp',
-            'mini-app': 'external_link_miniapp',
-            'webapp': 'external_link_miniapp',
-            'web_app': 'external_link_miniapp',
-            'web-app': 'external_link_miniapp',
-            'external_link_miniapp': 'external_link_miniapp',
-            'xray': 'xray',
-            'xraychecker': 'xray',
-            'xray_metrics': 'xray',
-            'metrics': 'xray',
+            "off": "disabled",
+            "none": "disabled",
+            "disabled": "disabled",
+            "external": "external_link",
+            "link": "external_link",
+            "url": "external_link",
+            "external_link": "external_link",
+            "miniapp": "external_link_miniapp",
+            "mini_app": "external_link_miniapp",
+            "mini-app": "external_link_miniapp",
+            "webapp": "external_link_miniapp",
+            "web_app": "external_link_miniapp",
+            "web-app": "external_link_miniapp",
+            "external_link_miniapp": "external_link_miniapp",
+            "xray": "xray",
+            "xraychecker": "xray",
+            "xray_metrics": "xray",
+            "metrics": "xray",
         }
 
         mode = aliases.get(normalized, normalized)
-        if mode not in {'disabled', 'external_link', 'external_link_miniapp', 'xray'}:
-            raise ValueError('SERVER_STATUS_MODE must be one of: disabled, external_link, external_link_miniapp, xray')
+        if mode not in {"disabled", "external_link", "external_link_miniapp", "xray"}:
+            raise ValueError(
+                "SERVER_STATUS_MODE must be one of: disabled, external_link, external_link_miniapp, xray"
+            )
         return mode
 
-    @field_validator('SERVER_STATUS_ITEMS_PER_PAGE', mode='before')
+    @field_validator("SERVER_STATUS_ITEMS_PER_PAGE", mode="before")
     @classmethod
     def ensure_positive_server_status_page_size(cls, value: int | None) -> int:
         try:
@@ -910,7 +965,7 @@ class Settings(BaseSettings):
         except (TypeError, ValueError):
             return 10
 
-    @field_validator('SERVER_STATUS_REQUEST_TIMEOUT', mode='before')
+    @field_validator("SERVER_STATUS_REQUEST_TIMEOUT", mode="before")
     @classmethod
     def ensure_positive_server_status_timeout(cls, value: int | None) -> int:
         try:
@@ -921,7 +976,7 @@ class Settings(BaseSettings):
         except (TypeError, ValueError):
             return 10
 
-    @field_validator('LOG_FILE', mode='before')
+    @field_validator("LOG_FILE", mode="before")
     @classmethod
     def ensure_log_dir(cls, v):
         log_path = Path(v)
@@ -934,12 +989,12 @@ class Settings(BaseSettings):
 
         mode = self.DATABASE_MODE.lower()
 
-        if mode == 'sqlite':
+        if mode == "sqlite":
             return self._get_sqlite_url()
-        if mode == 'postgresql':
+        if mode == "postgresql":
             return self._get_postgresql_url()
-        if mode == 'auto':
-            if os.getenv('DOCKER_ENV') == 'true' or os.path.exists('/.dockerenv'):
+        if mode == "auto":
+            if os.getenv("DOCKER_ENV") == "true" or os.path.exists("/.dockerenv"):
                 return self._get_postgresql_url()
             return self._get_sqlite_url()
         return self._get_auto_database_url()
@@ -947,30 +1002,34 @@ class Settings(BaseSettings):
     def _get_sqlite_url(self) -> str:
         sqlite_path = Path(self.SQLITE_PATH)
         sqlite_path.parent.mkdir(parents=True, exist_ok=True)
-        return f'sqlite+aiosqlite:///{sqlite_path.absolute()}'
+        return f"sqlite+aiosqlite:///{sqlite_path.absolute()}"
 
     def _get_postgresql_url(self) -> str:
         return (
-            f'postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}'
-            f'@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}'
+            f"postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
+            f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
         )
 
     def _get_auto_database_url(self) -> str:
-        if os.getenv('DOCKER_ENV') == 'true' or os.path.exists('/.dockerenv'):
+        if os.getenv("DOCKER_ENV") == "true" or os.path.exists("/.dockerenv"):
             return self._get_postgresql_url()
         return self._get_sqlite_url()
 
     def is_postgresql(self) -> bool:
         """Проверяет, используется ли PostgreSQL"""
-        return 'postgresql' in self.get_database_url()
+        return "postgresql" in self.get_database_url()
 
     def is_sqlite(self) -> bool:
         """Проверяет, используется ли SQLite"""
-        return 'sqlite' in self.get_database_url()
+        return "sqlite" in self.get_database_url()
 
     def get_proxy_url(self) -> str | None:
         """Return SOCKS5 proxy URL or None."""
         return self.PROXY_URL if self.PROXY_URL else None
+
+    def get_telegram_api_url(self) -> str | None:
+        """Return custom Telegram API server URL or None (uses default api.telegram.org)."""
+        return self.TELEGRAM_API_URL if self.TELEGRAM_API_URL else None
 
     def get_nalogo_proxy_url(self) -> str | None:
         """Return SOCKS proxy URL for nalogo or None.
@@ -979,7 +1038,9 @@ class Settings(BaseSettings):
         """
         return self.NALOGO_PROXY_URL or self.PROXY_URL
 
-    def is_admin(self, telegram_id: int | None = None, email: str | None = None) -> bool:
+    def is_admin(
+        self, telegram_id: int | None = None, email: str | None = None
+    ) -> bool:
         """
         Check if user is admin by telegram_id or email.
 
@@ -1003,7 +1064,7 @@ class Settings(BaseSettings):
             if isinstance(admin_ids, str):
                 if not admin_ids.strip():
                     return []
-                return [int(x.strip()) for x in admin_ids.split(',') if x.strip()]
+                return [int(x.strip()) for x in admin_ids.split(",") if x.strip()]
 
             return []
 
@@ -1018,7 +1079,7 @@ class Settings(BaseSettings):
             if isinstance(admin_emails, str):
                 if not admin_emails.strip():
                     return []
-                return [e.strip().lower() for e in admin_emails.split(',') if e.strip()]
+                return [e.strip().lower() for e in admin_emails.split(",") if e.strip()]
 
             return []
 
@@ -1027,12 +1088,12 @@ class Settings(BaseSettings):
 
     def get_test_email(self) -> str | None:
         """Get test email for development/testing."""
-        email = (self.TEST_EMAIL or '').strip().lower()
+        email = (self.TEST_EMAIL or "").strip().lower()
         return email or None
 
     def get_test_email_password(self) -> str | None:
         """Get test email password."""
-        password = (self.TEST_EMAIL_PASSWORD or '').strip()
+        password = (self.TEST_EMAIL_PASSWORD or "").strip()
         return password or None
 
     def is_test_email(self, email: str) -> bool:
@@ -1053,21 +1114,21 @@ class Settings(BaseSettings):
 
     def get_remnawave_auth_params(self) -> dict[str, str | None]:
         return {
-            'base_url': self.REMNAWAVE_API_URL,
-            'api_key': self.REMNAWAVE_API_KEY,
-            'secret_key': self.REMNAWAVE_SECRET_KEY,
-            'username': self.REMNAWAVE_USERNAME,
-            'password': self.REMNAWAVE_PASSWORD,
-            'caddy_token': self.REMNAWAVE_CADDY_TOKEN,
-            'auth_type': self.REMNAWAVE_AUTH_TYPE,
+            "base_url": self.REMNAWAVE_API_URL,
+            "api_key": self.REMNAWAVE_API_KEY,
+            "secret_key": self.REMNAWAVE_SECRET_KEY,
+            "username": self.REMNAWAVE_USERNAME,
+            "password": self.REMNAWAVE_PASSWORD,
+            "caddy_token": self.REMNAWAVE_CADDY_TOKEN,
+            "auth_type": self.REMNAWAVE_AUTH_TYPE,
         }
 
     def get_pal24_sbp_button_text(self, fallback: str) -> str:
-        value = (self.PAL24_SBP_BUTTON_TEXT or '').strip()
+        value = (self.PAL24_SBP_BUTTON_TEXT or "").strip()
         return value or fallback
 
     def get_pal24_card_button_text(self, fallback: str) -> str:
-        value = (self.PAL24_CARD_BUTTON_TEXT or '').strip()
+        value = (self.PAL24_CARD_BUTTON_TEXT or "").strip()
         return value or fallback
 
     def is_pal24_sbp_button_visible(self) -> bool:
@@ -1079,7 +1140,7 @@ class Settings(BaseSettings):
     def get_remnawave_user_delete_mode(self) -> str:
         """Возвращает режим удаления пользователей: 'delete' или 'disable'"""
         mode = self.REMNAWAVE_USER_DELETE_MODE.lower().strip()
-        return mode if mode in ['delete', 'disable'] else 'delete'
+        return mode if mode in ["delete", "disable"] else "delete"
 
     def format_remnawave_user_description(
         self,
@@ -1095,40 +1156,43 @@ class Settings(BaseSettings):
 
         Поддерживает как Telegram-пользователей, так и email-only пользователей.
         """
-        template = self.REMNAWAVE_USER_DESCRIPTION_TEMPLATE or 'Bot user: {full_name} {username}'
-        template_for_formatting = template.replace('@{username}', '{username}')
+        template = (
+            self.REMNAWAVE_USER_DESCRIPTION_TEMPLATE
+            or "Bot user: {full_name} {username}"
+        )
+        template_for_formatting = template.replace("@{username}", "{username}")
 
-        username_clean = (username or '').lstrip('@')
+        username_clean = (username or "").lstrip("@")
 
         # Формируем идентификатор для description
         identifier_parts = []
         if telegram_id:
-            identifier_parts.append(f'TG: {telegram_id}')
+            identifier_parts.append(f"TG: {telegram_id}")
         if email:
-            identifier_parts.append(f'Email: {email}')
+            identifier_parts.append(f"Email: {email}")
         if user_id and not identifier_parts:
-            identifier_parts.append(f'ID: {user_id}')
+            identifier_parts.append(f"ID: {user_id}")
 
         values = defaultdict(
             str,
             {
-                'full_name': full_name,
-                'username': f'@{username_clean}' if username_clean else '',
-                'username_clean': username_clean,
-                'telegram_id': str(telegram_id) if telegram_id else '',
-                'email': email or '',
-                'user_id': str(user_id) if user_id else '',
-                'identifier': ' | '.join(identifier_parts),
+                "full_name": full_name,
+                "username": f"@{username_clean}" if username_clean else "",
+                "username_clean": username_clean,
+                "telegram_id": str(telegram_id) if telegram_id else "",
+                "email": email or "",
+                "user_id": str(user_id) if user_id else "",
+                "identifier": " | ".join(identifier_parts),
             },
         )
 
         description = template_for_formatting.format_map(values)
 
         if not username_clean:
-            description = re.sub(r'@(?=\W|$)', '', description)
-            description = re.sub(r'\(\s*\)', '', description)
+            description = re.sub(r"@(?=\W|$)", "", description)
+            description = re.sub(r"\(\s*\)", "", description)
 
-        description = re.sub(r'\s+', ' ', description).strip()
+        description = re.sub(r"\s+", " ", description).strip()
         return description
 
     def format_remnawave_username(
@@ -1145,37 +1209,41 @@ class Settings(BaseSettings):
 
         Для email-пользователей (telegram_id=None) использует email prefix + user_id.
         """
-        template = self.REMNAWAVE_USER_USERNAME_TEMPLATE or 'user_{telegram_id}'
+        template = self.REMNAWAVE_USER_USERNAME_TEMPLATE or "user_{telegram_id}"
 
-        username_clean = (username or '').lstrip('@')
-        full_name_value = full_name or ''
+        username_clean = (username or "").lstrip("@")
+        full_name_value = full_name or ""
 
         # Remnawave разрешает только буквы, цифры, подчёркивания и дефисы
         def _sanitize(value: str) -> str:
-            result = re.sub(r'[^0-9A-Za-z_-]+', '_', value)
-            return re.sub(r'_+', '_', result).strip('_-')
+            result = re.sub(r"[^0-9A-Za-z_-]+", "_", value)
+            return re.sub(r"_+", "_", result).strip("_-")
 
         # Для email-пользователей формируем уникальный identifier
         if telegram_id:
             identifier = str(telegram_id)
         elif email:
-            email_prefix = _sanitize(email.split('@')[0][:10])
-            identifier = _sanitize(f'email_{email_prefix}_{user_id}' if user_id else f'email_{email_prefix}')
+            email_prefix = _sanitize(email.split("@")[0][:10])
+            identifier = _sanitize(
+                f"email_{email_prefix}_{user_id}"
+                if user_id
+                else f"email_{email_prefix}"
+            )
         elif user_id:
-            identifier = f'id_{user_id}'
+            identifier = f"id_{user_id}"
         else:
-            identifier = 'unknown'
+            identifier = "unknown"
 
         values = defaultdict(
             str,
             {
-                'full_name': full_name_value,
-                'username': username_clean,
-                'username_clean': username_clean,
-                'telegram_id': str(telegram_id) if telegram_id else identifier,
-                'identifier': identifier,
-                'email': _sanitize(email.split('@')[0]) if email else '',
-                'user_id': str(user_id) if user_id else '',
+                "full_name": full_name_value,
+                "username": username_clean,
+                "username_clean": username_clean,
+                "telegram_id": str(telegram_id) if telegram_id else identifier,
+                "identifier": identifier,
+                "email": _sanitize(email.split("@")[0]) if email else "",
+                "user_id": str(user_id) if user_id else "",
             },
         )
 
@@ -1183,16 +1251,16 @@ class Settings(BaseSettings):
         sanitized_username = _sanitize(raw_username)
 
         if not sanitized_username:
-            sanitized_username = _sanitize(f'user_{identifier}')
+            sanitized_username = _sanitize(f"user_{identifier}")
 
-        return sanitized_username[:36].strip('_-') or 'user'
+        return sanitized_username[:36].strip("_-") or "user"
 
     @staticmethod
     def parse_daily_time_list(raw_value: str | None) -> list[time]:
         if not raw_value:
             return []
 
-        segments = re.split(r'[\s,;]+', raw_value.strip())
+        segments = re.split(r"[\s,;]+", raw_value.strip())
         seen: set[tuple[int, int]] = set()
         parsed: list[time] = []
 
@@ -1201,7 +1269,7 @@ class Settings(BaseSettings):
                 continue
 
             try:
-                hours_str, minutes_str = segment.split(':', 1)
+                hours_str, minutes_str = segment.split(":", 1)
                 hours = int(hours_str)
                 minutes = int(minutes_str)
             except (ValueError, AttributeError):
@@ -1227,7 +1295,7 @@ class Settings(BaseSettings):
         return (
             self.REMNAWAVE_WEBHOOK_ENABLED
             and bool(self.REMNAWAVE_WEBHOOK_SECRET)
-            and len(self.REMNAWAVE_WEBHOOK_SECRET or '') >= 32
+            and len(self.REMNAWAVE_WEBHOOK_SECRET or "") >= 32
         )
 
     def get_traffic_monitored_nodes(self) -> list[str]:
@@ -1235,30 +1303,30 @@ class Settings(BaseSettings):
         if not self.TRAFFIC_MONITORED_NODES:
             return []
         # Убираем комментарии (все после #)
-        value = self.TRAFFIC_MONITORED_NODES.split('#')[0].strip()
+        value = self.TRAFFIC_MONITORED_NODES.split("#")[0].strip()
         if not value:
             return []
-        return [n.strip() for n in value.split(',') if n.strip()]
+        return [n.strip() for n in value.split(",") if n.strip()]
 
     def get_traffic_ignored_nodes(self) -> list[str]:
         """Возвращает список UUID нод для исключения из мониторинга"""
         if not self.TRAFFIC_IGNORED_NODES:
             return []
         # Убираем комментарии (все после #)
-        value = self.TRAFFIC_IGNORED_NODES.split('#')[0].strip()
+        value = self.TRAFFIC_IGNORED_NODES.split("#")[0].strip()
         if not value:
             return []
-        return [n.strip() for n in value.split(',') if n.strip()]
+        return [n.strip() for n in value.split(",") if n.strip()]
 
     def get_traffic_excluded_user_uuids(self) -> list[str]:
         """Возвращает список UUID пользователей для исключения из мониторинга (например, тунельные/служебные)"""
         if not self.TRAFFIC_EXCLUDED_USER_UUIDS:
             return []
         # Убираем комментарии (все после #)
-        value = self.TRAFFIC_EXCLUDED_USER_UUIDS.split('#')[0].strip()
+        value = self.TRAFFIC_EXCLUDED_USER_UUIDS.split("#")[0].strip()
         if not value:
             return []
-        return [uuid.strip().lower() for uuid in value.split(',') if uuid.strip()]
+        return [uuid.strip().lower() for uuid in value.split(",") if uuid.strip()]
 
     def get_traffic_daily_check_time(self) -> time | None:
         """Возвращает время суточной проверки трафика"""
@@ -1271,7 +1339,7 @@ class Settings(BaseSettings):
             return []
 
         if isinstance(raw_value, str):
-            candidates = re.split(r'[\n,]+', raw_value)
+            candidates = re.split(r"[\n,]+", raw_value)
         else:
             candidates = list(raw_value)
 
@@ -1294,31 +1362,31 @@ class Settings(BaseSettings):
             if isinstance(days, str):
                 if not days.strip():
                     return [3, 1]
-                return [int(x.strip()) for x in days.split(',') if x.strip()]
+                return [int(x.strip()) for x in days.split(",") if x.strip()]
             return [3, 1]
         except (ValueError, AttributeError):
             return [3, 1]
 
     def is_autopay_enabled_by_default(self) -> bool:
-        value = getattr(self, 'DEFAULT_AUTOPAY_ENABLED', True)
+        value = getattr(self, "DEFAULT_AUTOPAY_ENABLED", True)
 
         if isinstance(value, str):
             normalized = value.strip().lower()
-            return normalized in {'1', 'true', 'yes', 'on'}
+            return normalized in {"1", "true", "yes", "on"}
 
         return bool(value)
 
     def is_auto_purchase_after_topup_enabled(self) -> bool:
-        value = getattr(self, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', False)
+        value = getattr(self, "AUTO_PURCHASE_AFTER_TOPUP_ENABLED", False)
 
         if isinstance(value, str):
             normalized = value.strip().lower()
-            return normalized in {'1', 'true', 'yes', 'on'}
+            return normalized in {"1", "true", "yes", "on"}
 
         return bool(value)
 
     def get_available_languages(self) -> list[str]:
-        defaults = ['ru', 'en', 'ua', 'zh', 'fa']
+        defaults = ["ru", "en", "ua", "zh", "fa"]
 
         try:
             langs = self.AVAILABLE_LANGUAGES
@@ -1330,7 +1398,7 @@ class Settings(BaseSettings):
         if isinstance(langs, str):
             if not langs.strip():
                 return defaults
-            candidates = [chunk.strip() for chunk in langs.split(',')]
+            candidates = [chunk.strip() for chunk in langs.split(",")]
         elif isinstance(langs, (list, tuple, set)):
             candidates = [str(item).strip() for item in langs]
         else:
@@ -1354,7 +1422,7 @@ class Settings(BaseSettings):
         return cleaned or defaults
 
     def is_language_selection_enabled(self) -> bool:
-        return bool(getattr(self, 'LANGUAGE_SELECTION_ENABLED', True))
+        return bool(getattr(self, "LANGUAGE_SELECTION_ENABLED", True))
 
     def format_price(self, price_kopeks: int, round_kopeks: bool | None = None) -> str:
         """
@@ -1369,9 +1437,11 @@ class Settings(BaseSettings):
             Отформатированная строка цены (например, "150 ₽")
         """
         # Используем настройку если не передано явно
-        should_round = round_kopeks if round_kopeks is not None else self.PRICE_ROUNDING_ENABLED
+        should_round = (
+            round_kopeks if round_kopeks is not None else self.PRICE_ROUNDING_ENABLED
+        )
 
-        sign = '-' if price_kopeks < 0 else ''
+        sign = "-" if price_kopeks < 0 else ""
         abs_kopeks = abs(price_kopeks)
         rubles, kopeks = divmod(abs_kopeks, 100)
 
@@ -1379,14 +1449,14 @@ class Settings(BaseSettings):
             # Округление: ≤50 коп вниз, >50 коп вверх
             if kopeks > 50:
                 rubles += 1
-            return f'{sign}{rubles} ₽'
+            return f"{sign}{rubles} ₽"
 
         # Без округления - показываем точное значение
         if kopeks:
-            value = f'{sign}{rubles}.{kopeks:02d}'.rstrip('0').rstrip('.')
-            return f'{value} ₽'
+            value = f"{sign}{rubles}.{kopeks:02d}".rstrip("0").rstrip(".")
+            return f"{value} ₽"
 
-        return f'{sign}{rubles} ₽'
+        return f"{sign}{rubles} ₽"
 
     def get_reports_chat_id(self) -> str | None:
         if self.ADMIN_REPORTS_CHAT_ID:
@@ -1402,14 +1472,16 @@ class Settings(BaseSettings):
             return None
 
         try:
-            hours_str, minutes_str = value.strip().split(':', 1)
+            hours_str, minutes_str = value.strip().split(":", 1)
             hours = int(hours_str)
             minutes = int(minutes_str)
             if not (0 <= hours <= 23 and 0 <= minutes <= 59):
                 raise ValueError
             return time(hour=hours, minute=minutes)
         except (ValueError, AttributeError):
-            logger.warning('Некорректное значение ADMIN_REPORTS_SEND_TIME', send_time_value=value)
+            logger.warning(
+                "Некорректное значение ADMIN_REPORTS_SEND_TIME", send_time_value=value
+            )
             return None
 
     def kopeks_to_rubles(self, kopeks: int) -> float:
@@ -1429,14 +1501,17 @@ class Settings(BaseSettings):
 
         if len(cleaned) > 16:
             logger.warning(
-                'Некорректная длина : максимум 16 символов, получено',
+                "Некорректная длина : максимум 16 символов, получено",
                 setting_name=setting_name,
                 cleaned_count=len(cleaned),
             )
             return None
 
         if not USER_TAG_PATTERN.fullmatch(cleaned):
-            logger.warning('Некорректный формат : допустимы только A-Z, 0-9 и подчёркивание', setting_name=setting_name)
+            logger.warning(
+                "Некорректный формат : допустимы только A-Z, 0-9 и подчёркивание",
+                setting_name=setting_name,
+            )
             return None
 
         return cleaned
@@ -1445,40 +1520,42 @@ class Settings(BaseSettings):
         return self.TRIAL_WARNING_HOURS
 
     def get_trial_user_tag(self) -> str | None:
-        return self._normalize_user_tag(self.TRIAL_USER_TAG, 'TRIAL_USER_TAG')
+        return self._normalize_user_tag(self.TRIAL_USER_TAG, "TRIAL_USER_TAG")
 
     def is_trial_disabled_for_user(self, auth_type: str | None) -> bool:
         disabled_for = self.TRIAL_DISABLED_FOR
-        if disabled_for == 'all':
+        if disabled_for == "all":
             return True
         # 'email' means all non-Telegram users (email, google, yandex, discord, vk, etc.)
-        if disabled_for == 'email' and auth_type not in (None, 'telegram'):
+        if disabled_for == "email" and auth_type not in (None, "telegram"):
             return True
-        if disabled_for == 'telegram' and (auth_type is None or auth_type == 'telegram'):
+        if disabled_for == "telegram" and (
+            auth_type is None or auth_type == "telegram"
+        ):
             return True
         return False
 
     def get_paid_subscription_user_tag(self) -> str | None:
         return self._normalize_user_tag(
             self.PAID_SUBSCRIPTION_USER_TAG,
-            'PAID_SUBSCRIPTION_USER_TAG',
+            "PAID_SUBSCRIPTION_USER_TAG",
         )
 
     def get_bot_username(self) -> str | None:
-        username = getattr(self, 'BOT_USERNAME', None)
+        username = getattr(self, "BOT_USERNAME", None)
         if not username:
             return None
-        normalized = str(username).strip().lstrip('@')
+        normalized = str(username).strip().lstrip("@")
         return normalized or None
 
     def is_notifications_enabled(self) -> bool:
         return self.ENABLE_NOTIFICATIONS
 
     def get_main_menu_mode(self) -> str:
-        return getattr(self, 'MAIN_MENU_MODE', 'default')
+        return getattr(self, "MAIN_MENU_MODE", "default")
 
     def is_cabinet_mode(self) -> bool:
-        return self.get_main_menu_mode() == 'cabinet'
+        return self.get_main_menu_mode() == "cabinet"
 
     def is_text_main_menu_mode(self) -> bool:
         """Backward-compatible alias for :meth:`is_cabinet_mode`."""
@@ -1486,27 +1563,29 @@ class Settings(BaseSettings):
 
     def get_main_menu_miniapp_url(self) -> str | None:
         for candidate in [self.MINIAPP_CUSTOM_URL, self.MINIAPP_PURCHASE_URL]:
-            value = (candidate or '').strip()
+            value = (candidate or "").strip()
             if value:
                 return value
         return None
 
-    _CABINET_URL_DEFAULT = 'https://example.com/cabinet'
+    _CABINET_URL_DEFAULT = "https://example.com/cabinet"
 
     def _encode_referral_code(self, referral_code: str) -> str:
         """Validate and URL-encode a referral code."""
         if not referral_code:
-            raise ValueError('referral_code must not be empty or None')
-        return _url_quote(referral_code, safe='')
+            raise ValueError("referral_code must not be empty or None")
+        return _url_quote(referral_code, safe="")
 
     def _normalized_cabinet_url(self) -> str | None:
         """Return normalized cabinet URL, or None if not configured."""
-        cabinet_url = (self.CABINET_URL or '').strip().rstrip('/')
+        cabinet_url = (self.CABINET_URL or "").strip().rstrip("/")
         if not cabinet_url or cabinet_url == self._CABINET_URL_DEFAULT:
             return None
         return cabinet_url
 
-    def get_referral_link(self, referral_code: str, bot_username: str | None = None) -> str:
+    def get_referral_link(
+        self, referral_code: str, bot_username: str | None = None
+    ) -> str:
         """Build a referral link pointing to the web cabinet.
 
         Falls back to a Telegram bot deep link when CABINET_URL is not configured.
@@ -1516,11 +1595,13 @@ class Settings(BaseSettings):
             return cabinet_link
         return self.get_bot_referral_link(referral_code, bot_username)
 
-    def get_bot_referral_link(self, referral_code: str, bot_username: str | None = None) -> str:
+    def get_bot_referral_link(
+        self, referral_code: str, bot_username: str | None = None
+    ) -> str:
         """Always return the Telegram bot deep link for a referral code."""
         safe_code = self._encode_referral_code(referral_code)
-        username = bot_username or self.get_bot_username() or 'bot'
-        return f'https://t.me/{username}?start={safe_code}'
+        username = bot_username or self.get_bot_username() or "bot"
+        return f"https://t.me/{username}?start={safe_code}"
 
     def get_cabinet_referral_link(self, referral_code: str) -> str | None:
         """Return the cabinet referral link, or None if cabinet is not configured."""
@@ -1528,8 +1609,8 @@ class Settings(BaseSettings):
         if not cabinet_url:
             return None
         safe_code = self._encode_referral_code(referral_code)
-        sep = '&' if '?' in cabinet_url else '?'
-        return f'{cabinet_url}{sep}ref={safe_code}'
+        sep = "&" if "?" in cabinet_url else "?"
+        return f"{cabinet_url}{sep}ref={safe_code}"
 
     def is_deep_links_enabled(self) -> bool:
         return self.ENABLE_DEEP_LINKS
@@ -1546,19 +1627,19 @@ class Settings(BaseSettings):
         desc_en = _clean(self.MINIAPP_SERVICE_DESCRIPTION_EN)
         desc_ru = _clean(self.MINIAPP_SERVICE_DESCRIPTION_RU)
 
-        default_name = name_en or name_ru or 'RemnaWave VPN'
-        default_description = desc_en or desc_ru or 'Secure & Fast Connection'
+        default_name = name_en or name_ru or "RemnaWave VPN"
+        default_description = desc_en or desc_ru or "Secure & Fast Connection"
 
         return {
-            'service_name': {
-                'default': default_name,
-                'en': name_en,
-                'ru': name_ru,
+            "service_name": {
+                "default": default_name,
+                "en": name_en,
+                "ru": name_ru,
             },
-            'service_description': {
-                'default': default_description,
-                'en': desc_en,
-                'ru': desc_ru,
+            "service_description": {
+                "default": default_description,
+                "en": desc_en,
+                "ru": desc_ru,
             },
         }
 
@@ -1567,45 +1648,52 @@ class Settings(BaseSettings):
 
     def build_external_admin_token(self, bot_username: str) -> str:
         """Генерирует детерминированный и криптографически стойкий токен внешней админки."""
-        normalized = (bot_username or '').strip().lstrip('@').lower()
+        normalized = (bot_username or "").strip().lstrip("@").lower()
         if not normalized:
-            raise ValueError('Bot username is required to build external admin token')
+            raise ValueError("Bot username is required to build external admin token")
 
-        secret = (self.BOT_TOKEN or '').strip()
+        secret = (self.BOT_TOKEN or "").strip()
         if not secret:
-            raise ValueError('Bot token is required to build external admin token')
+            raise ValueError("Bot token is required to build external admin token")
 
         digest = hmac.new(
-            key=secret.encode('utf-8'),
-            msg=f'remnawave.external_admin::{normalized}'.encode(),
+            key=secret.encode("utf-8"),
+            msg=f"remnawave.external_admin::{normalized}".encode(),
             digestmod=hashlib.sha256,
         ).hexdigest()
         return digest[:48]
 
     def get_external_admin_token(self) -> str | None:
-        token = (self.EXTERNAL_ADMIN_TOKEN or '').strip()
+        token = (self.EXTERNAL_ADMIN_TOKEN or "").strip()
         return token or None
 
     def get_external_admin_bot_id(self) -> int | None:
         try:
-            return int(self.EXTERNAL_ADMIN_TOKEN_BOT_ID) if self.EXTERNAL_ADMIN_TOKEN_BOT_ID else None
-        except (TypeError, ValueError):  # pragma: no cover - защитная ветка для некорректных значений
+            return (
+                int(self.EXTERNAL_ADMIN_TOKEN_BOT_ID)
+                if self.EXTERNAL_ADMIN_TOKEN_BOT_ID
+                else None
+            )
+        except (
+            TypeError,
+            ValueError,
+        ):  # pragma: no cover - защитная ветка для некорректных значений
             logger.warning(
-                'Некорректный идентификатор бота для внешней админки',
+                "Некорректный идентификатор бота для внешней админки",
                 EXTERNAL_ADMIN_TOKEN_BOT_ID=self.EXTERNAL_ADMIN_TOKEN_BOT_ID,
             )
             return None
 
     def is_traffic_selectable(self) -> bool:
-        return self.TRAFFIC_SELECTION_MODE.lower() == 'selectable'
+        return self.TRAFFIC_SELECTION_MODE.lower() == "selectable"
 
     def is_traffic_fixed(self) -> bool:
         """Возвращает True если выбор трафика отключён (fixed или fixed_with_topup)"""
-        return self.TRAFFIC_SELECTION_MODE.lower() in ('fixed', 'fixed_with_topup')
+        return self.TRAFFIC_SELECTION_MODE.lower() in ("fixed", "fixed_with_topup")
 
     def is_traffic_topup_blocked(self) -> bool:
         """Возвращает True если докупка трафика полностью заблокирована (только fixed)"""
-        return self.TRAFFIC_SELECTION_MODE.lower() == 'fixed'
+        return self.TRAFFIC_SELECTION_MODE.lower() == "fixed"
 
     def get_fixed_traffic_limit(self) -> int:
         return self.FIXED_TRAFFIC_LIMIT_GB
@@ -1622,18 +1710,18 @@ class Settings(BaseSettings):
             return self.get_traffic_packages()
 
         packages = []
-        for package_config in config_str.split(','):
+        for package_config in config_str.split(","):
             package_config = package_config.strip()
             if not package_config:
                 continue
 
-            parts = package_config.split(':')
+            parts = package_config.split(":")
             if len(parts) >= 2:
                 try:
                     gb = int(parts[0])
                     price = int(parts[1])
-                    enabled = parts[2].lower() == 'true' if len(parts) > 2 else True
-                    packages.append({'gb': gb, 'price': price, 'enabled': enabled})
+                    enabled = parts[2].lower() == "true" if len(parts) > 2 else True
+                    packages.append({"gb": gb, "price": price, "enabled": enabled})
                 except (ValueError, IndexError):
                     continue
 
@@ -1642,15 +1730,15 @@ class Settings(BaseSettings):
     def get_traffic_topup_price(self, gb: int | None) -> int:
         """Возвращает цену докупки для указанного количества ГБ."""
         packages = self.get_traffic_topup_packages()
-        enabled_packages = [pkg for pkg in packages if pkg['enabled']]
+        enabled_packages = [pkg for pkg in packages if pkg["enabled"]]
 
         if not enabled_packages:
             return 0
 
         # Ищем точное совпадение
         for pkg in enabled_packages:
-            if pkg['gb'] == gb:
-                return pkg['price']
+            if pkg["gb"] == gb:
+                return pkg["price"]
 
         # Если не нашли - возвращаем 0
         return 0
@@ -1667,13 +1755,16 @@ class Settings(BaseSettings):
     def get_devices_selection_disabled_amount(self) -> int | None:
         raw_value = self.DEVICES_SELECTION_DISABLED_AMOUNT
 
-        if raw_value in (None, ''):
+        if raw_value in (None, ""):
             return None
 
         try:
             value = int(raw_value)
         except (TypeError, ValueError):
-            logger.warning('Некорректное значение DEVICES_SELECTION_DISABLED_AMOUNT', raw_value=raw_value)
+            logger.warning(
+                "Некорректное значение DEVICES_SELECTION_DISABLED_AMOUNT",
+                raw_value=raw_value,
+            )
             return None
 
         if value <= 0:
@@ -1686,7 +1777,7 @@ class Settings(BaseSettings):
 
     def is_multi_tariff_enabled(self) -> bool:
         """Проверяет, включен ли мультитарифный режим."""
-        return self.MULTI_TARIFF_ENABLED and self.SALES_MODE == 'tariffs'
+        return self.MULTI_TARIFF_ENABLED and self.SALES_MODE == "tariffs"
 
     def get_max_active_subscriptions(self) -> int:
         """Максимальное число одновременных подписок (>1 только в multi-tariff)."""
@@ -1694,15 +1785,17 @@ class Settings(BaseSettings):
 
     def is_tariffs_mode(self) -> bool:
         """Проверяет, включен ли режим продаж 'Тарифы'."""
-        return self.SALES_MODE == 'tariffs'
+        return self.SALES_MODE == "tariffs"
 
     def is_classic_mode(self) -> bool:
         """Проверяет, включен ли классический режим продаж."""
-        return self.SALES_MODE != 'tariffs'
+        return self.SALES_MODE != "tariffs"
 
     def get_sales_mode(self) -> str:
         """Возвращает текущий режим продаж."""
-        return self.SALES_MODE if self.SALES_MODE in ('classic', 'tariffs') else 'tariffs'
+        return (
+            self.SALES_MODE if self.SALES_MODE in ("classic", "tariffs") else "tariffs"
+        )
 
     def get_trial_tariff_id(self) -> int:
         """Возвращает ID тарифа для триала (0 = использовать стандартные настройки)."""
@@ -1721,7 +1814,8 @@ class Settings(BaseSettings):
             value = int(self.TRIAL_ACTIVATION_PRICE)
         except (TypeError, ValueError):
             logger.warning(
-                'Некорректное значение TRIAL_ACTIVATION_PRICE', TRIAL_ACTIVATION_PRICE=self.TRIAL_ACTIVATION_PRICE
+                "Некорректное значение TRIAL_ACTIVATION_PRICE",
+                TRIAL_ACTIVATION_PRICE=self.TRIAL_ACTIVATION_PRICE,
             )
             return 0
 
@@ -1731,14 +1825,22 @@ class Settings(BaseSettings):
         return value
 
     def is_yookassa_enabled(self) -> bool:
-        return self.YOOKASSA_ENABLED and self.YOOKASSA_SHOP_ID is not None and self.YOOKASSA_SECRET_KEY is not None
+        return (
+            self.YOOKASSA_ENABLED
+            and self.YOOKASSA_SHOP_ID is not None
+            and self.YOOKASSA_SECRET_KEY is not None
+        )
 
     def get_yookassa_display_name(self) -> str:
-        name = (self.YOOKASSA_DISPLAY_NAME or '').strip()
-        return name or 'YooKassa'
+        name = (self.YOOKASSA_DISPLAY_NAME or "").strip()
+        return name or "YooKassa"
 
     def is_nalogo_enabled(self) -> bool:
-        return self.NALOGO_ENABLED and self.NALOGO_INN is not None and self.NALOGO_PASSWORD is not None
+        return (
+            self.NALOGO_ENABLED
+            and self.NALOGO_INN is not None
+            and self.NALOGO_PASSWORD is not None
+        )
 
     def is_support_topup_enabled(self) -> bool:
         return bool(self.SUPPORT_TOPUP_ENABLED)
@@ -1747,22 +1849,26 @@ class Settings(BaseSettings):
         if self.YOOKASSA_RETURN_URL:
             return self.YOOKASSA_RETURN_URL
         if self.WEBHOOK_URL:
-            return f'{self.WEBHOOK_URL}/payment-success'
-        return 'https://t.me/'
+            return f"{self.WEBHOOK_URL}/payment-success"
+        return "https://t.me/"
 
     def is_cryptobot_enabled(self) -> bool:
         return self.CRYPTOBOT_ENABLED and self.CRYPTOBOT_API_TOKEN is not None
 
     def get_cryptobot_display_name(self) -> str:
-        name = (self.CRYPTOBOT_DISPLAY_NAME or '').strip()
-        return name or 'CryptoBot'
+        name = (self.CRYPTOBOT_DISPLAY_NAME or "").strip()
+        return name or "CryptoBot"
 
     def is_heleket_enabled(self) -> bool:
-        return self.HELEKET_ENABLED and self.HELEKET_MERCHANT_ID is not None and self.HELEKET_API_KEY is not None
+        return (
+            self.HELEKET_ENABLED
+            and self.HELEKET_MERCHANT_ID is not None
+            and self.HELEKET_API_KEY is not None
+        )
 
     def get_heleket_display_name(self) -> str:
-        name = (self.HELEKET_DISPLAY_NAME or '').strip()
-        return name or 'Heleket Crypto'
+        name = (self.HELEKET_DISPLAY_NAME or "").strip()
+        return name or "Heleket Crypto"
 
     def is_mulenpay_enabled(self) -> bool:
         return (
@@ -1773,42 +1879,50 @@ class Settings(BaseSettings):
         )
 
     def get_mulenpay_display_name(self) -> str:
-        name = (self.MULENPAY_DISPLAY_NAME or '').strip()
+        name = (self.MULENPAY_DISPLAY_NAME or "").strip()
         if not name:
-            return 'Mulen Pay'
+            return "Mulen Pay"
         return name
 
     def get_mulenpay_display_name_html(self) -> str:
         return html.escape(self.get_mulenpay_display_name())
 
     def get_mulenpay_expected_origin(self) -> str | None:
-        override = (self.MULENPAY_IFRAME_EXPECTED_ORIGIN or '').strip()
+        override = (self.MULENPAY_IFRAME_EXPECTED_ORIGIN or "").strip()
         if override:
             return override
 
-        base_url = (self.MULENPAY_BASE_URL or '').strip()
+        base_url = (self.MULENPAY_BASE_URL or "").strip()
         if not base_url:
             return None
 
         parsed = urlparse(base_url)
         if parsed.scheme and parsed.netloc:
-            return f'{parsed.scheme}://{parsed.netloc}'
+            return f"{parsed.scheme}://{parsed.netloc}"
         return None
 
     def is_pal24_enabled(self) -> bool:
-        return self.PAL24_ENABLED and self.PAL24_API_TOKEN is not None and self.PAL24_SHOP_ID is not None
+        return (
+            self.PAL24_ENABLED
+            and self.PAL24_API_TOKEN is not None
+            and self.PAL24_SHOP_ID is not None
+        )
 
     def get_pal24_display_name(self) -> str:
-        name = (self.PAL24_DISPLAY_NAME or '').strip()
-        return name or 'PAL24'
+        name = (self.PAL24_DISPLAY_NAME or "").strip()
+        return name or "PAL24"
 
     def is_platega_enabled(self) -> bool:
-        return self.PLATEGA_ENABLED and self.PLATEGA_MERCHANT_ID is not None and self.PLATEGA_SECRET is not None
+        return (
+            self.PLATEGA_ENABLED
+            and self.PLATEGA_MERCHANT_ID is not None
+            and self.PLATEGA_SECRET is not None
+        )
 
     def get_platega_display_name(self) -> str:
-        name = (self.PLATEGA_DISPLAY_NAME or '').strip()
+        name = (self.PLATEGA_DISPLAY_NAME or "").strip()
         if not name:
-            return 'Platega'
+            return "Platega"
         return name
 
     def get_platega_display_name_html(self) -> str:
@@ -1818,29 +1932,29 @@ class Settings(BaseSettings):
         if self.PLATEGA_RETURN_URL:
             return self.PLATEGA_RETURN_URL
         if self.WEBHOOK_URL:
-            return f'{self.WEBHOOK_URL}/payment-success'
+            return f"{self.WEBHOOK_URL}/payment-success"
         return None
 
     def get_platega_failed_url(self) -> str | None:
         if self.PLATEGA_FAILED_URL:
             return self.PLATEGA_FAILED_URL
         if self.WEBHOOK_URL:
-            return f'{self.WEBHOOK_URL}/payment-failed'
+            return f"{self.WEBHOOK_URL}/payment-failed"
         return None
 
     def get_platega_active_methods(self) -> list[int]:
-        raw_value = str(self.PLATEGA_ACTIVE_METHODS or '')
-        normalized = raw_value.replace(';', ',')
+        raw_value = str(self.PLATEGA_ACTIVE_METHODS or "")
+        normalized = raw_value.replace(";", ",")
         methods: list[int] = []
         seen: set[int] = set()
-        for part in normalized.split(','):
+        for part in normalized.split(","):
             part = part.strip()
             if not part:
                 continue
             try:
                 method_code = int(part)
             except ValueError:
-                logger.warning('Некорректный код метода Platega', part=part)
+                logger.warning("Некорректный код метода Platega", part=part)
                 continue
             if method_code in {2, 11, 12, 13} and method_code not in seen:
                 methods.append(method_code)
@@ -1854,32 +1968,32 @@ class Settings(BaseSettings):
     @staticmethod
     def get_platega_method_definitions() -> dict[int, dict[str, str]]:
         return {
-            2: {'name': 'СБП (QR)', 'title': '🏦 СБП (QR)'},
-            11: {'name': 'Карты (RUB)', 'title': '💳 Карты (RUB)'},
-            12: {'name': 'Международные карты', 'title': '🌍 Международные карты'},
-            13: {'name': 'Криптовалюта', 'title': '🪙 Криптовалюта'},
+            2: {"name": "СБП (QR)", "title": "🏦 СБП (QR)"},
+            11: {"name": "Карты (RUB)", "title": "💳 Карты (RUB)"},
+            12: {"name": "Международные карты", "title": "🌍 Международные карты"},
+            13: {"name": "Криптовалюта", "title": "🪙 Криптовалюта"},
         }
 
     def get_platega_method_display_name(self, method_code: int) -> str:
         definitions = self.get_platega_method_definitions()
         info = definitions.get(method_code)
-        if info and info.get('name'):
-            return info['name']
-        return f'Метод {method_code}'
+        if info and info.get("name"):
+            return info["name"]
+        return f"Метод {method_code}"
 
     def get_platega_method_display_title(self, method_code: int) -> str:
         definitions = self.get_platega_method_definitions()
         info = definitions.get(method_code)
         if not info:
-            return f'Platega {method_code}'
-        return info.get('title') or info.get('name') or f'Platega {method_code}'
+            return f"Platega {method_code}"
+        return info.get("title") or info.get("name") or f"Platega {method_code}"
 
     def is_wata_enabled(self) -> bool:
         return self.WATA_ENABLED and self.WATA_ACCESS_TOKEN is not None
 
     def get_wata_display_name(self) -> str:
-        name = (self.WATA_DISPLAY_NAME or '').strip()
-        return name or 'Wata'
+        name = (self.WATA_DISPLAY_NAME or "").strip()
+        return name or "Wata"
 
     def is_cloudpayments_enabled(self) -> bool:
         return (
@@ -1889,8 +2003,8 @@ class Settings(BaseSettings):
         )
 
     def get_cloudpayments_display_name(self) -> str:
-        name = (self.CLOUDPAYMENTS_DISPLAY_NAME or '').strip()
-        return name or 'CloudPayments'
+        name = (self.CLOUDPAYMENTS_DISPLAY_NAME or "").strip()
+        return name or "CloudPayments"
 
     def is_freekassa_enabled(self) -> bool:
         return (
@@ -1902,8 +2016,8 @@ class Settings(BaseSettings):
         )
 
     def get_freekassa_display_name(self) -> str:
-        name = (self.FREEKASSA_DISPLAY_NAME or '').strip()
-        return name or 'Freekassa'
+        name = (self.FREEKASSA_DISPLAY_NAME or "").strip()
+        return name or "Freekassa"
 
     def get_freekassa_display_name_html(self) -> str:
         return html.escape(self.get_freekassa_display_name())
@@ -1912,8 +2026,8 @@ class Settings(BaseSettings):
         return self.FREEKASSA_SBP_ENABLED and self.is_freekassa_enabled()
 
     def get_freekassa_sbp_display_name(self) -> str:
-        name = (self.FREEKASSA_SBP_DISPLAY_NAME or '').strip()
-        return name or 'СБП (QR код)'
+        name = (self.FREEKASSA_SBP_DISPLAY_NAME or "").strip()
+        return name or "СБП (QR код)"
 
     def get_freekassa_sbp_display_name_html(self) -> str:
         return html.escape(self.get_freekassa_sbp_display_name())
@@ -1922,8 +2036,8 @@ class Settings(BaseSettings):
         return self.FREEKASSA_CARD_ENABLED and self.is_freekassa_enabled()
 
     def get_freekassa_card_display_name(self) -> str:
-        name = (self.FREEKASSA_CARD_DISPLAY_NAME or '').strip()
-        return name or 'Карта РФ'
+        name = (self.FREEKASSA_CARD_DISPLAY_NAME or "").strip()
+        return name or "Карта РФ"
 
     def get_freekassa_card_display_name_html(self) -> str:
         return html.escape(self.get_freekassa_card_display_name())
@@ -1937,8 +2051,8 @@ class Settings(BaseSettings):
         )
 
     def get_kassa_ai_display_name(self) -> str:
-        name = (self.KASSA_AI_DISPLAY_NAME or '').strip()
-        return name or 'KassaAI'
+        name = (self.KASSA_AI_DISPLAY_NAME or "").strip()
+        return name or "KassaAI"
 
     def get_kassa_ai_display_name_html(self) -> str:
         return html.escape(self.get_kassa_ai_display_name())
@@ -1947,18 +2061,22 @@ class Settings(BaseSettings):
         return self.RIOPAY_ENABLED and self.RIOPAY_API_TOKEN is not None
 
     def get_riopay_display_name(self) -> str:
-        name = (self.RIOPAY_DISPLAY_NAME or '').strip()
-        return name or 'RioPay'
+        name = (self.RIOPAY_DISPLAY_NAME or "").strip()
+        return name or "RioPay"
 
     def get_riopay_display_name_html(self) -> str:
         return html.escape(self.get_riopay_display_name())
 
     def is_severpay_enabled(self) -> bool:
-        return self.SEVERPAY_ENABLED and self.SEVERPAY_MID is not None and self.SEVERPAY_TOKEN is not None
+        return (
+            self.SEVERPAY_ENABLED
+            and self.SEVERPAY_MID is not None
+            and self.SEVERPAY_TOKEN is not None
+        )
 
     def get_severpay_display_name(self) -> str:
-        name = (self.SEVERPAY_DISPLAY_NAME or '').strip()
-        return name if name else 'SeverPay'
+        name = (self.SEVERPAY_DISPLAY_NAME or "").strip()
+        return name if name else "SeverPay"
 
     def get_severpay_display_name_html(self) -> str:
         return html.escape(self.get_severpay_display_name())
@@ -1967,8 +2085,8 @@ class Settings(BaseSettings):
         return self.KASSA_AI_SBP_ENABLED and self.is_kassa_ai_enabled()
 
     def get_kassa_ai_sbp_display_name(self) -> str:
-        name = (self.KASSA_AI_SBP_DISPLAY_NAME or '').strip()
-        return name if name else 'СБП (KassaAI)'
+        name = (self.KASSA_AI_SBP_DISPLAY_NAME or "").strip()
+        return name if name else "СБП (KassaAI)"
 
     def get_kassa_ai_sbp_display_name_html(self) -> str:
         return html.escape(self.get_kassa_ai_sbp_display_name())
@@ -1977,8 +2095,8 @@ class Settings(BaseSettings):
         return self.KASSA_AI_CARD_ENABLED and self.is_kassa_ai_enabled()
 
     def get_kassa_ai_card_display_name(self) -> str:
-        name = (self.KASSA_AI_CARD_DISPLAY_NAME or '').strip()
-        return name if name else 'Карта (KassaAI)'
+        name = (self.KASSA_AI_CARD_DISPLAY_NAME or "").strip()
+        return name if name else "Карта (KassaAI)"
 
     def get_kassa_ai_card_display_name_html(self) -> str:
         return html.escape(self.get_kassa_ai_card_display_name())
@@ -1987,8 +2105,8 @@ class Settings(BaseSettings):
         return self.KASSA_AI_SBERPAY_ENABLED and self.is_kassa_ai_enabled()
 
     def get_kassa_ai_sberpay_display_name(self) -> str:
-        name = (self.KASSA_AI_SBERPAY_DISPLAY_NAME or '').strip()
-        return name if name else 'SberPay (KassaAI)'
+        name = (self.KASSA_AI_SBERPAY_DISPLAY_NAME or "").strip()
+        return name if name else "SberPay (KassaAI)"
 
     def get_kassa_ai_sberpay_display_name_html(self) -> str:
         return html.escape(self.get_kassa_ai_sberpay_display_name())
@@ -1999,12 +2117,15 @@ class Settings(BaseSettings):
     def get_payment_verification_auto_check_interval(self) -> int:
         try:
             minutes = int(self.PAYMENT_VERIFICATION_AUTO_CHECK_INTERVAL_MINUTES)
-        except (TypeError, ValueError):  # pragma: no cover - защитная проверка конфигурации
+        except (
+            TypeError,
+            ValueError,
+        ):  # pragma: no cover - защитная проверка конфигурации
             minutes = 10
 
         if minutes <= 0:
             logger.warning(
-                'Некорректный интервал автопроверки платежей: . Используется значение по умолчанию 10 минут.',
+                "Некорректный интервал автопроверки платежей: . Используется значение по умолчанию 10 минут.",
                 PAYMENT_VERIFICATION_AUTO_CHECK_INTERVAL_MINUTES=self.PAYMENT_VERIFICATION_AUTO_CHECK_INTERVAL_MINUTES,
             )
             return 10
@@ -2013,17 +2134,17 @@ class Settings(BaseSettings):
 
     def get_cryptobot_base_url(self) -> str:
         if self.CRYPTOBOT_TESTNET:
-            return 'https://testnet-pay.crypt.bot'
+            return "https://testnet-pay.crypt.bot"
         return self.CRYPTOBOT_BASE_URL
 
     def get_cryptobot_assets(self) -> list[str]:
         try:
             assets = self.CRYPTOBOT_ASSETS.strip()
             if not assets:
-                return ['USDT', 'TON']
-            return [asset.strip() for asset in assets.split(',') if asset.strip()]
+                return ["USDT", "TON"]
+            return [asset.strip() for asset in assets.split(",") if asset.strip()]
         except (ValueError, AttributeError):
-            return ['USDT', 'TON']
+            return ["USDT", "TON"]
 
     def get_cryptobot_invoice_expires_seconds(self) -> int:
         return self.CRYPTOBOT_INVOICE_EXPIRES_HOURS * 3600
@@ -2045,14 +2166,16 @@ class Settings(BaseSettings):
         if self.HELEKET_CALLBACK_URL:
             return self.HELEKET_CALLBACK_URL
         if self.WEBHOOK_URL:
-            return f'{self.WEBHOOK_URL}{self.HELEKET_WEBHOOK_PATH}'
+            return f"{self.WEBHOOK_URL}{self.HELEKET_WEBHOOK_PATH}"
         return None
 
     def is_happ_cryptolink_mode(self) -> bool:
-        return self.CONNECT_BUTTON_MODE == 'happ_cryptolink'
+        return self.CONNECT_BUTTON_MODE == "happ_cryptolink"
 
     def is_happ_download_button_enabled(self) -> bool:
-        return self.is_happ_cryptolink_mode() and self.CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED
+        return (
+            self.is_happ_cryptolink_mode() and self.CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED
+        )
 
     def should_hide_subscription_link(self) -> bool:
         """Returns True when subscription links must be hidden from the interface."""
@@ -2062,30 +2185,33 @@ class Settings(BaseSettings):
         return self.HIDE_SUBSCRIPTION_LINK
 
     def is_contests_enabled(self) -> bool:
-        if getattr(self, 'CONTESTS_ENABLED', False):
+        if getattr(self, "CONTESTS_ENABLED", False):
             return True
         # legacy fallback
-        return bool(getattr(self, 'REFERRAL_CONTESTS_ENABLED', False))
+        return bool(getattr(self, "REFERRAL_CONTESTS_ENABLED", False))
 
     def is_referral_contests_enabled(self) -> bool:
         # kept for backward compatibility
         return self.is_contests_enabled()
 
     def get_happ_cryptolink_redirect_template(self) -> str | None:
-        template = (self.HAPP_CRYPTOLINK_REDIRECT_TEMPLATE or '').strip()
+        template = (self.HAPP_CRYPTOLINK_REDIRECT_TEMPLATE or "").strip()
         return template or None
 
     def get_happ_download_link(self, platform: str) -> str | None:
         platform_key = platform.lower()
 
-        if platform_key == 'pc':
-            platform_key = 'windows'
+        if platform_key == "pc":
+            platform_key = "windows"
 
         links = {
-            'ios': (self.HAPP_DOWNLOAD_LINK_IOS or '').strip(),
-            'android': (self.HAPP_DOWNLOAD_LINK_ANDROID or '').strip(),
-            'macos': (self.HAPP_DOWNLOAD_LINK_MACOS or '').strip(),
-            'windows': ((self.HAPP_DOWNLOAD_LINK_WINDOWS or '').strip() or (self.HAPP_DOWNLOAD_LINK_PC or '').strip()),
+            "ios": (self.HAPP_DOWNLOAD_LINK_IOS or "").strip(),
+            "android": (self.HAPP_DOWNLOAD_LINK_ANDROID or "").strip(),
+            "macos": (self.HAPP_DOWNLOAD_LINK_MACOS or "").strip(),
+            "windows": (
+                (self.HAPP_DOWNLOAD_LINK_WINDOWS or "").strip()
+                or (self.HAPP_DOWNLOAD_LINK_PC or "").strip()
+            ),
         }
         link = links.get(platform_key)
         return link or None
@@ -2111,17 +2237,17 @@ class Settings(BaseSettings):
 
     def get_base_promo_group_period_discounts(self) -> dict[int, int]:
         try:
-            config_str = (self.BASE_PROMO_GROUP_PERIOD_DISCOUNTS or '').strip()
+            config_str = (self.BASE_PROMO_GROUP_PERIOD_DISCOUNTS or "").strip()
             if not config_str:
                 return {}
 
             discounts: dict[int, int] = {}
-            for part in config_str.split(','):
+            for part in config_str.split(","):
                 part = part.strip()
                 if not part:
                     continue
 
-                period_and_discount = part.split(':')
+                period_and_discount = part.split(":")
                 if len(period_and_discount) != 2:
                     continue
 
@@ -2165,7 +2291,7 @@ class Settings(BaseSettings):
                 allowed_periods = {14, 30, 60, 90, 180, 360}
             else:
                 allowed_periods = set()
-                for period_str in periods_str.split(','):
+                for period_str in periods_str.split(","):
                     period_str = period_str.strip()
                     if period_str:
                         allowed_periods.add(int(period_str))
@@ -2191,7 +2317,7 @@ class Settings(BaseSettings):
                 allowed_periods = {30, 60, 90, 180, 360}
             else:
                 allowed_periods = set()
-                for period_str in periods_str.split(','):
+                for period_str in periods_str.split(","):
                     period_str = period_str.strip()
                     if period_str:
                         allowed_periods.add(int(period_str))
@@ -2214,7 +2340,7 @@ class Settings(BaseSettings):
                 return [14, 30, 60, 90, 180, 360]
 
             periods = []
-            for period_str in periods_str.split(','):
+            for period_str in periods_str.split(","):
                 period_str = period_str.strip()
                 if period_str:
                     periods.append(int(period_str))
@@ -2233,7 +2359,7 @@ class Settings(BaseSettings):
                 return [30, 60, 90, 180, 360]
 
             periods = []
-            for period_str in periods_str.split(','):
+            for period_str in periods_str.split(","):
                 period_str = period_str.strip()
                 if period_str:
                     periods.append(int(period_str))
@@ -2242,35 +2368,46 @@ class Settings(BaseSettings):
             return [30, 60, 90, 180, 360]
 
     def get_balance_payment_description(
-        self, amount_kopeks: int, telegram_user_id: int | None = None, user_db_id: int | None = None
+        self,
+        amount_kopeks: int,
+        telegram_user_id: int | None = None,
+        user_db_id: int | None = None,
     ) -> str:
         # Базовое описание
-        description = f'{self.PAYMENT_BALANCE_DESCRIPTION} на {self.format_price(amount_kopeks)}'
+        description = (
+            f"{self.PAYMENT_BALANCE_DESCRIPTION} на {self.format_price(amount_kopeks)}"
+        )
 
         # Добавляем идентификатор пользователя (TG ID приоритет, fallback на DB ID)
         if telegram_user_id is not None:
-            description += f' (ID {telegram_user_id})'
+            description += f" (ID {telegram_user_id})"
         elif user_db_id is not None:
-            description += f' (U{user_db_id})'
+            description += f" (U{user_db_id})"
 
         # Формируем финальную строку по шаблону
-        return self.PAYMENT_BALANCE_TEMPLATE.format(service_name=self.PAYMENT_SERVICE_NAME, description=description)
+        return self.PAYMENT_BALANCE_TEMPLATE.format(
+            service_name=self.PAYMENT_SERVICE_NAME, description=description
+        )
 
-    def get_subscription_payment_description(self, period_days: int, amount_kopeks: int) -> str:
+    def get_subscription_payment_description(
+        self, period_days: int, amount_kopeks: int
+    ) -> str:
         return self.PAYMENT_SUBSCRIPTION_TEMPLATE.format(
             service_name=self.PAYMENT_SERVICE_NAME,
-            description=f'{self.PAYMENT_SUBSCRIPTION_DESCRIPTION} на {period_days} дней',
+            description=f"{self.PAYMENT_SUBSCRIPTION_DESCRIPTION} на {period_days} дней",
         )
 
     def get_custom_payment_description(self, description: str) -> str:
-        return self.PAYMENT_BALANCE_TEMPLATE.format(service_name=self.PAYMENT_SERVICE_NAME, description=description)
+        return self.PAYMENT_BALANCE_TEMPLATE.format(
+            service_name=self.PAYMENT_SERVICE_NAME, description=description
+        )
 
     def get_stars_rate(self) -> float:
         return self.TELEGRAM_STARS_RATE_RUB
 
     def get_telegram_stars_display_name(self) -> str:
-        name = (self.TELEGRAM_STARS_DISPLAY_NAME or '').strip()
-        return name or 'Telegram Stars'
+        name = (self.TELEGRAM_STARS_DISPLAY_NAME or "").strip()
+        return name or "Telegram Stars"
 
     def stars_to_rubles(self, stars: int) -> float:
         return stars * self.get_stars_rate()
@@ -2278,7 +2415,7 @@ class Settings(BaseSettings):
     def rubles_to_stars(self, rubles: float) -> int:
         rate = self.get_stars_rate()
         if rate <= 0:
-            raise ValueError('Stars rate must be positive')
+            raise ValueError("Stars rate must be positive")
         return max(1, round(rubles / rate))
 
     def get_admin_notifications_chat_id(self) -> int | None:
@@ -2291,7 +2428,10 @@ class Settings(BaseSettings):
             return None
 
     def is_admin_notifications_enabled(self) -> bool:
-        return self.ADMIN_NOTIFICATIONS_ENABLED and self.get_admin_notifications_chat_id() is not None
+        return (
+            self.ADMIN_NOTIFICATIONS_ENABLED
+            and self.get_admin_notifications_chat_id() is not None
+        )
 
     def get_backup_send_chat_id(self) -> int | None:
         if not self.BACKUP_SEND_CHAT_ID:
@@ -2306,7 +2446,7 @@ class Settings(BaseSettings):
         return self.BACKUP_SEND_ENABLED and self.get_backup_send_chat_id() is not None
 
     def get_backup_archive_password(self) -> str | None:
-        password = (self.BACKUP_ARCHIVE_PASSWORD or '').strip()
+        password = (self.BACKUP_ARCHIVE_PASSWORD or "").strip()
         return password or None
 
     # === Log Rotation Methods ===
@@ -2341,15 +2481,15 @@ class Settings(BaseSettings):
 
     def get_referral_settings(self) -> dict:
         return {
-            'program_enabled': self.is_referral_program_enabled(),
-            'minimum_topup_kopeks': self.REFERRAL_MINIMUM_TOPUP_KOPEKS,
-            'first_topup_bonus_kopeks': self.REFERRAL_FIRST_TOPUP_BONUS_KOPEKS,
-            'inviter_bonus_kopeks': self.REFERRAL_INVITER_BONUS_KOPEKS,
-            'commission_percent': self.REFERRAL_COMMISSION_PERCENT,
-            'notifications_enabled': self.REFERRAL_NOTIFICATIONS_ENABLED,
-            'withdrawal_enabled': self.REFERRAL_WITHDRAWAL_ENABLED,
-            'withdrawal_min_amount_kopeks': self.REFERRAL_WITHDRAWAL_MIN_AMOUNT_KOPEKS,
-            'withdrawal_cooldown_days': self.REFERRAL_WITHDRAWAL_COOLDOWN_DAYS,
+            "program_enabled": self.is_referral_program_enabled(),
+            "minimum_topup_kopeks": self.REFERRAL_MINIMUM_TOPUP_KOPEKS,
+            "first_topup_bonus_kopeks": self.REFERRAL_FIRST_TOPUP_BONUS_KOPEKS,
+            "inviter_bonus_kopeks": self.REFERRAL_INVITER_BONUS_KOPEKS,
+            "commission_percent": self.REFERRAL_COMMISSION_PERCENT,
+            "notifications_enabled": self.REFERRAL_NOTIFICATIONS_ENABLED,
+            "withdrawal_enabled": self.REFERRAL_WITHDRAWAL_ENABLED,
+            "withdrawal_min_amount_kopeks": self.REFERRAL_WITHDRAWAL_MIN_AMOUNT_KOPEKS,
+            "withdrawal_cooldown_days": self.REFERRAL_WITHDRAWAL_COOLDOWN_DAYS,
         }
 
     def is_referral_withdrawal_enabled(self) -> bool:
@@ -2370,28 +2510,28 @@ class Settings(BaseSettings):
             if not config_str:
                 return self._get_fallback_traffic_packages()
 
-            for package_config in config_str.split(','):
+            for package_config in config_str.split(","):
                 package_config = package_config.strip()
                 if not package_config:
                     continue
 
-                parts = package_config.split(':')
+                parts = package_config.split(":")
                 if len(parts) != 3:
                     continue
 
                 try:
                     gb = int(parts[0])
                     price = int(parts[1])
-                    enabled = parts[2].lower() == 'true'
+                    enabled = parts[2].lower() == "true"
 
-                    packages.append({'gb': gb, 'price': price, 'enabled': enabled})
+                    packages.append({"gb": gb, "price": price, "enabled": enabled})
                 except ValueError:
                     continue
 
             return packages or self._get_fallback_traffic_packages()
 
         except Exception as e:
-            logger.warning('ERROR PARSING CONFIG', error=e)
+            logger.warning("ERROR PARSING CONFIG", error=e)
             return self._get_fallback_traffic_packages()
 
     def is_version_check_enabled(self) -> bool:
@@ -2407,21 +2547,21 @@ class Settings(BaseSettings):
         try:
             if self.TRAFFIC_PACKAGES_CONFIG.strip():
                 packages = []
-                for package_config in self.TRAFFIC_PACKAGES_CONFIG.split(','):
+                for package_config in self.TRAFFIC_PACKAGES_CONFIG.split(","):
                     package_config = package_config.strip()
                     if not package_config:
                         continue
 
-                    parts = package_config.split(':')
+                    parts = package_config.split(":")
                     if len(parts) != 3:
                         continue
 
                     try:
                         gb = int(parts[0])
                         price = int(parts[1])
-                        enabled = parts[2].lower() == 'true'
+                        enabled = parts[2].lower() == "true"
 
-                        packages.append({'gb': gb, 'price': price, 'enabled': enabled})
+                        packages.append({"gb": gb, "price": price, "enabled": enabled})
                     except ValueError:
                         continue
 
@@ -2431,20 +2571,20 @@ class Settings(BaseSettings):
             pass
 
         return [
-            {'gb': 5, 'price': self.PRICE_TRAFFIC_5GB, 'enabled': True},
-            {'gb': 10, 'price': self.PRICE_TRAFFIC_10GB, 'enabled': True},
-            {'gb': 25, 'price': self.PRICE_TRAFFIC_25GB, 'enabled': True},
-            {'gb': 50, 'price': self.PRICE_TRAFFIC_50GB, 'enabled': True},
-            {'gb': 100, 'price': self.PRICE_TRAFFIC_100GB, 'enabled': True},
-            {'gb': 250, 'price': self.PRICE_TRAFFIC_250GB, 'enabled': True},
-            {'gb': 500, 'price': self.PRICE_TRAFFIC_500GB, 'enabled': True},
-            {'gb': 1000, 'price': self.PRICE_TRAFFIC_1000GB, 'enabled': True},
-            {'gb': 0, 'price': self.PRICE_TRAFFIC_UNLIMITED, 'enabled': True},
+            {"gb": 5, "price": self.PRICE_TRAFFIC_5GB, "enabled": True},
+            {"gb": 10, "price": self.PRICE_TRAFFIC_10GB, "enabled": True},
+            {"gb": 25, "price": self.PRICE_TRAFFIC_25GB, "enabled": True},
+            {"gb": 50, "price": self.PRICE_TRAFFIC_50GB, "enabled": True},
+            {"gb": 100, "price": self.PRICE_TRAFFIC_100GB, "enabled": True},
+            {"gb": 250, "price": self.PRICE_TRAFFIC_250GB, "enabled": True},
+            {"gb": 500, "price": self.PRICE_TRAFFIC_500GB, "enabled": True},
+            {"gb": 1000, "price": self.PRICE_TRAFFIC_1000GB, "enabled": True},
+            {"gb": 0, "price": self.PRICE_TRAFFIC_UNLIMITED, "enabled": True},
         ]
 
     def get_traffic_price(self, gb: int | None) -> int:
         packages = self.get_traffic_packages()
-        enabled_packages = [pkg for pkg in packages if pkg['enabled']]
+        enabled_packages = [pkg for pkg in packages if pkg["enabled"]]
 
         if not enabled_packages:
             return 0
@@ -2453,34 +2593,40 @@ class Settings(BaseSettings):
             gb = 0
 
         for package in enabled_packages:
-            if package['gb'] == gb:
-                return package['price']
+            if package["gb"] == gb:
+                return package["price"]
 
-        unlimited_package = next((pkg for pkg in enabled_packages if pkg['gb'] == 0), None)
+        unlimited_package = next(
+            (pkg for pkg in enabled_packages if pkg["gb"] == 0), None
+        )
 
         if gb <= 0:
-            return unlimited_package['price'] if unlimited_package else 0
+            return unlimited_package["price"] if unlimited_package else 0
 
-        finite_packages = [pkg for pkg in enabled_packages if pkg['gb'] > 0]
+        finite_packages = [pkg for pkg in enabled_packages if pkg["gb"] > 0]
 
         if not finite_packages:
-            return unlimited_package['price'] if unlimited_package else 0
+            return unlimited_package["price"] if unlimited_package else 0
 
-        max_package = max(finite_packages, key=lambda x: x['gb'])
+        max_package = max(finite_packages, key=lambda x: x["gb"])
 
-        if gb >= max_package['gb']:
-            return unlimited_package['price'] if unlimited_package else max_package['price']
+        if gb >= max_package["gb"]:
+            return (
+                unlimited_package["price"]
+                if unlimited_package
+                else max_package["price"]
+            )
 
-        suitable_packages = [pkg for pkg in finite_packages if pkg['gb'] >= gb]
+        suitable_packages = [pkg for pkg in finite_packages if pkg["gb"] >= gb]
 
         if suitable_packages:
-            nearest_package = min(suitable_packages, key=lambda x: x['gb'])
-            return nearest_package['price']
+            nearest_package = min(suitable_packages, key=lambda x: x["gb"])
+            return nearest_package["price"]
 
-        return unlimited_package['price'] if unlimited_package else 0
+        return unlimited_package["price"] if unlimited_package else 0
 
     def _clean_support_contact(self) -> str:
-        return (self.SUPPORT_USERNAME or '').strip()
+        return (self.SUPPORT_USERNAME or "").strip()
 
     def get_support_contact_url(self) -> str | None:
         contact = self._clean_support_contact()
@@ -2488,22 +2634,24 @@ class Settings(BaseSettings):
         if not contact:
             return None
 
-        if contact.startswith(('http://', 'https://', 'tg://')):
+        if contact.startswith(("http://", "https://", "tg://")):
             return contact
 
-        contact_without_prefix = contact.lstrip('@')
+        contact_without_prefix = contact.lstrip("@")
 
-        if contact_without_prefix.startswith(('t.me/', 'telegram.me/', 'telegram.dog/')):
-            return f'https://{contact_without_prefix}'
+        if contact_without_prefix.startswith(
+            ("t.me/", "telegram.me/", "telegram.dog/")
+        ):
+            return f"https://{contact_without_prefix}"
 
-        if contact.startswith(('t.me/', 'telegram.me/', 'telegram.dog/')):
-            return f'https://{contact}'
+        if contact.startswith(("t.me/", "telegram.me/", "telegram.dog/")):
+            return f"https://{contact}"
 
-        if '.' in contact_without_prefix:
-            return f'https://{contact_without_prefix}'
+        if "." in contact_without_prefix:
+            return f"https://{contact_without_prefix}"
 
         if contact_without_prefix:
-            return f'https://t.me/{contact_without_prefix}'
+            return f"https://t.me/{contact_without_prefix}"
 
         return None
 
@@ -2511,26 +2659,26 @@ class Settings(BaseSettings):
         contact = self._clean_support_contact()
 
         if not contact:
-            return ''
+            return ""
 
-        if contact.startswith('@'):
+        if contact.startswith("@"):
             return contact
 
-        if contact.startswith(('http://', 'https://', 'tg://')):
+        if contact.startswith(("http://", "https://", "tg://")):
             return contact
 
-        if contact.startswith(('t.me/', 'telegram.me/', 'telegram.dog/')):
+        if contact.startswith(("t.me/", "telegram.me/", "telegram.dog/")):
             url = self.get_support_contact_url()
             return url or contact
 
-        contact_without_prefix = contact.lstrip('@')
+        contact_without_prefix = contact.lstrip("@")
 
-        if '.' in contact_without_prefix:
+        if "." in contact_without_prefix:
             url = self.get_support_contact_url()
             return url or contact
 
-        if re.fullmatch(r'[A-Za-z0-9_]{3,}', contact_without_prefix):
-            return f'@{contact_without_prefix}'
+        if re.fullmatch(r"[A-Za-z0-9_]{3,}", contact_without_prefix):
+            return f"@{contact_without_prefix}"
 
         return contact
 
@@ -2541,24 +2689,24 @@ class Settings(BaseSettings):
         return self.SERVER_STATUS_MODE
 
     def is_server_status_enabled(self) -> bool:
-        return self.get_server_status_mode() != 'disabled'
+        return self.get_server_status_mode() != "disabled"
 
     def get_server_status_external_url(self) -> str | None:
-        url = (self.SERVER_STATUS_EXTERNAL_URL or '').strip()
+        url = (self.SERVER_STATUS_EXTERNAL_URL or "").strip()
         return url or None
 
     def get_server_status_metrics_url(self) -> str | None:
-        url = (self.SERVER_STATUS_METRICS_URL or '').strip()
+        url = (self.SERVER_STATUS_METRICS_URL or "").strip()
         return url or None
 
     def get_server_status_metrics_auth(self) -> tuple[str, str] | None:
-        username = (self.SERVER_STATUS_METRICS_USERNAME or '').strip()
+        username = (self.SERVER_STATUS_METRICS_USERNAME or "").strip()
         password_raw = self.SERVER_STATUS_METRICS_PASSWORD
 
         if not username:
             return None
 
-        password = '' if password_raw is None else str(password_raw)
+        password = "" if password_raw is None else str(password_raw)
         return username, password
 
     def get_server_status_items_per_page(self) -> int:
@@ -2571,29 +2719,29 @@ class Settings(BaseSettings):
         return bool(self.WEB_API_ENABLED)
 
     def get_web_api_allowed_origins(self) -> list[str]:
-        raw = (self.WEB_API_ALLOWED_ORIGINS or '').split(',')
+        raw = (self.WEB_API_ALLOWED_ORIGINS or "").split(",")
         origins = [origin.strip() for origin in raw if origin.strip()]
-        return origins or ['*']
+        return origins or ["*"]
 
     def get_web_api_docs_config(self) -> dict[str, str | None]:
         if self.WEB_API_DOCS_ENABLED:
             return {
-                'docs_url': '/docs',
-                'redoc_url': '/redoc',
-                'openapi_url': '/openapi.json',
+                "docs_url": "/docs",
+                "redoc_url": "/redoc",
+                "openapi_url": "/openapi.json",
             }
 
-        return {'docs_url': None, 'redoc_url': None, 'openapi_url': None}
+        return {"docs_url": None, "redoc_url": None, "openapi_url": None}
 
     def get_support_system_mode(self) -> str:
-        mode = (self.SUPPORT_SYSTEM_MODE or 'both').strip().lower()
-        return mode if mode in {'tickets', 'contact', 'both'} else 'both'
+        mode = (self.SUPPORT_SYSTEM_MODE or "both").strip().lower()
+        return mode if mode in {"tickets", "contact", "both"} else "both"
 
     def is_support_tickets_enabled(self) -> bool:
-        return self.get_support_system_mode() in {'tickets', 'both'}
+        return self.get_support_system_mode() in {"tickets", "both"}
 
     def is_support_contact_enabled(self) -> bool:
-        return self.get_support_system_mode() in {'contact', 'both'}
+        return self.get_support_system_mode() in {"contact", "both"}
 
     # MiniApp tickets settings
     def is_miniapp_tickets_enabled(self) -> bool:
@@ -2602,25 +2750,27 @@ class Settings(BaseSettings):
 
     def get_miniapp_support_type(self) -> str:
         """Get miniapp support type: tickets, profile, or url."""
-        support_type = (self.MINIAPP_SUPPORT_TYPE or 'tickets').strip().lower()
-        return support_type if support_type in {'tickets', 'profile', 'url'} else 'tickets'
+        support_type = (self.MINIAPP_SUPPORT_TYPE or "tickets").strip().lower()
+        return (
+            support_type if support_type in {"tickets", "profile", "url"} else "tickets"
+        )
 
     def get_miniapp_support_url(self) -> str:
         """Get custom support URL for miniapp (when type is 'url')."""
-        return (self.MINIAPP_SUPPORT_URL or '').strip()
+        return (self.MINIAPP_SUPPORT_URL or "").strip()
 
     def get_bot_run_mode(self) -> str:
-        mode = (self.BOT_RUN_MODE or 'polling').strip().lower()
-        if mode not in {'polling', 'webhook'}:
-            return 'polling'
+        mode = (self.BOT_RUN_MODE or "polling").strip().lower()
+        if mode not in {"polling", "webhook"}:
+            return "polling"
         return mode
 
     def get_telegram_webhook_path(self) -> str:
-        raw_path = (self.WEBHOOK_PATH or '/webhook').strip()
+        raw_path = (self.WEBHOOK_PATH or "/webhook").strip()
         if not raw_path:
-            raw_path = '/webhook'
-        if not raw_path.startswith('/'):
-            raw_path = '/' + raw_path
+            raw_path = "/webhook"
+        if not raw_path.startswith("/"):
+            raw_path = "/" + raw_path
         return raw_path
 
     def get_webhook_queue_maxsize(self) -> int:
@@ -2652,16 +2802,16 @@ class Settings(BaseSettings):
         return max(1.0, timeout)
 
     def get_telegram_webhook_url(self) -> str | None:
-        base_url = (self.WEBHOOK_URL or '').strip()
+        base_url = (self.WEBHOOK_URL or "").strip()
         if not base_url:
             return None
         path = self.get_telegram_webhook_path()
-        return f'{base_url.rstrip("/")}{path}'
+        return f"{base_url.rstrip('/')}{path}"
 
     def get_miniapp_static_path(self) -> Path:
-        raw_path = (self.MINIAPP_STATIC_PATH or 'miniapp').strip()
+        raw_path = (self.MINIAPP_STATIC_PATH or "miniapp").strip()
         if not raw_path:
-            raw_path = 'miniapp'
+            raw_path = "miniapp"
         return Path(raw_path)
 
     def get_media_upload_path(self) -> Path:
@@ -2677,8 +2827,8 @@ class Settings(BaseSettings):
         import warnings
 
         warnings.warn(
-            'CABINET_JWT_SECRET is not set, falling back to BOT_TOKEN. '
-            'Set CABINET_JWT_SECRET to a unique secret in production: '
+            "CABINET_JWT_SECRET is not set, falling back to BOT_TOKEN. "
+            "Set CABINET_JWT_SECRET to a unique secret in production: "
             'python -c "import secrets; print(secrets.token_urlsafe(64))"',
             UserWarning,
             stacklevel=2,
@@ -2694,7 +2844,7 @@ class Settings(BaseSettings):
     def get_cabinet_allowed_origins(self) -> list[str]:
         if not self.CABINET_ALLOWED_ORIGINS:
             return []
-        return [o.strip() for o in self.CABINET_ALLOWED_ORIGINS.split(',') if o.strip()]
+        return [o.strip() for o in self.CABINET_ALLOWED_ORIGINS.split(",") if o.strip()]
 
     def is_cabinet_email_verification_enabled(self) -> bool:
         return bool(self.CABINET_EMAIL_VERIFICATION_ENABLED)
@@ -2715,7 +2865,7 @@ class Settings(BaseSettings):
         """Parse CABINET_TRUSTED_PROXIES into a set of IP strings/CIDRs."""
         if not self.CABINET_TRUSTED_PROXIES:
             return set()
-        return {p.strip() for p in self.CABINET_TRUSTED_PROXIES.split(',') if p.strip()}
+        return {p.strip() for p in self.CABINET_TRUSTED_PROXIES.split(",") if p.strip()}
 
     def is_smtp_configured(self) -> bool:
         # For servers without AUTH, only host and from_email are required
@@ -2731,35 +2881,39 @@ class Settings(BaseSettings):
     def get_oauth_providers_config(self) -> dict[str, dict[str, str | bool]]:
         """Return config for all OAuth providers (enabled or not)."""
         return {
-            'google': {
-                'client_id': self.OAUTH_GOOGLE_CLIENT_ID,
-                'client_secret': self.OAUTH_GOOGLE_CLIENT_SECRET,
-                'enabled': self.OAUTH_GOOGLE_ENABLED,
-                'display_name': 'Google',
+            "google": {
+                "client_id": self.OAUTH_GOOGLE_CLIENT_ID,
+                "client_secret": self.OAUTH_GOOGLE_CLIENT_SECRET,
+                "enabled": self.OAUTH_GOOGLE_ENABLED,
+                "display_name": "Google",
             },
-            'yandex': {
-                'client_id': self.OAUTH_YANDEX_CLIENT_ID,
-                'client_secret': self.OAUTH_YANDEX_CLIENT_SECRET,
-                'enabled': self.OAUTH_YANDEX_ENABLED,
-                'display_name': 'Yandex',
+            "yandex": {
+                "client_id": self.OAUTH_YANDEX_CLIENT_ID,
+                "client_secret": self.OAUTH_YANDEX_CLIENT_SECRET,
+                "enabled": self.OAUTH_YANDEX_ENABLED,
+                "display_name": "Yandex",
             },
-            'discord': {
-                'client_id': self.OAUTH_DISCORD_CLIENT_ID,
-                'client_secret': self.OAUTH_DISCORD_CLIENT_SECRET,
-                'enabled': self.OAUTH_DISCORD_ENABLED,
-                'display_name': 'Discord',
+            "discord": {
+                "client_id": self.OAUTH_DISCORD_CLIENT_ID,
+                "client_secret": self.OAUTH_DISCORD_CLIENT_SECRET,
+                "enabled": self.OAUTH_DISCORD_ENABLED,
+                "display_name": "Discord",
             },
-            'vk': {
-                'client_id': self.OAUTH_VK_CLIENT_ID,
-                'client_secret': self.OAUTH_VK_CLIENT_SECRET,
-                'enabled': self.OAUTH_VK_ENABLED,
-                'display_name': 'VK',
+            "vk": {
+                "client_id": self.OAUTH_VK_CLIENT_ID,
+                "client_secret": self.OAUTH_VK_CLIENT_SECRET,
+                "enabled": self.OAUTH_VK_ENABLED,
+                "display_name": "VK",
             },
         }
 
     def get_enabled_oauth_provider_names(self) -> list[str]:
         """Return list of enabled OAuth provider names."""
-        return [name for name, cfg in self.get_oauth_providers_config().items() if cfg['enabled']]
+        return [
+            name
+            for name, cfg in self.get_oauth_providers_config().items()
+            if cfg["enabled"]
+        ]
 
     # Ban System helpers
     def is_ban_system_enabled(self) -> bool:
@@ -2770,7 +2924,7 @@ class Settings(BaseSettings):
 
     def get_ban_system_api_url(self) -> str | None:
         if self.BAN_SYSTEM_API_URL:
-            return self.BAN_SYSTEM_API_URL.rstrip('/')
+            return self.BAN_SYSTEM_API_URL.rstrip("/")
         return None
 
     def get_ban_system_api_token(self) -> str | None:
@@ -2779,15 +2933,17 @@ class Settings(BaseSettings):
     def get_ban_system_request_timeout(self) -> int:
         return max(1, self.BAN_SYSTEM_REQUEST_TIMEOUT)
 
-    model_config = {'env_file': '.env', 'env_file_encoding': 'utf-8', 'extra': 'ignore'}
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
-    @field_validator('TIMEZONE')
+    @field_validator("TIMEZONE")
     @classmethod
     def validate_timezone(cls, value: str) -> str:
         try:
             ZoneInfo(value)
         except Exception as exc:  # pragma: no cover - defensive validation
-            raise ValueError(f'Некорректный идентификатор часового пояса: {value}') from exc
+            raise ValueError(
+                f"Некорректный идентификатор часового пояса: {value}"
+            ) from exc
         return value
 
 
@@ -2795,12 +2951,12 @@ settings = Settings()
 ENV_OVERRIDE_KEYS = set(settings.model_fields_set)
 
 _PERIOD_PRICE_FIELDS: dict[int, str] = {
-    14: 'PRICE_14_DAYS',
-    30: 'PRICE_30_DAYS',
-    60: 'PRICE_60_DAYS',
-    90: 'PRICE_90_DAYS',
-    180: 'PRICE_180_DAYS',
-    360: 'PRICE_360_DAYS',
+    14: "PRICE_14_DAYS",
+    30: "PRICE_30_DAYS",
+    60: "PRICE_60_DAYS",
+    90: "PRICE_90_DAYS",
+    180: "PRICE_180_DAYS",
+    360: "PRICE_360_DAYS",
 }
 
 # Хранилище периодов/цен из БД (приоритет над .env)
@@ -2842,7 +2998,10 @@ def refresh_period_prices() -> None:
     else:
         # Classic mode или нет цен в БД — берём из settings
         PERIOD_PRICES.update(
-            {days: getattr(settings, field_name, 0) for days, field_name in _PERIOD_PRICE_FIELDS.items()}
+            {
+                days: getattr(settings, field_name, 0)
+                for days, field_name in _PERIOD_PRICE_FIELDS.items()
+            }
         )
 
 
@@ -2857,7 +3016,10 @@ def _build_classic_period_prices() -> dict[int, int]:
     this always reflects the env/settings values — the canonical prices for
     classic (non-tariff) subscriptions.
     """
-    return {days: getattr(settings, field_name, 0) for days, field_name in _PERIOD_PRICE_FIELDS.items()}
+    return {
+        days: getattr(settings, field_name, 0)
+        for days, field_name in _PERIOD_PRICE_FIELDS.items()
+    }
 
 
 CLASSIC_PERIOD_PRICES: dict[int, int] = _build_classic_period_prices()
@@ -2871,7 +3033,7 @@ def refresh_classic_period_prices() -> None:
 
 def get_traffic_prices() -> dict[int, int]:
     packages = settings.get_traffic_packages()
-    return {package['gb']: package['price'] for package in packages}
+    return {package["gb"]: package["price"] for package in packages}
 
 
 TRAFFIC_PRICES = get_traffic_prices()


### PR DESCRIPTION
## Summary

Add support for custom Telegram Bot API server URL via `TELEGRAM_API_URL` environment variable.

Enables bot operation in regions where `api.telegram.org` is blocked (Russia, Iran, China) by allowing configuration of alternative API endpoints.

## Changes

- **`app/config.py`**: Add `TELEGRAM_API_URL` field to Settings + `get_telegram_api_url()` getter
- **`app/bot_factory.py`**: Pass `api=TelegramAPIServer.from_base(url)` to AiohttpSession when configured
- **`.env.example`**: Document new variable with usage examples

## How it works

```env
# .env
TELEGRAM_API_URL=https://your-telegram-proxy.workers.dev
```

Uses native aiogram `TelegramAPIServer.from_base()` — no monkey-patching, no hacks. Works together with existing `PROXY_URL` (both can be used simultaneously).

## Use cases

- **Cloudflare Worker proxy** — free, zero-maintenance bypass for blocked regions
- **Self-hosted [telegram-bot-api](https://github.com/tdlib/telegram-bot-api)** — removes 50MB upload / 20MB download limits
- **Any compatible reverse proxy** — nginx, Caddy, etc.

## Backward compatible

Defaults to `api.telegram.org` when `TELEGRAM_API_URL` is not set. No breaking changes.

## Related

- #2862 — Feature request for selective proxying (NALOGO_PROXY_URL pattern)
- #2863 — Fix PROXY_URL for Telegram OIDC JWKS requests