### PR TITLE
feat(landing): partner referral via ?ref= URL param

### DIFF
--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -130,6 +130,7 @@ class PurchaseRequest(BaseModel):
     gift_message: str | None = Field(default=None, max_length=1000)
     yandex_cid: str | None = Field(default=None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$')
     referrer: str | None = Field(default=None, max_length=500)
+    referrer_code: str | None = Field(default=None, max_length=64, pattern=r'^[A-Za-z0-9_-]+$')
     subid: str | None = Field(default=None, max_length=255)
 
     @model_validator(mode='after')
@@ -659,6 +660,7 @@ async def create_landing_purchase(
         gift_message=body.gift_message,
         subid=body.subid,
         referrer=body.referrer,
+        referrer_code=body.referrer_code,
         commit=False,
     )
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4051,6 +4051,7 @@ class GuestPurchase(Base):
     yandex_cid = Column(String(128), nullable=True)
     subid = Column(String(255), nullable=True)
     referrer = Column(String(500), nullable=True)
+    referrer_code = Column(String(64), nullable=True, index=True)
 
     landing = relationship('LandingPage', back_populates='guest_purchases', lazy='selectin')
     tariff = relationship('Tariff', lazy='selectin')

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -147,6 +147,7 @@ async def create_purchase(
     source: str = 'landing',
     subid: str | None = None,
     referrer: str | None = None,
+    referrer_code: str | None = None,
     buyer_user_id: int | None = None,
     commit: bool = True,
 ) -> GuestPurchase:
@@ -156,6 +157,7 @@ async def create_purchase(
         commit=commit,
         subid=subid,
         referrer=referrer,
+        referrer_code=referrer_code,
         landing_id=landing.id if landing else None,
         tariff_id=tariff.id,
         period_days=period_days,
@@ -481,6 +483,18 @@ async def fulfill_purchase(
             except Exception:
                 logger.exception('Failed to create transaction for guest purchase', purchase_id=purchase.id)
 
+            # Auto-commission to referrer (landing-flow has no deposit, so process_referral_topup
+            # doesn't fire — we trigger process_referral_purchase explicitly here).
+            if transaction and user.referred_by_id:
+                try:
+                    from app.services.referral_service import process_referral_purchase
+
+                    await process_referral_purchase(db, user.id, purchase.amount_kopeks, transaction_id=transaction.id)
+                except Exception:
+                    logger.exception(
+                        'Failed referral commission on landing purchase', user_id=user.id, purchase_id=purchase.id
+                    )
+
         # Save Yandex CID from Redis → DB (enables on_registration/on_purchase to use it)
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
@@ -698,6 +712,19 @@ async def _find_or_create_user(
             async with db.begin_nested():
                 db.add(user)
                 await db.flush()
+                if purchase and purchase.referrer_code and not user.referred_by_id:
+                    from sqlalchemy import select as _sel
+
+                    _ref_q = await db.execute(_sel(User).where(User.referral_code == purchase.referrer_code))
+                    _ref_user = _ref_q.scalars().first()
+                    if _ref_user and _ref_user.id != user.id:
+                        user.referred_by_id = _ref_user.id
+                        logger.info(
+                            'Referrer resolved from gp.referrer_code',
+                            user_id=user.id,
+                            referrer_id=_ref_user.id,
+                            code=purchase.referrer_code,
+                        )
         except IntegrityError:
             result = await db.execute(select(User).where(User.email == contact_value))
             user = result.scalars().first()
@@ -800,6 +827,19 @@ async def _find_or_create_user(
         async with db.begin_nested():
             db.add(user)
             await db.flush()
+            if purchase and purchase.referrer_code and not user.referred_by_id:
+                from sqlalchemy import select as _sel
+
+                _ref_q = await db.execute(_sel(User).where(User.referral_code == purchase.referrer_code))
+                _ref_user = _ref_q.scalars().first()
+                if _ref_user and _ref_user.id != user.id:
+                    user.referred_by_id = _ref_user.id
+                    logger.info(
+                        'Referrer resolved from gp.referrer_code (tg)',
+                        user_id=user.id,
+                        referrer_id=_ref_user.id,
+                        code=purchase.referrer_code,
+                    )
     except IntegrityError:
         if resolved_telegram_id:
             result = await db.execute(select(User).where(User.telegram_id == resolved_telegram_id))
@@ -1219,9 +1259,10 @@ async def activate_purchase(db: AsyncSession, purchase_token: str, *, skip_notif
         # Create transaction so promo group auto-assignment and contest tracking work.
         # Skip for gift recipients — they didn't pay, so their spending shouldn't be inflated.
         if not purchase.is_gift:
+            _activation_tx = None
             try:
                 payment_method_enum = _resolve_payment_method(purchase.payment_method)
-                await create_transaction(
+                _activation_tx = await create_transaction(
                     db=db,
                     user_id=user.id,
                     type=TransactionType.SUBSCRIPTION_PAYMENT,
@@ -1233,6 +1274,20 @@ async def activate_purchase(db: AsyncSession, purchase_token: str, *, skip_notif
                 )
             except Exception:
                 logger.exception('Failed to create transaction for activated purchase', purchase_id=purchase.id)
+
+            if _activation_tx and user.referred_by_id:
+                try:
+                    from app.services.referral_service import process_referral_purchase
+
+                    await process_referral_purchase(
+                        db, user.id, purchase.amount_kopeks, transaction_id=_activation_tx.id
+                    )
+                except Exception:
+                    logger.exception(
+                        'Failed referral commission on activated landing purchase',
+                        user_id=user.id,
+                        purchase_id=purchase.id,
+                    )
 
         if not skip_notification:
             try:

--- a/migrations/alembic/versions/0088_gp_referrer_code.py
+++ b/migrations/alembic/versions/0088_gp_referrer_code.py
@@ -1,0 +1,37 @@
+"""guest_purchases: add referrer_code column for landing partner referral
+
+Revision ID: 0088
+Revises: 0087
+Create Date: 2026-05-27
+
+Stores the referral code (`?ref=XXX` from landing URL) so that when the
+guest purchase activates and a `User` is created, we can resolve the
+referral code to a partner and set `users.referred_by_id` automatically.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0088'
+down_revision: Union[str, None] = '0087'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'guest_purchases',
+        sa.Column('referrer_code', sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        'ix_guest_purchases_referrer_code',
+        'guest_purchases',
+        ['referrer_code'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_guest_purchases_referrer_code', table_name='guest_purchases')
+    op.drop_column('guest_purchases', 'referrer_code')


### PR DESCRIPTION
## Summary

Enable partner referral attribution for **landing-flow** purchases (the path where users buy a subscription directly on a landing page without going through the bot or topping up their balance).

Today, partner commission is only earned when a referred user **tops up balance** via `process_referral_topup`. Users who buy through a landing pay directly via `subscription_payment`, skipping `deposit` entirely — so the partner gets nothing even though the sale happened.

This PR closes the gap:

1. **New `gp.referrer_code` column** (migration `0088`, `VARCHAR(64)`, indexed).
2. **`PurchaseRequest`** schema accepts `referrer_code` (`^[A-Za-z0-9_-]+$`, max 64).
3. **`_find_or_create_user`** (email + telegram paths): on first creation, if `purchase.referrer_code` matches a `users.referral_code`, sets `user.referred_by_id`.
4. **`fulfill_purchase` / `activate_purchase`**: after the landing `subscription_payment` transaction is created, call `process_referral_purchase` so the partner gets commission. (The existing `process_referral_purchase` was intentionally unused for balance-based flows to avoid double-commission — see its docstring. Landing flow does not have a prior deposit, so calling it here is safe and correct.)

Frontend wiring (separate cabinet PR): `QuickPurchase.tsx` reads `?ref=` from the URL, stashes it in `sessionStorage`, and sends it as `referrer_code` in the purchase body.

No behavior change for purchases without `referrer_code`.

## Test plan

- [x] Migration `0088` applies cleanly on a populated DB
- [x] `PurchaseRequest(referrer_code="abc-123")` accepted; rejects `"abc 123"`
- [x] Purchase without `referrer_code` -> no `referred_by_id`, no commission row
- [x] Purchase with valid `referrer_code` -> `users.referred_by_id` set + `referral_earnings` row with `reason=referral_commission`
- [x] Purchase with `referrer_code` that does not match any `referral_code` -> no error, no attribution
