### PR TITLE
fix: do not reset subscription_crypto_link when cryptoLink absent in webhook

### DIFF
--- a/app/services/remnawave_webhook_service.py
+++ b/app/services/remnawave_webhook_service.py
@@ -977,10 +977,8 @@ class RemnaWaveWebhookService:
             if subscription.subscription_crypto_link != subscription_crypto_link:
                 subscription.subscription_crypto_link = subscription_crypto_link
                 changed = True
-        elif subscription_url and subscription.subscription_crypto_link:
-            # URL обновился, а крипто-ссылка не пришла — сбрасываем старую
-            subscription.subscription_crypto_link = None
-            changed = True
+        # NOTE: панель не включает cryptoLink в каждый webhook user.modified
+        # Отсутствие поля не означает что его нужно сбрасывать
 
         # Always stamp to protect from sync overwrite, even if no fields changed
         self._stamp_webhook_update(subscription)


### PR DESCRIPTION
Remnawave panel does not include cryptoLink in every user.modified webhook — 
it only sends changed fields. Absence of cryptoLink does not mean it was 
removed. The old logic incorrectly cleared subscription_crypto_link when 
subscriptionUrl was present but cryptoLink was absent, causing happ:// 
links to disappear until the next full sync.

Fix: remove the elif block that reset crypto_link on missing cryptoLink.