### PR TITLE
Добавить поддержку v2raytun в TV Quick Connect

### DIFF
--- a/app/cabinet/routes/subscription_modules/status.py
+++ b/app/cabinet/routes/subscription_modules/status.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +24,11 @@ from app.database.crud.tariff import get_tariff_by_id
 from app.database.models import ServerSquad, User
 from app.services.remnawave_service import RemnaWaveService
 from app.services.system_settings_service import bot_configuration_service
+from app.services.tv_quick_connect import (
+    TvQuickConnectSendError,
+    parse_tv_quick_connect_target,
+    send_tv_quick_connect_target,
+)
 
 from ...dependencies import get_cabinet_db, get_current_cabinet_user
 from ...schemas.subscription import (
@@ -35,6 +41,10 @@ from .helpers import _subscription_to_response, resolve_subscription
 logger = structlog.get_logger(__name__)
 
 router = APIRouter()
+
+
+class TvQuickConnectRequest(BaseModel):
+    qr_data: str = Field(..., min_length=1, max_length=4096)
 
 
 @router.get('/info', response_model=SubscriptionStatusResponse)
@@ -212,6 +222,66 @@ async def get_happ_downloads(
     return {
         'platforms': available_platforms,
         'happ_enabled': bool(available_platforms),
+    }
+
+
+# ============ TV Quick Connect ============
+
+
+@router.post('/tv-quick-connect')
+async def tv_quick_connect(
+    payload: TvQuickConnectRequest,
+    user: User = Depends(get_current_cabinet_user),
+    db: AsyncSession = Depends(get_cabinet_db),
+    subscription_id: int | None = Query(None, description='Subscription ID for multi-tariff'),
+) -> dict[str, Any]:
+    """Send user's subscription to a TV app using a scanned TV QR payload."""
+    subscription = await resolve_subscription(db, user, subscription_id)
+
+    if not subscription:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='No subscription found',
+        )
+
+    subscription_url = subscription.subscription_url
+    if not subscription_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Subscription link not yet generated',
+        )
+
+    target = parse_tv_quick_connect_target(payload.qr_data)
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Unsupported TV QR code',
+        )
+
+    try:
+        await send_tv_quick_connect_target(target, subscription_url)
+    except TvQuickConnectSendError as e:
+        logger.warning(
+            'TV quick connect failed',
+            user_id=user.id,
+            subscription_id=subscription.id,
+            provider=target.provider,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Failed to send subscription to TV',
+        ) from e
+
+    logger.info(
+        'TV quick connect sent',
+        user_id=user.id,
+        subscription_id=subscription.id,
+        provider=target.provider,
+    )
+    return {
+        'status': 'sent',
+        'provider': target.provider,
     }
 
 

