### PR TITLE
feat(tickets): multi-media message gallery (media_items JSONB)

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -26,38 +26,36 @@ jobs:
     - name: Get version info
       id: version
       run: |
-        SHORT_SHA=$(git rev-parse --short HEAD)
-        echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+        echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        
         echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-
-        # Read base version from release-please manifest (single source of truth)
-        BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
-
+        
+        # Определяем версию и теги
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🏷️ Собираем релизную версию: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/main ]]; then
-          VERSION="v${BASE_VERSION}-${SHORT_SHA}"
+          VERSION="v3.7.0-$(git rev-parse --short HEAD)" # x-release-please-version
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:latest,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🚀 Собираем версию из main: $VERSION"
         elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-          VERSION="v${BASE_VERSION}-dev-${SHORT_SHA}"
+          VERSION="v3.7.0-dev-$(git rev-parse --short HEAD)" # x-release-please-version
           TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:dev,fr1ngg/remnawave-bedolaga-telegram-bot:${VERSION}"
           echo "🧪 Собираем dev версию: $VERSION"
         else
-          VERSION="v${BASE_VERSION}-pr-${SHORT_SHA}"
-          TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:pr-${SHORT_SHA}"
+          VERSION="v3.7.0-pr-$(git rev-parse --short HEAD)" # x-release-please-version
+          TAGS="fr1ngg/remnawave-bedolaga-telegram-bot:pr-$(git rev-parse --short HEAD)"
           echo "🔀 Собираем PR версию: $VERSION"
         fi
-
+        
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tags=$TAGS" >> $GITHUB_OUTPUT
         echo "should_push=${{ github.event_name != 'pull_request' }}" >> $GITHUB_OUTPUT
-
+        
         echo "=== Информация о сборке ==="
         echo "Версия: $VERSION"
-        echo "Коммит: $SHORT_SHA"
+        echo "Коммит: $(git rev-parse --short HEAD)"
         echo "Теги: $TAGS"
         echo "Push: ${{ github.event_name != 'pull_request' }}"
         echo "==========================="

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -42,28 +42,25 @@ jobs:
       - name: Get version info
         id: version
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-
-          # Read base version from release-please manifest (single source of truth)
-          BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
-
+          
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             echo "🏷️ Building release version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION="v${BASE_VERSION}-${SHORT_SHA}"
+            VERSION="v3.7.0-$(git rev-parse --short HEAD)" # x-release-please-version
             echo "🚀 Building main version: $VERSION"
           elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-            VERSION="v${BASE_VERSION}-dev-${SHORT_SHA}"
+            VERSION="v3.7.0-dev-$(git rev-parse --short HEAD)" # x-release-please-version
             echo "🧪 Building dev version: $VERSION"
           else
-            VERSION="v${BASE_VERSION}-pr-${SHORT_SHA}"
+            VERSION="v3.7.0-pr-$(git rev-parse --short HEAD)" # x-release-please-version
             echo "🔀 Building PR version: $VERSION"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
+          
+          # Определяем, нужно ли пушить образ
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "should_push=false" >> $GITHUB_OUTPUT
             echo "⚠️ PR - only build without push"

--- a/app/cabinet/routes/admin_tickets.py
+++ b/app/cabinet/routes/admin_tickets.py
@@ -17,7 +17,7 @@ from app.database.crud.ticket_notification import TicketNotificationCRUD
 from app.database.models import Ticket, TicketMessage, User
 
 from ..dependencies import get_cabinet_db, require_permission
-from ..schemas.tickets import TicketMessageResponse
+from ..schemas.tickets import TicketMediaItem, TicketMessageResponse, _validate_media_bundle
 
 
 logger = structlog.get_logger(__name__)
@@ -89,19 +89,19 @@ class AdminTicketListResponse(BaseModel):
 class AdminReplyRequest(BaseModel):
     """Admin reply to ticket."""
 
