### PR TITLE
feat(overpay): p12 certificate upload via bot admin and cabinet api

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -34,6 +34,7 @@ from app.handlers.admin import (
     maintenance as admin_maintenance,
     messages as admin_messages,
     monitoring as admin_monitoring,
+    overpay_certificate as admin_overpay_certificate,
     payments as admin_payments,
     polls as admin_polls,
     pricing as admin_pricing,
@@ -222,6 +223,7 @@ async def setup_bot() -> tuple[Bot, Dispatcher]:
     admin_blocked_users.register_handlers(dp)
     admin_required_channels.register_handlers(dp)
     admin_quick_amounts.register_handlers(dp)
+    admin_overpay_certificate.register_handlers(dp)
     register_channel_member_handlers(dp)
     register_gift_activation_handlers(dp)
     common.register_handlers(dp)

--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -22,6 +22,7 @@ from .admin_news import router as admin_news_router
 from .admin_news_categories import router as admin_news_categories_router
 from .admin_news_media import router as admin_news_media_router
 from .admin_news_tags import router as admin_news_tags_router
+from .admin_overpay_certificate import router as admin_overpay_certificate_router
 from .admin_partners import router as admin_partners_router
 from .admin_payment_methods import router as admin_payment_methods_router
 from .admin_payments import router as admin_payments_router
@@ -160,6 +161,7 @@ router.include_router(admin_news_media_router)
 router.include_router(admin_news_router)
 router.include_router(admin_info_pages_router)
 router.include_router(admin_legal_pages_router)
+router.include_router(admin_overpay_certificate_router)
 
 # WebSocket route
 router.include_router(websocket_router)

--- a/app/cabinet/routes/admin_overpay_certificate.py
+++ b/app/cabinet/routes/admin_overpay_certificate.py
@@ -1,0 +1,90 @@
+import structlog
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import User
+from app.services import overpay_certificate_service
+
+from ..dependencies import get_cabinet_db, require_permission
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/admin/overpay', tags=['Cabinet Admin Overpay'])
+
+
+class OverpayCertificateStatusResponse(BaseModel):
+    uploaded: bool
+    valid: bool
+    path: str
+    subject: str | None = None
+    not_valid_after: str | None = None
+    has_chain: bool | None = None
+    env_locked_path: bool
+    env_locked_passphrase: bool
+
+
+class OverpayCertificateUploadResponse(BaseModel):
+    subject: str
+    not_valid_after: str
+    has_chain: bool
+    path: str
+    env_locked_path: bool
+    env_locked_passphrase: bool
+    warning: str | None = None
+
+
+@router.get('/certificate', response_model=OverpayCertificateStatusResponse)
+async def get_certificate_status(
+    admin: User = Depends(require_permission('settings:read')),
+) -> OverpayCertificateStatusResponse:
+    return OverpayCertificateStatusResponse(**overpay_certificate_service.get_status())
+
+
+@router.post('/certificate', response_model=OverpayCertificateUploadResponse)
+async def upload_certificate(
+    file: UploadFile = File(...),
+    passphrase: str = Form(''),
+    admin: User = Depends(require_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> OverpayCertificateUploadResponse:
+    data = await file.read(overpay_certificate_service.MAX_P12_SIZE + 1)
+    await file.close()
+
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Empty file',
+        )
+
+    if len(data) > overpay_certificate_service.MAX_P12_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail='File too large. Maximum size: 1 MB',
+        )
+
+    try:
+        metadata = await overpay_certificate_service.store_certificate(db, data, passphrase)
+    except ValueError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(error),
+        ) from None
+
+    logger.info(
+        'Admin uploaded Overpay certificate via cabinet',
+        admin_id=admin.id,
+        subject=metadata['subject'],
+        not_valid_after=metadata['not_valid_after'],
+    )
+    return OverpayCertificateUploadResponse(**metadata)
+
+
+@router.delete('/certificate', status_code=status.HTTP_204_NO_CONTENT)
+async def delete_certificate(
+    admin: User = Depends(require_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> None:
+    await overpay_certificate_service.delete_certificate(db)
+    logger.info('Admin deleted Overpay certificate via cabinet', admin_id=admin.id)

--- a/app/cabinet/routes/admin_overpay_certificate.py
+++ b/app/cabinet/routes/admin_overpay_certificate.py
@@ -60,7 +60,7 @@ async def upload_certificate(
 
     if len(data) > overpay_certificate_service.MAX_P12_SIZE:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail='File too large. Maximum size: 1 MB',
         )
 

--- a/app/handlers/admin/__init__.py
+++ b/app/handlers/admin/__init__.py
@@ -13,6 +13,7 @@ from . import (
     maintenance,
     messages,
     monitoring,
+    overpay_certificate,
     payments,
     polls,
     pricing,

--- a/app/handlers/admin/overpay_certificate.py
+++ b/app/handlers/admin/overpay_certificate.py
@@ -3,7 +3,7 @@ import io
 
 import structlog
 from aiogram import Dispatcher, F, Router
-from aiogram.exceptions import TelegramBadRequest
+from aiogram.exceptions import TelegramAPIError, TelegramBadRequest
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
@@ -172,7 +172,7 @@ async def process_certificate_passphrase(message: Message, state: FSMContext, **
 
     try:
         await message.delete()
-    except TelegramBadRequest:
+    except TelegramAPIError:
         pass
 
     data = await state.get_data()

--- a/app/handlers/admin/overpay_certificate.py
+++ b/app/handlers/admin/overpay_certificate.py
@@ -1,0 +1,215 @@
+import html
+import io
+
+import structlog
+from aiogram import Dispatcher, F, Router
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+from app.database.database import AsyncSessionLocal
+from app.services import overpay_certificate_service as cert_service
+from app.utils.decorators import admin_required, error_handler
+
+
+logger = structlog.get_logger(__name__)
+
+router = Router(name='admin_overpay_certificate')
+
+ALLOWED_EXTENSIONS = ('.p12', '.pfx')
+
+ENV_LOCK_NOTE = (
+    '⚠️ OVERPAY_P12_PATH или OVERPAY_P12_PASSPHRASE заданы через переменные окружения — значения из БД не применяются.'
+)
+
+
+class OverpayCertStates(StatesGroup):
+    waiting_for_file = State()
+    waiting_for_passphrase = State()
+
+
+def _cancel_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text='◀️ Отмена', callback_data='overpay_cert')]])
+
+
+def _back_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text='◀️ К сертификату', callback_data='overpay_cert')]]
+    )
+
+
+def _status_view() -> tuple[str, InlineKeyboardMarkup]:
+    status = cert_service.get_status()
+    lines = ['📜 <b>Сертификат Overpay</b>', '']
+
+    if not status['uploaded']:
+        lines.append('Статус: ❌ не загружен')
+    elif status['valid']:
+        lines.append('Статус: ✅ загружен')
+        lines.append(f'Субъект: <code>{html.escape(status["subject"])}</code>')
+        lines.append(f'Действует до: <code>{status["not_valid_after"]}</code>')
+    else:
+        lines.append('Статус: ⚠️ файл найден, но не читается с текущим паролем')
+
+    if status['uploaded']:
+        lines.append(f'Путь: <code>{html.escape(status["path"])}</code>')
+
+    if status['env_locked_path'] or status['env_locked_passphrase']:
+        lines.append('')
+        lines.append(ENV_LOCK_NOTE)
+
+    buttons = [[InlineKeyboardButton(text='📎 Загрузить', callback_data='overpay_cert:upload')]]
+    if status['uploaded']:
+        buttons.append([InlineKeyboardButton(text='🗑 Удалить', callback_data='overpay_cert:delete')])
+    buttons.append([InlineKeyboardButton(text='◀️ Назад', callback_data='admin_submenu_settings')])
+
+    return '\n'.join(lines), InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+@router.callback_query(F.data == 'overpay_cert')
+@admin_required
+@error_handler
+async def show_certificate_status(callback: CallbackQuery, state: FSMContext, **kwargs) -> None:
+    await state.clear()
+    text, keyboard = _status_view()
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
+
+
+@router.callback_query(F.data == 'overpay_cert:upload')
+@admin_required
+@error_handler
+async def start_certificate_upload(callback: CallbackQuery, state: FSMContext, **kwargs) -> None:
+    await state.set_state(OverpayCertStates.waiting_for_file)
+    await callback.message.edit_text(
+        '📎 <b>Загрузка сертификата Overpay</b>\n\nОтправьте файл сертификата (.p12 или .pfx) размером до 1 МБ.',
+        reply_markup=_cancel_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == 'overpay_cert:delete')
+@admin_required
+@error_handler
+async def confirm_certificate_delete(callback: CallbackQuery, **kwargs) -> None:
+    await callback.message.edit_text(
+        '🗑 <b>Удаление сертификата Overpay</b>\n\n'
+        'Файл будет удалён, настройки пути и пароля очищены. Платежи через Overpay перестанут работать. Продолжить?',
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(text='✅ Удалить', callback_data='overpay_cert:delete_confirm'),
+                    InlineKeyboardButton(text='◀️ Отмена', callback_data='overpay_cert'),
+                ]
+            ]
+        ),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == 'overpay_cert:delete_confirm')
+@admin_required
+@error_handler
+async def delete_certificate(callback: CallbackQuery, state: FSMContext, **kwargs) -> None:
+    await state.clear()
+    async with AsyncSessionLocal() as db:
+        await cert_service.delete_certificate(db)
+    await callback.answer('Сертификат удалён', show_alert=True)
+    text, keyboard = _status_view()
+    await callback.message.edit_text(text, reply_markup=keyboard)
+
+
+@router.message(OverpayCertStates.waiting_for_file)
+@admin_required
+@error_handler
+async def process_certificate_file(message: Message, state: FSMContext, **kwargs) -> None:
+    document = message.document
+    if not document:
+        await message.answer(
+            '❌ Отправьте файл сертификата документом (.p12 или .pfx).',
+            reply_markup=_cancel_keyboard(),
+        )
+        return
+
+    file_name = document.file_name or ''
+    if not file_name.lower().endswith(ALLOWED_EXTENSIONS):
+        await message.answer(
+            '❌ Неподдерживаемый формат файла. Загрузите .p12 или .pfx.',
+            reply_markup=_cancel_keyboard(),
+        )
+        return
+
+    if document.file_size and document.file_size > cert_service.MAX_P12_SIZE:
+        await message.answer(
+            '❌ Файл слишком большой (максимум 1 МБ).',
+            reply_markup=_cancel_keyboard(),
+        )
+        return
+
+    await state.update_data(overpay_cert_file_id=document.file_id)
+    await state.set_state(OverpayCertStates.waiting_for_passphrase)
+    await message.answer(
+        '🔑 Отправьте пароль от контейнера P12.\n'
+        'Если пароля нет — отправьте <code>-</code>.\n\n'
+        'Сообщение с паролем будет удалено.',
+        reply_markup=_cancel_keyboard(),
+    )
+
+
+@router.message(OverpayCertStates.waiting_for_passphrase)
+@admin_required
+@error_handler
+async def process_certificate_passphrase(message: Message, state: FSMContext, **kwargs) -> None:
+    if not message.text:
+        await message.answer(
+            '❌ Отправьте пароль текстовым сообщением (или <code>-</code>, если пароля нет).',
+            reply_markup=_cancel_keyboard(),
+        )
+        return
+
+    passphrase = '' if message.text.strip() == '-' else message.text
+
+    try:
+        await message.delete()
+    except TelegramBadRequest:
+        pass
+
+    data = await state.get_data()
+    file_id = data.get('overpay_cert_file_id')
+    await state.clear()
+
+    if not file_id:
+        await message.answer('❌ Файл не найден. Начните загрузку заново.', reply_markup=_back_keyboard())
+        return
+
+    buffer = io.BytesIO()
+    try:
+        await message.bot.download(file_id, destination=buffer)
+    except TelegramBadRequest as error:
+        logger.warning('Overpay: не удалось скачать файл сертификата', error=error)
+        await message.answer('❌ Не удалось скачать файл. Начните загрузку заново.', reply_markup=_back_keyboard())
+        return
+
+    async with AsyncSessionLocal() as db:
+        try:
+            metadata = await cert_service.store_certificate(db, buffer.getvalue(), passphrase)
+        except ValueError as error:
+            await message.answer(f'❌ {error}', reply_markup=_back_keyboard())
+            return
+
+    lines = [
+        '✅ <b>Сертификат Overpay сохранён</b>',
+        '',
+        f'Субъект: <code>{html.escape(metadata["subject"])}</code>',
+        f'Действует до: <code>{metadata["not_valid_after"]}</code>',
+    ]
+    if metadata['warning']:
+        lines.append('')
+        lines.append(f'⚠️ {metadata["warning"]}')
+
+    await message.answer('\n'.join(lines), reply_markup=_back_keyboard())
+
+
+def register_handlers(dp: Dispatcher) -> None:
+    dp.include_router(router)

