### PR TITLE
fix: use PROXY_URL for Telegram OIDC JWKS requests

### DIFF
--- a/app/cabinet/auth/telegram_auth.py
+++ b/app/cabinet/auth/telegram_auth.py
@@ -195,7 +195,8 @@ async def _get_jwks(force: bool = False) -> dict[str, Any]:
         if not force and _jwks_cache and _jwks_cache_expiry and now < _jwks_cache_expiry:
             return _jwks_cache
 
-        async with httpx.AsyncClient(timeout=10) as client:
+        proxy = settings.PROXY_URL if hasattr(settings, "PROXY_URL") and settings.PROXY_URL else None
+        async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
             response = await client.get(_JWKS_URL)
             response.raise_for_status()
             _jwks_cache = response.json()


### PR DESCRIPTION
When PROXY_URL is set (e.g. SOCKS5 proxy for regions where Telegram is blocked), 
the JWKS fetch in telegram_auth.py bypasses the proxy and fails with connection error.

Fix: pass proxy from settings.PROXY_URL to httpx.AsyncClient.