### PR TITLE
fix(admin-notify): show real trial duration and traffic on activation

### DIFF
--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -329,8 +329,16 @@ class AdminNotificationService:
                 occurred_at=datetime.now(UTC),
                 extra={
                     'charged_amount_kopeks': charged_amount_kopeks,
-                    'trial_duration_days': settings.TRIAL_DURATION_DAYS,
-                    'traffic_limit_gb': settings.TRIAL_TRAFFIC_LIMIT_GB,
+                    'trial_duration_days': (
+                        max(1, round((subscription.end_date - subscription.start_date).total_seconds() / 86400))
+                        if subscription.end_date and subscription.start_date
+                        else settings.TRIAL_DURATION_DAYS
+                    ),
+                    'traffic_limit_gb': (
+                        subscription.traffic_limit_gb
+                        if subscription.traffic_limit_gb is not None
+                        else settings.TRIAL_TRAFFIC_LIMIT_GB
+                    ),
                     'device_limit': subscription.device_limit,
                 },
             )
@@ -382,11 +390,23 @@ class AdminNotificationService:
 
             message_lines.append('')
 
+            trial_duration_days = settings.TRIAL_DURATION_DAYS
+            if subscription.end_date and subscription.start_date:
+                trial_duration_days = max(
+                    1, round((subscription.end_date - subscription.start_date).total_seconds() / 86400)
+                )
+
+            trial_traffic_gb = (
+                subscription.traffic_limit_gb
+                if subscription.traffic_limit_gb is not None
+                else settings.TRIAL_TRAFFIC_LIMIT_GB
+            )
+
             message_lines.extend(
                 [
                     '⏰ <b>Параметры триала:</b>',
-                    f'📅 Период: {settings.TRIAL_DURATION_DAYS} дней',
-                    f'📊 Трафик: {self._format_traffic(settings.TRIAL_TRAFFIC_LIMIT_GB)}',
+                    f'📅 Период: {trial_duration_days} дней',
+                    f'📊 Трафик: {self._format_traffic(trial_traffic_gb)}',
                     f'📱 Устройства: {trial_device_limit}',
                     f'🌐 Сервер: {subscription.connected_squads[0] if subscription.connected_squads else "По умолчанию"}',
                 ]


### PR DESCRIPTION
## Summary
- В уведомлении админу об активации триала и в `extra` записываемого события `activation` использовались глобальные `settings.TRIAL_DURATION_DAYS` и `settings.TRIAL_TRAFFIC_LIMIT_GB`.
- Из-за этого, когда подписка создавалась с кастомными параметрами триала (триал по тарифу, промо-настройки и т.п.), админ видел значения по умолчанию, а не реальные параметры, выданные пользователю.
- Теперь длительность считается из `subscription.end_date - subscription.start_date`, а лимит трафика читается напрямую из `subscription.traffic_limit_gb`. К `settings.*` откатываемся только если этих значений нет.

## Why
Уведомление и журналируемое событие должны отражать то, что фактически получил пользователь — иначе админская аналитика и алерты по триалам опираются на неверные значения.

## Scope
- `app/services/admin_notification_service.py` — изменения только в `send_trial_activation_notification` (поля `extra` события + текст сообщения).
- Поведение при отсутствии `start_date`/`end_date`/`traffic_limit_gb` остаётся прежним: фоллбэк на `settings.*`.

## Test plan
- [ ] Активировать триал со стандартными настройками — значения совпадают с прежним поведением.
- [ ] Активировать триал по тарифу с нестандартной длительностью/трафиком — в уведомлении и в `extra` отображаются реальные значения подписки, а не глобальные дефолты.
- [ ] Проверить, что при `subscription.traffic_limit_gb == 0` (безлимит) форматирование через `_format_traffic` отрабатывает корректно.