### PR TITLE
fix(etoplatezhi): customer_id=None for telegram-less users causes anti-fraud declines

### DIFF
--- a/app/services/payment/etoplatezhi.py
+++ b/app/services/payment/etoplatezhi.py
@@ -78,10 +78,8 @@ class EtoplatezhiPaymentMixin:
         # Получаем telegram_id пользователя для order_id
         payment_module = import_module('app.services.payment_service')
         if user_id is not None:
-            user = await payment_module.get_user_by_id(db, user_id)
             tg_id = user_id
         else:
-            user = None
             tg_id = 'guest'
 
         # Генерируем уникальный order_id с telegram_id для удобного поиска

--- a/app/services/payment/etoplatezhi.py
+++ b/app/services/payment/etoplatezhi.py
@@ -79,7 +79,7 @@ class EtoplatezhiPaymentMixin:
         payment_module = import_module('app.services.payment_service')
         if user_id is not None:
             user = await payment_module.get_user_by_id(db, user_id)
-            tg_id = user.telegram_id if user else user_id
+            tg_id = user_id
         else:
             user = None
             tg_id = 'guest'


### PR DESCRIPTION
Users without a telegram_id (registered via web cabinet / email / Telegram-OIDC) get `customer_id="None"` sent to EtoPlatezhi, because the order_id/customer_id is derived from `user.telegram_id` which is None for them.

EtoPlatezhi's Risk System then sees thousands of distinct transactions (different users, amounts, cards) under a single customer `"None"` and declines them as fraud — observed as `code: "402", message: "RCS reject. Declined by Risk System"`. In our production this was ~700 declined cabinet balance top-ups per day (~95% decline rate for telegram-less users vs ~50% for telegram users).

The guest-payment branch was already patched for the same anti-fraud reason (unique `guest{uuid}` id); this fixes the registered-but-telegram-less user case.

Fix: use the always-present, always-unique internal `user_id` as the customer identifier instead of the possibly-None telegram_id.

Verified in production: switching customer_id from "None" to the user_id stops the 402 RCS declines.