### PR TITLE
fix: fire Yandex Metrika purchase conversion on every paid purchase

### DIFF
--- a/app/cabinet/routes/subscription_modules/devices.py
+++ b/app/cabinet/routes/subscription_modules/devices.py
@@ -599,10 +599,11 @@ async def purchase_devices(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(
+            # Purchase event fires centrally from create_transaction; here we
+            # only persist the request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(
                 user.id,
                 request.yandex_cid,
-                price_kopeks,
             )
         except Exception as yconv_err:
             logger.debug('yandex_conv purchase hook failed (non-fatal)', user_id=user.id, error=str(yconv_err))

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -525,10 +525,11 @@ async def submit_purchase(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(
+            # Purchase event fires centrally from create_transaction; here we
+            # only persist the request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(
                 user.id,
                 request.yandex_cid,
-                pricing.final_total,
             )
         except Exception as yconv_err:
             logger.debug('yandex_conv purchase hook failed (non-fatal)', user_id=user.id, error=str(yconv_err))
@@ -994,10 +995,11 @@ async def purchase_tariff(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(
+            # Purchase event fires centrally from create_transaction; here we
+            # only persist the request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(
                 user.id,
                 request.yandex_cid,
-                price_kopeks,
             )
         except Exception as yconv_err:
             logger.debug('yandex_conv purchase hook failed (non-fatal)', user_id=user.id, error=str(yconv_err))
@@ -1380,13 +1382,11 @@ async def activate_trial(
     try:
         from app.services import yandex_offline_conv_service as yandex_conv
 
+        # 'trial-add' event still fires here. The paid-trial 'purchase' event is
+        # NOT fired here anymore: when a trial activation fee is charged it
+        # creates a SUBSCRIPTION_PAYMENT transaction, which fires the purchase
+        # event centrally from create_transaction (avoids double-fire).
         await yandex_conv.store_cid_and_fire_trial(user.id, cabinet_cid)
-        if requires_payment and settings.TRIAL_ACTIVATION_PRICE > 0:
-            await yandex_conv.store_cid_and_fire_purchase(
-                user.id,
-                cabinet_cid,
-                settings.TRIAL_ACTIVATION_PRICE,
-            )
     except Exception as yconv_err:
         logger.debug(
             'yandex_conv trial/purchase hook failed (non-fatal)',

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1253,6 +1253,24 @@ async def activate_trial(
                 detail='Failed to charge trial activation fee',
             )
 
+        # Persist the request-body CID BEFORE create_transaction. The
+        # SUBSCRIPTION_PAYMENT below fires the purchase event centrally
+        # (background fire_purchase_bg reads the CID from the DB), so the CID
+        # must be stored and committed first or the fire races it and no-ops
+        # (#558449). store_cid_and_fire_trial below still handles the separate
+        # 'trial-add' event.
+        cabinet_cid = request.yandex_cid if request is not None else None
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+
+            await yandex_conv.store_cid_only(user.id, cabinet_cid)
+        except Exception as yconv_err:
+            logger.debug(
+                'yandex_conv CID persist (pre-transaction) failed (non-fatal)',
+                user_id=user.id,
+                error=str(yconv_err),
+            )
+
         # Создаём транзакцию для учёта списания за триал
         await create_transaction(
             db,

--- a/app/cabinet/routes/subscription_modules/renewal.py
+++ b/app/cabinet/routes/subscription_modules/renewal.py
@@ -270,10 +270,11 @@ async def renew_subscription(
     try:
         from app.services import yandex_offline_conv_service as yandex_conv
 
-        await yandex_conv.store_cid_and_fire_purchase(
+        # Purchase event fires centrally from create_transaction; here we only
+        # persist the request-body CID synchronously (#558449).
+        await yandex_conv.store_cid_only(
             user.id,
             request.yandex_cid,
-            price_kopeks,
         )
     except Exception as yconv_err:
         logger.debug('yandex_conv purchase hook failed (non-fatal)', user_id=user.id, error=str(yconv_err))

--- a/app/cabinet/routes/subscription_modules/servers.py
+++ b/app/cabinet/routes/subscription_modules/servers.py
@@ -274,7 +274,9 @@ async def update_countries(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(user.id, cid, total_cost)
+            # Purchase event fires centrally from create_transaction; here we
+            # only persist the request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(user.id, cid)
         except Exception as yconv_err:
             logger.debug(
                 'yandex_conv purchase hook failed (non-fatal)',

--- a/app/cabinet/routes/subscription_modules/tariff_switch.py
+++ b/app/cabinet/routes/subscription_modules/tariff_switch.py
@@ -546,10 +546,12 @@ async def switch_tariff(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(
+            # Purchase event fires centrally from create_transaction (the
+            # SUBSCRIPTION_PAYMENT created above); here we only persist the
+            # request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(
                 user.id,
                 request.yandex_cid,
-                upgrade_cost,
             )
         except Exception as yconv_err:
             logger.debug(

--- a/app/cabinet/routes/subscription_modules/tariff_switch.py
+++ b/app/cabinet/routes/subscription_modules/tariff_switch.py
@@ -373,6 +373,26 @@ async def switch_tariff(
                 detail='Failed to charge balance',
             )
 
+        # Persist the request-body CID BEFORE create_transaction. The
+        # SUBSCRIPTION_PAYMENT below fires the purchase event centrally via
+        # emit_transaction_side_effects -> background fire_purchase_bg, which
+        # reads the CID from the DB. Storing (and committing) the CID first
+        # closes the race where the background fire would see no CID and no-op
+        # (#558449).
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+
+            await yandex_conv.store_cid_only(
+                user.id,
+                request.yandex_cid,
+            )
+        except Exception as yconv_err:
+            logger.debug(
+                'yandex_conv CID persist (pre-transaction) failed (non-fatal)',
+                user_id=user.id,
+                error=str(yconv_err),
+            )
+
         # Create transaction (commit=False to keep FOR UPDATE lock held)
         switch_transaction = await create_transaction(
             db=db,
@@ -538,27 +558,10 @@ async def switch_tariff(
     await db.refresh(subscription)
     await db.refresh(user)
 
-    # Yandex.Metrika offline conversion. Tariff switch is a paid purchase event
-    # when upgrade_cost > 0 — without this call paid upgrades wouldn't appear in
-    # offline-conv reports even though the user paid. Skip on free downgrades.
-    # Sibling to #558449 (the broader yandex-conv fix missed this path).
-    if upgrade_cost > 0:
-        try:
-            from app.services import yandex_offline_conv_service as yandex_conv
-
-            # Purchase event fires centrally from create_transaction (the
-            # SUBSCRIPTION_PAYMENT created above); here we only persist the
-            # request-body CID synchronously (#558449).
-            await yandex_conv.store_cid_only(
-                user.id,
-                request.yandex_cid,
-            )
-        except Exception as yconv_err:
-            logger.debug(
-                'yandex_conv purchase hook failed (non-fatal)',
-                user_id=user.id,
-                error=str(yconv_err),
-            )
+    # Yandex.Metrika offline conversion: the request-body CID for a paid tariff
+    # switch (upgrade_cost > 0) is now persisted BEFORE create_transaction above,
+    # so the central purchase event fired by the SUBSCRIPTION_PAYMENT sees the
+    # CID and does not race it (#558449). Nothing to do here.
 
     response: dict[str, Any] = {
         'success': True,

--- a/app/cabinet/routes/subscription_modules/traffic.py
+++ b/app/cabinet/routes/subscription_modules/traffic.py
@@ -407,10 +407,11 @@ async def purchase_traffic(
     try:
         from app.services import yandex_offline_conv_service as yandex_conv
 
-        await yandex_conv.store_cid_and_fire_purchase(
+        # Purchase event fires centrally from create_transaction; here we only
+        # persist the request-body CID synchronously (#558449).
+        await yandex_conv.store_cid_only(
             user.id,
             request.yandex_cid,
-            final_price,
         )
     except Exception as yconv_err:
         logger.debug('yandex_conv purchase hook failed (non-fatal)', user_id=user.id, error=str(yconv_err))
@@ -682,10 +683,11 @@ async def switch_traffic_package(
         try:
             from app.services import yandex_offline_conv_service as yandex_conv
 
-            await yandex_conv.store_cid_and_fire_purchase(
+            # Purchase event fires centrally from create_transaction; here we
+            # only persist the request-body CID synchronously (#558449).
+            await yandex_conv.store_cid_only(
                 user.id,
                 request.yandex_cid,
-                charged,
             )
         except Exception as yconv_err:
             logger.debug(

--- a/app/database/crud/transaction.py
+++ b/app/database/crud/transaction.py
@@ -159,6 +159,19 @@ async def create_transaction(
             except Exception as exc:
                 logger.debug('Не удалось записать событие конкурса для пользователя', user_id=user_id, exc=exc)
 
+            # Yandex.Metrika offline conversion — central chokepoint.
+            # Every completed SUBSCRIPTION_PAYMENT (cabinet, bot handlers, guest,
+            # stars, trial→paid conversion, autopay/recurring, IAP, webhooks)
+            # passes through here, so the purchase event fires exactly once per
+            # paid purchase. Background task with its own DB session; no-ops when
+            # the service is disabled or no CID is stored.
+            try:
+                from app.services import yandex_offline_conv_service as yandex_conv
+
+                yandex_conv.spawn_bg(yandex_conv.fire_purchase_bg(user_id, abs(amount_kopeks)))
+            except Exception as exc:
+                logger.debug('Не удалось отправить Yandex purchase для пользователя', user_id=user_id, exc=exc)
+
     return transaction
 
 
@@ -219,6 +232,17 @@ async def emit_transaction_side_effects(
             )
         except Exception as exc:
             logger.debug('Не удалось записать событие конкурса для пользователя', user_id=user_id, exc=exc)
+
+        # Yandex.Metrika offline conversion — central chokepoint (deferred path
+        # for create_transaction(commit=False) callers). Fires the purchase event
+        # exactly once per completed SUBSCRIPTION_PAYMENT. Background task with
+        # its own DB session; no-ops when disabled or no CID stored.
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+
+            yandex_conv.spawn_bg(yandex_conv.fire_purchase_bg(user_id, abs(amount_kopeks)))
+        except Exception as exc:
+            logger.debug('Не удалось отправить Yandex purchase для пользователя', user_id=user_id, exc=exc)
 
 
 async def get_transaction_by_id(db: AsyncSession, transaction_id: int) -> Transaction | None:

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -462,6 +462,21 @@ async def fulfill_purchase(
         await db.commit()
         await db.refresh(purchase, attribute_names=['landing', 'user', 'buyer'])
 
+        # Save Yandex CID from Redis → DB BEFORE create_transaction, so the
+        # central purchase hook fired from create_transaction (every completed
+        # SUBSCRIPTION_PAYMENT) can read the stored CID. Without this ordering
+        # the background fire would race the CID write and no-op.
+        try:
+            from app.services import yandex_offline_conv_service as yandex_conv
+            from app.utils.cache import cache
+
+            _cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
+            if _cached_cid:
+                await yandex_conv.store_cid(db, user.id, _cached_cid, source='landing')
+                await db.commit()
+        except Exception:
+            logger.debug('Failed to save CID from Redis')
+
         # Create transaction so promo group auto-assignment and contest tracking work.
         # Skip for gift recipients — they didn't pay, so their spending shouldn't be inflated.
         transaction = None
@@ -489,18 +504,6 @@ async def fulfill_purchase(
                 except Exception:
                     pass
 
-        # Save Yandex CID from Redis → DB (enables on_registration/on_purchase to use it)
-        try:
-            from app.services import yandex_offline_conv_service as yandex_conv
-            from app.utils.cache import cache
-
-            _cached_cid = await cache.get(f'yacid:purchase:{purchase.token}')
-            if _cached_cid:
-                await yandex_conv.store_cid(db, user.id, _cached_cid, source='landing')
-                await db.commit()
-        except Exception:
-            logger.debug('Failed to save CID from Redis')
-
         # Registration event (new accounts only) + S2S postback
         if is_new_account:
             try:
@@ -520,14 +523,9 @@ async def fulfill_purchase(
             except Exception:
                 logger.debug('S2S postback registration hook error')
 
-        # Purchase event + S2S postback (always for paid purchases)
-        try:
-            from app.services import yandex_offline_conv_service as yandex_conv
-
-            await yandex_conv.on_purchase(db, user.id, purchase.amount_kopeks)
-        except Exception:
-            logger.debug('Yandex on_purchase hook error')
-
+        # Purchase event fires centrally from create_transaction (the
+        # SUBSCRIPTION_PAYMENT created above, after the CID was persisted).
+        # S2S postback is independent and still fires here.
         try:
             from app.database.crud.yandex_client_id import get_subid
             from app.services.s2s_postback_service import send_postback

--- a/app/services/yandex_offline_conv_service.py
+++ b/app/services/yandex_offline_conv_service.py
@@ -302,6 +302,32 @@ async def store_cid_and_fire_purchase(
         logger.warning('Failed to store CID and fire purchase', user_id=user_id, error=str(exc))
 
 
+async def store_cid_only(
+    user_id: int,
+    cid: str | None,
+    *,
+    source: str = 'cabinet',
+) -> None:
+    """Persist a freshly-provided CID WITHOUT firing a purchase event.
+
+    Used by purchase endpoints that previously called
+    ``store_cid_and_fire_purchase``. The actual purchase event now fires
+    exactly once from the central ``create_transaction`` chokepoint (every
+    completed SUBSCRIPTION_PAYMENT), so these call sites only need to close
+    the CID-persist race documented in #558449 by storing the request-body
+    CID synchronously before that central hook runs.
+    """
+    if not _is_enabled() or not cid:
+        return
+    try:
+        async with AsyncSessionLocal() as db:
+            stored = await store_cid(db, user_id, cid, source=source)
+            if stored:
+                await db.commit()
+    except Exception as exc:
+        logger.warning('Failed to store CID', user_id=user_id, error=str(exc))
+
+
 async def store_cid_and_fire_trial(
     user_id: int,
     cid: str | None,
@@ -375,6 +401,14 @@ async def on_purchase(db: AsyncSession, user_id: int, amount_kopeks: int) -> Non
             return
         if not row.yandex_cid or row.yandex_cid.startswith('_'):
             return  # placeholder row — real CID not yet received
+
+        # Best-effort pageview refresh so Metrika keeps the visit/session alive
+        # before the ecommerce purchase hit. Must never block or fail the
+        # purchase send.
+        try:
+            await _post_collect(_pageview_payload(row.yandex_cid), 'pageview', row.yandex_cid)
+        except Exception:
+            pass
 
         amount_rubles = amount_kopeks / 100
         payload = _ecommerce_purchase_payload(row.yandex_cid, amount_rubles)

--- a/tests/database/test_central_purchase_hook.py
+++ b/tests/database/test_central_purchase_hook.py
@@ -1,0 +1,348 @@
+"""Central Yandex.Metrika purchase-fire hook in `create_transaction` (PR #2982).
+
+Background
+----------
+The per-endpoint `store_cid_and_fire_purchase` helper was replaced by a single
+central chokepoint in `app.database.crud.transaction`. Every completed
+SUBSCRIPTION_PAYMENT — from cabinet, bot handlers, guest purchase, stars,
+trial→paid conversion, autopay/recurring, IAP and webhooks — flows through
+`create_transaction` (commit=True path) or, for callers that defer their own
+commit, through `emit_transaction_side_effects` (commit=False path). The
+purchase event must therefore fire **exactly once** per paid purchase and
+**never** for deposits, gifts, refunds or not-yet-completed transactions.
+
+These tests pin that contract:
+  1. completed SUBSCRIPTION_PAYMENT → fires once with (user_id, abs(amount)),
+  2. DEPOSIT / GIFT_PAYMENT / other types → never fires,
+  3. is_completed=False → never fires inline,
+  4. deferred path (emit_transaction_side_effects) → fires once,
+  5. the two paths are mutually exclusive (commit flag), so a single
+     transaction never double-fires,
+  6. the amount is always the positive abs() value even though
+     SUBSCRIPTION_PAYMENT is stored as a negative (debit) amount.
+
+The Yandex service (`spawn_bg` / `fire_purchase_bg`) and every other lazy
+side-effect import (`event_emitter`, promo-group assignment, referral contest)
+are mocked so no real network or DB I/O happens — assertions are on the mocks.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.database.crud import transaction as tx_crud
+from app.database.models import TransactionType
+
+
+def _stub_db() -> SimpleNamespace:
+    """Minimal AsyncSession double: records add, satisfies commit/flush/refresh."""
+    db = SimpleNamespace()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def yandex_spy(monkeypatch):
+    """Patch the Yandex service hooks plus the other lazy side-effects.
+
+    Returns the (spawn_bg, fire_purchase_bg) MagicMocks. `fire_purchase_bg` is a
+    plain MagicMock (not AsyncMock): in production it returns a coroutine that
+    `spawn_bg` schedules; here it returns a MagicMock that `spawn_bg` (also
+    mocked) merely records — so nothing is left un-awaited.
+    """
+    spawn_mock = MagicMock()
+    fire_mock = MagicMock()
+    monkeypatch.setattr('app.services.yandex_offline_conv_service.spawn_bg', spawn_mock)
+    monkeypatch.setattr('app.services.yandex_offline_conv_service.fire_purchase_bg', fire_mock)
+
+    # Neutralise the other lazy-imported side-effects so they don't touch the
+    # stub DB / event bus. They're wrapped in try/except in the SUT, but we keep
+    # the test focused on the Yandex contract.
+    monkeypatch.setattr(
+        'app.services.event_emitter.event_emitter.emit',
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        'app.services.promo_group_assignment.maybe_assign_promo_group_by_total_spent',
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        'app.services.referral_contest_service.referral_contest_service.on_subscription_payment',
+        AsyncMock(return_value=None),
+    )
+    return spawn_mock, fire_mock
+
+
+# ── create_transaction (commit=True, inline path) ──────────────────────────────
+
+
+async def test_completed_subscription_payment_fires_once(yandex_spy):
+    """Completed SUBSCRIPTION_PAYMENT → fire_purchase_bg(user_id, abs(amount)) once."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=29900,
+        description='Подписка 30 дней',
+        is_completed=True,
+        commit=True,
+    )
+
+    fire_mock.assert_called_once_with(42, 29900)
+    spawn_mock.assert_called_once()
+
+
+async def test_deposit_does_not_fire(yandex_spy):
+    """DEPOSIT is a balance top-up, not a purchase → no purchase event."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.DEPOSIT,
+        amount_kopeks=50000,
+        description='Пополнение баланса',
+        is_completed=True,
+        commit=True,
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_gift_payment_does_not_fire(yandex_spy):
+    """GIFT_PAYMENT is not a self-purchase → no purchase event."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.GIFT_PAYMENT,
+        amount_kopeks=29900,
+        description='Подарок другу',
+        is_completed=True,
+        commit=True,
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_refund_does_not_fire(yandex_spy):
+    """REFUND must never count as a purchase conversion."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.REFUND,
+        amount_kopeks=29900,
+        description='Возврат',
+        is_completed=True,
+        commit=True,
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_not_completed_subscription_payment_does_not_fire_inline(yandex_spy):
+    """A pending (is_completed=False) SUBSCRIPTION_PAYMENT must not fire inline."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=29900,
+        description='Подписка (ожидает оплаты)',
+        is_completed=False,
+        commit=True,
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_commit_false_does_not_fire_inline(yandex_spy):
+    """commit=False defers all side-effects → nothing fires from create_transaction.
+
+    This is the other half of "no double-fire": the inline hook is gated behind
+    `commit=True`, so deferred callers don't fire here (they fire later via
+    emit_transaction_side_effects).
+    """
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=29900,
+        description='Подписка 30 дней',
+        is_completed=True,
+        commit=False,
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_negative_stored_amount_fires_positive_abs(yandex_spy):
+    """SUBSCRIPTION_PAYMENT is stored as a negative debit; the conversion event
+    must receive the positive abs() amount, not the negative stored value."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    # create_transaction itself negates positive subscription amounts for storage;
+    # the Yandex hook must still report the positive purchase value.
+    await tx_crud.create_transaction(
+        db,
+        user_id=7,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=79900,
+        description='Подписка 90 дней',
+        is_completed=True,
+        commit=True,
+    )
+
+    fire_mock.assert_called_once_with(7, 79900)
+    assert fire_mock.call_args.args[1] > 0
+
+
+# ── emit_transaction_side_effects (commit=False deferred path) ─────────────────
+
+
+async def test_deferred_subscription_payment_fires_once(yandex_spy):
+    """emit_transaction_side_effects on a completed SUBSCRIPTION_PAYMENT → fires once."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+    fake_tx = SimpleNamespace(id=123)
+
+    await tx_crud.emit_transaction_side_effects(
+        db,
+        fake_tx,
+        amount_kopeks=29900,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        is_completed=True,
+        description='Подписка 30 дней',
+    )
+
+    fire_mock.assert_called_once_with(42, 29900)
+    spawn_mock.assert_called_once()
+
+
+async def test_deferred_deposit_does_not_fire(yandex_spy):
+    """Deferred DEPOSIT side-effects must not fire a purchase event."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+    fake_tx = SimpleNamespace(id=124)
+
+    await tx_crud.emit_transaction_side_effects(
+        db,
+        fake_tx,
+        amount_kopeks=50000,
+        user_id=42,
+        type=TransactionType.DEPOSIT,
+        is_completed=True,
+        description='Пополнение',
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_deferred_not_completed_does_not_fire(yandex_spy):
+    """Deferred SUBSCRIPTION_PAYMENT that isn't completed must not fire."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+    fake_tx = SimpleNamespace(id=125)
+
+    await tx_crud.emit_transaction_side_effects(
+        db,
+        fake_tx,
+        amount_kopeks=29900,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        is_completed=False,
+        description='Подписка (ожидает оплаты)',
+    )
+
+    fire_mock.assert_not_called()
+    spawn_mock.assert_not_called()
+
+
+async def test_deferred_negative_amount_fires_positive_abs(yandex_spy):
+    """Deferred path must also pass the positive abs() amount."""
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+    fake_tx = SimpleNamespace(id=126)
+
+    # Callers may pass the already-stored negative debit amount.
+    await tx_crud.emit_transaction_side_effects(
+        db,
+        fake_tx,
+        amount_kopeks=-29900,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        is_completed=True,
+        description='Подписка 30 дней',
+    )
+
+    fire_mock.assert_called_once_with(42, 29900)
+    assert fire_mock.call_args.args[1] > 0
+
+
+# ── no double-fire across the two paths for a single transaction ───────────────
+
+
+async def test_single_transaction_does_not_double_fire(yandex_spy):
+    """One purchase = one fire. The inline (commit=True) path and the deferred
+    (emit_transaction_side_effects) path are mutually exclusive by design:
+    commit=True callers don't call emit_*, and commit=False callers rely on it.
+
+    Simulate a commit=False caller: create_transaction must NOT fire, then the
+    explicit emit_transaction_side_effects fires exactly once — total of one.
+    """
+    spawn_mock, fire_mock = yandex_spy
+    db = _stub_db()
+
+    tx = await tx_crud.create_transaction(
+        db,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        amount_kopeks=29900,
+        description='Подписка 30 дней',
+        is_completed=True,
+        commit=False,
+    )
+    # No inline fire on the deferred path.
+    fire_mock.assert_not_called()
+
+    await tx_crud.emit_transaction_side_effects(
+        db,
+        tx,
+        amount_kopeks=29900,
+        user_id=42,
+        type=TransactionType.SUBSCRIPTION_PAYMENT,
+        is_completed=True,
+        description='Подписка 30 дней',
+    )
+
+    # Exactly one fire total for the single purchase.
+    fire_mock.assert_called_once_with(42, 29900)
+    spawn_mock.assert_called_once()


### PR DESCRIPTION
Central `on_purchase` hook in `create_transaction` so renewals/trial-conversions/all paid paths send the ecommerce purchase event (previously only some paths fired → repeat purchases lost); + best-effort pageview refresh so stale-session ClientIDs still attribute.

The hook fires exactly once per completed `SUBSCRIPTION_PAYMENT`, mirroring the existing `referral_contest_service.on_subscription_payment` exactly-once pattern: inline for `commit=True` callers, deferred in `emit_transaction_side_effects()` for `commit=False` callers. Per-path `store_cid_and_fire_purchase` calls are reduced to `store_cid_only` (CID persist, no fire); guest landing flow persists the CID before `create_transaction` so the background fire reads a committed row.

No schema change, no new deps, ClientID/Measurement-Protocol only.