### PR TITLE
fix: grant all available squads for unrestricted trials

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1219,9 +1219,11 @@ async def activate_trial(
                     trial_tariff = None
 
         if trial_tariff:
+            from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
             trial_traffic_limit = trial_tariff.traffic_limit_gb
             trial_device_limit = trial_tariff.device_limit
-            trial_squads = trial_tariff.allowed_squads or []
+            trial_squads = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
             tariff_id_for_trial = trial_tariff.id
             tariff_trial_days = getattr(trial_tariff, 'trial_duration_days', None)
             if tariff_trial_days:
@@ -1235,7 +1237,7 @@ async def activate_trial(
     except Exception as e:
         logger.error('Error getting trial tariff', error=e)
 
-    # BUG-12 fix: If no squads from tariff, fallback to trial-eligible servers
+    # No trial tariff configured, use the legacy random trial squad fallback.
     if not trial_squads:
         from app.database.crud.server_squad import get_random_trial_squad_uuid
 

--- a/app/database/crud/server_squad.py
+++ b/app/database/crud/server_squad.py
@@ -155,6 +155,20 @@ async def get_available_server_squads(
     return result.scalars().unique().all()
 
 
+async def get_effective_tariff_squad_uuids(
+    db: AsyncSession,
+    allowed_squads: Sequence[str] | None,
+) -> list[str]:
+    """Resolve tariff squads, treating an empty list as "all available squads"."""
+
+    normalized = [str(squad_uuid) for squad_uuid in (allowed_squads or []) if squad_uuid]
+    if normalized:
+        return list(dict.fromkeys(normalized))
+
+    available = await get_available_server_squads(db)
+    return [squad.squad_uuid for squad in available if squad.squad_uuid]
+
+
 async def get_active_server_squads(db: AsyncSession) -> list[ServerSquad]:
     """Возвращает список активных серверов, доступных для подключения."""
 

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -142,8 +142,8 @@ async def create_trial_subscription(
     if device_limit is None:
         device_limit = settings.TRIAL_DEVICE_LIMIT
 
-    # Если переданы connected_squads, используем их
-    # Иначе используем squad_uuid или получаем случайный
+    # Если переданы connected_squads, используем их.
+    # Иначе используем squad_uuid или все доступные сквады по умолчанию.
     final_squads = []
     if connected_squads:
         final_squads = connected_squads
@@ -151,13 +151,14 @@ async def create_trial_subscription(
         final_squads = [squad_uuid]
     else:
         try:
-            from app.database.crud.server_squad import get_random_trial_squad_uuid
+            from app.database.crud.server_squad import get_effective_tariff_squad_uuids
 
-            random_squad = await get_random_trial_squad_uuid(db)
-            if random_squad:
-                final_squads = [random_squad]
+            final_squads = await get_effective_tariff_squad_uuids(db, None)
+            if final_squads:
                 logger.debug(
-                    'Выбран сквад для триальной подписки пользователя', random_squad=random_squad, user_id=user_id
+                    'Выбраны дефолтные сквады для триальной подписки пользователя',
+                    final_squads=final_squads,
+                    user_id=user_id,
                 )
         except Exception as error:
             logger.error('Не удалось получить сквад для триальной подписки пользователя', user_id=user_id, error=error)

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -4518,11 +4518,9 @@ async def _grant_paid_subscription(
         trial_squads: list[str] = []
 
         try:
-            from app.database.crud.server_squad import get_random_trial_squad_uuid
+            from app.database.crud.server_squad import get_effective_tariff_squad_uuids
 
-            trial_uuid = await get_random_trial_squad_uuid(db)
-            if trial_uuid:
-                trial_squads = [trial_uuid]
+            trial_squads = await get_effective_tariff_squad_uuids(db, None)
         except Exception as error:
             logger.error('Не удалось подобрать сквад при выдаче подписки админом', admin_id=admin_id, error=error)
 

--- a/app/handlers/subscription/purchase.py
+++ b/app/handlers/subscription/purchase.py
@@ -922,9 +922,11 @@ async def activate_trial(callback: types.CallbackQuery, db_user: User, db: Async
                         trial_tariff = await get_tariff_by_id(db, trial_tariff_id)
 
                 if trial_tariff:
+                    from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
                     trial_traffic_limit = trial_tariff.traffic_limit_gb
                     trial_device_limit = trial_tariff.device_limit
-                    trial_squads = trial_tariff.allowed_squads or []
+                    trial_squads = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
                     tariff_id_for_trial = trial_tariff.id
                     tariff_trial_days = getattr(trial_tariff, 'trial_duration_days', None)
                     if tariff_trial_days:
@@ -937,7 +939,7 @@ async def activate_trial(callback: types.CallbackQuery, db_user: User, db: Async
             except Exception as e:
                 logger.error('Ошибка получения триального тарифа', error=e)
 
-        # BUG-12 fix: If no squads from tariff, fallback to trial-eligible servers
+        # No trial tariff configured, use the legacy random trial squad fallback.
         if not trial_squads:
             from app.database.crud.server_squad import get_random_trial_squad_uuid
 
@@ -3307,9 +3309,11 @@ async def handle_trial_pay_with_balance(callback: types.CallbackQuery, db_user: 
                     if trial_tariff_id > 0:
                         trial_tariff = await _get_tariff(db, trial_tariff_id)
                 if trial_tariff:
+                    from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
                     trial_traffic_limit = trial_tariff.traffic_limit_gb
                     trial_device_limit = trial_tariff.device_limit
-                    trial_squads = trial_tariff.allowed_squads or []
+                    trial_squads = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
                     tariff_id_for_trial = trial_tariff.id
                     tariff_trial_days = getattr(trial_tariff, 'trial_duration_days', None)
                     if tariff_trial_days:
@@ -3322,7 +3326,7 @@ async def handle_trial_pay_with_balance(callback: types.CallbackQuery, db_user: 
             except Exception as e:
                 logger.error('Ошибка получения триального тарифа для платного триала', error=e)
 
-        # BUG-12 fix: If no squads from tariff, fallback to trial-eligible servers
+        # No trial tariff configured, use the legacy random trial squad fallback.
         if not trial_squads:
             from app.database.crud.server_squad import get_random_trial_squad_uuid
 
@@ -3673,9 +3677,11 @@ async def handle_trial_payment_method(callback: types.CallbackQuery, db_user: Us
                     if trial_tariff_id > 0:
                         trial_tariff = await _get_tariff(db, trial_tariff_id)
                 if trial_tariff:
+                    from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
                     trial_traffic = trial_tariff.traffic_limit_gb
                     trial_devices = trial_tariff.device_limit
-                    trial_squads_list = trial_tariff.allowed_squads or []
+                    trial_squads_list = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
                     tariff_id_for_trial = trial_tariff.id
                     tariff_trial_days = getattr(trial_tariff, 'trial_duration_days', None)
                     if tariff_trial_days:
@@ -3688,7 +3694,7 @@ async def handle_trial_payment_method(callback: types.CallbackQuery, db_user: Us
             except Exception as e:
                 logger.error('Ошибка получения триального тарифа для платного триала', error=e)
 
-        # Если тариф не задал серверы, получаем случайный сквад
+        # Если триальный тариф не найден, используем legacy fallback со случайным сквадом.
         if not trial_squads_list:
             from app.database.crud.server_squad import get_random_trial_squad_uuid
 

--- a/app/services/campaign_service.py
+++ b/app/services/campaign_service.py
@@ -159,17 +159,13 @@ class AdvertisingCampaignService:
         device_limit = campaign.subscription_device_limit
         if device_limit is None:
             device_limit = settings.DEFAULT_DEVICE_LIMIT
-        squads = list(campaign.subscription_squads or [])
+        try:
+            from app.database.crud.server_squad import get_effective_tariff_squad_uuids
 
-        if not squads:
-            try:
-                from app.database.crud.server_squad import get_random_trial_squad_uuid
-
-                trial_uuid = await get_random_trial_squad_uuid(db)
-                if trial_uuid:
-                    squads = [trial_uuid]
-            except Exception as error:
-                logger.error('Не удалось подобрать сквад для кампании', campaign_id=campaign.id, error=error)
+            squads = await get_effective_tariff_squad_uuids(db, campaign.subscription_squads)
+        except Exception as error:
+            logger.error('Не удалось подобрать сквады для кампании', campaign_id=campaign.id, error=error)
+            squads = list(campaign.subscription_squads or [])
 
         if existing_subscription:
             # Multi-tariff: extend the best existing subscription
@@ -305,17 +301,13 @@ class AdvertisingCampaignService:
 
         traffic_limit = tariff.traffic_limit_gb
         device_limit = tariff.device_limit
-        squads = list(tariff.allowed_squads or [])
+        try:
+            from app.database.crud.server_squad import get_effective_tariff_squad_uuids
 
-        if not squads:
-            try:
-                from app.database.crud.server_squad import get_random_trial_squad_uuid
-
-                trial_uuid = await get_random_trial_squad_uuid(db)
-                if trial_uuid:
-                    squads = [trial_uuid]
-            except Exception as error:
-                logger.error('Не удалось подобрать сквад для тарифа кампании', campaign_id=campaign.id, error=error)
+            squads = await get_effective_tariff_squad_uuids(db, tariff.allowed_squads)
+        except Exception as error:
+            logger.error('Не удалось подобрать сквады для тарифа кампании', campaign_id=campaign.id, error=error)
+            squads = list(tariff.allowed_squads or [])
 
         if existing_subscription:
             # Multi-tariff: extend the existing subscription for this tariff

--- a/app/services/promocode_service.py
+++ b/app/services/promocode_service.py
@@ -378,11 +378,12 @@ class PromoCodeService:
                             trial_tariff = await get_tariff(db, trial_tariff_id)
 
                 if trial_tariff:
+                    from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
                     trial_traffic_limit = trial_tariff.traffic_limit_gb
                     trial_device_limit = trial_tariff.device_limit
                     tariff_id_for_trial = trial_tariff.id
-                    if trial_tariff.allowed_squads:
-                        trial_squads = trial_tariff.allowed_squads
+                    trial_squads = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
             except Exception as e:
                 logger.error('Ошибка получения тарифа для триального промокода', error=e)
 

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -3834,9 +3834,11 @@ async def activate_subscription_trial_endpoint(
                     trial_tariff = await get_tariff_by_id(db, trial_tariff_id)
 
             if trial_tariff:
+                from app.database.crud.server_squad import get_effective_tariff_squad_uuids
+
                 trial_traffic_limit = trial_tariff.traffic_limit_gb
                 trial_device_limit = trial_tariff.device_limit
-                trial_squads = trial_tariff.allowed_squads or []
+                trial_squads = await get_effective_tariff_squad_uuids(db, trial_tariff.allowed_squads)
                 tariff_id_for_trial = trial_tariff.id
                 tariff_trial_days = getattr(trial_tariff, 'trial_duration_days', None)
                 if tariff_trial_days:

--- a/app/webapi/routes/subscriptions.py
+++ b/app/webapi/routes/subscriptions.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.config import settings
-from app.database.crud.server_squad import get_random_trial_squad_uuid
+from app.database.crud.server_squad import get_effective_tariff_squad_uuids
 from app.database.crud.subscription import (
     add_subscription_devices,
     add_subscription_squad,
@@ -75,16 +75,16 @@ async def _choose_trial_squads(
         return fallback_squads
 
     try:
-        squad_uuid = await get_random_trial_squad_uuid(db)
+        default_squads = await get_effective_tariff_squad_uuids(db, None)
     except Exception as error:
-        logger.error('Failed to select trial squad', error=error)
-        squad_uuid = None
+        logger.error('Failed to resolve default trial squads', error=error)
+        default_squads = []
 
-    if not squad_uuid:
+    if not default_squads:
         return []
 
-    logger.debug('Selected trial squad for subscription replacement', squad_uuid=squad_uuid)
-    return [squad_uuid]
+    logger.debug('Selected default trial squads for subscription replacement', squad_uuids=default_squads)
+    return default_squads
 
 
 async def _get_subscription(db: AsyncSession, subscription_id: int) -> Subscription:

--- a/tests/database/crud/test_subscription.py
+++ b/tests/database/crud/test_subscription.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from app.database.crud.subscription import create_trial_subscription
+
+
+async def test_create_trial_subscription_uses_all_available_squads_by_default(monkeypatch):
+    db = Mock()
+    db.add = Mock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    monkeypatch.setattr('app.database.crud.subscription.get_subscription_by_user_id', AsyncMock(return_value=None))
+    monkeypatch.setattr('app.database.crud.subscription.generate_unique_short_id', AsyncMock(return_value='abc123'))
+    monkeypatch.setattr(
+        'app.database.crud.server_squad.get_available_server_squads',
+        AsyncMock(
+            return_value=[
+                SimpleNamespace(squad_uuid='fi-uuid'),
+                SimpleNamespace(squad_uuid='ru-uuid'),
+            ]
+        ),
+    )
+    get_server_ids_mock = AsyncMock(return_value=[11, 12])
+    add_user_to_servers_mock = AsyncMock()
+    monkeypatch.setattr('app.database.crud.server_squad.get_server_ids_by_uuids', get_server_ids_mock)
+    monkeypatch.setattr('app.database.crud.server_squad.add_user_to_servers', add_user_to_servers_mock)
+
+    subscription = await create_trial_subscription(
+        db,
+        user_id=1,
+        duration_days=14,
+        traffic_limit_gb=100,
+        device_limit=5,
+    )
+
+    assert subscription.connected_squads == ['fi-uuid', 'ru-uuid']
+    db.add.assert_called_once_with(subscription)
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once_with(subscription)
+    get_server_ids_mock.assert_awaited_once_with(db, ['fi-uuid', 'ru-uuid'])
+    add_user_to_servers_mock.assert_awaited_once_with(db, [11, 12])

--- a/tests/services/test_promocode_service.py
+++ b/tests/services/test_promocode_service.py
@@ -2,8 +2,10 @@
 Tests for PromoCodeService - focus on promo group integration
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from app.database.models import PromoCodeType
 from app.services.promocode_service import PromoCodeService
 
 
@@ -382,3 +384,90 @@ async def test_promocode_data_includes_promo_group_id(
     assert 'promocode' in result
     assert 'promo_group_id' in result['promocode']
     assert result['promocode']['promo_group_id'] == sample_promo_group.id
+
+
+async def test_activate_trial_promocode_uses_all_available_squads_when_tariff_has_no_restrictions(
+    monkeypatch,
+):
+    sample_user = SimpleNamespace(
+        id=1,
+        telegram_id=123456789,
+        username='testuser',
+        full_name='Test User',
+        balance_kopeks=0,
+        language='ru',
+        has_had_paid_subscription=False,
+        total_spent_kopeks=0,
+    )
+    mock_db_session = AsyncMock()
+    mock_db_session.commit = AsyncMock()
+    mock_db_session.rollback = AsyncMock()
+    mock_db_session.refresh = AsyncMock()
+    mock_db_session.delete = AsyncMock()
+
+    promocode = SimpleNamespace(
+        id=10,
+        code='KRTN14',
+        type=PromoCodeType.TRIAL_SUBSCRIPTION.value,
+        balance_bonus_kopeks=0,
+        subscription_days=14,
+        tariff_id=7,
+        promo_group_id=None,
+        promo_group=None,
+        first_purchase_only=False,
+        max_uses=20,
+        current_uses=0,
+        is_active=True,
+        is_valid=True,
+        valid_until=None,
+    )
+    trial_tariff = SimpleNamespace(
+        id=7,
+        name='Trial',
+        traffic_limit_gb=100,
+        device_limit=5,
+        allowed_squads=[],
+        trial_duration_days=14,
+    )
+    created_subscription = SimpleNamespace(id=99)
+
+    monkeypatch.setattr('app.services.promocode_service.RemnaWaveService', lambda: SimpleNamespace())
+    create_remnawave_user_mock = AsyncMock()
+    monkeypatch.setattr(
+        'app.services.promocode_service.SubscriptionService',
+        lambda: SimpleNamespace(create_remnawave_user=create_remnawave_user_mock),
+    )
+    monkeypatch.setattr('app.services.promocode_service.get_user_by_id', AsyncMock(return_value=sample_user))
+    monkeypatch.setattr('app.services.promocode_service.get_promocode_by_code', AsyncMock(return_value=promocode))
+    monkeypatch.setattr('app.services.promocode_service.check_user_promocode_usage', AsyncMock(return_value=False))
+    monkeypatch.setattr('app.database.crud.promocode.count_user_recent_activations', AsyncMock(return_value=0))
+    monkeypatch.setattr('app.services.promocode_service.get_subscription_by_user_id', AsyncMock(return_value=None))
+    monkeypatch.setattr('app.services.promocode_service.create_promocode_use', AsyncMock(return_value=object()))
+    monkeypatch.setattr('app.database.crud.tariff.get_tariff_by_id', AsyncMock(return_value=trial_tariff))
+    monkeypatch.setattr('app.database.crud.tariff.get_trial_tariff', AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        'app.database.crud.server_squad.get_available_server_squads',
+        AsyncMock(
+            return_value=[
+                SimpleNamespace(squad_uuid='fi-uuid'),
+                SimpleNamespace(squad_uuid='ru-uuid'),
+            ]
+        ),
+    )
+    create_trial_subscription_mock = AsyncMock(return_value=created_subscription)
+    monkeypatch.setattr('app.database.crud.subscription.create_trial_subscription', create_trial_subscription_mock)
+
+    service = PromoCodeService()
+    result = await service.activate_promocode(mock_db_session, sample_user.id, promocode.code)
+
+    assert result['success'] is True
+    create_trial_subscription_mock.assert_awaited_once_with(
+        mock_db_session,
+        sample_user.id,
+        duration_days=14,
+        traffic_limit_gb=100,
+        device_limit=5,
+        connected_squads=['fi-uuid', 'ru-uuid'],
+        tariff_id=7,
+    )
+    create_remnawave_user_mock.assert_awaited_once_with(mock_db_session, created_subscription)


### PR DESCRIPTION
## Summary
- treat empty tariff squad lists as all currently available squads
- apply that rule across trial creation paths and default trial CRUD behavior
- add regression coverage for promo activation and direct trial creation

## Production context
- fixes the bug where unrestricted trials were assigned a single random squad (for example only Russia) instead of all available locations
- existing affected production user has already been remediated in data