### PR TITLE
fix(remnawave): email users get a unique username instead of constant 'user'

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1295,19 +1295,31 @@ async def activate_trial(
     logger.info('Trial subscription activated for user', user_id=user.id)
 
     # Create RemnaWave user
+    subscription_service = SubscriptionService()
+    panel_user = None
     try:
-        subscription_service = SubscriptionService()
         if subscription_service.is_configured:
-            await subscription_service.create_remnawave_user(db, subscription)
+            panel_user = await subscription_service.create_remnawave_user(db, subscription)
             await db.refresh(subscription)
     except Exception as e:
         logger.error('Failed to create RemnaWave user for trial', error=e)
+
+    # create_remnawave_user проглатывает RemnaWaveAPIError внутри себя и
+    # возвращает None (не пробрасывает) — поэтому одного except недостаточно.
+    # Без явной проверки результата кабинет показывал бы триал «активен» без
+    # subscription_url, а юзер так и не появлялся бы в панели Remnawave.
+    if subscription_service.is_configured and panel_user is None:
         from app.services.remnawave_retry_queue import remnawave_retry_queue
 
         remnawave_retry_queue.enqueue(
             subscription_id=subscription.id,
             user_id=user.id,
             action='create',
+        )
+        logger.warning(
+            'Trial RemnaWave user not provisioned, enqueued for retry',
+            user_id=user.id,
+            subscription_id=subscription.id,
         )
 
     # Send admin notification about trial activation

--- a/app/config.py
+++ b/app/config.py
@@ -1475,7 +1475,14 @@ class Settings(BaseSettings):
         raw_username = template.format_map(values).strip()
         sanitized_username = _sanitize(raw_username)
 
-        if not sanitized_username:
+        # Degenerate render: ни одна переменная шаблона не дала уникального
+        # значения. Напр. шаблон `user_{username}` для email-only юзера (у
+        # которого нет Telegram-username) рендерится в `user` — одинаково для
+        # ВСЕХ таких юзеров → RemnaWave отвечает 409 "username already exists"
+        # на каждую регистрацию после первой. `skeleton` — тот же шаблон с
+        # пустыми переменными; равенство ему значит «шаблон ничего не дал».
+        skeleton = _sanitize(template.format_map(defaultdict(str)))
+        if not sanitized_username or sanitized_username == skeleton:
             sanitized_username = _sanitize(f'user_{identifier}')
 
         # Резервируем место под caller-suffix, не опускаясь ниже минимальной длины.

--- a/app/services/remnawave_retry_queue.py
+++ b/app/services/remnawave_retry_queue.py
@@ -95,9 +95,18 @@ class RemnaWaveRetryQueue:
                         continue
 
                     if item.action == 'create':
-                        await service.create_remnawave_user(db, sub)
+                        result = await service.create_remnawave_user(db, sub)
                     else:
-                        await service.update_remnawave_user(db, sub)
+                        result = await service.update_remnawave_user(db, sub)
+
+                    # create_remnawave_user / update_remnawave_user проглатывают
+                    # RemnaWaveAPIError внутри себя и возвращают None (не
+                    # пробрасывают). Без проверки результата воркер счёл бы
+                    # провал успехом и выбросил бы элемент из очереди после
+                    # первого тика — подписка осталась бы без юзера в панели.
+                    if result is None:
+                        self._requeue(item, f'{item.action}_remnawave_user returned None')
+                        continue
 
                     logger.info(
                         'Retry succeeded',


### PR DESCRIPTION
## 📝 Описание
Email-only пользователи кабинета не имеют Telegram-@username, поэтому шаблон вида `user_{username}` (значение `REMNAWAVE_USER_USERNAME_TEMPLATE`) рендерится в `user` для **каждого** из них. RemnaWave отклоняет вторую и последующие такие регистрации с `409 User username already exists` — триал создаётся локально, но пользователь в панели не появляется.

`create_remnawave_user` ловит `RemnaWaveAPIError` внутри себя и возвращает `None` (не пробрасывает), поэтому ни `try/except` в `activate_trial`, ни воркер retry-очереди ошибку не видят: подписка остаётся без пользователя в панели, кабинет показывает «подписка активна» без `subscription_url`.

## 🎯 Мотивация
Регистрация в веб-кабинете через email + активация триала не создаёт пользователя в панели Remnawave. Через Telegram всё работает (у TG-юзеров есть валидный уникальный `@username`).

Не связано с `6c20858` (sanitize email dots): тот фикс чистит слоты `{email}`/`{identifier}`, а проблемный шаблон использует `{username}` — баг воспроизводится одинаково на email с точкой и без.

## 🔧 Тип изменений
- [x] Bug fix (исправление)

## 🔧 Изменения
- **`app/config.py` → `format_remnawave_username`**: детект «вырожденного» рендера — если результат равен скелету шаблона (тот же шаблон с пустыми переменными), значит ни одна переменная не дала уникального значения → откат на `user_<identifier>` (`email_<prefix>_<user_id>`, уникален за счёт PK). TG-юзеры с `@username` не затрагиваются; TG-юзеры без username попутно чинятся.
- **`app/cabinet/routes/subscription_modules/purchase.py` → `activate_trial`**: проверяется возвращаемое значение `create_remnawave_user`; при `None` подписка ставится в retry-очередь (раньше при проглоченной ошибке этого не происходило).
- **`app/services/remnawave_retry_queue.py` → `process_pending`**: воркер проверяет результат `create_remnawave_user`/`update_remnawave_user`; при `None` элемент возвращается в очередь через `_requeue()`. Раньше `None` (проглоченный сбой) логировался как «Retry succeeded», и элемент выбрасывался из очереди после первого тика.

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Проверена работа в Docker
- [x] Проверена совместимость с существующим API (TG-flow не затронут)

## 🧪 Тестирование
- [x] Локальное тестирование — генератор `format_remnawave_username` на кейсах: email с точкой / без точки / plus-адрес / два юзера с одинаковым префиксом / TG с username / TG без username — все результаты валидны (`^[a-zA-Z0-9_-]{6,32}$`) и уникальны
- [x] Тестирование с реальным Remnawave API — для email-юзера создаётся `user_email_<prefix>_<id>`, панель отдаёт UUID, `subscription_url` открывается (HTTP 200)
