### PR TITLE
fix(tickets): allow empty message when media attached

### DIFF
--- a/app/cabinet/routes/admin_tickets.py
+++ b/app/cabinet/routes/admin_tickets.py
@@ -89,7 +89,7 @@ class AdminTicketListResponse(BaseModel):
 class AdminReplyRequest(BaseModel):
     """Admin reply to ticket."""
 
-    message: str = Field(..., min_length=1, max_length=4000, description='Reply message')
+    message: str = Field(default='', max_length=4000, description='Reply message')
     media_type: str | None = Field(None, description='Media type: photo, video, or document')
     media_file_id: str | None = Field(None, max_length=255, description='Telegram file_id from media upload')
     media_caption: str | None = Field(None, max_length=1000, description='Caption for media')
@@ -102,6 +102,9 @@ class AdminReplyRequest(BaseModel):
             raise ValueError('media_file_id is required when media_type is provided')
         if self.media_type and self.media_type not in {'photo', 'video', 'document'}:
             raise ValueError('media_type must be one of: photo, video, document')
+        # Either message text or media is required
+        if not self.message.strip() and not self.media_file_id:
+            raise ValueError('message or media_file_id is required')
         return self
 
 

--- a/app/cabinet/schemas/tickets.py
+++ b/app/cabinet/schemas/tickets.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class TicketMessageResponse(BaseModel):
@@ -78,7 +78,13 @@ class TicketCreateRequest(BaseModel):
 class TicketMessageCreateRequest(BaseModel):
     """Request to add message to ticket."""
 
-    message: str = Field(..., min_length=1, max_length=4000, description='Message text')
+    message: str = Field(default='', max_length=4000, description='Message text')
     media_type: str | None = Field(None, description='Media type: photo, video, document')
     media_file_id: str | None = Field(None, description='Telegram file_id of uploaded media')
     media_caption: str | None = Field(None, max_length=1000, description='Media caption')
+
+    @model_validator(mode='after')
+    def validate_has_content(self) -> 'TicketMessageCreateRequest':
+        if not self.message.strip() and not self.media_file_id:
+            raise ValueError('message or media_file_id is required')
+        return self


### PR DESCRIPTION
## Summary

Fixes a UX regression where admin multi-image uploads in ticket replies silently drop all but the first image.

## Root cause

Both `AdminReplyRequest` (`app/cabinet/routes/admin_tickets.py`) and `TicketMessageCreateRequest` (`app/cabinet/schemas/tickets.py`) declare:

```python
message: str = Field(..., min_length=1, max_length=4000)
```

The cabinet frontend, when replying with N attachments, sends:

1. First reply: text + first media
2. Replies 2..N: `message: ''` + media

Because of `min_length=1`, the backend returns **422 Unprocessable Entity** on every follow-up reply, and the frontend `catch {}` swallows the errors silently. Admin sees the text + first image land in the ticket, remaining images disappear.

## Fix

- Drop `min_length=1` from both schemas, default `message` to empty string.
- Add a `model_validator` to both schemas that enforces: either non-empty `message` OR `media_file_id` must be provided.
- Semantically this matches how the frontend (and Telegram) already treats media-only follow-up messages.

## Files

- `app/cabinet/routes/admin_tickets.py` — `AdminReplyRequest`
- `app/cabinet/schemas/tickets.py` — `TicketMessageCreateRequest`

## Test plan

- [x] Build bot image, restart, verify existing single-message replies still work
- [x] Admin replies with text + 1 image → 1 message stored (as before)
- [x] Admin replies with text + 5 images → 5 messages stored (first has text, others media-only)
- [x] Admin replies with text only, no media → still works
- [x] Admin replies with media only, no text → now works (previously rejected)
- [x] POST with both empty message AND no media → returns 422 with clear error (`message or media_file_id is required`)