### PR TITLE
feat(webauth): auto-register new users on QR deeplink + carry referral code

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -74,6 +74,7 @@ from ..schemas.auth import (
     AutoLoginRequest,
     CampaignBonusInfo,
     DeepLinkPollRequest,
+    DeepLinkTokenRequest,
     DeepLinkTokenResponse,
     EmailChangeRequest,
     EmailChangeResponse,
@@ -2085,11 +2086,16 @@ async def get_email_change_status(
 @router.post('/deeplink/request', response_model=DeepLinkTokenResponse)
 async def request_deep_link_token(
     raw_request: Request,
+    payload: DeepLinkTokenRequest | None = None,
 ):
     """Generate a one-time deep link auth token.
 
     Frontend shows t.me/{bot}?start=webauth_{token} to the user.
     No auth required (user is not logged in yet).
+
+    An optional ``referral_code`` may be supplied; it is stored with the token
+    and attached only if the deep link results in a NEW user registration in
+    the bot. The body is optional for backward compatibility.
     """
     client_ip = get_client_ip(raw_request)
     if await RateLimitCache.is_ip_rate_limited(client_ip, 'deeplink_request', limit=10, window=60, fail_closed=True):
@@ -2099,8 +2105,9 @@ async def request_deep_link_token(
             headers={'Retry-After': '60'},
         )
 
+    referral_code = payload.referral_code if payload else None
     try:
-        token = await create_web_auth_token()
+        token = await create_web_auth_token(referral_code=referral_code)
     except RuntimeError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/app/cabinet/schemas/auth.py
+++ b/app/cabinet/schemas/auth.py
@@ -192,6 +192,25 @@ class EmailChangeResponse(BaseModel):
     expires_in_minutes: int = Field(..., description='Code expiration time in minutes')
 
 
+class DeepLinkTokenRequest(BaseModel):
+    """Request to create a deep link auth token.
+
+    ``referral_code`` is optional and UNTRUSTED. It is only applied when the
+    deep link leads to a NEW user registration in the bot — existing users are
+    never re-attached to a referrer. Self-referral is blocked bot-side. Omitting
+    it (or sending an empty body) keeps the original behaviour: register without
+    a referrer.
+    """
+
+    referral_code: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        pattern=r'^[a-zA-Z0-9_-]+$',
+        description='Optional referral code to attach if a new user registers',
+    )
+
+
 class DeepLinkTokenResponse(BaseModel):
     """Response with deep link auth token."""
 

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -56,7 +56,11 @@ from app.services.referral_service import (
 )
 from app.services.subscription_service import SubscriptionService
 from app.services.support_settings_service import SupportSettingsService
-from app.services.web_auth_service import WEB_AUTH_TOKEN_MIN_LENGTH, link_web_auth_token
+from app.services.web_auth_service import (
+    WEB_AUTH_TOKEN_MIN_LENGTH,
+    link_web_auth_token,
+    poll_web_auth_token,
+)
 from app.states import RegistrationStates
 from app.utils.promo_offer import (
     build_promo_offer_hint,
@@ -782,6 +786,64 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
         web_auth_token = start_parameter.removeprefix('webauth_')
         if len(web_auth_token) >= WEB_AUTH_TOKEN_MIN_LENGTH:
             user = db_user or await get_user_by_telegram_id(db, message.from_user.id)
+
+            # First-time user (no row yet): auto-register so the cabinet QR
+            # login works for new users too, instead of rejecting them. The
+            # referral code carried in the token (if any) is attached ONLY
+            # here, on fresh registration — existing users are never
+            # re-attached to a referrer.
+            if not user:
+                referrer = None
+                try:
+                    token_data = await poll_web_auth_token(web_auth_token)
+                except Exception as exc:
+                    token_data = None
+                    logger.warning('Failed to read web auth token for referral', error=exc)
+                ref_code = (token_data or {}).get('referral_code')
+                if ref_code:
+                    try:
+                        candidate = await get_user_by_referral_code(db, ref_code)
+                    except Exception as exc:
+                        candidate = None
+                        logger.warning(
+                            'Failed to resolve webauth referral code',
+                            referral_code=ref_code,
+                            error=exc,
+                        )
+                    # Self-referral guard by telegram_id (user not created yet).
+                    # Invalid/unknown code → register without a referrer.
+                    if candidate and candidate.telegram_id != message.from_user.id:
+                        referrer = candidate
+
+                user = await create_user(
+                    db,
+                    telegram_id=message.from_user.id,
+                    username=message.from_user.username,
+                    first_name=message.from_user.first_name,
+                    last_name=message.from_user.last_name,
+                    language=(message.from_user.language_code or 'ru'),
+                    referred_by_id=referrer.id if referrer else None,
+                )
+                logger.info(
+                    'Auto-registered new user via web auth deep link',
+                    telegram_id=message.from_user.id,
+                    user_id=user.id,
+                    referrer_id=user.referred_by_id,
+                )
+                # Fire referral bonus when a referrer was resolved (either from
+                # the token code above or a Redis pending referral applied
+                # inside create_user). Mirrors the cabinet auth flow; never
+                # raises into the auth path.
+                if user.referred_by_id:
+                    try:
+                        await process_referral_registration(db, user.id, user.referred_by_id, message.bot)
+                    except Exception as exc:
+                        logger.warning(
+                            'webauth referral registration failed',
+                            user_id=user.id,
+                            error=exc,
+                        )
+
             if user and user.status != UserStatus.DELETED.value:
                 texts = get_texts(user.language)
                 keyboard = types.InlineKeyboardMarkup(
@@ -806,7 +868,7 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
                     reply_markup=keyboard,
                 )
             else:
-                logger.warning('Web auth attempt from unregistered user', telegram_id=message.from_user.id)
+                logger.warning('Web auth attempt from deleted user', telegram_id=message.from_user.id)
                 await message.answer('❌ Сначала зарегистрируйтесь в боте, затем попробуйте войти в кабинет.')
             return
         start_parameter = None  # Invalid token, ignore

--- a/app/services/web_auth_service.py
+++ b/app/services/web_auth_service.py
@@ -27,8 +27,14 @@ WEB_AUTH_TOKEN_MIN_LENGTH = 16
 WEB_AUTH_PREFIX = 'web_auth'
 
 
-async def create_web_auth_token() -> str:
+async def create_web_auth_token(referral_code: str | None = None) -> str:
     """Generate a web auth token and store it in Redis (pending state).
+
+    ``referral_code`` is optional and UNTRUSTED. It is persisted in the token
+    so the bot can read it on /start and attach a referrer ONLY when the deep
+    link results in a NEW user registration. Existing users are never
+    re-attached. The bot validates the code (resolution + self-referral guard);
+    we just carry it through.
 
     Returns the raw token string (URL-safe, 24 bytes of entropy).
     """
@@ -38,6 +44,8 @@ async def create_web_auth_token() -> str:
         'status': 'pending',
         'created_at': datetime.now(UTC).isoformat(),
     }
+    if referral_code:
+        value['referral_code'] = referral_code
     stored = await cache.set(key, value, expire=WEB_AUTH_TOKEN_TTL)
     if not stored:
         logger.error('Failed to store web auth token in Redis')


### PR DESCRIPTION
## Summary

The web-auth QR deep link (`/start webauth_{token}`, used by the cabinet login QR) previously **rejected any user without an existing bot account** — first-time users scanning the QR got `❌ Сначала зарегистрируйтесь в боте` and could not log in.

This PR makes the QR login work for new users too, and lets a referral code ride along with the token so a referrer is credited when the QR results in a fresh registration.

## Changes

- **`web_auth_service.create_web_auth_token(referral_code=None)`** — stores the (untrusted) referral code alongside the pending token in Redis so the bot can read it on `/start`.
- **`DeepLinkTokenRequest`** schema — new optional body for `POST /cabinet/auth/deeplink/request` with a validated `referral_code` (`^[a-zA-Z0-9_-]$`, ≤64). Body is optional → fully backward compatible (empty body still returns a token).
- **`/deeplink/request`** — accepts the optional body and passes `referral_code` through.
- **Bot `/start` `webauth_` branch** — when there is no user row yet, auto-register the user (same as the cabinet auth route already does), then show the standard login-confirm keyboard. The referrer is attached **only on this fresh registration**.

## Behaviour / edge cases

- Existing users: unchanged — never re-attached to a referrer.
- `referral_code` is untrusted: resolved via `get_user_by_referral_code`; unknown/invalid code → register **without** a referrer (no crash, no rejection).
- Self-referral blocked by `telegram_id` before the user row exists (and again inside `process_referral_registration`).
- Referral bonus fires via `process_referral_registration` for both a token-supplied code and a Redis pending-referral resolved inside `create_user` (uses `user.referred_by_id` as source of truth — mirrors the cabinet auth flow).
- No change to token TTL, rate-limit (10/60s), replay protection, or the poll/confirm steps.

## Flow

```
Before: new user scans QR → /start webauth_TOKEN → ❌ "Сначала зарегистрируйтесь"
After:  new user scans QR → /start webauth_TOKEN
        → read referral_code from token (if present)
        → resolve referrer (skip self-referral / unknown code)
        → create_user(referred_by_id=...)   # ACTIVE by default
        → process_referral_registration (bonus)
        → "🔐 Подтвердите вход"  [✅ Да, войти] [❌ Нет]
        → confirm → link_web_auth_token → browser logged in
```

## Tested

- Empty body → `200` (backward compatible).
- `{"referral_code":"ABC123xy"}` → `200`; Redis token value contains `"referral_code": "ABC123xy"`.
- `{"referral_code":"bad code!!"}` → `422` (pattern validation).
- Bot boots clean, polling up, no tracebacks.

## Follow-up (not in this PR)

The backend now *accepts* `referral_code`, but the React cabinet (`bedolaga-cabinet`) still needs a small change to actually *send* the visitor's referral code in the `/deeplink/request` call.
