### PR TITLE
feat(admin): show all active subscriptions in user profile

### DIFF
--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -1261,6 +1261,7 @@ async def show_user_management(callback: types.CallbackQuery, db_user: User, db:
 
     user = profile['user']
     subscription = profile['subscription']
+    active_subscriptions = profile.get('active_subscriptions') or ([subscription] if subscription else [])
 
     texts = get_texts(db_user.language)
 
@@ -1293,33 +1294,59 @@ async def show_user_management(callback: types.CallbackQuery, db_user: User, db:
         )
     ]
 
-    if subscription:
-        subscription_type = (
+    def _format_subscription_block(sub, index: int | None = None) -> str:
+        sub_type = (
             texts.ADMIN_USER_SUBSCRIPTION_TYPE_TRIAL
-            if subscription.is_trial
+            if sub.is_trial
             else texts.ADMIN_USER_SUBSCRIPTION_TYPE_PAID
         )
-        subscription_status = (
+        sub_status = (
             texts.ADMIN_USER_SUBSCRIPTION_STATUS_ACTIVE
-            if subscription.is_active
+            if sub.is_active
             else texts.ADMIN_USER_SUBSCRIPTION_STATUS_INACTIVE
         )
-        traffic_usage = texts.ADMIN_USER_TRAFFIC_USAGE.format(
-            used=f'{subscription.traffic_used_gb:.1f}',
-            limit=subscription.traffic_limit_gb,
+        traffic = texts.ADMIN_USER_TRAFFIC_USAGE.format(
+            used=f'{sub.traffic_used_gb:.1f}',
+            limit=sub.traffic_limit_gb,
         )
-        sections.append(
-            texts.ADMIN_USER_MANAGEMENT_SUBSCRIPTION.format(
-                type=subscription_type,
-                status=subscription_status,
-                end_date=format_datetime(subscription.end_date),
-                traffic=traffic_usage,
-                devices=subscription.device_limit,
-                countries=len(subscription.connected_squads or []),
-            )
+        common = {
+            'type': sub_type,
+            'status': sub_status,
+            'end_date': format_datetime(sub.end_date),
+            'traffic': traffic,
+            'devices': sub.device_limit,
+            'countries': len(sub.connected_squads or []),
+        }
+        if index is None:
+            return texts.ADMIN_USER_MANAGEMENT_SUBSCRIPTION.format(**common)
+
+        tariff_name = getattr(getattr(sub, 'tariff', None), 'name', None)
+        tariff_suffix = f' — {html.escape(tariff_name)}' if tariff_name else ''
+        item_template = texts.t(
+            'ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM',
+            '▫️ <b>#{index}{tariff}</b>\n'
+            '• Тип: {type}\n'
+            '• Статус: {status}\n'
+            '• До: {end_date}\n'
+            '• Трафик: {traffic}\n'
+            '• Устройства: {devices}\n'
+            '• Стран: {countries}',
         )
-    else:
+        return item_template.format(index=index, tariff=tariff_suffix, **common)
+
+    if not active_subscriptions:
         sections.append(texts.ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE)
+    elif len(active_subscriptions) == 1:
+        sections.append(_format_subscription_block(active_subscriptions[0]))
+    else:
+        sections.append(
+            texts.t(
+                'ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER',
+                '<b>Подписки ({count}):</b>',
+            ).format(count=len(active_subscriptions))
+        )
+        for idx, sub in enumerate(active_subscriptions, start=1):
+            sections.append(_format_subscription_block(sub, index=idx))
 
     # Display promo groups
     primary_group = user.get_primary_promo_group()

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -1295,11 +1295,7 @@ async def show_user_management(callback: types.CallbackQuery, db_user: User, db:
     ]
 
     def _format_subscription_block(sub, index: int | None = None) -> str:
-        sub_type = (
-            texts.ADMIN_USER_SUBSCRIPTION_TYPE_TRIAL
-            if sub.is_trial
-            else texts.ADMIN_USER_SUBSCRIPTION_TYPE_PAID
-        )
+        sub_type = texts.ADMIN_USER_SUBSCRIPTION_TYPE_TRIAL if sub.is_trial else texts.ADMIN_USER_SUBSCRIPTION_TYPE_PAID
         sub_status = (
             texts.ADMIN_USER_SUBSCRIPTION_STATUS_ACTIVE
             if sub.is_active

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -819,6 +819,8 @@
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP": "<b>Promo group:</b>\n• Name: {name}\n• Server discount: {server_discount}%\n• Traffic discount: {traffic_discount}%\n• Device discount: {device_discount}%",
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP_NONE": "<b>Promo group:</b> Not assigned",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION": "<b>Subscription:</b>\n• Type: {type}\n• Status: {status}\n• Until: {end_date}\n• Traffic: {traffic}\n• Devices: {devices}\n• Countries: {countries}",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER": "<b>Subscriptions ({count}):</b>",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM": "▫️ <b>#{index}{tariff}</b>\n• Type: {type}\n• Status: {status}\n• Until: {end_date}\n• Traffic: {traffic}\n• Devices: {devices}\n• Countries: {countries}",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE": "<b>Subscription:</b> None",
   "ADMIN_USER_PROMO_GROUP_ALREADY": "ℹ️ The user is already in this promo group.",
   "ADMIN_USER_PROMO_GROUP_BACK": "⬅️ Back to user",

--- a/app/localization/locales/fa.json
+++ b/app/localization/locales/fa.json
@@ -828,6 +828,8 @@
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP": "<b>گروه تخفیف:</b>\n• نام: {name}\n• تخفیف سرور: {server_discount}%\n• تخفیف ترافیک: {traffic_discount}%\n• تخفیف دستگاه: {device_discount}%",
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP_NONE": "<b>گروه تخفیف:</b> تعیین نشده",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION": "<b>اشتراک:</b>\n• نوع: {type}\n• وضعیت: {status}\n• تا: {end_date}\n• ترافیک: {traffic}\n• دستگاه‌ها: {devices}\n• کشورها: {countries}",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER": "<b>اشتراک‌ها ({count}):</b>",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM": "▫️ <b>#{index}{tariff}</b>\n• نوع: {type}\n• وضعیت: {status}\n• تا: {end_date}\n• ترافیک: {traffic}\n• دستگاه‌ها: {devices}\n• کشورها: {countries}",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE": "<b>اشتراک:</b> ندارد",
   "ADMIN_USER_PROMO_GROUP_ALREADY": "ℹ️ کاربر قبلاً در این گروه است.",
   "ADMIN_USER_PROMO_GROUP_BACK": "⬅️ بازگشت به کاربر",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -828,6 +828,8 @@
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP": "<b>Промогруппа:</b>\n• Название: {name}\n• Скидка на сервера: {server_discount}%\n• Скидка на трафик: {traffic_discount}%\n• Скидка на устройства: {device_discount}%",
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP_NONE": "<b>Промогруппа:</b> Не назначена",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION": "<b>Подписка:</b>\n• Тип: {type}\n• Статус: {status}\n• До: {end_date}\n• Трафик: {traffic}\n• Устройства: {devices}\n• Стран: {countries}",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER": "<b>Подписки ({count}):</b>",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM": "▫️ <b>#{index}{tariff}</b>\n• Тип: {type}\n• Статус: {status}\n• До: {end_date}\n• Трафик: {traffic}\n• Устройства: {devices}\n• Стран: {countries}",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE": "<b>Подписка:</b> Отсутствует",
   "ADMIN_USER_PROMO_GROUP_ALREADY": "ℹ️ Пользователь уже состоит в этой промогруппе.",
   "ADMIN_USER_PROMO_GROUP_BACK": "⬅️ К пользователю",

--- a/app/localization/locales/ua.json
+++ b/app/localization/locales/ua.json
@@ -750,6 +750,8 @@
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP": "<b>Промогрупа:</b>\n• Назва: {name}\n• Знижка на сервери: {server_discount}%\n• Знижка на трафік: {traffic_discount}%\n• Знижка на пристрої: {device_discount}%",
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP_NONE": "<b>Промогрупа:</b> Не призначена",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION": "<b>Підписка:</b>\n• Тип: {type}\n• Статус: {status}\n• До: {end_date}\n• Трафік: {traffic}\n• Пристрої: {devices}\n• Країн: {countries}",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER": "<b>Підписки ({count}):</b>",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM": "▫️ <b>#{index}{tariff}</b>\n• Тип: {type}\n• Статус: {status}\n• До: {end_date}\n• Трафік: {traffic}\n• Пристрої: {devices}\n• Країн: {countries}",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE": "<b>Підписка:</b> Відсутня",
   "ADMIN_USER_PROMO_GROUP_ALREADY": "ℹ️ Користувач вже перебуває у цій промогрупі.",
   "ADMIN_USER_PROMO_GROUP_BACK": "⬅️ До користувача",

--- a/app/localization/locales/zh.json
+++ b/app/localization/locales/zh.json
@@ -748,6 +748,8 @@
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP": "<b>促销组：</b>\n•名称：{name}\n•服务器折扣：{server_discount}%\n•流量折扣：{traffic_discount}%\n•设备折扣：{device_discount}%",
   "ADMIN_USER_MANAGEMENT_PROMO_GROUP_NONE": "<b>促销组：</b>未指定",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION": "<b>订阅：</b>\n•类型：{type}\n•状态：{status}\n•截止日期：{end_date}\n•流量：{traffic}\n•设备：{devices}\n•国家：{countries}",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER": "<b>订阅（{count}）：</b>",
+  "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM": "▫️ <b>#{index}{tariff}</b>\n•类型：{type}\n•状态：{status}\n•截止日期：{end_date}\n•流量：{traffic}\n•设备：{devices}\n•国家：{countries}",
   "ADMIN_USER_MANAGEMENT_SUBSCRIPTION_NONE": "<b>订阅：</b>无",
   "ADMIN_USER_PROMO_GROUP_ALREADY": "ℹ️用户已在此促销组中。",
   "ADMIN_USER_PROMO_GROUP_BACK": "⬅️返回用户",

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -209,23 +209,27 @@ class UserService:
             if not user:
                 return None
 
+            active_subscriptions: list[Subscription] = []
             if settings.is_multi_tariff_enabled():
                 from app.database.crud.subscription import get_active_subscriptions_by_user_id
 
-                active_subs = await get_active_subscriptions_by_user_id(db, user_id)
-                if active_subs:
-                    _non_daily = [s for s in active_subs if not getattr(s, 'is_daily_tariff', False)]
-                    _pool = _non_daily or active_subs
+                active_subscriptions = await get_active_subscriptions_by_user_id(db, user_id)
+                if active_subscriptions:
+                    _non_daily = [s for s in active_subscriptions if not getattr(s, 'is_daily_tariff', False)]
+                    _pool = _non_daily or active_subscriptions
                     subscription = max(_pool, key=lambda s: s.days_left)
                 else:
                     subscription = None
             else:
                 subscription = await get_subscription_by_user_id(db, user_id)
+                if subscription is not None:
+                    active_subscriptions = [subscription]
             transactions_count = await get_user_transactions_count(db, user_id)
 
             return {
                 'user': user,
                 'subscription': subscription,
+                'active_subscriptions': active_subscriptions,
                 'transactions_count': transactions_count,
                 'is_admin': settings.is_admin(user.telegram_id, user.email),
                 'registration_days': (datetime.now(UTC) - user.created_at).days,


### PR DESCRIPTION
## 🎯 Summary

В админ-карточке пользователя (`👤 Управление пользователем`) сейчас отображается только одна подписка — та, у которой больше всего осталось дней (`max(..., key=lambda s: s.days_left)` в `UserService.get_user_profile`). В режиме `MULTI_TARIFF_ENABLED=true` у одного пользователя может быть несколько одновременных активных подписок (`MAX_ACTIVE_SUBSCRIPTIONS > 1`), и админ не видит остальные — состояние других подписок (трафик, срок, лимит устройств) полностью скрыто.

После этого PR блок «Подписка» в карточке адаптивный:
- 0 подписок — `<b>Подписка:</b> Отсутствует` (как было).
- 1 подписка — текущий вид без изменений.
- N подписок — заголовок `<b>Подписки (N):</b>` и по блоку на каждую с порядковым номером и названием тарифа (если оно есть).

Пример при двух подписках:

```
<b>Подписки (2):</b>

▫️ <b>#1 — Базовый тариф</b>
• Тип: 💎 Платная
• Статус: ✅ Активна
• До: 31.05.2026 14:56
• Трафик: 0.0/40 ГБ
• Устройства: 5
• Стран: 1

▫️ <b>#2 — Premium</b>
• Тип: 💎 Платная
• Статус: ✅ Активна
• До: 18.06.2026 09:12
• Трафик: 12.4/200 ГБ
• Устройства: 10
• Стран: 3
```

## 🔧 Changes

- `app/services/user_service.py` — `get_user_profile` теперь возвращает `active_subscriptions: list[Subscription]` помимо `subscription`. В multi-tariff это все активные подписки (через `get_active_subscriptions_by_user_id`), в обычном режиме — `[subscription]` либо пустой список. Ключ `subscription` сохранён, остальные ~10 вызовов `get_user_profile` не затронуты.
- `app/handlers/admin/users.py::show_user_management` — общий рендер блока подписки вынесен в локальную функцию `_format_subscription_block`. При N>1 добавляется заголовок + пронумерованные блоки с названием тарифа.
- `app/localization/locales/{ru,en,ua,fa,zh}.json` — добавлены ключи `ADMIN_USER_MANAGEMENT_SUBSCRIPTIONS_HEADER` и `ADMIN_USER_MANAGEMENT_SUBSCRIPTION_ITEM` для всех 5 локалей. Существующий `ADMIN_USER_MANAGEMENT_SUBSCRIPTION` оставлен и используется для случая с одной подпиской (полностью обратная совместимость).

## ✅ Test plan

- [ ] Открыть карточку пользователя с **0** активными подписками — блок `Подписка: Отсутствует`, как раньше.
- [ ] Открыть карточку пользователя с **1** активной подпиской — отображение идентично текущему.
- [ ] В multi-tariff режиме открыть карточку пользователя с **≥2** активными подписками — отображается заголовок `Подписки (N):` и по блоку на каждую, у каждой видно тариф/статус/трафик/устройства/срок.
- [ ] Проверить, что подписка с пустым `tariff` рендерится без хвоста ` — {имя}` и не падает.
- [ ] Проверить на ru/en локалях (на остальных строки добавлены, но визуально достаточно одной).