### PR TITLE
fix(email): inject cabinet_url + alias legacy placeholders ({amount}, {balance}, {reason})

### DIFF
--- a/app/cabinet/services/email_template_overrides.py
+++ b/app/cabinet/services/email_template_overrides.py
@@ -196,7 +196,7 @@ async def get_rendered_override(
     # Simple variable substitution for context vars like {username}, {verification_url}, etc.
     if context:
         for key, value in context.items():
-            body_html = body_html.replace(f'{{{key}}}', html.escape(str(value)))
+            body_html = body_html.replace(f'{{{key}}}', html.escape(str(value)) if value is not None else '')
 
     rendered = templates._wrap_override_template(body_html, language)
     subject = override['subject']
@@ -204,7 +204,7 @@ async def get_rendered_override(
     # Also substitute in subject
     if context:
         for key, value in context.items():
-            safe_value = str(value).replace('\r', '').replace('\n', '')
+            safe_value = str(value).replace('\r', '').replace('\n', '') if value is not None else ''
             subject = subject.replace(f'{{{key}}}', safe_value)
 
     return (subject, rendered)

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -523,10 +523,12 @@ def _build_cabinet_main_menu_keyboard(
                         continue
                     lang_text = section_cfg.get('labels', {}).get(language, '') or texts.MENU_LANGUAGE
                     resolved_lang_emoji = section_cfg.get('icon_custom_emoji_id') or None
+                    resolved_lang_style = _resolve_style(section_cfg.get('style'))
                     row_buttons.append(
                         InlineKeyboardButton(
                             text=lang_text,
                             callback_data='menu_language',
+                            style=resolved_lang_style,
                             icon_custom_emoji_id=resolved_lang_emoji,
                         )
                     )
@@ -534,7 +536,8 @@ def _build_cabinet_main_menu_keyboard(
                 case 'admin':
                     if not is_admin:
                         continue
-                    admin_row = [InlineKeyboardButton(text=texts.MENU_ADMIN, callback_data='admin_panel')]
+                    admin_callback_style = _resolve_style(section_cfg.get('style'))
+                    admin_row = [InlineKeyboardButton(text=texts.MENU_ADMIN, callback_data='admin_panel', style=admin_callback_style)]
                     if section_cfg.get('enabled', True):
                         admin_web_text = section_cfg.get('labels', {}).get(language, '') or '🖥 Веб-Админка'
                         admin_row.append(_cabinet_button(admin_web_text, '/admin', 'admin_panel'))

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -537,7 +537,11 @@ def _build_cabinet_main_menu_keyboard(
                     if not is_admin:
                         continue
                     admin_callback_style = _resolve_style(section_cfg.get('style'))
-                    admin_row = [InlineKeyboardButton(text=texts.MENU_ADMIN, callback_data='admin_panel', style=admin_callback_style)]
+                    admin_row = [
+                        InlineKeyboardButton(
+                            text=texts.MENU_ADMIN, callback_data='admin_panel', style=admin_callback_style
+                        )
+                    ]
                     if section_cfg.get('enabled', True):
                         admin_web_text = section_cfg.get('labels', {}).get(language, '') or '🖥 Веб-Админка'
                         admin_row.append(_cabinet_button(admin_web_text, '/admin', 'admin_panel'))

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -269,6 +269,30 @@ class NotificationDeliveryService:
             # Get email template (check DB override first, then fall back to hardcoded)
             language = user.language or 'ru'
 
+            # Inject common context values used across all email templates
+            context = {
+                'cabinet_url': getattr(settings, 'CABINET_URL', '') or '',
+                **context,
+            }
+
+            # Backwards-compat aliases for DB templates that use shorter
+            # placeholder names than the corresponding notify_* method ships.
+            # E.g. {amount} vs amount_kopeks, {reason} vs comment, {balance}.
+            if 'amount' not in context:
+                if context.get('formatted_amount'):
+                    context['amount'] = context['formatted_amount']
+                elif 'amount_kopeks' in context:
+                    context['amount'] = settings.format_price(context['amount_kopeks'])
+                elif 'bonus_kopeks' in context:
+                    context['amount'] = settings.format_price(context['bonus_kopeks'])
+            if 'balance' not in context:
+                if context.get('formatted_balance'):
+                    context['balance'] = context['formatted_balance']
+                elif 'new_balance_kopeks' in context:
+                    context['balance'] = settings.format_price(context['new_balance_kopeks'])
+            if 'reason' not in context and context.get('comment'):
+                context['reason'] = context['comment']
+
             # Try DB override (get_rendered_override substitutes context vars and wraps in base template)
             template = None
             try:


### PR DESCRIPTION
## Problem

Email templates in DB use `{cabinet_url}` placeholder in CTA `href` and shorter placeholder names than the corresponding `notify_*` methods actually ship in their context.

### Concrete user-visible bug

Customer reports the orange "Продлить подписку" button in `subscription_expiring` email returns them to the inbox instead of opening the cabinet. Link in the sent email looks like:

```
https://resend.com/emails/%7Bcabinet_url%7D?utm_source=email&utm_medium=transactional&utm_campaign=subscription_expiring
```

`%7B` / `%7D` are URL-encoded `{` / `}` — meaning `{cabinet_url}` was never substituted. The DB template body contains:

```html
<a href="{cabinet_url}?utm_source=email&utm_medium=transactional&utm_campaign=subscription_expiring" ...>
  Продлить подписку
</a>
```

But `notify_subscription_expiring` only ships `{'days_left': ..., 'expires_at': ...}` — no `cabinet_url`. After `template_overrides.get_rendered_override` substitutes context vars, `{cabinet_url}` becomes empty string → href is relative `?utm_source=...` → the SMTP provider (Resend) wraps it in their tracker link, browser cannot resolve it, mail clients fall back to inbox.

### Audit of all templates vs `notify_*` contexts

Comparing placeholders extracted from `email_templates` rows vs context dicts in `notification_delivery_service.py`:

| Template | Needs | `notify_*` ships | Missing |
|---|---|---|---|
| `subscription_expiring` | cabinet_url, expires_at | days_left, expires_at | **cabinet_url** |
| `subscription_expired` | cabinet_url | () | **cabinet_url** |
| `unban_notification` | cabinet_url | () | **cabinet_url** |
| `autopay_failed` | cabinet_url, reason | reason | **cabinet_url** |
| `autopay_success` | cabinet_url, formatted_amount, new_expires_at | formatted_amount, new_expires_at | **cabinet_url** |
| `partner_application_approved` | cabinet_url | commission_percent, comment | **cabinet_url** |
| `referral_bonus` | amount | bonus_kopeks, bonus_rubles, formatted_bonus, referral_name | **amount** |
| `withdrawal_approved` | amount | amount_kopeks, formatted_amount, comment | **amount** |
| `withdrawal_rejected` | amount, reason | amount_kopeks, formatted_amount, comment | **amount, reason** |
| `daily_debit` | amount, balance | amount_kopeks, formatted_amount, new_balance_kopeks, formatted_balance | **amount, balance** |
| `partner_application_rejected` | reason | comment | **reason** |

## Fix

Inject common values into context inside `_send_email_notification` once, before override rendering:

1. `cabinet_url` from `settings.CABINET_URL`
2. Compatibility aliases when not already provided:
   - `{amount}` ← `formatted_amount` / `format_price(amount_kopeks)` / `format_price(bonus_kopeks)`
   - `{balance}` ← `formatted_balance` / `format_price(new_balance_kopeks)`
   - `{reason}` ← `comment`

This avoids touching every `notify_*` method individually and keeps the fix in one place. Existing context keys take precedence (caller can still override).

## Tested

Deployed to production (matrixvpn.top). Subscription-expiring emails now render the orange CTA with proper `https://matrixvpn.top?utm_source=email&...` href.