### PR TITLE
fix: do not update first_name/last_name from OIDC claims

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -815,10 +815,9 @@ async def auth_telegram_oidc(
     # Update user info from OIDC claims
     if username and username != user.username:
         user.username = username
-    if first_name and first_name != user.first_name:
-        user.first_name = first_name
-    if last_name is not None and last_name != user.last_name:
-        user.last_name = last_name
+    # NOTE: не обновляем first_name/last_name из OIDC
+    # Telegram OIDC возвращает только поле name как полное имя без разделения на first/last
+    # Имя правильно заполняется через middleware при обычном использовании бота
 
     user.cabinet_last_login = datetime.now(UTC)
     await db.commit()


### PR DESCRIPTION
Telegram OIDC only returns 'name' as a full name string (e.g. "Vasya Pupkin")
without separate given_name/family_name fields. The old logic wrote the full 
name into first_name and kept the old last_name from a previous session, 
causing duplicated surname (e.g. "Vasya Pupkin Pupkin").

The correct name is already set via auth middleware when the user interacts 
with the bot normally. There is no need to update first_name/last_name from 
OIDC claims at all.

Fix: remove first_name/last_name update from OIDC login flow, keep only 
username and cabinet_last_login updates.