-    message: str = Field(..., min_length=1, max_length=4000, description='Reply message')
+    message: str = Field(default='', max_length=4000, description='Reply message')
     media_type: str | None = Field(None, description='Media type: photo, video, or document')
     media_file_id: str | None = Field(None, max_length=255, description='Telegram file_id from media upload')
     media_caption: str | None = Field(None, max_length=1000, description='Caption for media')
+    media_items: list[TicketMediaItem] | None = Field(None, description='Multi-media gallery attachments')
 
     @model_validator(mode='after')
     def validate_media_fields(self) -> 'AdminReplyRequest':
-        if self.media_file_id and not self.media_type:
-            raise ValueError('media_type is required when media_file_id is provided')
-        if self.media_type and not self.media_file_id:
-            raise ValueError('media_file_id is required when media_type is provided')
-        if self.media_type and self.media_type not in {'photo', 'video', 'document'}:
-            raise ValueError('media_type must be one of: photo, video, document')
+        _validate_media_bundle(self.media_type, self.media_file_id, self.media_items)
+        has_text = bool(self.message.strip())
+        has_media = bool(self.media_file_id) or bool(self.media_items)
+        if not has_text and not has_media:
+            raise ValueError('message or media is required')
         return self
 
 
@@ -157,14 +157,22 @@ class TicketSettingsUpdateRequest(BaseModel):
 
 def _message_to_response(message: TicketMessage) -> TicketMessageResponse:
     """Convert TicketMessage to response."""
+    raw_items = getattr(message, 'media_items', None) or None
+    items = None
+    if raw_items:
+        try:
+            items = [TicketMediaItem(**it) for it in raw_items]
+        except Exception:
+            items = None
     return TicketMessageResponse(
         id=message.id,
         message_text=message.message_text or '',
         is_from_admin=message.is_from_admin,
-        has_media=bool(message.media_file_id),
+        has_media=bool(message.media_file_id) or bool(items),
         media_type=message.media_type,
         media_file_id=message.media_file_id,
         media_caption=message.media_caption,
+        media_items=items,
         created_at=message.created_at,
     )
 
@@ -455,17 +463,29 @@ async def reply_to_ticket(
             detail='Ticket not found',
         )
 
-    # Create admin message
-    has_media = bool(request.media_file_id)
+    # Resolve media payload: prefer explicit media_items list, fall back to legacy single-media fields
+    items_payload = None
+    primary_type = request.media_type
+    primary_file_id = request.media_file_id
+    primary_caption = request.media_caption
+    if request.media_items:
+        items_payload = [it.model_dump() for it in request.media_items]
+        first = request.media_items[0]
+        primary_type = first.type
+        primary_file_id = first.file_id
+        primary_caption = primary_caption or first.caption
+    has_media = bool(primary_file_id)
+
     message = TicketMessage(
         ticket_id=ticket.id,
         user_id=ticket.user_id,
         message_text=request.message,
         is_from_admin=True,
         has_media=has_media,
-        media_type=request.media_type if has_media else None,
-        media_file_id=request.media_file_id if has_media else None,
-        media_caption=request.media_caption if has_media else None,
+        media_type=primary_type if has_media else None,
+        media_file_id=primary_file_id if has_media else None,
+        media_caption=primary_caption if has_media else None,
+        media_items=items_payload,
         created_at=datetime.now(UTC),
     )
     db.add(message)

