### PR TITLE
fix(sync): prevent MissingGreenlet hang in sync_users_from_panel

### DIFF
--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -1314,6 +1314,12 @@ class RemnaWaveService:
 
             logger.info('🔄 Начинаем синхронизацию типа', sync_type=sync_type)
 
+            # FIX MissingGreenlet: bot_users_* (selectinload) читаются ПОСЛЕ db.commit().
+            # expire_on_commit=True протухает их → implicit lazy-reload вне async greenlet
+            # → MissingGreenlet → залипшие коннекты → деградация пула → виснет API/кабинет.
+            # Держим объекты живыми на всю синхронизацию (она сама — источник истины).
+            db.sync_session.expire_on_commit = False
+
             async with self.get_api_client() as api:
                 panel_users = []
                 start = 0


### PR DESCRIPTION
## Problem

`RemnawaveService.sync_users_from_panel` (non-multi-tariff path) hangs the bot's API with a flood of `MissingGreenlet: greenlet_spawn has not been called; can't call await_only()`.

### Root cause
1. All bot users are bulk-loaded once with eager relations:
   ```python
   select(User).options(selectinload(User.subscriptions).selectinload(Subscription.tariff))
   ```
   into `bot_users_by_email` / `bot_users_by_uuid` / `bot_users_by_telegram_id`.
2. The sync then performs periodic `await db.commit()`. With the default `expire_on_commit=True`, every ORM object in those dicts becomes **expired**.
3. Later loops read attributes on the expired objects:
   - email-only loop: `db_user.remnawave_uuid`
   - deactivation comprehension: `getattr(db_user, 'subscriptions', ...)`, `getattr(db_user, 'remnawave_uuid', ...)`
4. Reading an expired attribute triggers an **implicit lazy-reload outside the async greenlet** -> `MissingGreenlet`.

In production with ~7k email-only panel users this raised per user per sync cycle, leaking pool connections until the FastAPI port hung and the web cabinet went down (~25h to full outage).

## Fix
Set `db.sync_session.expire_on_commit = False` at the start of the sync. Objects are eagerly loaded, so they stay populated across commits -> no implicit lazy IO -> no `MissingGreenlet`. The sync is the source of truth, so reading its own just-committed values is safe. Fixes both read sites without per-row refresh queries.
