### PR TITLE
fix: cabinet_refresh_tokens migration + notification_settings jsonb

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1264,7 +1264,7 @@ class User(Base):
     user_promo_groups = relationship('UserPromoGroup', back_populates='user', cascade='all, delete-orphan')
     poll_responses = relationship('PollResponse', back_populates='user')
     admin_roles_rel = relationship('UserRole', foreign_keys='[UserRole.user_id]', back_populates='user')
-    notification_settings = Column(JSON, nullable=True, default=dict)
+    notification_settings = Column(JSONB, nullable=True, default=dict)
     last_pinned_message_id = Column(Integer, nullable=True)
 
     # Ограничения пользователя

--- a/migrations/alembic/versions/0056_create_cabinet_refresh_tokens.py
+++ b/migrations/alembic/versions/0056_create_cabinet_refresh_tokens.py
@@ -1,0 +1,40 @@
+"""create cabinet_refresh_tokens table
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-04-13
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0056'
+down_revision: Union[str, None] = '0055'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'cabinet_refresh_tokens',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('token_hash', sa.String(255), nullable=False),
+        sa.Column('device_info', sa.String(500), nullable=True),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_cabinet_refresh_tokens_id', 'cabinet_refresh_tokens', ['id'])
+    op.create_index('ix_cabinet_refresh_tokens_token_hash', 'cabinet_refresh_tokens', ['token_hash'], unique=True)
+    op.create_index('ix_cabinet_refresh_tokens_user', 'cabinet_refresh_tokens', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_cabinet_refresh_tokens_user', table_name='cabinet_refresh_tokens')
+    op.drop_index('ix_cabinet_refresh_tokens_token_hash', table_name='cabinet_refresh_tokens')
+    op.drop_index('ix_cabinet_refresh_tokens_id', table_name='cabinet_refresh_tokens')
+    op.drop_table('cabinet_refresh_tokens')

--- a/migrations/alembic/versions/0056_create_cabinet_refresh_tokens.py
+++ b/migrations/alembic/versions/0056_create_cabinet_refresh_tokens.py
@@ -17,20 +17,37 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _has_table(table: str) -> bool:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    return table in inspector.get_table_names()
+
+
+def _has_index(table: str, index_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    return index_name in [idx['name'] for idx in inspector.get_indexes(table)]
+
+
 def upgrade() -> None:
-    op.create_table(
-        'cabinet_refresh_tokens',
-        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
-        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
-        sa.Column('token_hash', sa.String(255), nullable=False),
-        sa.Column('device_info', sa.String(500), nullable=True),
-        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
-        sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True),
-    )
-    op.create_index('ix_cabinet_refresh_tokens_id', 'cabinet_refresh_tokens', ['id'])
-    op.create_index('ix_cabinet_refresh_tokens_token_hash', 'cabinet_refresh_tokens', ['token_hash'], unique=True)
-    op.create_index('ix_cabinet_refresh_tokens_user', 'cabinet_refresh_tokens', ['user_id'])
+    if not _has_table('cabinet_refresh_tokens'):
+        op.create_table(
+            'cabinet_refresh_tokens',
+            sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('token_hash', sa.String(255), nullable=False),
+            sa.Column('device_info', sa.String(500), nullable=True),
+            sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True),
+        )
+
+    if not _has_index('cabinet_refresh_tokens', 'ix_cabinet_refresh_tokens_id'):
+        op.create_index('ix_cabinet_refresh_tokens_id', 'cabinet_refresh_tokens', ['id'])
+    if not _has_index('cabinet_refresh_tokens', 'ix_cabinet_refresh_tokens_token_hash'):
+        op.create_index('ix_cabinet_refresh_tokens_token_hash', 'cabinet_refresh_tokens', ['token_hash'], unique=True)
+    if not _has_index('cabinet_refresh_tokens', 'ix_cabinet_refresh_tokens_user'):
+        op.create_index('ix_cabinet_refresh_tokens_user', 'cabinet_refresh_tokens', ['user_id'])
 
 
 def downgrade() -> None:

--- a/migrations/alembic/versions/0057_alter_notification_settings_to_jsonb.py
+++ b/migrations/alembic/versions/0057_alter_notification_settings_to_jsonb.py
@@ -1,0 +1,52 @@
+"""alter notification_settings from json to jsonb
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-04-13
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0057'
+down_revision: Union[str, None] = '0056'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _get_column_type(table: str, column: str) -> str | None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = :column"
+        ),
+        {'table': table, 'column': column},
+    )
+    row = result.fetchone()
+    return row[0] if row else None
+
+
+def upgrade() -> None:
+    col_type = _get_column_type('users', 'notification_settings')
+    if col_type and col_type != 'jsonb':
+        op.execute(
+            sa.text(
+                "ALTER TABLE users "
+                "ALTER COLUMN notification_settings TYPE jsonb "
+                "USING notification_settings::jsonb"
+            )
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE users "
+            "ALTER COLUMN notification_settings TYPE json "
+            "USING notification_settings::json"
+        )
+    )


### PR DESCRIPTION
## Summary

- Added migration `0056`: create `cabinet_refresh_tokens` table (with checkfirst guards)
- Added migration `0057`: convert `notification_settings` from `json` to `jsonb` — fixes `could not identify an equality operator for type json` on DISTINCT queries
- Model: changed `notification_settings` from `Column(JSON)` to `Column(JSONB)`