### PR TITLE
Исправить синхронизацию MAINTENANCE_MODE между кабинетом, ботом и runtime-состоянием техработ

### DIFF
--- a/app/cabinet/routes/admin_settings.py
+++ b/app/cabinet/routes/admin_settings.py
@@ -21,6 +21,15 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix='/admin/settings', tags=['Admin Settings'])
 
 
+async def _sync_maintenance_mode_if_needed(key: str) -> None:
+    if key != 'MAINTENANCE_MODE':
+        return
+
+    from app.services.maintenance_service import maintenance_service
+
+    await maintenance_service.sync_with_settings()
+
+
 # ============ Schemas ============
 
 
@@ -246,6 +255,7 @@ async def update_setting(
         await bot_configuration_service.set_value(db, key, value)
     except ReadOnlySettingError as error:
         raise HTTPException(status.HTTP_403_FORBIDDEN, str(error)) from error
+    await _sync_maintenance_mode_if_needed(key)
     await db.commit()
 
     logger.info('Admin updated setting to', telegram_id=admin.telegram_id, key=key, value=value)
@@ -268,6 +278,7 @@ async def reset_setting(
         await bot_configuration_service.reset_value(db, key)
     except ReadOnlySettingError as error:
         raise HTTPException(status.HTTP_403_FORBIDDEN, str(error)) from error
+    await _sync_maintenance_mode_if_needed(key)
     await db.commit()
 
     logger.info('Admin reset setting', telegram_id=admin.telegram_id, key=key)

--- a/app/handlers/admin/maintenance.py
+++ b/app/handlers/admin/maintenance.py
@@ -10,6 +10,7 @@ from app.database.models import User
 from app.keyboards.admin import get_admin_main_keyboard, get_maintenance_keyboard
 from app.localization.texts import get_texts
 from app.services.maintenance_service import maintenance_service
+from app.services.system_settings_service import bot_configuration_service
 from app.utils.decorators import admin_required, error_handler
 
 
@@ -19,6 +20,14 @@ logger = structlog.get_logger(__name__)
 class MaintenanceStates(StatesGroup):
     waiting_for_reason = State()
     waiting_for_notification_message = State()
+
+
+async def _persist_maintenance_mode(db: AsyncSession, enabled: bool) -> None:
+    try:
+        await bot_configuration_service.set_value(db, 'MAINTENANCE_MODE', enabled)
+        await db.commit()
+    except Exception as error:
+        logger.error('Не удалось сохранить MAINTENANCE_MODE после переключения из бота', enabled=enabled, error=error)
 
 
 @admin_required
@@ -103,6 +112,8 @@ async def toggle_maintenance_mode(callback: types.CallbackQuery, db_user: User, 
     if is_active:
         success = await maintenance_service.disable_maintenance()
         if success:
+            await _persist_maintenance_mode(db, False)
+        if success:
             await callback.answer('Режим техработ выключен', show_alert=True)
         else:
             await callback.answer('Ошибка выключения режима техработ', show_alert=True)
@@ -131,6 +142,8 @@ async def process_maintenance_reason(message: types.Message, db_user: User, db: 
         reason = message.text[:200]
 
     success = await maintenance_service.enable_maintenance(reason=reason, auto=False)
+    if success:
+        await _persist_maintenance_mode(db, True)
 
     if success:
         response_text = 'Режим техработ включен'

--- a/app/services/maintenance_service.py
+++ b/app/services/maintenance_service.py
@@ -36,6 +36,8 @@ class MaintenanceService:
 
     def set_bot(self, bot):
         self._bot = bot
+        if settings.is_maintenance_mode() and not self._status.is_active:
+            asyncio.create_task(self.enable_maintenance(reason='Включено из системных настроек', auto=False))
         logger.info('Бот установлен для maintenance_service')
 
     @property
@@ -206,6 +208,11 @@ class MaintenanceService:
         except Exception as e:
             logger.error('Ошибка выключения режима техработ', error=e)
             return False
+
+    async def sync_with_settings(self) -> bool:
+        if settings.is_maintenance_mode():
+            return await self.enable_maintenance(reason='Включено из системных настроек', auto=False)
+        return await self.disable_maintenance()
 
     async def start_monitoring(self) -> bool:
         try:

--- a/app/webapi/routes/config.py
+++ b/app/webapi/routes/config.py
@@ -23,6 +23,15 @@ from ..schemas.config import (
 router = APIRouter()
 
 
+async def _sync_maintenance_mode_if_needed(key: str) -> None:
+    if key != 'MAINTENANCE_MODE':
+        return
+
+    from app.services.maintenance_service import maintenance_service
+
+    await maintenance_service.sync_with_settings()
+
+
 def _coerce_value(key: str, value: Any) -> Any:
     definition = bot_configuration_service.get_definition(key)
 
@@ -159,6 +168,7 @@ async def update_setting(
         await bot_configuration_service.set_value(db, key, value)
     except ReadOnlySettingError as error:
         raise HTTPException(status.HTTP_403_FORBIDDEN, str(error)) from error
+    await _sync_maintenance_mode_if_needed(key)
     await db.commit()
 
     return _serialize_definition(definition)
@@ -179,5 +189,6 @@ async def reset_setting(
         await bot_configuration_service.reset_value(db, key)
     except ReadOnlySettingError as error:
         raise HTTPException(status.HTTP_403_FORBIDDEN, str(error)) from error
+    await _sync_maintenance_mode_if_needed(key)
     await db.commit()
     return _serialize_definition(definition)


### PR DESCRIPTION
## Что сделано

Исправлена логика работы `MAINTENANCE_MODE`, чтобы режим техработ корректно синхронизировался между:

- системной настройкой в кабинете
- config API
- Telegram-ботом
- runtime-состоянием `maintenance_service`

Раньше `MAINTENANCE_MODE` в ряде сценариев менял только значение в настройках, но не всегда реально включал или выключал техработы. Также при ручном переключении техработ через бот менялось только runtime-состояние, а значение `MAINTENANCE_MODE` в настройках могло остаться старым. Из-за этого кабинет и бот могли показывать разное состояние.

## Что исправлено

### 1. Синхронизация `MAINTENANCE_MODE` -> runtime
Теперь при изменении `MAINTENANCE_MODE` из кабинета или через config API новое значение сразу применяется к `maintenance_service`.

Что сделано:
- добавлен вызов синхронизации после обновления настройки в кабинете
- добавлен такой же вызов после обновления настройки через web API
- добавлен метод `sync_with_settings()` в `maintenance_service`

### 2. Синхронизация runtime -> `MAINTENANCE_MODE`
Теперь при ручном включении или выключении техработ из админ-панели Telegram-бота новое состояние сохраняется обратно в `MAINTENANCE_MODE`.

Что это дает:
- если техработы выключили в боте, кабинет после обновления страницы тоже покажет выключенное состояние
- если техработы включили в боте, кабинет увидит это как актуальное значение настройки

### 3. Применение сохраненного `MAINTENANCE_MODE` при старте
Если в системных настройках `MAINTENANCE_MODE` уже включен, при старте приложения `maintenance_service` автоматически переводится в состояние техработ.

Это устраняет ситуацию, когда флаг в настройках уже был включен, но runtime-состояние после запуска приложения оставалось обычным.

## Измененные файлы

- `app/services/maintenance_service.py`
- `app/cabinet/routes/admin_settings.py`
- `app/webapi/routes/config.py`
- `app/handlers/admin/maintenance.py`

## Какой баг закрывается

Исправляются сценарии, в которых:
- в кабинете `MAINTENANCE_MODE` включен, но техработы фактически не активированы
- техработы выключены через бот, но кабинет продолжает показывать включенный переключатель
- после перезапуска приложения сохраненный `MAINTENANCE_MODE` не применяется к runtime-состоянию

## Примечания

- логика автоматического включения техработ при недоступности API RemnaWave специально не менялась
- PR касается только синхронизации ручного режима техработ и значения `MAINTENANCE_MODE`