--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -231,6 +231,12 @@ def get_admin_settings_submenu_keyboard(language: str = 'ru') -> InlineKeyboardM
             ],
             [
                 InlineKeyboardButton(
+                    text=_t(texts, 'ADMIN_SETTINGS_OVERPAY_CERT', '📜 Сертификат Overpay'),
+                    callback_data='overpay_cert',
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text=_t(texts, 'ADMIN_SETTINGS_APP_CONFIG', '📱 Конфиг приложений'),
                     callback_data='admin_remna_config',
                 )

--- a/app/services/overpay_certificate_service.py
+++ b/app/services/overpay_certificate_service.py
@@ -1,0 +1,136 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import structlog
+from cryptography.hazmat.primitives.serialization import pkcs12
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.services.overpay_service import overpay_service
+from app.services.system_settings_service import bot_configuration_service
+
+
+logger = structlog.get_logger(__name__)
+
+CERTS_DIR = Path('/app/data/certs')
+CERT_FILENAME = 'overpay.p12'
+MAX_P12_SIZE = 1024 * 1024
+
+ENV_LOCK_WARNING = (
+    'OVERPAY_P12_PATH или OVERPAY_P12_PASSPHRASE заданы через переменные окружения, '
+    'поэтому сохранённые в БД значения не применяются. Файл записан в {path}: '
+    'если переменная окружения указывает на этот путь, новый сертификат будет использоваться, '
+    'иначе обновите переменные окружения и перезапустите бота.'
+)
+
+
+def get_canonical_path() -> Path:
+    return CERTS_DIR / CERT_FILENAME
+
+
+def _env_locked_flags() -> tuple[bool, bool]:
+    return (
+        bot_configuration_service.is_env_overridden('OVERPAY_P12_PATH'),
+        bot_configuration_service.is_env_overridden('OVERPAY_P12_PASSPHRASE'),
+    )
+
+
+def validate_p12(p12_bytes: bytes, passphrase: str | None) -> dict[str, Any]:
+    if len(p12_bytes) > MAX_P12_SIZE:
+        raise ValueError('Файл сертификата больше 1 МБ')
+
+    passphrase_bytes = passphrase.encode('utf-8') if passphrase else None
+    try:
+        private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(p12_bytes, passphrase_bytes)
+    except Exception as error:
+        raise ValueError('Не удалось прочитать P12: неверный пароль или повреждённый файл') from error
+
+    if private_key is None or certificate is None:
+        raise ValueError('P12 не содержит приватный ключ и сертификат')
+
+    not_valid_after = getattr(certificate, 'not_valid_after_utc', None) or certificate.not_valid_after
+    return {
+        'subject': certificate.subject.rfc4514_string(),
+        'not_valid_after': not_valid_after.isoformat(),
+        'has_chain': bool(additional_certs),
+    }
+
+
+def _write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.tmp')
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, 'wb') as tmp_file:
+            tmp_file.write(data)
+        tmp_path.replace(path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+async def store_certificate(db: AsyncSession, p12_bytes: bytes, passphrase: str | None) -> dict[str, Any]:
+    metadata = validate_p12(p12_bytes, passphrase)
+    path = get_canonical_path()
+    _write_atomic(path, p12_bytes)
+
+    await bot_configuration_service.set_value(db, 'OVERPAY_P12_PATH', str(path))
+    await bot_configuration_service.set_value(db, 'OVERPAY_P12_PASSPHRASE', passphrase or '')
+    await db.commit()
+    await overpay_service.close()
+
+    env_locked_path, env_locked_passphrase = _env_locked_flags()
+    metadata['path'] = str(path)
+    metadata['env_locked_path'] = env_locked_path
+    metadata['env_locked_passphrase'] = env_locked_passphrase
+    metadata['warning'] = ENV_LOCK_WARNING.format(path=path) if env_locked_path or env_locked_passphrase else None
+
+    logger.info(
+        'Overpay: сертификат сохранён',
+        path=str(path),
+        subject=metadata['subject'],
+        not_valid_after=metadata['not_valid_after'],
+    )
+    return metadata
+
+
+async def delete_certificate(db: AsyncSession) -> None:
+    get_canonical_path().unlink(missing_ok=True)
+
+    await bot_configuration_service.set_value(db, 'OVERPAY_P12_PATH', None)
+    await bot_configuration_service.set_value(db, 'OVERPAY_P12_PASSPHRASE', None)
+    await db.commit()
+    await overpay_service.close()
+
+    logger.info('Overpay: сертификат удалён')
+
+
+def get_status() -> dict[str, Any]:
+    env_locked_path, env_locked_passphrase = _env_locked_flags()
+    effective_path = settings.OVERPAY_P12_PATH or str(get_canonical_path())
+    path = Path(effective_path)
+    uploaded = path.is_file()
+
+    status: dict[str, Any] = {
+        'uploaded': uploaded,
+        'valid': False,
+        'path': effective_path,
+        'subject': None,
+        'not_valid_after': None,
+        'has_chain': None,
+        'env_locked_path': env_locked_path,
+        'env_locked_passphrase': env_locked_passphrase,
+    }
+
+    if not uploaded:
+        return status
+
+    try:
+        metadata = validate_p12(path.read_bytes(), settings.OVERPAY_P12_PASSPHRASE)
+    except (ValueError, OSError):
+        return status
+
+    status.update(metadata)
+    status['valid'] = True
+    return status

--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -102,7 +102,7 @@ class BotConfigurationService:
         """
         if key in cls.PLAIN_TEXT_KEYS:
             return False
-        return any(keyword in key.upper() for keyword in ('TOKEN', 'SECRET', 'PASSWORD', 'KEY'))
+        return any(keyword in key.upper() for keyword in ('TOKEN', 'SECRET', 'PASSWORD', 'PASSPHRASE', 'KEY'))
 
     @classmethod
     def is_masked_secret(cls, key: str, value: Any) -> bool:
@@ -1179,8 +1179,8 @@ class BotConfigurationService:
                 return '—'
             if key in cls.PLAIN_TEXT_KEYS:
                 return cleaned
-            if any(keyword in key.upper() for keyword in ('TOKEN', 'SECRET', 'PASSWORD', 'KEY')):
-                return '••••••••'
+            if cls.is_secret_key(key):
+                return cls.SECRET_MASK
             items = cls._split_comma_values(cleaned)
             if items:
                 return ', '.join(items)

--- a/tests/cabinet/test_admin_overpay_certificate_routes.py
+++ b/tests/cabinet/test_admin_overpay_certificate_routes.py
@@ -1,0 +1,145 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import BestAvailableEncryption, pkcs12
+from cryptography.x509.oid import NameOID
+from fastapi import HTTPException
+
+from app.services import overpay_certificate_service as cert_service
+
+
+@pytest.fixture(scope='module')
+def p12_bytes():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'overpay-test')])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    return pkcs12.serialize_key_and_certificates(b'test', key, cert, None, BestAvailableEncryption(b'secret'))
+
+
+@pytest.fixture
+def stubbed_service(monkeypatch, tmp_path):
+    config_service = SimpleNamespace(set_value=AsyncMock(), is_env_overridden=lambda key: False)
+    overpay = SimpleNamespace(close=AsyncMock())
+    monkeypatch.setattr(cert_service, 'CERTS_DIR', tmp_path / 'certs')
+    monkeypatch.setattr(cert_service, 'bot_configuration_service', config_service)
+    monkeypatch.setattr(cert_service, 'overpay_service', overpay)
+    return config_service
+
+
+def _fake_upload(data: bytes):
+    return SimpleNamespace(read=AsyncMock(return_value=data), close=AsyncMock())
+
+
+def test_admin_overpay_certificate_routes_registered():
+    from app.cabinet.routes import router
+
+    methods = set()
+    for route in router.routes:
+        if route.path == '/cabinet/admin/overpay/certificate':
+            methods |= route.methods
+    assert methods == {'GET', 'POST', 'DELETE'}
+
+
+@pytest.mark.asyncio
+async def test_upload_certificate_commits(stubbed_service, p12_bytes):
+    from app.cabinet.routes import admin_overpay_certificate
+
+    db = AsyncMock()
+    response = await admin_overpay_certificate.upload_certificate(
+        file=_fake_upload(p12_bytes),
+        passphrase='secret',
+        admin=SimpleNamespace(id=1),
+        db=db,
+    )
+
+    assert response.subject == 'CN=overpay-test'
+    assert response.path == str(cert_service.get_canonical_path())
+    assert response.warning is None
+    assert cert_service.get_canonical_path().read_bytes() == p12_bytes
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_certificate_env_locked_warning(stubbed_service, p12_bytes):
+    from app.cabinet.routes import admin_overpay_certificate
+
+    stubbed_service.is_env_overridden = lambda key: True
+    db = AsyncMock()
+    response = await admin_overpay_certificate.upload_certificate(
+        file=_fake_upload(p12_bytes),
+        passphrase='secret',
+        admin=SimpleNamespace(id=1),
+        db=db,
+    )
+
+    assert response.env_locked_path is True
+    assert response.env_locked_passphrase is True
+    assert response.warning
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_certificate_invalid_returns_422(stubbed_service):
+    from app.cabinet.routes import admin_overpay_certificate
+
+    db = AsyncMock()
+    with pytest.raises(HTTPException) as exc_info:
+        await admin_overpay_certificate.upload_certificate(
+            file=_fake_upload(b'garbage'),
+            passphrase='',
+            admin=SimpleNamespace(id=1),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 422
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upload_certificate_oversize_returns_413(stubbed_service):
+    from app.cabinet.routes import admin_overpay_certificate
+
+    db = AsyncMock()
+    with pytest.raises(HTTPException) as exc_info:
+        await admin_overpay_certificate.upload_certificate(
+            file=_fake_upload(b'0' * (cert_service.MAX_P12_SIZE + 1)),
+            passphrase='',
+            admin=SimpleNamespace(id=1),
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 413
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_certificate_commits(stubbed_service, p12_bytes):
+    from app.cabinet.routes import admin_overpay_certificate
+
+    db = AsyncMock()
+    await admin_overpay_certificate.upload_certificate(
+        file=_fake_upload(p12_bytes),
+        passphrase='secret',
+        admin=SimpleNamespace(id=1),
+        db=db,
+    )
+    db.reset_mock()
+
+    await admin_overpay_certificate.delete_certificate(admin=SimpleNamespace(id=1), db=db)
+
+    assert not cert_service.get_canonical_path().exists()
+    db.commit.assert_awaited_once()

--- a/tests/services/test_overpay_certificate_service.py
+++ b/tests/services/test_overpay_certificate_service.py
@@ -1,0 +1,181 @@
+import stat
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import BestAvailableEncryption, NoEncryption, pkcs12
+from cryptography.x509.oid import NameOID
+
+from app.services import overpay_certificate_service as cert_service
+
+
+@pytest.fixture(scope='module')
+def cert_and_key():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'overpay-test')])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    return cert, key
+
+
+def _build_p12(cert, key, password: bytes | None, cas=None) -> bytes:
+    encryption = BestAvailableEncryption(password) if password else NoEncryption()
+    return pkcs12.serialize_key_and_certificates(b'test', key, cert, cas, encryption)
+
+
+def test_validate_p12_with_password(cert_and_key):
+    cert, key = cert_and_key
+    p12_bytes = _build_p12(cert, key, b'secret')
+
+    metadata = cert_service.validate_p12(p12_bytes, 'secret')
+
+    assert metadata['subject'] == 'CN=overpay-test'
+    assert datetime.fromisoformat(metadata['not_valid_after']) > datetime.now(UTC)
+    assert metadata['has_chain'] is False
+
+
+def test_validate_p12_without_password(cert_and_key):
+    cert, key = cert_and_key
+    p12_bytes = _build_p12(cert, key, None, cas=[cert])
+
+    metadata = cert_service.validate_p12(p12_bytes, None)
+
+    assert metadata['subject'] == 'CN=overpay-test'
+    assert metadata['has_chain'] is True
+
+
+def test_validate_p12_wrong_passphrase(cert_and_key):
+    cert, key = cert_and_key
+    p12_bytes = _build_p12(cert, key, b'secret')
+
+    with pytest.raises(ValueError, match='неверный пароль'):
+        cert_service.validate_p12(p12_bytes, 'wrong')
+
+
+def test_validate_p12_garbage_bytes():
+    with pytest.raises(ValueError, match='неверный пароль'):
+        cert_service.validate_p12(b'not a p12 file', None)
+
+
+def test_validate_p12_oversize():
+    with pytest.raises(ValueError, match='1 МБ'):
+        cert_service.validate_p12(b'0' * (cert_service.MAX_P12_SIZE + 1), None)
+
+
+@pytest.fixture
+def stubbed_env(monkeypatch, tmp_path):
+    config_service = SimpleNamespace(set_value=AsyncMock(), is_env_overridden=lambda key: False)
+    overpay = SimpleNamespace(close=AsyncMock())
+    monkeypatch.setattr(cert_service, 'CERTS_DIR', tmp_path / 'certs')
+    monkeypatch.setattr(cert_service, 'bot_configuration_service', config_service)
+    monkeypatch.setattr(cert_service, 'overpay_service', overpay)
+    return config_service, overpay
+
+
+@pytest.mark.asyncio
+async def test_store_certificate(cert_and_key, stubbed_env):
+    cert, key = cert_and_key
+    config_service, overpay = stubbed_env
+    p12_bytes = _build_p12(cert, key, b'secret')
+    db = AsyncMock()
+
+    metadata = await cert_service.store_certificate(db, p12_bytes, 'secret')
+
+    stored_path = cert_service.get_canonical_path()
+    assert stored_path.read_bytes() == p12_bytes
+    assert stat.S_IMODE(stored_path.stat().st_mode) == 0o600
+    assert metadata['subject'] == 'CN=overpay-test'
+    assert metadata['path'] == str(stored_path)
+    assert metadata['env_locked_path'] is False
+    assert metadata['warning'] is None
+    config_service.set_value.assert_any_await(db, 'OVERPAY_P12_PATH', str(stored_path))
+    config_service.set_value.assert_any_await(db, 'OVERPAY_P12_PASSPHRASE', 'secret')
+    db.commit.assert_awaited_once()
+    overpay.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_certificate_env_locked_warning(cert_and_key, stubbed_env):
+    cert, key = cert_and_key
+    config_service, _overpay = stubbed_env
+    config_service.is_env_overridden = lambda key: key == 'OVERPAY_P12_PATH'
+    p12_bytes = _build_p12(cert, key, None)
+    db = AsyncMock()
+
+    metadata = await cert_service.store_certificate(db, p12_bytes, None)
+
+    assert metadata['env_locked_path'] is True
+    assert metadata['env_locked_passphrase'] is False
+    assert 'переменные окружения' in metadata['warning']
+    assert cert_service.get_canonical_path().exists()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_certificate_invalid_writes_nothing(stubbed_env):
+    config_service, overpay = stubbed_env
+    db = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await cert_service.store_certificate(db, b'garbage', None)
+
+    assert not cert_service.get_canonical_path().exists()
+    config_service.set_value.assert_not_awaited()
+    db.commit.assert_not_awaited()
+    overpay.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_certificate(cert_and_key, stubbed_env):
+    cert, key = cert_and_key
+    config_service, overpay = stubbed_env
+    db = AsyncMock()
+    await cert_service.store_certificate(db, _build_p12(cert, key, None), None)
+    db.reset_mock()
+    config_service.set_value.reset_mock()
+    overpay.close.reset_mock()
+
+    await cert_service.delete_certificate(db)
+
+    assert not cert_service.get_canonical_path().exists()
+    config_service.set_value.assert_any_await(db, 'OVERPAY_P12_PATH', None)
+    config_service.set_value.assert_any_await(db, 'OVERPAY_P12_PASSPHRASE', None)
+    db.commit.assert_awaited_once()
+    overpay.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_status(cert_and_key, stubbed_env, monkeypatch):
+    cert, key = cert_and_key
+    monkeypatch.setattr(cert_service.settings, 'OVERPAY_P12_PATH', None, raising=False)
+    monkeypatch.setattr(cert_service.settings, 'OVERPAY_P12_PASSPHRASE', 'secret', raising=False)
+
+    status = cert_service.get_status()
+    assert status['uploaded'] is False
+    assert status['valid'] is False
+    assert status['path'] == str(cert_service.get_canonical_path())
+
+    db = AsyncMock()
+    await cert_service.store_certificate(db, _build_p12(cert, key, b'secret'), 'secret')
+
+    status = cert_service.get_status()
+    assert status['uploaded'] is True
+    assert status['valid'] is True
+    assert status['subject'] == 'CN=overpay-test'
+
+    monkeypatch.setattr(cert_service.settings, 'OVERPAY_P12_PASSPHRASE', 'wrong', raising=False)
+    status = cert_service.get_status()
+    assert status['uploaded'] is True
+    assert status['valid'] is False

--- a/tests/services/test_settings_secret_masking.py
+++ b/tests/services/test_settings_secret_masking.py
@@ -25,6 +25,7 @@ MASK = svc.SECRET_MASK
         'SMTP_PASSWORD',
         'REMNAWAVE_API_KEY',
         'BOT_TOKEN',
+        'OVERPAY_P12_PASSPHRASE',
     ],
 )
 def test_is_secret_key_matches_secret_names(key: str) -> None:


### PR DESCRIPTION
## Что сделано

Загрузка mTLS-сертификата (.p12) Overpay без ручного копирования файла на сервер.

### Сервис (`overpay_certificate_service.py`)
- Валидация p12 той же библиотекой `cryptography`, что использует рантайм: неверный пароль или битый файл отклоняются до сохранения, лимит 1 МБ
- Атомарная запись в `/app/data/certs/overpay.p12` (каталог 0700, файл 0600), установка `OVERPAY_P12_PATH`/`OVERPAY_P12_PASSPHRASE` и сброс кешированного SSL-контекста — новый сертификат подхватывается без рестарта
- Статус: subject, срок действия, читаемость с текущим паролем, флаги env-переопределений с честным предупреждением

### Бот
- Кнопка «📜 Сертификат Overpay» в настройках админки: статус → отправка .p12 документом → ввод пароля (`-` = без пароля, сообщение с паролем удаляется) → результат проверки; удаление с подтверждением

### Кабинет-API
- `GET/POST(multipart)/DELETE /cabinet/admin/overpay/certificate` (права `settings:read`/`settings:edit`), 413/422 с внятными ошибками

### Безопасность
- `PASSPHRASE` добавлен в эвристику секретных ключей — пароль маскируется в экранах настроек бота и кабинетном API настроек

## Проверка
- pytest: 1445 passed; ruff check + format clean
- 16 новых тестов (сервис: сгенерированный self-signed p12, happy/wrong-pass/garbage/oversize/atomic; роуты: пути, коммиты, 413/422, env-lock)

UI-часть для веб-админки: BEDOLAGA-DEV/bedolaga-cabinet (отдельный PR)