### PR TITLE
feat: add WEBHOOK_IP to allow Telegram bypass DNS lookup for webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -974,6 +974,9 @@ DEBUG=false
 WEBHOOK_URL=
 WEBHOOK_PATH=/webhook
 WEBHOOK_SECRET_TOKEN=
+# IP адрес сервера для setWebhook — Telegram будет использовать его напрямую без DNS резолва домена
+# Необходимо в регионах где Telegram не может резолвить домены (РФ и др.)
+# WEBHOOK_IP=
 WEBHOOK_DROP_PENDING_UPDATES=true
 WEBHOOK_MAX_QUEUE_SIZE=1024
 WEBHOOK_WORKERS=4

--- a/app/config.py
+++ b/app/config.py
@@ -768,6 +768,7 @@ class Settings(BaseSettings):
     WEBHOOK_URL: str | None = None
     WEBHOOK_PATH: str = '/webhook'
     WEBHOOK_SECRET_TOKEN: str | None = None
+    WEBHOOK_IP: str | None = None  # IP адрес для setWebhook, чтобы Telegram не резолвил домен
     WEBHOOK_DROP_PENDING_UPDATES: bool = True
     WEBHOOK_MAX_QUEUE_SIZE: int = 1024
     WEBHOOK_WORKERS: int = 4

--- a/main.py
+++ b/main.py
@@ -607,6 +607,7 @@ async def main():
                         secret_token=settings.WEBHOOK_SECRET_TOKEN,
                         drop_pending_updates=False,  # Обрабатываем накопившиеся обновления
                         allowed_updates=allowed_updates,
+                        **({"ip_address": settings.WEBHOOK_IP} if settings.WEBHOOK_IP else {}),
                     )
                     stage.log(f'Webhook установлен: {webhook_url}')
                     stage.log(f'Allowed updates: {", ".join(sorted(allowed_updates)) if allowed_updates else "all"}')

--- a/main.py
+++ b/main.py
@@ -607,7 +607,7 @@ async def main():
                         secret_token=settings.WEBHOOK_SECRET_TOKEN,
                         drop_pending_updates=False,  # Обрабатываем накопившиеся обновления
                         allowed_updates=allowed_updates,
-                        **({"ip_address": settings.WEBHOOK_IP} if settings.WEBHOOK_IP else {}),
+                        **({'ip_address': settings.WEBHOOK_IP} if settings.WEBHOOK_IP else {}),
                     )
                     stage.log(f'Webhook установлен: {webhook_url}')
                     stage.log(f'Allowed updates: {", ".join(sorted(allowed_updates)) if allowed_updates else "all"}')


### PR DESCRIPTION
## 📝 Описание
Добавлена поддержка параметра WEBHOOK_IP для передачи IP адреса в setWebhook.

## 🎯 Мотивация
В некоторых случаях DNS серверы не отвечают на запросы от Telegram серверов,
из-за чего Telegram не может зарезолвить домен webhook и регистрация падает.
Передача IP адреса напрямую позволяет боту работать в webhook режиме.

## 🔧 Тип изменений
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
Требуется обновление документации:
https://docs.bedolagam.ru/getting-started/docker-deployment
https://docs.bedolagam.ru/getting-started/environment

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] .env.example обновлён с комментарием
- [x] Проверена работа в Docker
- [x] Обратная совместимость — параметр необязательный, по умолчанию не используется