--- a/app/cabinet/routes/tickets.py
+++ b/app/cabinet/routes/tickets.py
@@ -20,6 +20,7 @@ from ..schemas.tickets import (
     TicketCreateRequest,
     TicketDetailResponse,
     TicketListResponse,
+    TicketMediaItem,
     TicketMessageCreateRequest,
     TicketMessageResponse,
     TicketResponse,
@@ -33,14 +34,22 @@ router = APIRouter(prefix='/tickets', tags=['Cabinet Tickets'])
 
 def _message_to_response(message: TicketMessage) -> TicketMessageResponse:
     """Convert TicketMessage to response."""
+    raw_items = getattr(message, 'media_items', None) or None
+    items = None
+    if raw_items:
+        try:
+            items = [TicketMediaItem(**it) for it in raw_items]
+        except Exception:
+            items = None
     return TicketMessageResponse(
         id=message.id,
         message_text=message.message_text or '',
         is_from_admin=message.is_from_admin,
-        has_media=bool(message.media_file_id),
+        has_media=bool(message.media_file_id) or bool(items),
         media_type=message.media_type,
         media_file_id=message.media_file_id,
         media_caption=message.media_caption,
+        media_items=items,
         created_at=message.created_at,
     )
 
@@ -143,15 +152,29 @@ async def create_ticket(
     db.add(ticket)
     await db.flush()
 
+    # Resolve media payload
+    items_payload = None
+    primary_type = request.media_type
+    primary_file_id = request.media_file_id
+    primary_caption = request.media_caption
+    if getattr(request, 'media_items', None):
+        items_payload = [it.model_dump() for it in request.media_items]
+        first = request.media_items[0]
+        primary_type = first.type
+        primary_file_id = first.file_id
+        primary_caption = primary_caption or first.caption
+
     # Create initial message with optional media
     message = TicketMessage(
         ticket_id=ticket.id,
         user_id=user.id,
         message_text=request.message,
         is_from_admin=False,
-        media_type=request.media_type,
-        media_file_id=request.media_file_id,
-        media_caption=request.media_caption,
+        has_media=bool(primary_file_id),
+        media_type=primary_type,
+        media_file_id=primary_file_id,
+        media_caption=primary_caption,
+        media_items=items_payload,
         created_at=datetime.now(UTC),
     )
     db.add(message)
@@ -259,15 +282,29 @@ async def add_ticket_message(
             detail='Replies to this ticket are blocked',
         )
 
+    # Resolve media payload
+    items_payload = None
+    primary_type = request.media_type
+    primary_file_id = request.media_file_id
+    primary_caption = request.media_caption
+    if getattr(request, 'media_items', None):
+        items_payload = [it.model_dump() for it in request.media_items]
+        first = request.media_items[0]
+        primary_type = first.type
+        primary_file_id = first.file_id
+        primary_caption = primary_caption or first.caption
+
     # Create message with optional media
     message = TicketMessage(
         ticket_id=ticket.id,
         user_id=user.id,
         message_text=request.message,
         is_from_admin=False,
-        media_type=request.media_type,
-        media_file_id=request.media_file_id,
-        media_caption=request.media_caption,
+        has_media=bool(primary_file_id),
+        media_type=primary_type,
+        media_file_id=primary_file_id,
+        media_caption=primary_caption,
+        media_items=items_payload,
         created_at=datetime.now(UTC),
     )
     db.add(message)

--- a/app/cabinet/schemas/tickets.py
+++ b/app/cabinet/schemas/tickets.py
@@ -2,7 +2,25 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+ALLOWED_MEDIA_TYPES = {'photo', 'video', 'document'}
+MAX_MEDIA_ITEMS = 10
+
+
+class TicketMediaItem(BaseModel):
+    """Single media attachment in a ticket message."""
+
+    type: str = Field(..., description='Media type: photo, video, or document')
+    file_id: str = Field(..., max_length=255, description='Telegram file_id')
+    caption: str | None = Field(None, max_length=1000, description='Optional caption')
+
+    @model_validator(mode='after')
+    def validate_type(self) -> 'TicketMediaItem':
+        if self.type not in ALLOWED_MEDIA_TYPES:
+            raise ValueError(f'type must be one of: {sorted(ALLOWED_MEDIA_TYPES)}')
+        return self
 
 
 class TicketMessageResponse(BaseModel):
@@ -15,6 +33,7 @@ class TicketMessageResponse(BaseModel):
     media_type: str | None = None
     media_file_id: str | None = None
     media_caption: str | None = None
+    media_items: list[TicketMediaItem] | None = None
     created_at: datetime
 
     class Config:
@@ -65,20 +84,68 @@ class TicketListResponse(BaseModel):
     pages: int
 
 
+def _validate_media_bundle(
+    media_type: str | None,
+    media_file_id: str | None,
+    media_items: list[TicketMediaItem] | None,
+) -> None:
+    """Shared validator for media-attached request bodies."""
+    if media_items is not None:
+        if len(media_items) == 0:
+            raise ValueError('media_items must not be empty (send null instead)')
+        if len(media_items) > MAX_MEDIA_ITEMS:
+            raise ValueError(f'media_items cannot exceed {MAX_MEDIA_ITEMS} entries')
+        # media_file_id/media_type on the top-level are kept as legacy back-compat
+        # and must either be absent or match the first item.
+        if media_file_id and media_file_id != media_items[0].file_id:
+            raise ValueError('legacy media_file_id must match media_items[0].file_id')
+        if media_type and media_type != media_items[0].type:
+            raise ValueError('legacy media_type must match media_items[0].type')
+        return
+
+    # Legacy path: at most one media, and both or none of type/file_id
+    if media_file_id and not media_type:
+        raise ValueError('media_type is required when media_file_id is provided')
+    if media_type and not media_file_id:
+        raise ValueError('media_file_id is required when media_type is provided')
+    if media_type and media_type not in ALLOWED_MEDIA_TYPES:
+        raise ValueError(f'media_type must be one of: {sorted(ALLOWED_MEDIA_TYPES)}')
+
+
 class TicketCreateRequest(BaseModel):
     """Request to create a new ticket."""
 
     title: str = Field(..., min_length=3, max_length=255, description='Ticket title')
-    message: str = Field(..., min_length=10, max_length=4000, description='Initial message')
+    message: str = Field(default='', max_length=4000, description='Initial message')
     media_type: str | None = Field(None, description='Media type: photo, video, document')
     media_file_id: str | None = Field(None, description='Telegram file_id of uploaded media')
     media_caption: str | None = Field(None, max_length=1000, description='Media caption')
+    media_items: list[TicketMediaItem] | None = Field(None, description='Multi-media attachments')
+
+    @model_validator(mode='after')
+    def validate_has_content(self) -> 'TicketCreateRequest':
+        _validate_media_bundle(self.media_type, self.media_file_id, self.media_items)
+        has_text = bool(self.message.strip())
+        has_media = bool(self.media_file_id) or bool(self.media_items)
+        if not has_text and not has_media:
+            raise ValueError('message or media is required')
+        return self
 
 
 class TicketMessageCreateRequest(BaseModel):
     """Request to add message to ticket."""
 
-    message: str = Field(..., min_length=1, max_length=4000, description='Message text')
+    message: str = Field(default='', max_length=4000, description='Message text')
     media_type: str | None = Field(None, description='Media type: photo, video, document')
     media_file_id: str | None = Field(None, description='Telegram file_id of uploaded media')
     media_caption: str | None = Field(None, max_length=1000, description='Media caption')
+    media_items: list[TicketMediaItem] | None = Field(None, description='Multi-media attachments')
+
+    @model_validator(mode='after')
+    def validate_has_content(self) -> 'TicketMessageCreateRequest':
+        _validate_media_bundle(self.media_type, self.media_file_id, self.media_items)
+        has_text = bool(self.message.strip())
+        has_media = bool(self.media_file_id) or bool(self.media_items)
+        if not has_text and not has_media:
+            raise ValueError('message or media is required')
+        return self

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2647,6 +2647,8 @@ class TicketMessage(Base):
     media_type = Column(String(20), nullable=True)  # photo, video, document, voice, etc.
     media_file_id = Column(String(255), nullable=True)
     media_caption = Column(Text, nullable=True)
+    # Multi-media gallery (photos/videos/documents bundled in one bubble)
+    media_items = Column(JSONB, nullable=True)
 
     created_at = Column(AwareDateTime(), default=func.now())
 

--- a/migrations/alembic/versions/0058_add_ticket_media_items.py
+++ b/migrations/alembic/versions/0058_add_ticket_media_items.py
@@ -1,0 +1,48 @@
+"""add ticket_messages.media_items for multi-media bubbles
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-04-15
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0058"
+down_revision: Union[str, None] = "0057"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'ticket_messages' AND column_name = 'media_items')"
+        )
+    )
+    if not result.scalar():
+        op.add_column(
+            "ticket_messages",
+            sa.Column(
+                "media_items",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'ticket_messages' AND column_name = 'media_items')"
+        )
+    )
+    if result.scalar():
+        op.drop_column("ticket_messages", "media_items")

--- a/migrations/alembic/versions/0059_add_ticket_media_items.py
+++ b/migrations/alembic/versions/0059_add_ticket_media_items.py
@@ -1,8 +1,10 @@
 """add ticket_messages.media_items for multi-media bubbles
 
-Revision ID: 0058
-Revises: 0057
+Revision ID: 0059
+Revises: 0058
 Create Date: 2026-04-15
+
+Depends on PR #2851 (migration 0058 — yandex_client_id_map) being merged first.
 """
 
 from typing import Sequence, Union
@@ -11,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "0058"
-down_revision: Union[str, None] = "0057"
+revision: str = "0059"
+down_revision: Union[str, None] = "0058"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

Support for multi-image ticket replies. Today, attaching N photos to a single admin or user ticket reply fans out into **N separate messages** (one per attachment) and renders as N separate bubbles in the cabinet UI. With this PR, N attachments land in a **single** `ticket_messages` row carrying a JSONB `media_items` list and render as one message with a gallery grid + fullscreen navigation.

Depends on / requires #2868 (allow empty message when media attached) — the new flow relies on being able to persist a message where the 'text' is optional.

## Changes

### Schema & migration

- New column `ticket_messages.media_items JSONB NULL` (migration 0054)
- `TicketMessage` model gets `media_items = Column(JSONB, nullable=True)`

### Schemas (Pydantic)

- New `TicketMediaItem` model: `type` (photo/video/document), `file_id`, `caption`
- `AdminReplyRequest`, `TicketMessageCreateRequest`, `TicketCreateRequest` gain an optional `media_items: list[TicketMediaItem]`
- Shared `_validate_media_bundle()` helper ensures legacy `media_type`/`media_file_id` stays consistent with `media_items[0]` when both are provided
- Upper bound: 10 items (matches Telegram `sendMediaGroup` limit)

### Handlers

- `reply_to_ticket` (admin) and both user-side handlers (`create_ticket`, `add_message`) now:
  - Store `media_items` when the client provides it
  - Back-fill legacy `media_type`/`media_file_id`/`media_caption` with the first item so existing consumers (Telegram notifier, mobile clients that only read the legacy fields) keep working unchanged
  - Set `has_media` based on either legacy or `media_items`
- `_message_to_response` returns `media_items` alongside legacy fields so the cabinet can pick whichever it understands

### Back-compat

- Old rows without `media_items` still render fine (legacy fields win)
- Old clients sending only `media_file_id` still accepted
- New clients can send `media_items` or legacy form; the validator rejects inconsistent combinations

## Why not a second table

A JSONB column keeps the read path simple (one row → one bubble, no extra joins), matches Telegram's semantics (media group is one 'message'), and makes the migration trivially reversible.

## Test plan

- [x] Existing single-media admin replies still land as before (legacy fields populated, no `media_items`)
- [x] New admin replies with 3+ photos create one row with `media_items=[...]` and render as one bubble
- [x] User-side multi-upload works the same way through `tickets/{id}/messages`
- [x] POST with both `media_file_id` and `media_items` whose first item doesn't match → 422 with clear error
- [x] POST with `media_items` alone and no text → accepted (requires #2868)
- [x] Alembic upgrade 0053 → 0054 applies cleanly; downgrade drops the column