### PR TITLE
fix: restore referrer field in admin landing purchases response

### DIFF
--- a/app/cabinet/routes/admin_landings.py
+++ b/app/cabinet/routes/admin_landings.py
@@ -550,6 +550,7 @@ class LandingPurchaseItem(BaseModel):
     currency: str
     payment_method: str | None = None
     status: str
+    referrer: str | None = None
     created_at: datetime | None = None
     paid_at: datetime | None = None
 
@@ -1007,6 +1008,7 @@ async def get_landing_purchases(
             GuestPurchase.currency,
             GuestPurchase.payment_method,
             GuestPurchase.status,
+            GuestPurchase.referrer,
             GuestPurchase.created_at,
             GuestPurchase.paid_at,
         )
@@ -1032,6 +1034,7 @@ async def get_landing_purchases(
             currency=row.currency,
             payment_method=row.payment_method,
             status=row.status,
+            referrer=row.referrer,
             created_at=row.created_at,
             paid_at=row.paid_at,
         )


### PR DESCRIPTION
## Problem

In v3.51.0 (Dev #2899 merge) the `referrer` field was accidentally dropped from both the `LandingPurchaseItem` Pydantic schema and the SELECT statement in `get_landing_purchases`. As a result, the admin UI stopped displaying the referrer source for landing purchases, even though the column is still populated correctly in the DB.

## Fix

Restore 3 lines in `app/cabinet/routes/admin_landings.py`:
- Add `referrer: str | None = None` to `LandingPurchaseItem` schema
- Add `GuestPurchase.referrer` to the SELECT in `get_landing_purchases`
- Pass `referrer=row.referrer` to the LandingPurchaseItem constructor

## Verification

Verified via Pydantic introspection:

```
LandingPurchaseItem fields: [\..., status, referrer, created_at, paid_at]
```

Admin UI now displays the referrer column for landing purchases again.