--- a/app/services/tv_quick_connect.py
+++ b/app/services/tv_quick_connect.py
@@ -1,0 +1,199 @@
+"""TV quick-connect helpers for Happ and v2raytun."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+import httpx
+import websockets
+from websockets.exceptions import WebSocketException
+
+
+HAPP_TV_API = 'https://check.happ.su/sendtv'
+V2RAYTUN_STREAMVAULT_WS = 'wss://vault.v2raytunpulse.com'
+
+_HAPP_CODE_RE = re.compile(r'^[A-Z0-9]{5}$', re.IGNORECASE)
+_V2RAYTUN_KEY_RE = re.compile(r'^[0-9a-f]{32}$', re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class TvQuickConnectTarget:
+    provider: str
+    value: str
+
+
+class TvQuickConnectSendError(RuntimeError):
+    """Raised when a supported TV quick-connect provider rejects the request."""
+
+
+def parse_tv_quick_connect_target(qr_data: str) -> TvQuickConnectTarget | None:
+    """Parse QR payload from supported TV apps.
+
+    Happ shows a 5-character code. v2raytun TV shows a 32-character
+    StreamVault key in the QR code.
+    """
+    text = (qr_data or '').strip()
+    if not text:
+        return None
+
+    happ_code = _extract_happ_code(text)
+    if happ_code:
+        return TvQuickConnectTarget(provider='happ', value=happ_code)
+
+    v2raytun_key = _extract_v2raytun_key(text)
+    if v2raytun_key:
+        return TvQuickConnectTarget(provider='v2raytun', value=v2raytun_key)
+
+    return None
+
+
+async def send_tv_quick_connect_target(target: TvQuickConnectTarget, subscription_url: str) -> None:
+    if target.provider == 'happ':
+        await send_happ_tv_subscription(target.value, subscription_url)
+        return
+
+    if target.provider == 'v2raytun':
+        await send_v2raytun_streamvault_subscription(target.value, subscription_url)
+        return
+
+    raise TvQuickConnectSendError(f'Unsupported TV provider: {target.provider}')
+
+
+async def send_happ_tv_subscription(code: str, subscription_url: str) -> None:
+    encoded_subscription = base64.b64encode(subscription_url.encode('utf-8')).decode('ascii')
+    url = f'{HAPP_TV_API}/{code}'
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.post(url, json={'data': encoded_subscription})
+    except httpx.HTTPError as exc:
+        raise TvQuickConnectSendError('Happ TV request failed') from exc
+
+    if not response.is_success:
+        raise TvQuickConnectSendError(f'Happ TV returned HTTP {response.status_code}')
+
+
+async def send_v2raytun_streamvault_subscription(
+    key: str,
+    subscription_url: str,
+    *,
+    timeout_seconds: float = 10.0,
+) -> None:
+    request = {
+        'action': 'PUT',
+        'key': key.lower(),
+        'value': subscription_url,
+    }
+
+    try:
+        async with websockets.connect(
+            V2RAYTUN_STREAMVAULT_WS,
+            open_timeout=timeout_seconds,
+            close_timeout=3,
+        ) as websocket:
+            await websocket.send(json.dumps(request, ensure_ascii=False, separators=(',', ':')))
+            raw_response = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+    except (OSError, TimeoutError, WebSocketException) as exc:
+        raise TvQuickConnectSendError('v2raytun StreamVault request failed') from exc
+
+    if isinstance(raw_response, bytes):
+        raw_response = raw_response.decode('utf-8', errors='replace')
+
+    try:
+        response: dict[str, Any] = json.loads(raw_response)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise TvQuickConnectSendError('v2raytun StreamVault returned invalid response') from exc
+
+    response_status = str(response.get('status', '')).upper()
+    if response_status != 'SUCCESS':
+        message = response.get('message') or 'v2raytun StreamVault rejected request'
+        raise TvQuickConnectSendError(str(message))
+
+
+def _extract_happ_code(text: str) -> str | None:
+    if _HAPP_CODE_RE.fullmatch(text):
+        return text.upper()
+
+    url_candidates = _extract_url_candidates(text)
+    for candidate in url_candidates:
+        if _HAPP_CODE_RE.fullmatch(candidate):
+            return candidate.upper()
+
+    match = re.search(r'[/=]([A-Z0-9]{5})(?:[/?&\s]|$)', text, re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+
+    return None
+
+
+def _extract_v2raytun_key(text: str) -> str | None:
+    if _V2RAYTUN_KEY_RE.fullmatch(text):
+        return text.lower()
+
+    for candidate in _extract_json_string_candidates(text):
+        if _V2RAYTUN_KEY_RE.fullmatch(candidate):
+            return candidate.lower()
+
+    for candidate in _extract_url_candidates(text):
+        if _V2RAYTUN_KEY_RE.fullmatch(candidate):
+            return candidate.lower()
+
+    return None
+
+
+def _extract_json_string_candidates(text: str) -> list[str]:
+    try:
+        payload = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return []
+
+    candidates: list[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, str):
+            candidates.append(value.strip())
+            return
+        if isinstance(value, dict):
+            for item in value.values():
+                walk(item)
+            return
+        if isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(payload)
+    return candidates
+
+
+def _extract_url_candidates(text: str) -> list[str]:
+    decoded_text = unquote(text.strip())
+    try:
+        parsed = urlparse(decoded_text)
+    except ValueError:
+        return []
+
+    if not parsed.scheme:
+        return []
+
+    candidates: list[str] = []
+    if parsed.netloc:
+        candidates.append(unquote(parsed.netloc.strip('/')))
+
+    path_parts = [unquote(part) for part in parsed.path.split('/') if part]
+    candidates.extend(path_parts)
+
+    query_values = []
+    if parsed.query:
+        for pair in parsed.query.split('&'):
+            if '=' in pair:
+                _, value = pair.split('=', 1)
+                query_values.append(unquote(value))
+    candidates.extend(query_values)
+
+    return [candidate.strip() for candidate in candidates if candidate.strip()]

--- a/tests/cabinet/test_tv_quick_connect.py
+++ b/tests/cabinet/test_tv_quick_connect.py
@@ -1,0 +1,47 @@
+from app.services.tv_quick_connect import parse_tv_quick_connect_target
+
+
+def test_parse_happ_tv_code_direct():
+    target = parse_tv_quick_connect_target('a1b2c')
+
+    assert target is not None
+    assert target.provider == 'happ'
+    assert target.value == 'A1B2C'
+
+
+def test_parse_happ_tv_code_from_url():
+    target = parse_tv_quick_connect_target('https://check.happ.su/sendtv/A1B2C')
+
+    assert target is not None
+    assert target.provider == 'happ'
+    assert target.value == 'A1B2C'
+
+
+def test_parse_v2raytun_streamvault_key_direct():
+    target = parse_tv_quick_connect_target('c43ea727b1d748279ebd4af8c096f726')
+
+    assert target is not None
+    assert target.provider == 'v2raytun'
+    assert target.value == 'c43ea727b1d748279ebd4af8c096f726'
+
+
+def test_parse_v2raytun_streamvault_key_from_json():
+    target = parse_tv_quick_connect_target('{"key":"C43EA727B1D748279EBD4AF8C096F726"}')
+
+    assert target is not None
+    assert target.provider == 'v2raytun'
+    assert target.value == 'c43ea727b1d748279ebd4af8c096f726'
+
+
+def test_parse_v2raytun_streamvault_key_from_url():
+    target = parse_tv_quick_connect_target(
+        'v2raytun://c43ea727b1d748279ebd4af8c096f726'
+    )
+
+    assert target is not None
+    assert target.provider == 'v2raytun'
+    assert target.value == 'c43ea727b1d748279ebd4af8c096f726'
+
+
+def test_parse_unsupported_qr():
+    assert parse_tv_quick_connect_target('https://example.com/subscription') is None


### PR DESCRIPTION
## Что изменено

Добавлена backend-поддержка TV Quick Connect не только для Happ, но и для v2raytun на Android TV.

## Основные изменения

- Добавлен endpoint `POST /cabinet/subscription/tv-quick-connect`.
- Добавлен парсинг TV QR payload:
  - Happ: 5-символьный TV-код.
  - v2raytun: 32-символьный StreamVault key из QR-кода на телевизоре.
- Для Happ сохранена отправка через существующий API `https://check.happ.su/sendtv`.
- Для v2raytun добавлена отправка подписки через WebSocket StreamVault: `wss://vault.v2raytunpulse.com`.
- Сохранена поддержка `subscription_id` для multi-tariff сценариев.
- Добавлены тесты парсинга QR payload.

## Зачем

Текущий TV Quick Connect работает только с Happ-кодами. v2raytun на Android TV использует QR pairing flow, поэтому кабинет должен передавать сырой QR payload на backend, а backend уже должен определить провайдера и отправить подписку нужным способом.

## Связанный PR

Cabinet/frontend PR: https://github.com/BEDOLAGA-DEV/bedolaga-cabinet/pull/421