### PR TITLE
feat: yclid-keyed Yandex offline conversions (repeat-purchase attribution)

### DIFF
--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -136,6 +136,7 @@ class PurchaseRequest(BaseModel):
     yandex_cid: str | None = Field(default=None, max_length=128, pattern=r'^[A-Za-z0-9._:-]{4,128}$')
     referrer: str | None = Field(default=None, max_length=500)
     subid: str | None = Field(default=None, max_length=255)
+    yclid: str | None = Field(default=None, max_length=64, pattern=r'^[0-9]{1,64}$')
 
     @model_validator(mode='after')
     def validate_contacts(self) -> 'PurchaseRequest':
@@ -874,6 +875,13 @@ async def create_landing_purchase(
     if body.yandex_cid and settings.YANDEX_OFFLINE_CONV_ENABLED:
         try:
             await cache.set(f'yacid:purchase:{purchase.token}', body.yandex_cid, expire=86400)
+        except Exception:
+            pass
+
+    # Persist yclid in cache for the yclid-keyed offline conversion upload
+    if body.yclid and settings.YANDEX_OFFLINE_CONV_ENABLED:
+        try:
+            await cache.set(f'yclid:purchase:{purchase.token}', body.yclid, expire=86400)
         except Exception:
             pass
 

--- a/app/config.py
+++ b/app/config.py
@@ -658,6 +658,9 @@ class Settings(BaseSettings):
     YANDEX_OFFLINE_CONV_DL: str = ''
     YANDEX_OFFLINE_CONV_DT: str = ''
     YANDEX_OFFLINE_CONV_CURRENCY: str = 'RUB'
+    # Offline Conversions API (mc.yandex.ru via OAuth, yclid-keyed)
+    YANDEX_OFFLINE_CONV_OAUTH_TOKEN: str = ''
+    YANDEX_OFFLINE_CONV_PURCHASE_GOAL_ID: str = ''
 
     # ── S2S Postback (server-to-server affiliate notifications) ──
     S2S_POSTBACK_ENABLED: bool = False

--- a/app/database/crud/yandex_client_id.py
+++ b/app/database/crud/yandex_client_id.py
@@ -22,6 +22,7 @@ async def upsert_cid(
     source: str = 'web',
     counter_id: str | None = None,
     subid: str | None = None,
+    yclid: str | None = None,
 ) -> YandexClientIdMap:
     """Insert or update Yandex ClientID for a user (race-safe via ON CONFLICT)."""
     now = datetime.now(UTC)
@@ -34,10 +35,14 @@ async def upsert_cid(
         values['counter_id'] = counter_id
     if subid:
         values['subid'] = subid
+    # Only overwrite yclid when a non-empty one is provided — never null-out
+    # an existing yclid on a later call that lacks it.
+    if yclid:
+        values['yclid'] = yclid
 
     stmt = (
         pg_insert(YandexClientIdMap)
-        .values(user_id=user_id, yandex_cid=cid, source=source, counter_id=counter_id, subid=subid)
+        .values(user_id=user_id, yandex_cid=cid, source=source, counter_id=counter_id, subid=subid, yclid=yclid)
         .on_conflict_do_update(index_elements=['user_id'], set_=values)
         .returning(YandexClientIdMap)
     )

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4196,6 +4196,7 @@ class YandexClientIdMap(Base):
     registration_sent = Column(Boolean, default=False, server_default=text('false'), nullable=False)
     trial_sent = Column(Boolean, default=False, server_default=text('false'), nullable=False)
     subid = Column(String(255), nullable=True)
+    yclid = Column(String(64), nullable=True)
     created_at = Column(AwareDateTime(), server_default=func.now())
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
 

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -495,8 +495,11 @@ async def fulfill_purchase(
             from app.utils.cache import cache
 
             _cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
+            _cached_yclid = await cache.get(f'yclid:purchase:{purchase.token}')
             if _cached_cid:
-                await yandex_conv.store_cid(db, user.id, _cached_cid, source='landing')
+                await yandex_conv.store_cid(
+                    db, user.id, _cached_cid, source='landing', yclid=_cached_yclid
+                )
                 await db.commit()
         except Exception:
             logger.debug('Failed to save CID from Redis')

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -34,6 +34,7 @@ MAX_RETRIES = 3
 RETRY_DELAY = 1.0
 
 _CID_RE = re.compile(r'^[A-Za-z0-9._:-]{4,128}$')
+_YCLID_RE = re.compile(r'^[0-9]{1,64}$')
 _http_client: httpx.AsyncClient | None = None
 
 
@@ -65,6 +66,21 @@ def _mask_cid(cid: str) -> str:
     if len(cid) <= 4:
         return '****'
     return '*' * (len(cid) - 4) + cid[-4:]
+
+
+def _normalize_yclid(yclid: str | None) -> str | None:
+    if not isinstance(yclid, str):
+        return None
+    yclid = yclid.strip()
+    if not yclid or not _YCLID_RE.match(yclid):
+        return None
+    return yclid
+
+
+def _mask_yclid(yclid: str) -> str:
+    if len(yclid) <= 4:
+        return '****'
+    return '*' * (len(yclid) - 4) + yclid[-4:]
 
 
 def _base_payload(cid: str) -> dict[str, str]:
@@ -236,14 +252,22 @@ async def store_cid(
     user_id: int,
     cid: str | None,
     source: str = 'web',
+    yclid: str | None = None,
 ) -> bool:
-    """Store Yandex ClientID for a user. Returns True if stored."""
+    """Store Yandex ClientID (and optional yclid) for a user. Returns True if stored."""
     normalized = _normalize_cid(cid)
     if not normalized:
         return False
 
     try:
-        await upsert_cid(db, user_id, normalized, source=source, counter_id=settings.YANDEX_OFFLINE_CONV_COUNTER_ID)
+        await upsert_cid(
+            db,
+            user_id,
+            normalized,
+            source=source,
+            counter_id=settings.YANDEX_OFFLINE_CONV_COUNTER_ID,
+            yclid=_normalize_yclid(yclid),
+        )
         logger.info('stored CID', user_id=user_id, source=source)
         return True
     except Exception as exc:
@@ -364,6 +388,77 @@ async def on_trial(db: AsyncSession, user_id: int) -> None:
         logger.error('trial-add event failed', user_id=user_id, error=str(exc))
 
 
+async def _upload_offline_conversion_yclid(yclid: str, amount_rubles: float, ts: int) -> bool:
+    """Upload a single offline conversion to the Metrika Offline Conversions API.
+
+    Keyed by yclid (session-independent), so repeat purchases by the same user
+    keep their Yandex Direct attribution — unlike the ClientID-based
+    Measurement Protocol collect, which only attributes the first purchase.
+    Returns True when Metrika accepts the upload (response contains 'uploading').
+    """
+    token = getattr(settings, 'YANDEX_OFFLINE_CONV_OAUTH_TOKEN', '') or ''
+    counter = str(getattr(settings, 'YANDEX_OFFLINE_CONV_COUNTER_ID', '') or '')
+    goal = str(getattr(settings, 'YANDEX_OFFLINE_CONV_PURCHASE_GOAL_ID', '') or '')
+    if not (token and counter and goal and yclid):
+        return False
+
+    currency = getattr(settings, 'YANDEX_OFFLINE_CONV_CURRENCY', '') or 'RUB'
+    csv = f'Yclid,Target,DateTime,Price,Currency\n{yclid},{goal},{ts},{amount_rubles},{currency}\n'
+    url = (
+        f'https://api-metrika.yandex.net/management/v1/counter/{counter}'
+        f'/offline_conversions/upload?client_id_type=YCLID'
+    )
+    masked = _mask_yclid(yclid)
+    headers = {'Authorization': f'OAuth {token}'}
+    files = {'file': ('conv.csv', csv, 'text/csv')}
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            client = _get_client()
+            resp = await client.post(url, headers=headers, files=files)
+
+            if 200 <= resp.status_code < 300:
+                ok = False
+                try:
+                    ok = 'uploading' in (resp.json() or {})
+                except Exception:
+                    ok = False
+                if ok:
+                    logger.info('offline conversion uploaded', yclid=masked, amount=amount_rubles)
+                    return True
+                logger.error(
+                    'offline conversion not accepted', yclid=masked, status=resp.status_code, body=resp.text[:200]
+                )
+                return False
+
+            if 500 <= resp.status_code < 600 and attempt < MAX_RETRIES:
+                logger.warning(
+                    'offline conversion server error',
+                    attempt=attempt,
+                    max=MAX_RETRIES,
+                    yclid=masked,
+                    status=resp.status_code,
+                )
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+
+            logger.error(
+                'offline conversion rejected', yclid=masked, status=resp.status_code, body=resp.text[:200]
+            )
+            return False
+
+        except Exception as exc:
+            logger.warning(
+                'offline conversion request error', attempt=attempt, max=MAX_RETRIES, yclid=masked, error=str(exc)
+            )
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(RETRY_DELAY)
+                continue
+            return False
+
+    return False
+
+
 async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> None:
     """Fire ecommerce purchase event (every payment)."""
     if not _is_enabled():
@@ -383,6 +478,19 @@ async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> Non
             logger.info('purchase event sent', user_id=user_id, amount=amount_rubles)
     except Exception as exc:
         logger.error('purchase event failed', user_id=user_id, error=str(exc))
+
+    # Additive: yclid-keyed offline conversion (session-independent → repeat
+    # purchases attribute correctly to Yandex Direct). Only fires when a yclid
+    # was captured for this user. Never blocks the ClientID collect above.
+    try:
+        row = locals().get('row')
+        if row is None:
+            row = await get_cid(db, user_id)
+        yclid = _normalize_yclid(getattr(row, 'yclid', None)) if row else None
+        if yclid:
+            await _upload_offline_conversion_yclid(yclid, amount_kopeks / 100, int(time.time()))
+    except Exception as exc:
+        logger.error('purchase offline conversion (yclid) failed', user_id=user_id, error=str(exc))
 
 
 def parse_cid_from_start_param(param: str) -> tuple[str | None, str]:

--- a/migrations/alembic/versions/0090_yclid.py
+++ b/migrations/alembic/versions/0090_yclid.py
@@ -1,0 +1,51 @@
+"""yandex_client_id_map: add yclid column for offline-conversion uploads
+
+Captures the Yandex click id (`?yclid=...` from the landing URL) so that on
+every purchase we can upload an offline conversion to the Metrika Offline
+Conversions API keyed by yclid. Unlike the ClientID-based Measurement
+Protocol (session-bound, only attributes the first purchase), the yclid is
+session-independent → repeat purchases by the same user attribute correctly.
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-06-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '0090'
+down_revision: Union[str, None] = '0089'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = 'yandex_client_id_map'
+_COLUMN = 'yclid'
+
+
+def _column_exists(bind: sa.engine.Connection) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return False
+    return any(col['name'] == _COLUMN for col in inspector.get_columns(_TABLE))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_TABLE):
+        return
+    if not _column_exists(bind):
+        op.add_column(
+            _TABLE,
+            sa.Column(_COLUMN, sa.String(length=64), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _column_exists(bind):
+        op.drop_column(_TABLE, _COLUMN)


### PR DESCRIPTION
Extends the existing Yandex offline-conversions (ClientID/Measurement Protocol) with yclid support.

Problem: ClientID-based collect attributes only the FIRST purchase to a Yandex Direct campaign — repeat purchases by the same user happen in later sessions without the yclid, so they are attributed to direct/internal traffic and lost for Direct ROI.

Fix: capture the yclid (present in the landing URL `?yclid=...`) and, on every purchase that has one, upload an offline conversion to the Metrika Offline Conversions API keyed by yclid (session-independent → repeats attribute to the original click). ClientID collect is kept unchanged; yclid path is additive and only fires when yclid is present.

- migration: +`yclid VARCHAR(64)` (nullable) on `yandex_client_id_map`
- `upsert_cid`: optional yclid (only overwrites when provided)
- `yandex_offline_conv_service`: `_upload_offline_conversion_yclid()` (POST .../offline_conversions/upload?client_id_type=YCLID, retries, masked logging); `on_purchase` fires it additively when a yclid is stored; `store_cid` forwards yclid
- landing purchase endpoint: accept `yclid`, cache it; `fulfill_purchase`: persist it before `on_purchase`
- new settings: `YANDEX_OFFLINE_CONV_OAUTH_TOKEN`, `YANDEX_OFFLINE_CONV_PURCHASE_GOAL_ID` (counter id reuses existing `YANDEX_OFFLINE_CONV_COUNTER_ID`)

No secrets committed (all via env). Validated against the live Metrika API (upload accepted, status UPLOADED).
