### PR TITLE
[codex] Add scoped YooKassa bot and cabinet flows

### DIFF
--- a/app/cabinet/routes/balance.py
+++ b/app/cabinet/routes/balance.py
@@ -371,6 +371,7 @@ async def create_topup(
                     description=description,
                     metadata=yookassa_metadata,
                     return_url=cabinet_return_url,
+                    yookassa_scope='cabinet',
                 )
             else:
                 result = await payment_service.create_yookassa_payment(
@@ -380,6 +381,7 @@ async def create_topup(
                     description=description,
                     metadata=yookassa_metadata,
                     return_url=cabinet_return_url,
+                    yookassa_scope='cabinet',
                 )
 
             if result:

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ import html
 import os
 import re
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import time
 from pathlib import Path
 from typing import ClassVar, Literal
@@ -22,6 +23,21 @@ USER_TAG_PATTERN = re.compile(r'^[A-Z0-9_]{1,16}$')
 
 
 logger = structlog.get_logger(__name__)
+
+
+YooKassaScope = Literal['bot', 'cabinet']
+
+
+@dataclass(frozen=True)
+class YooKassaConfig:
+    scope: YooKassaScope | None
+    enabled: bool
+    display_name: str
+    shop_id: str | None
+    secret_key: str | None
+    return_url: str
+    sbp_enabled: bool
+    recurrent_enabled: bool
 
 
 class Settings(BaseSettings):
@@ -420,6 +436,20 @@ class Settings(BaseSettings):
 
     YOOKASSA_ENABLED: bool = False
     YOOKASSA_DISPLAY_NAME: str = 'YooKassa'
+    YOOKASSA_BOT_ENABLED: bool | None = None
+    YOOKASSA_BOT_DISPLAY_NAME: str | None = None
+    YOOKASSA_BOT_SHOP_ID: str | None = None
+    YOOKASSA_BOT_SECRET_KEY: str | None = None
+    YOOKASSA_BOT_RETURN_URL: str | None = None
+    YOOKASSA_BOT_SBP_ENABLED: bool | None = None
+    YOOKASSA_BOT_RECURRENT_ENABLED: bool | None = None
+    YOOKASSA_CABINET_ENABLED: bool | None = None
+    YOOKASSA_CABINET_DISPLAY_NAME: str | None = None
+    YOOKASSA_CABINET_SHOP_ID: str | None = None
+    YOOKASSA_CABINET_SECRET_KEY: str | None = None
+    YOOKASSA_CABINET_RETURN_URL: str | None = None
+    YOOKASSA_CABINET_SBP_ENABLED: bool | None = None
+    YOOKASSA_CABINET_RECURRENT_ENABLED: bool | None = None
     # HTTP socket timeouts for yookassa SDK requests. The SDK itself
     # ships with NO timeout, so a hanging YK endpoint will block a
     # worker thread forever (until TCP keep-alive eventually kills it,
@@ -2067,12 +2097,91 @@ class Settings(BaseSettings):
 
         return value
 
-    def is_yookassa_enabled(self) -> bool:
-        return self.YOOKASSA_ENABLED and self.YOOKASSA_SHOP_ID is not None and self.YOOKASSA_SECRET_KEY is not None
+    def _normalize_yookassa_scope(self, scope: str | None) -> YooKassaScope | None:
+        if scope is None:
+            return None
+        if scope not in ('bot', 'cabinet'):
+            raise ValueError(f'Unsupported YooKassa scope: {scope}')
+        return scope
 
-    def get_yookassa_display_name(self) -> str:
+    def _get_legacy_yookassa_return_url(self) -> str:
+        if self.YOOKASSA_RETURN_URL:
+            return self.YOOKASSA_RETURN_URL
+        if self.WEBHOOK_URL:
+            return f'{self.WEBHOOK_URL}/payment-success'
+        return 'https://t.me/'
+
+    def _get_yookassa_scope_value(self, scope: YooKassaScope, field: str):
+        return getattr(self, f'YOOKASSA_{scope.upper()}_{field}')
+
+    def get_yookassa_config(self, scope: str | None = None) -> YooKassaConfig:
+        normalized_scope = self._normalize_yookassa_scope(scope)
+        if normalized_scope is None:
+            shop_id = self.YOOKASSA_SHOP_ID
+            secret_key = self.YOOKASSA_SECRET_KEY
+            enabled = self.YOOKASSA_ENABLED and shop_id is not None and secret_key is not None
+            display_name = (self.YOOKASSA_DISPLAY_NAME or '').strip() or 'YooKassa'
+            return YooKassaConfig(
+                scope=None,
+                enabled=enabled,
+                display_name=display_name,
+                shop_id=shop_id,
+                secret_key=secret_key,
+                return_url=self._get_legacy_yookassa_return_url(),
+                sbp_enabled=bool(self.YOOKASSA_SBP_ENABLED),
+                recurrent_enabled=bool(self.YOOKASSA_RECURRENT_ENABLED),
+            )
+
+        enabled_value = self._get_yookassa_scope_value(normalized_scope, 'ENABLED')
+        if enabled_value is None:
+            enabled_value = self.YOOKASSA_ENABLED
+
+        display_name = self._get_yookassa_scope_value(normalized_scope, 'DISPLAY_NAME')
+        if display_name is None:
+            display_name = self.YOOKASSA_DISPLAY_NAME
+
+        scoped_shop_id = self._get_yookassa_scope_value(normalized_scope, 'SHOP_ID')
+        scoped_secret_key = self._get_yookassa_scope_value(normalized_scope, 'SECRET_KEY')
+        has_scoped_credentials = scoped_shop_id is not None or scoped_secret_key is not None
+        shop_id = scoped_shop_id if has_scoped_credentials else self.YOOKASSA_SHOP_ID
+        secret_key = scoped_secret_key if has_scoped_credentials else self.YOOKASSA_SECRET_KEY
+        return_url = self._get_yookassa_scope_value(normalized_scope, 'RETURN_URL') or self._get_legacy_yookassa_return_url()
+
+        sbp_enabled = self._get_yookassa_scope_value(normalized_scope, 'SBP_ENABLED')
+        if sbp_enabled is None:
+            sbp_enabled = self.YOOKASSA_SBP_ENABLED
+
+        recurrent_enabled = self._get_yookassa_scope_value(normalized_scope, 'RECURRENT_ENABLED')
+        if recurrent_enabled is None:
+            recurrent_enabled = self.YOOKASSA_RECURRENT_ENABLED
+
+        return YooKassaConfig(
+            scope=normalized_scope,
+            enabled=bool(enabled_value and shop_id is not None and secret_key is not None),
+            display_name=(display_name or '').strip() or 'YooKassa',
+            shop_id=shop_id,
+            secret_key=secret_key,
+            return_url=return_url,
+            sbp_enabled=bool(sbp_enabled),
+            recurrent_enabled=bool(recurrent_enabled),
+        )
+
+    def is_yookassa_enabled(self, scope: str | None = None) -> bool:
+        if scope is None:
+            return self.YOOKASSA_ENABLED and self.YOOKASSA_SHOP_ID is not None and self.YOOKASSA_SECRET_KEY is not None
+        return self.get_yookassa_config(scope).enabled
+
+    def get_yookassa_display_name(self, scope: str | None = None) -> str:
+        if scope is not None:
+            return self.get_yookassa_config(scope).display_name
         name = (self.YOOKASSA_DISPLAY_NAME or '').strip()
         return name or 'YooKassa'
+
+    def is_yookassa_sbp_enabled(self, scope: str | None = None) -> bool:
+        return self.get_yookassa_config(scope).sbp_enabled
+
+    def is_yookassa_recurrent_enabled(self, scope: str | None = None) -> bool:
+        return self.get_yookassa_config(scope).recurrent_enabled
 
     def is_nalogo_enabled(self) -> bool:
         return self.NALOGO_ENABLED and self.NALOGO_INN is not None and self.NALOGO_PASSWORD is not None
@@ -2080,12 +2189,10 @@ class Settings(BaseSettings):
     def is_support_topup_enabled(self) -> bool:
         return bool(self.SUPPORT_TOPUP_ENABLED)
 
-    def get_yookassa_return_url(self) -> str:
-        if self.YOOKASSA_RETURN_URL:
-            return self.YOOKASSA_RETURN_URL
-        if self.WEBHOOK_URL:
-            return f'{self.WEBHOOK_URL}/payment-success'
-        return 'https://t.me/'
+    def get_yookassa_return_url(self, scope: str | None = None) -> str:
+        if scope is not None:
+            return self.get_yookassa_config(scope).return_url
+        return self._get_legacy_yookassa_return_url()
 
     def is_cryptobot_enabled(self) -> bool:
         return self.CRYPTOBOT_ENABLED and self.CRYPTOBOT_API_TOKEN is not None

--- a/app/database/crud/saved_payment_method.py
+++ b/app/database/crud/saved_payment_method.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 
 import structlog
-from sqlalchemy import select, update
+from sqlalchemy import and_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,27 +22,36 @@ async def create_saved_payment_method(
     card_expiry_month: str | None = None,
     card_expiry_year: str | None = None,
     title: str | None = None,
+    yookassa_scope: str | None = None,
 ) -> SavedPaymentMethod | None:
     """Создаёт или реактивирует сохранённый метод оплаты."""
 
     # Проверяем, есть ли уже такой метод (включая деактивированные)
+    conditions = [
+        SavedPaymentMethod.yookassa_payment_method_id == yookassa_payment_method_id,
+        SavedPaymentMethod.user_id == user_id,
+    ]
+    if yookassa_scope is not None:
+        conditions.append(SavedPaymentMethod.yookassa_scope == yookassa_scope)
+
+    update_values = {
+        'is_active': True,
+        'method_type': method_type,
+        'card_first6': card_first6,
+        'card_last4': card_last4,
+        'card_type': card_type,
+        'card_expiry_month': card_expiry_month,
+        'card_expiry_year': card_expiry_year,
+        'title': title,
+        'updated_at': datetime.now(UTC),
+    }
+    if yookassa_scope is not None:
+        update_values['yookassa_scope'] = yookassa_scope
+
     result = await db.execute(
         update(SavedPaymentMethod)
-        .where(
-            SavedPaymentMethod.yookassa_payment_method_id == yookassa_payment_method_id,
-            SavedPaymentMethod.user_id == user_id,
-        )
-        .values(
-            is_active=True,
-            method_type=method_type,
-            card_first6=card_first6,
-            card_last4=card_last4,
-            card_type=card_type,
-            card_expiry_month=card_expiry_month,
-            card_expiry_year=card_expiry_year,
-            title=title,
-            updated_at=datetime.now(UTC),
-        )
+        .where(and_(*conditions))
+        .values(**update_values)
         .returning(SavedPaymentMethod)
     )
     reactivated = result.scalar_one_or_none()
@@ -52,6 +61,7 @@ async def create_saved_payment_method(
             'Реактивирован сохранённый метод оплаты',
             saved_method_id=reactivated.id,
             user_id=user_id,
+            yookassa_scope=yookassa_scope,
             method_type=method_type,
             card_last4=card_last4,
         )
@@ -59,6 +69,7 @@ async def create_saved_payment_method(
 
     method = SavedPaymentMethod(
         user_id=user_id,
+        yookassa_scope=yookassa_scope,
         yookassa_payment_method_id=yookassa_payment_method_id,
         method_type=method_type,
         card_first6=card_first6,
@@ -77,6 +88,7 @@ async def create_saved_payment_method(
         logger.error(
             'Ошибка создания сохранённого метода оплаты',
             yookassa_payment_method_id=yookassa_payment_method_id,
+            yookassa_scope=yookassa_scope,
             user_id=user_id,
             e=e,
         )
@@ -87,6 +99,7 @@ async def create_saved_payment_method(
         'Создан сохранённый метод оплаты',
         saved_method_id=method.id,
         user_id=user_id,
+        yookassa_scope=yookassa_scope,
         method_type=method_type,
         card_last4=card_last4,
     )
@@ -96,14 +109,19 @@ async def create_saved_payment_method(
 async def get_active_payment_methods_by_user(
     db: AsyncSession,
     user_id: int,
+    yookassa_scope: str | None = None,
 ) -> list[SavedPaymentMethod]:
     """Получить все активные сохранённые методы оплаты пользователя."""
+    conditions = [
+        SavedPaymentMethod.user_id == user_id,
+        SavedPaymentMethod.is_active == True,
+    ]
+    if yookassa_scope is not None:
+        conditions.append(SavedPaymentMethod.yookassa_scope == yookassa_scope)
+
     result = await db.execute(
         select(SavedPaymentMethod)
-        .where(
-            SavedPaymentMethod.user_id == user_id,
-            SavedPaymentMethod.is_active == True,
-        )
+        .where(and_(*conditions))
         .order_by(SavedPaymentMethod.created_at.desc())
     )
     return list(result.scalars().all())
@@ -112,16 +130,21 @@ async def get_active_payment_methods_by_user(
 async def get_user_ids_with_active_payment_methods(
     db: AsyncSession,
     user_ids: list[int],
+    yookassa_scope: str | None = None,
 ) -> set[int]:
     """Вернуть подмножество user_ids, у которых есть хотя бы один активный метод оплаты."""
     if not user_ids:
         return set()
+    conditions = [
+        SavedPaymentMethod.user_id.in_(user_ids),
+        SavedPaymentMethod.is_active == True,
+    ]
+    if yookassa_scope is not None:
+        conditions.append(SavedPaymentMethod.yookassa_scope == yookassa_scope)
+
     result = await db.execute(
         select(SavedPaymentMethod.user_id)
-        .where(
-            SavedPaymentMethod.user_id.in_(user_ids),
-            SavedPaymentMethod.is_active == True,
-        )
+        .where(and_(*conditions))
         .distinct()
     )
     return set(result.scalars().all())
@@ -131,11 +154,14 @@ async def get_payment_method_by_yookassa_id(
     db: AsyncSession,
     yookassa_payment_method_id: str,
     include_inactive: bool = False,
+    yookassa_scope: str | None = None,
 ) -> SavedPaymentMethod | None:
     """Найти сохранённый метод по YooKassa payment_method.id."""
     query = select(SavedPaymentMethod).where(
         SavedPaymentMethod.yookassa_payment_method_id == yookassa_payment_method_id,
     )
+    if yookassa_scope is not None:
+        query = query.where(SavedPaymentMethod.yookassa_scope == yookassa_scope)
     if not include_inactive:
         query = query.where(SavedPaymentMethod.is_active == True)
     result = await db.execute(query)

--- a/app/database/crud/yookassa.py
+++ b/app/database/crud/yookassa.py
@@ -25,18 +25,20 @@ async def create_yookassa_payment(
     payment_method_type: str | None = None,
     yookassa_created_at: datetime | None = None,
     test_mode: bool = False,
+    yookassa_scope: str | None = None,
 ) -> YooKassaPayment | None:
     # Идемпотентно по yookassa_payment_id. Рекуррентный автоплатёж использует
     # детерминированный ключ идемпотентности на (подписку, карту, день), поэтому
     # повторные запуски в тот же день получают от YooKassa ТОТ ЖЕ payment_id.
     # Повторная вставка била по unique-индексу и (ошибочно) логировалась как
     # «FK violation user_id», заваливая админ-чат. Если запись уже есть — вернём её.
-    existing = await get_yookassa_payment_by_id(db, yookassa_payment_id)
+    existing = await get_yookassa_payment_by_id(db, yookassa_payment_id, yookassa_scope=yookassa_scope)
     if existing is not None:
         return existing
 
     payment = YooKassaPayment(
         user_id=user_id,
+        yookassa_scope=yookassa_scope,
         yookassa_payment_id=yookassa_payment_id,
         amount_kopeks=amount_kopeks,
         currency=currency,
@@ -56,7 +58,7 @@ async def create_yookassa_payment(
         await db.rollback()
         # Проиграли гонку вставки по тому же yookassa_payment_id — это успех
         # (идемпотентность): вернём запись, которую успел создать конкурент.
-        existing = await get_yookassa_payment_by_id(db, yookassa_payment_id)
+        existing = await get_yookassa_payment_by_id(db, yookassa_payment_id, yookassa_scope=yookassa_scope)
         if existing is not None:
             return existing
         # Иначе это настоящая проблема целостности (например, FK по user_id) —
@@ -64,6 +66,7 @@ async def create_yookassa_payment(
         logger.error(
             'IntegrityError при создании платежа YooKassa (не дубликат payment_id)',
             yookassa_payment_id=yookassa_payment_id,
+            yookassa_scope=yookassa_scope,
             user_id=user_id,
             error=str(e),
         )
@@ -73,17 +76,24 @@ async def create_yookassa_payment(
     logger.info(
         'Создан платеж YooKassa',
         yookassa_payment_id=yookassa_payment_id,
+        yookassa_scope=yookassa_scope,
         amount_rubles=amount_kopeks / 100,
         user_id=user_id,
     )
     return payment
 
 
-async def get_yookassa_payment_by_id(db: AsyncSession, yookassa_payment_id: str) -> YooKassaPayment | None:
+async def get_yookassa_payment_by_id(
+    db: AsyncSession,
+    yookassa_payment_id: str,
+    yookassa_scope: str | None = None,
+) -> YooKassaPayment | None:
+    conditions = [YooKassaPayment.yookassa_payment_id == yookassa_payment_id]
+    if yookassa_scope is not None:
+        conditions.append(YooKassaPayment.yookassa_scope == yookassa_scope)
+
     result = await db.execute(
-        select(YooKassaPayment)
-        .options(selectinload(YooKassaPayment.user))
-        .where(YooKassaPayment.yookassa_payment_id == yookassa_payment_id)
+        select(YooKassaPayment).options(selectinload(YooKassaPayment.user)).where(and_(*conditions))
     )
     return result.scalar_one_or_none()
 
@@ -163,12 +173,20 @@ async def link_yookassa_payment_to_transaction(
 
 
 async def get_user_yookassa_payments(
-    db: AsyncSession, user_id: int, limit: int = 50, offset: int = 0
+    db: AsyncSession,
+    user_id: int,
+    limit: int = 50,
+    offset: int = 0,
+    yookassa_scope: str | None = None,
 ) -> list[YooKassaPayment]:
+    conditions = [YooKassaPayment.user_id == user_id]
+    if yookassa_scope is not None:
+        conditions.append(YooKassaPayment.yookassa_scope == yookassa_scope)
+
     result = await db.execute(
         select(YooKassaPayment)
         .options(selectinload(YooKassaPayment.transaction))
-        .where(YooKassaPayment.user_id == user_id)
+        .where(and_(*conditions))
         .order_by(YooKassaPayment.created_at.desc())
         .limit(limit)
         .offset(offset)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -206,9 +206,11 @@ class WheelSpinPaymentType(Enum):
 
 class YooKassaPayment(Base):
     __tablename__ = 'yookassa_payments'
+    __table_args__ = (Index('ix_yookassa_payments_scope_payment_id', 'yookassa_scope', 'yookassa_payment_id'),)
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=True)
+    yookassa_scope = Column(String(32), nullable=True)
     yookassa_payment_id = Column(String(255), unique=True, nullable=False, index=True)
     amount_kopeks = Column(Integer, nullable=False)
     currency = Column(String(3), default='RUB', nullable=False)
@@ -255,10 +257,14 @@ class YooKassaPayment(Base):
 
 class SavedPaymentMethod(Base):
     __tablename__ = 'saved_payment_methods'
-    __table_args__ = (Index('ix_saved_payment_methods_user_active', 'user_id', 'is_active'),)
+    __table_args__ = (
+        Index('ix_saved_payment_methods_user_active', 'user_id', 'is_active'),
+        Index('ix_saved_payment_methods_user_scope_active', 'user_id', 'yookassa_scope', 'is_active'),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
+    yookassa_scope = Column(String(32), nullable=True)
 
     # YooKassa payment_method.id — ключ для рекуррентных списаний
     yookassa_payment_method_id = Column(String(255), unique=True, nullable=False, index=True)

--- a/app/external/yookassa_webhook.py
+++ b/app/external/yookassa_webhook.py
@@ -71,6 +71,24 @@ YOOKASSA_ALLOWED_EVENTS: tuple[str, ...] = (
     'payment.waiting_for_capture',
     'payment.canceled',
 )
+YOOKASSA_WEBHOOK_SCOPES: tuple[str, ...] = ('bot', 'cabinet')
+
+
+def _is_yookassa_webhook_enabled() -> bool:
+    return (
+        settings.is_yookassa_enabled()
+        or settings.is_yookassa_enabled('bot')
+        or settings.is_yookassa_enabled('cabinet')
+    )
+
+
+def _scope_from_webhook_path(path: str) -> str | None:
+    base_path = settings.YOOKASSA_WEBHOOK_PATH.rstrip('/')
+    request_path = path.rstrip('/')
+    for scope in YOOKASSA_WEBHOOK_SCOPES:
+        if request_path == f'{base_path}/{scope}':
+            return scope
+    return None
 
 
 def collect_yookassa_ip_candidates(*values: str | None) -> list[str]:
@@ -206,6 +224,7 @@ class YooKassaWebhookHandler:
 
     async def handle_webhook(self, request: web.Request) -> web.Response:
         try:
+            yookassa_scope = request.match_info.get('yookassa_scope') or _scope_from_webhook_path(request.path)
             logger.info('📥 Получен YooKassa webhook', method=request.method, path=request.path)
 
             header_ip_candidates = collect_yookassa_ip_candidates(
@@ -290,7 +309,15 @@ class YooKassaWebhookHandler:
                         )
                         return web.Response(status=200, text='OK')
 
-                    success = await self.payment_service.process_yookassa_webhook(db, webhook_data)
+                    callback_kwargs = {}
+                    if yookassa_scope is not None:
+                        callback_kwargs['yookassa_scope'] = yookassa_scope
+
+                    success = await self.payment_service.process_yookassa_webhook(
+                        db,
+                        webhook_data,
+                        **callback_kwargs,
+                    )
 
                     if success:
                         await db.commit()
@@ -322,6 +349,11 @@ class YooKassaWebhookHandler:
         app.router.add_post(webhook_path, self.handle_webhook)
         app.router.add_get(webhook_path, self._get_handler)
         app.router.add_options(webhook_path, self._options_handler)
+        for scope in YOOKASSA_WEBHOOK_SCOPES:
+            scoped_path = f'{webhook_path}/{scope}'
+            app.router.add_post(scoped_path, self.handle_webhook)
+            app.router.add_get(scoped_path, self._get_handler)
+            app.router.add_options(scoped_path, self._options_handler)
 
         logger.info('✅ Настроен YooKassa webhook (POST)', webhook_path=webhook_path)
 
@@ -332,6 +364,7 @@ class YooKassaWebhookHandler:
                 'message': 'YooKassa webhook endpoint is working',
                 'method': 'GET',
                 'path': request.path,
+                'scope': request.match_info.get('yookassa_scope') or _scope_from_webhook_path(request.path),
                 'note': 'Use POST method for actual webhooks',
             }
         )
@@ -360,7 +393,7 @@ def create_yookassa_webhook_app(payment_service: PaymentService) -> web.Applicat
                 'service': 'yookassa_webhook',
                 'port': settings.YOOKASSA_WEBHOOK_PORT,
                 'path': settings.YOOKASSA_WEBHOOK_PATH,
-                'enabled': settings.is_yookassa_enabled(),
+                'enabled': _is_yookassa_webhook_enabled(),
             }
         )
 
@@ -370,7 +403,7 @@ def create_yookassa_webhook_app(payment_service: PaymentService) -> web.Applicat
 
 
 async def start_yookassa_webhook_server(payment_service: PaymentService) -> None:
-    if not settings.is_yookassa_enabled():
+    if not _is_yookassa_webhook_enabled():
         logger.info('ℹ️ YooKassa отключена, webhook сервер не запускается')
         return
 

--- a/app/handlers/balance/yookassa.py
+++ b/app/handlers/balance/yookassa.py
@@ -40,7 +40,7 @@ async def start_yookassa_payment(callback: types.CallbackQuery, db_user: User, s
         await callback.answer()
         return
 
-    if not settings.is_yookassa_enabled():
+    if not settings.is_yookassa_enabled('bot'):
         await callback.answer('❌ Оплата картой через YooKassa временно недоступна', show_alert=True)
         return
 
@@ -86,7 +86,7 @@ async def start_yookassa_sbp_payment(callback: types.CallbackQuery, db_user: Use
         await callback.answer()
         return
 
-    if not settings.is_yookassa_enabled() or not settings.YOOKASSA_SBP_ENABLED:
+    if not settings.is_yookassa_enabled('bot') or not settings.is_yookassa_sbp_enabled('bot'):
         await callback.answer('❌ Оплата через СБП временно недоступна', show_alert=True)
         return
 
@@ -137,7 +137,7 @@ async def process_yookassa_payment_amount(
 
     texts = get_texts(db_user.language)
 
-    if not settings.is_yookassa_enabled():
+    if not settings.is_yookassa_enabled('bot'):
         await message.answer('❌ Оплата через YooKassa временно недоступна')
         return
 
@@ -172,6 +172,7 @@ async def process_yookassa_payment_amount(
                 'user_username': db_user.username or '',
                 'purpose': 'balance_topup',
             },
+            yookassa_scope='bot',
         )
 
         if not payment_result:
@@ -292,7 +293,7 @@ async def process_yookassa_sbp_payment_amount(
 
     texts = get_texts(db_user.language)
 
-    if not settings.is_yookassa_enabled() or not settings.YOOKASSA_SBP_ENABLED:
+    if not settings.is_yookassa_enabled('bot') or not settings.is_yookassa_sbp_enabled('bot'):
         await message.answer('❌ Оплата через СБП временно недоступна')
         return
 
@@ -327,6 +328,7 @@ async def process_yookassa_sbp_payment_amount(
                 'user_username': db_user.username or '',
                 'purpose': 'balance_topup_sbp',
             },
+            yookassa_scope='bot',
         )
 
         if not payment_result:

--- a/app/handlers/simple_subscription.py
+++ b/app/handlers/simple_subscription.py
@@ -273,9 +273,9 @@ def _get_simple_subscription_payment_keyboard(language: str) -> types.InlineKeyb
             [types.InlineKeyboardButton(text='⭐ Telegram Stars', callback_data='simple_subscription_stars')]
         )
 
-    if settings.is_yookassa_enabled():
+    if settings.is_yookassa_enabled('bot'):
         yookassa_methods = []
-        if settings.YOOKASSA_SBP_ENABLED:
+        if settings.is_yookassa_sbp_enabled('bot'):
             yookassa_methods.append(
                 types.InlineKeyboardButton(text='🏦 YooKassa (СБП)', callback_data='simple_subscription_yookassa_sbp')
             )
@@ -918,11 +918,11 @@ async def handle_simple_subscription_payment_method(
 
         elif payment_method in ['yookassa', 'yookassa_sbp']:
             # Оплата через YooKassa
-            if not settings.is_yookassa_enabled():
+            if not settings.is_yookassa_enabled('bot'):
                 await callback.answer('❌ Оплата через YooKassa временно недоступна', show_alert=True)
                 return
 
-            if payment_method == 'yookassa_sbp' and not settings.YOOKASSA_SBP_ENABLED:
+            if payment_method == 'yookassa_sbp' and not settings.is_yookassa_sbp_enabled('bot'):
                 await callback.answer('❌ Оплата через СБП временно недоступна', show_alert=True)
                 return
 
@@ -959,6 +959,7 @@ async def handle_simple_subscription_payment_method(
                         'subscription_period': str(subscription_params['period_days']),
                         'payment_purpose': 'simple_subscription_purchase',
                     },
+                    yookassa_scope='bot',
                 )
             else:
                 payment_result = await payment_service.create_yookassa_payment(
@@ -976,6 +977,7 @@ async def handle_simple_subscription_payment_method(
                         'subscription_period': str(subscription_params['period_days']),
                         'payment_purpose': 'simple_subscription_purchase',
                     },
+                    yookassa_scope='bot',
                 )
 
             if not payment_result:

--- a/app/handlers/subscription/purchase.py
+++ b/app/handlers/subscription/purchase.py
@@ -732,9 +732,9 @@ def _get_trial_payment_keyboard(language: str, can_pay_from_balance: bool = Fals
     if settings.TELEGRAM_STARS_ENABLED:
         keyboard.append([types.InlineKeyboardButton(text='⭐ Telegram Stars', callback_data='trial_payment_stars')])
 
-    if settings.is_yookassa_enabled():
+    if settings.is_yookassa_enabled('bot'):
         yookassa_methods = []
-        if settings.YOOKASSA_SBP_ENABLED:
+        if settings.is_yookassa_sbp_enabled('bot'):
             yookassa_methods.append(
                 types.InlineKeyboardButton(text='🏦 YooKassa (СБП)', callback_data='trial_payment_yookassa_sbp')
             )
@@ -3747,6 +3747,7 @@ async def handle_trial_payment_method(callback: types.CallbackQuery, db_user: Us
                     'subscription_id': pending_subscription.id,
                     'user_id': db_user.id,
                 },
+                yookassa_scope='bot',
             )
 
             if not payment_result or not payment_result.get('confirmation_url'):
@@ -3785,6 +3786,7 @@ async def handle_trial_payment_method(callback: types.CallbackQuery, db_user: Us
                     'subscription_id': pending_subscription.id,
                     'user_id': db_user.id,
                 },
+                yookassa_scope='bot',
             )
 
             if not payment_result or not payment_result.get('confirmation_url'):

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -1551,7 +1551,7 @@ def get_balance_keyboard(language: str = DEFAULT_LANGUAGE) -> InlineKeyboardMark
             InlineKeyboardButton(text=texts.BALANCE_TOP_UP, callback_data='balance_topup'),
         ],
     ]
-    if settings.YOOKASSA_RECURRENT_ENABLED:
+    if settings.is_yookassa_recurrent_enabled('bot'):
         keyboard.append(
             [
                 InlineKeyboardButton(
@@ -1587,8 +1587,8 @@ def get_payment_methods_keyboard(amount_kopeks: int, language: str = DEFAULT_LAN
         )
         has_direct_payment_methods = True
 
-    if settings.is_yookassa_enabled():
-        if settings.YOOKASSA_SBP_ENABLED:
+    if settings.is_yookassa_enabled('bot'):
+        if settings.is_yookassa_sbp_enabled('bot'):
             keyboard.append(
                 [
                     InlineKeyboardButton(

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -566,12 +566,22 @@ class MonitoringService:
 
                 # Batch-запрос: собираем user_id с autopay и проверяем наличие карт одним запросом
                 users_with_cards: set[int] = set()
-                if settings.ENABLE_AUTOPAY and settings.YOOKASSA_RECURRENT_ENABLED:
+                if settings.ENABLE_AUTOPAY and settings.is_yookassa_recurrent_enabled('bot'):
                     autopay_user_ids = [s.user_id for s in expiring_subscriptions if s.autopay_enabled]
                     if autopay_user_ids:
                         from app.database.crud.saved_payment_method import get_user_ids_with_active_payment_methods
 
-                        users_with_cards = await get_user_ids_with_active_payment_methods(db, autopay_user_ids)
+                        users_with_cards = await get_user_ids_with_active_payment_methods(
+                            db,
+                            autopay_user_ids,
+                            yookassa_scope='bot',
+                        )
+                        if (
+                            not users_with_cards
+                            and settings.YOOKASSA_BOT_SHOP_ID is None
+                            and settings.YOOKASSA_BOT_SECRET_KEY is None
+                        ):
+                            users_with_cards = await get_user_ids_with_active_payment_methods(db, autopay_user_ids)
 
                 from app.utils.notification_prefs import (
                     get_subscription_expiry_days,

--- a/app/services/nalogo_queue_service.py
+++ b/app/services/nalogo_queue_service.py
@@ -166,7 +166,13 @@ class NalogoQueueService:
                 )
                 # Удаляем метку "в очереди" — чек больше не будет обрабатываться
                 if payment_id and payment_id != 'unknown':
-                    queued_key = f'nalogo:queued:{payment_id}'
+                    queued_key = NaloGoService.build_receipt_cache_key(
+                        'queued',
+                        payment_id,
+                        payment_provider=receipt_data.get('payment_provider'),
+                        payment_scope=receipt_data.get('payment_scope'),
+                        external_payment_id=receipt_data.get('external_payment_id'),
+                    )
                     await cache.delete(queued_key)
                 failed += 1
                 continue
@@ -212,6 +218,9 @@ class NalogoQueueService:
                     telegram_user_id=telegram_user_id,
                     amount_kopeks=amount_kopeks,
                     operation_time=operation_time,  # Время оплаты, а не отправки
+                    payment_provider=receipt_data.get('payment_provider'),
+                    payment_scope=receipt_data.get('payment_scope'),
+                    external_payment_id=receipt_data.get('external_payment_id'),
                 )
 
                 if receipt_uuid:
@@ -220,7 +229,13 @@ class NalogoQueueService:
 
                     # Удаляем метку "в очереди" (чек создан успешно)
                     if payment_id:
-                        queued_key = f'nalogo:queued:{payment_id}'
+                        queued_key = NaloGoService.build_receipt_cache_key(
+                            'queued',
+                            payment_id,
+                            payment_provider=receipt_data.get('payment_provider'),
+                            payment_scope=receipt_data.get('payment_scope'),
+                            external_payment_id=receipt_data.get('external_payment_id'),
+                        )
                         await cache.delete(queued_key)
 
                     logger.info(

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -64,6 +64,19 @@ class NaloGoService:
                 self.configured = False
 
     @staticmethod
+    def build_receipt_cache_key(
+        kind: str,
+        payment_id: str,
+        payment_provider: str | None = None,
+        payment_scope: str | None = None,
+        external_payment_id: str | None = None,
+    ) -> str:
+        scoped_payment_id = external_payment_id or payment_id
+        if payment_provider and payment_scope and scoped_payment_id:
+            return f'nalogo:{kind}:{payment_provider}:{payment_scope}:{scoped_payment_id}'
+        return f'nalogo:{kind}:{payment_id}'
+
+    @staticmethod
     def _is_service_unavailable(error: Exception) -> bool:
         """Проверяет, является ли ошибка временной недоступностью сервиса."""
         error_str = str(error).lower()
@@ -95,11 +108,20 @@ class NaloGoService:
         payment_id: str | None = None,
         telegram_user_id: int | None = None,
         amount_kopeks: int | None = None,
+        payment_provider: str | None = None,
+        payment_scope: str | None = None,
+        external_payment_id: str | None = None,
     ) -> bool:
         """Добавить чек в очередь для отложенной отправки."""
         if payment_id:
             # Защита от дубликатов: проверяем не был ли чек уже создан
-            created_key = f'nalogo:created:{payment_id}'
+            created_key = self.build_receipt_cache_key(
+                'created',
+                payment_id,
+                payment_provider=payment_provider,
+                payment_scope=payment_scope,
+                external_payment_id=external_payment_id,
+            )
             already_created = await cache.get(created_key)
             if already_created:
                 logger.info(
@@ -110,7 +132,13 @@ class NaloGoService:
                 return False
 
             # Атомарная проверка и установка флага "в очереди" (защита от race condition)
-            queued_key = f'nalogo:queued:{payment_id}'
+            queued_key = self.build_receipt_cache_key(
+                'queued',
+                payment_id,
+                payment_provider=payment_provider,
+                payment_scope=payment_scope,
+                external_payment_id=external_payment_id,
+            )
             lock_acquired = await cache.setnx(queued_key, 'queued', expire=7 * 24 * 3600)
             if not lock_acquired:
                 # Ключ уже существует — чек уже в очереди
@@ -123,6 +151,9 @@ class NaloGoService:
             'quantity': quantity,
             'client_info': client_info,
             'payment_id': payment_id,
+            'payment_provider': payment_provider,
+            'payment_scope': payment_scope,
+            'external_payment_id': external_payment_id,
             'telegram_user_id': telegram_user_id,
             'amount_kopeks': amount_kopeks,
             'created_at': datetime.now(UTC).isoformat(),
@@ -139,7 +170,13 @@ class NaloGoService:
             )
         # Если не удалось добавить в очередь — удаляем флаг
         elif payment_id:
-            queued_key = f'nalogo:queued:{payment_id}'
+            queued_key = self.build_receipt_cache_key(
+                'queued',
+                payment_id,
+                payment_provider=payment_provider,
+                payment_scope=payment_scope,
+                external_payment_id=external_payment_id,
+            )
             await cache.delete(queued_key)
         return success
 
@@ -153,6 +190,9 @@ class NaloGoService:
         telegram_user_id: int | None,
         amount_kopeks: int | None,
         error_message: str,
+        payment_provider: str | None = None,
+        payment_scope: str | None = None,
+        external_payment_id: str | None = None,
     ) -> bool:
         """Сохранить чек в очередь ожидающих проверки.
 
@@ -165,6 +205,9 @@ class NaloGoService:
             'quantity': quantity,
             'client_info': client_info,
             'payment_id': payment_id,
+            'payment_provider': payment_provider,
+            'payment_scope': payment_scope,
+            'external_payment_id': external_payment_id,
             'telegram_user_id': telegram_user_id,
             'amount_kopeks': amount_kopeks,
             'created_at': datetime.now(UTC).isoformat(),
@@ -215,7 +258,13 @@ class NaloGoService:
                 removed_receipt = receipt
                 if was_created and receipt_uuid:
                     # Сохраняем что чек создан
-                    created_key = f'nalogo:created:{payment_id}'
+                    created_key = self.build_receipt_cache_key(
+                        'created',
+                        payment_id,
+                        payment_provider=receipt.get('payment_provider'),
+                        payment_scope=receipt.get('payment_scope'),
+                        external_payment_id=receipt.get('external_payment_id'),
+                    )
                     await cache.set(created_key, receipt_uuid, expire=30 * 24 * 3600)
                     logger.info('Чек помечен как созданный', payment_id=payment_id, receipt_uuid=receipt_uuid)
             else:
@@ -260,6 +309,9 @@ class NaloGoService:
             queue_on_failure=False,  # Не добавлять обратно в очередь
             telegram_user_id=target_receipt.get('telegram_user_id'),
             amount_kopeks=target_receipt.get('amount_kopeks'),
+            payment_provider=target_receipt.get('payment_provider'),
+            payment_scope=target_receipt.get('payment_scope'),
+            external_payment_id=target_receipt.get('external_payment_id'),
         )
 
         if receipt_uuid:
@@ -305,6 +357,9 @@ class NaloGoService:
         telegram_user_id: int | None = None,
         amount_kopeks: int | None = None,
         operation_time: datetime | None = None,
+        payment_provider: str | None = None,
+        payment_scope: str | None = None,
+        external_payment_id: str | None = None,
     ) -> str | None:
         """Создание чека о доходе.
 
@@ -318,6 +373,9 @@ class NaloGoService:
             telegram_user_id: Telegram ID пользователя для формирования описания
             amount_kopeks: Сумма в копейках для формирования описания
             operation_time: Время операции (по умолчанию текущее)
+            payment_provider: Провайдер платежа для scoped dedup ключей
+            payment_scope: Scope/surface платежа для scoped dedup ключей
+            external_payment_id: ID платежа у провайдера, если отличается от payment_id
 
         Returns:
             UUID чека или None при ошибке
@@ -328,7 +386,13 @@ class NaloGoService:
 
         # Защита от дублей: проверяем не был ли уже создан чек для этого payment_id
         if payment_id:
-            created_key = f'nalogo:created:{payment_id}'
+            created_key = self.build_receipt_cache_key(
+                'created',
+                payment_id,
+                payment_provider=payment_provider,
+                payment_scope=payment_scope,
+                external_payment_id=external_payment_id,
+            )
             already_created = await cache.get(created_key)
             if already_created:
                 logger.info(
@@ -347,7 +411,16 @@ class NaloGoService:
                     # Аутентификация не прошла — чек не создавался, безопасно в очередь
                     if queue_on_failure:
                         await self._queue_receipt(
-                            name, amount, quantity, client_info, payment_id, telegram_user_id, amount_kopeks
+                            name,
+                            amount,
+                            quantity,
+                            client_info,
+                            payment_id,
+                            telegram_user_id,
+                            amount_kopeks,
+                            payment_provider=payment_provider,
+                            payment_scope=payment_scope,
+                            external_payment_id=external_payment_id,
                         )
                     return None
         except Exception as auth_error:
@@ -360,7 +433,16 @@ class NaloGoService:
                 )
                 if queue_on_failure:
                     await self._queue_receipt(
-                        name, amount, quantity, client_info, payment_id, telegram_user_id, amount_kopeks
+                        name,
+                        amount,
+                        quantity,
+                        client_info,
+                        payment_id,
+                        telegram_user_id,
+                        amount_kopeks,
+                        payment_provider=payment_provider,
+                        payment_scope=payment_scope,
+                        external_payment_id=external_payment_id,
                     )
             else:
                 logger.error('Ошибка аутентификации NaloGO', auth_error=sanitize_proxy_error(auth_error))
@@ -397,7 +479,13 @@ class NaloGoService:
 
                 # Сохраняем в Redis чтобы предотвратить дубли (TTL 30 дней)
                 if payment_id:
-                    created_key = f'nalogo:created:{payment_id}'
+                    created_key = self.build_receipt_cache_key(
+                        'created',
+                        payment_id,
+                        payment_provider=payment_provider,
+                        payment_scope=payment_scope,
+                        external_payment_id=external_payment_id,
+                    )
                     await cache.set(created_key, receipt_uuid, expire=30 * 24 * 3600)
 
                 return receipt_uuid
@@ -424,6 +512,9 @@ class NaloGoService:
                     telegram_user_id=telegram_user_id,
                     amount_kopeks=amount_kopeks,
                     error_message=error_msg,
+                    payment_provider=payment_provider,
+                    payment_scope=payment_scope,
+                    external_payment_id=external_payment_id,
                 )
             else:
                 logger.error('Ошибка создания чека в NaloGO', error=sanitize_proxy_error(error))

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -29,6 +29,29 @@ _INT32_MAX = 2_147_483_647
 class YooKassaPaymentMixin:
     """Mixin с операциями по созданию и подтверждению платежей YooKassa."""
 
+    def _get_yookassa_service_for_scope(self, yookassa_scope: str | None):
+        existing_service = getattr(self, 'yookassa_service', None)
+        if yookassa_scope is None:
+            if existing_service is not None:
+                return existing_service
+            if not settings.is_yookassa_enabled():
+                return None
+            from app.services.yookassa_service import YooKassaService
+
+            return YooKassaService()
+        if existing_service is not None and getattr(existing_service, 'scope', yookassa_scope) == yookassa_scope:
+            return existing_service
+        if not settings.is_yookassa_enabled(yookassa_scope):
+            return None
+        from app.services.yookassa_service import YooKassaService
+
+        return YooKassaService(scope=yookassa_scope)
+
+    @staticmethod
+    def _scope_from_yookassa_metadata(metadata: dict[str, Any]) -> str | None:
+        scope = metadata.get('yookassa_scope') or metadata.get('payment_scope')
+        return scope if scope in {'bot', 'cabinet'} else None
+
     @staticmethod
     def _format_amount_value(value: Any) -> str:
         """Форматирует сумму для хранения в webhook-объекте."""
@@ -99,9 +122,11 @@ class YooKassaPaymentMixin:
         receipt_phone: str | None = None,
         metadata: dict[str, Any] | None = None,
         return_url: str | None = None,
+        yookassa_scope: str | None = None,
     ) -> dict[str, Any] | None:
         """Создаёт обычный платёж в YooKassa и сохраняет локальную запись."""
-        if not getattr(self, 'yookassa_service', None):
+        yookassa_service = self._get_yookassa_service_for_scope(yookassa_scope)
+        if not yookassa_service:
             logger.error('YooKassa сервис не инициализирован')
             return None
 
@@ -133,8 +158,10 @@ class YooKassaPaymentMixin:
                     'type': existing_type or 'balance_topup',
                 }
             )
+            if yookassa_scope:
+                payment_metadata['yookassa_scope'] = yookassa_scope
 
-            yookassa_response = await self.yookassa_service.create_payment(
+            yookassa_response = await yookassa_service.create_payment(
                 amount=amount_rubles,
                 currency='RUB',
                 description=description,
@@ -170,6 +197,7 @@ class YooKassaPaymentMixin:
                 payment_method_type=None,
                 yookassa_created_at=yookassa_created_at,
                 test_mode=yookassa_response.get('test_mode', False),
+                yookassa_scope=yookassa_scope,
             )
 
             logger.info(
@@ -203,9 +231,11 @@ class YooKassaPaymentMixin:
         receipt_phone: str | None = None,
         metadata: dict[str, Any] | None = None,
         return_url: str | None = None,
+        yookassa_scope: str | None = None,
     ) -> dict[str, Any] | None:
         """Создаёт платёж по СБП через YooKassa."""
-        if not getattr(self, 'yookassa_service', None):
+        yookassa_service = self._get_yookassa_service_for_scope(yookassa_scope)
+        if not yookassa_service:
             logger.error('YooKassa сервис не инициализирован')
             return None
 
@@ -237,8 +267,10 @@ class YooKassaPaymentMixin:
                     'type': existing_type or 'balance_topup_sbp',
                 }
             )
+            if yookassa_scope:
+                payment_metadata['yookassa_scope'] = yookassa_scope
 
-            yookassa_response = await self.yookassa_service.create_sbp_payment(
+            yookassa_response = await yookassa_service.create_sbp_payment(
                 amount=amount_rubles,
                 currency='RUB',
                 description=description,
@@ -265,6 +297,7 @@ class YooKassaPaymentMixin:
                 payment_method_type='sbp',
                 yookassa_created_at=None,
                 test_mode=yookassa_response.get('test_mode', False),
+                yookassa_scope=yookassa_scope,
             )
 
             logger.info(
@@ -305,13 +338,13 @@ class YooKassaPaymentMixin:
         if not payment:
             return None
 
+        yookassa_scope = getattr(payment, 'yookassa_scope', None)
+        yookassa_service = self._get_yookassa_service_for_scope(yookassa_scope)
         remote_data: dict[str, Any] | None = None
 
-        if getattr(self, 'yookassa_service', None):
+        if yookassa_service:
             try:
-                remote_data = await self.yookassa_service.get_payment_info(  # type: ignore[union-attr]
-                    payment.yookassa_payment_id
-                )
+                remote_data = await yookassa_service.get_payment_info(payment.yookassa_payment_id)
             except Exception as error:  # pragma: no cover - defensive logging
                 logger.error(
                     'Ошибка получения статуса YooKassa', yookassa_payment_id=payment.yookassa_payment_id, error=error
@@ -1232,7 +1265,13 @@ class YooKassaPaymentMixin:
 
             # Проверяем, не сохранён ли уже (включая деактивированные —
             # если пользователь удалил карту, не реактивируем её)
-            existing = await get_payment_method_by_yookassa_id(db, pm_id, include_inactive=True)
+            yookassa_scope = getattr(payment, 'yookassa_scope', None)
+            existing = await get_payment_method_by_yookassa_id(
+                db,
+                pm_id,
+                include_inactive=True,
+                yookassa_scope=yookassa_scope,
+            )
             if existing:
                 logger.debug(
                     'Метод оплаты уже сохранён',
@@ -1277,6 +1316,7 @@ class YooKassaPaymentMixin:
                 card_expiry_month=expiry_month,
                 card_expiry_year=expiry_year,
                 title=title,
+                yookassa_scope=yookassa_scope,
             )
 
             if saved:
@@ -1329,6 +1369,9 @@ class YooKassaPaymentMixin:
                 amount=amount_rubles,
                 quantity=1,
                 payment_id=payment.yookassa_payment_id,
+                payment_provider='yookassa',
+                payment_scope=getattr(payment, 'yookassa_scope', None),
+                external_payment_id=payment.yookassa_payment_id,
                 telegram_user_id=telegram_user_id,
                 amount_kopeks=payment.amount_kopeks,
             )
@@ -1337,6 +1380,7 @@ class YooKassaPaymentMixin:
                 logger.info(
                     'Чек NaloGO создан для платежа',
                     yookassa_payment_id=payment.yookassa_payment_id,
+                    yookassa_scope=getattr(payment, 'yookassa_scope', None),
                     receipt_uuid=receipt_uuid,
                 )
 
@@ -1365,6 +1409,7 @@ class YooKassaPaymentMixin:
         self,
         db: AsyncSession,
         event: dict[str, Any],
+        yookassa_scope: str | None = None,
     ) -> bool:
         """Обрабатывает входящий webhook YooKassa и синхронизирует состояние платежа."""
         event_object = event.get('object', {})
@@ -1375,6 +1420,23 @@ class YooKassaPaymentMixin:
             # передавать его как kwarg — иначе TypeError. Берём другое имя.
             logger.warning('Webhook без payment id', webhook_event=event)
             return False
+
+        payment_module = import_module('app.services.payment_service')
+
+        if yookassa_scope is not None:
+            payment = await payment_module.get_yookassa_payment_by_id(
+                db,
+                yookassa_payment_id,
+                yookassa_scope=yookassa_scope,
+            )
+        else:
+            payment = await payment_module.get_yookassa_payment_by_id(db, yookassa_payment_id)
+        metadata_scope = self._scope_from_yookassa_metadata(
+            self._normalise_yookassa_metadata(event_object.get('metadata'))
+        )
+        resolved_scope = yookassa_scope or getattr(payment, 'yookassa_scope', None) or metadata_scope
+        if payment and resolved_scope and not getattr(payment, 'yookassa_scope', None):
+            payment.yookassa_scope = resolved_scope
 
         # The remote API call is a defence-in-depth cross-check of the
         # webhook payload — the payload itself already carries ``status``
@@ -1391,12 +1453,11 @@ class YooKassaPaymentMixin:
         # safe because the SDK monkey-patch in yookassa_service.py
         # guarantees the thread itself unblocks within ~15s socket-read.
         remote_data: dict[str, Any] | None = None
-        if getattr(self, 'yookassa_service', None):
+        yookassa_service = self._get_yookassa_service_for_scope(resolved_scope)
+        if yookassa_service:
             try:
                 remote_data = await asyncio.wait_for(
-                    self.yookassa_service.get_payment_info(  # type: ignore[union-attr]
-                        yookassa_payment_id
-                    ),
+                    yookassa_service.get_payment_info(yookassa_payment_id),
                     timeout=8,
                 )
             except TimeoutError:
@@ -1425,12 +1486,9 @@ class YooKassaPaymentMixin:
                 )
             event['object'] = event_object
 
-        payment_module = import_module('app.services.payment_service')
-
-        payment = await payment_module.get_yookassa_payment_by_id(db, yookassa_payment_id)
         if not payment:
             logger.warning('Локальный платеж для YooKassa id не найден', yookassa_payment_id=yookassa_payment_id)
-            payment = await self._restore_missing_yookassa_payment(db, event_object)
+            payment = await self._restore_missing_yookassa_payment(db, event_object, yookassa_scope=resolved_scope)
 
             if not payment:
                 logger.error(
@@ -1473,6 +1531,7 @@ class YooKassaPaymentMixin:
         self,
         db: AsyncSession,
         event_object: dict[str, Any],
+        yookassa_scope: str | None = None,
     ) -> YooKassaPayment | None:
         """Создает локальную запись платежа на основе данных webhook, если она отсутствует."""
 
@@ -1631,6 +1690,7 @@ class YooKassaPaymentMixin:
             payment_method_type=payment_method_type,
             yookassa_created_at=yookassa_created_at,
             test_mode=bool(event_object.get('test') or event_object.get('test_mode')),
+            yookassa_scope=yookassa_scope or self._scope_from_yookassa_metadata(metadata),
         )
 
         if not local_payment:

--- a/app/services/payment_method_config_service.py
+++ b/app/services/payment_method_config_service.py
@@ -48,8 +48,8 @@ def _get_method_defaults() -> dict:
             'available_sub_options': None,
         },
         'yookassa': {
-            'default_display_name': settings.get_yookassa_display_name(),
-            'is_configured': settings.is_yookassa_enabled(),
+            'default_display_name': settings.get_yookassa_display_name('cabinet'),
+            'is_configured': settings.is_yookassa_enabled('cabinet'),
             'default_min': settings.YOOKASSA_MIN_AMOUNT_KOPEKS,
             'default_max': settings.YOOKASSA_MAX_AMOUNT_KOPEKS,
             'available_sub_options': [

--- a/app/services/recurrent_payment_service.py
+++ b/app/services/recurrent_payment_service.py
@@ -27,6 +27,7 @@ from app.database.models import (
 
 
 logger = structlog.get_logger(__name__)
+YOOKASSA_RECURRENT_SCOPE = 'bot'
 
 
 @dataclass
@@ -81,10 +82,10 @@ async def process_recurrent_payments(db: AsyncSession, bot: Bot | None = None) -
     Returns:
         dict: Статистика обработки
     """
-    if not settings.YOOKASSA_RECURRENT_ENABLED:
+    if not settings.is_yookassa_recurrent_enabled(YOOKASSA_RECURRENT_SCOPE):
         return {'skipped': True, 'reason': 'recurrent_disabled'}
 
-    if not settings.YOOKASSA_ENABLED:
+    if not settings.is_yookassa_enabled(YOOKASSA_RECURRENT_SCOPE):
         return {'skipped': True, 'reason': 'yookassa_disabled'}
 
     if not settings.ENABLE_AUTOPAY:
@@ -295,7 +296,10 @@ async def _process_single_subscription(
         return 'skipped'
 
     # Нужно пополнить баланс — ищем сохранённую карту
-    saved_methods = await get_active_payment_methods_by_user(db, user.id)
+    yookassa_scope = YOOKASSA_RECURRENT_SCOPE
+    saved_methods = await get_active_payment_methods_by_user(db, user.id, yookassa_scope=yookassa_scope)
+    if not saved_methods and settings.YOOKASSA_BOT_SHOP_ID is None and settings.YOOKASSA_BOT_SECRET_KEY is None:
+        saved_methods = await get_active_payment_methods_by_user(db, user.id)
     if not saved_methods:
         return 'no_card'
 
@@ -305,7 +309,7 @@ async def _process_single_subscription(
     topup_amount_rubles = topup_amount_kopeks / 100
 
     # Создаём автоплатёж
-    yookassa_service = payment_service.yookassa_service
+    yookassa_service = payment_service._get_yookassa_service_for_scope(yookassa_scope)
     if not yookassa_service or not yookassa_service.configured:
         logger.warning('YooKassa сервис не сконфигурирован для рекуррентных платежей')
         return 'skipped'
@@ -319,13 +323,14 @@ async def _process_single_subscription(
         'purpose': 'recurrent_topup',
         'subscription_id': str(subscription.id),
         'source': 'recurrent_payment_service',
+        'yookassa_scope': yookassa_scope,
     }
 
     # Перебираем все сохранённые карты пока не найдём рабочую
     today = datetime.now(UTC).strftime('%Y-%m-%d')
     for saved_method in saved_methods:
         # Детерминированный ключ: при рестарте/повторе YooKassa вернёт тот же платёж
-        idem_key = f'recurrent_{subscription.id}_{saved_method.id}_{today}'
+        idem_key = f'recurrent_{yookassa_scope}_{subscription.id}_{saved_method.id}_{today}'
         result = await yookassa_service.create_autopayment(
             amount=topup_amount_rubles,
             currency='RUB',
@@ -366,6 +371,7 @@ async def _process_single_subscription(
                 description=description,
                 status=result.get('status', 'pending'),
                 metadata_json=metadata,
+                yookassa_scope=yookassa_scope,
                 yookassa_created_at=yookassa_created_at,
                 test_mode=result.get('test_mode', False),
             )

--- a/app/services/yookassa_service.py
+++ b/app/services/yookassa_service.py
@@ -1,19 +1,17 @@
-import asyncio
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import structlog
-from yookassa import Configuration, Payment as YooKassaPayment
-from yookassa.domain.common.confirmation_type import ConfirmationType
-from yookassa.domain.exceptions.not_found_error import NotFoundError as YooKassaNotFoundError
-from yookassa.domain.request.payment_request_builder import PaymentRequestBuilder
 
 from app.config import settings
 
 
 logger = structlog.get_logger(__name__)
+
+YOOKASSA_API_BASE_URL = 'https://api.yookassa.ru/v3'
 
 
 # ---------------------------------------------------------------------------
@@ -143,25 +141,24 @@ class YooKassaService:
         secret_key: str | None = None,
         configured_return_url: str | None = None,
         bot_username_for_default_return: str | None = None,
+        scope: str | None = None,
     ):
-        shop_id = shop_id or getattr(settings, 'YOOKASSA_SHOP_ID', None)
-        secret_key = secret_key or getattr(settings, 'YOOKASSA_SECRET_KEY', None)
-        configured_return_url = configured_return_url or getattr(settings, 'YOOKASSA_RETURN_URL', None)
+        yookassa_config = settings.get_yookassa_config(scope)
+        shop_id = shop_id or yookassa_config.shop_id
+        secret_key = secret_key or yookassa_config.secret_key
+        configured_return_url = configured_return_url or yookassa_config.return_url
 
-        self.configured = False
+        self.shop_id = shop_id
+        self.secret_key = secret_key
+        self.scope = scope
+        self.configured = bool(shop_id and secret_key)
 
         if not shop_id or not secret_key:
             logger.warning(
                 'YooKassa SHOP_ID или SECRET_KEY не настроены в settings. Функционал платежей будет ОТКЛЮЧЕН.'
             )
         else:
-            try:
-                Configuration.configure(shop_id, secret_key)
-                self.configured = True
-                logger.info('YooKassa SDK сконфигурирован для shop_id: ...', shop_id=shop_id[:5])
-            except Exception as error:
-                logger.error('Ошибка конфигурации YooKassa SDK', error=error, exc_info=True)
-                self.configured = False
+            logger.info('YooKassa HTTP client configured for shop_id prefix', shop_id_prefix=shop_id[:5], scope=scope)
 
         if not self.configured:
             self.return_url = 'https://t.me/'
@@ -180,6 +177,101 @@ class YooKassaService:
 
         logger.info('YooKassa Service return_url', return_url=self.return_url)
 
+    def _auth(self) -> httpx.BasicAuth:
+        return httpx.BasicAuth(self.shop_id or '', self.secret_key or '')
+
+    def _timeout_seconds(self) -> float:
+        read_timeout = max(1, int(getattr(settings, 'YOOKASSA_HTTP_READ_TIMEOUT', 15) or 15))
+        connect_timeout = max(1, int(getattr(settings, 'YOOKASSA_HTTP_CONNECT_TIMEOUT', 5) or 5))
+        return float(max(read_timeout, connect_timeout))
+
+    @staticmethod
+    def _amount_value(amount: float) -> str:
+        return f'{amount:.2f}'
+
+    @staticmethod
+    def _payment_response_to_dict(data: dict[str, Any]) -> dict[str, Any]:
+        amount = data.get('amount') or {}
+        confirmation = data.get('confirmation') or {}
+        payment_method = data.get('payment_method') or {}
+        payment_card = payment_method.get('card') if isinstance(payment_method, dict) else None
+
+        result = {
+            'id': data.get('id'),
+            'confirmation_url': confirmation.get('confirmation_url'),
+            'qr_confirmation_data': confirmation.get('confirmation_data'),
+            'confirmation': confirmation,
+            'status': data.get('status'),
+            'metadata': data.get('metadata') or {},
+            'amount_value': float(amount.get('value', 0) or 0),
+            'amount_currency': amount.get('currency'),
+            'paid': bool(data.get('paid', False)),
+            'refundable': bool(data.get('refundable', False)),
+            'created_at': data.get('created_at'),
+            'captured_at': data.get('captured_at'),
+            'description_from_yk': data.get('description'),
+            'description': data.get('description'),
+            'test_mode': data.get('test'),
+        }
+
+        if payment_method:
+            result.update(
+                {
+                    'payment_method_type': payment_method.get('type'),
+                    'payment_method_id': payment_method.get('id'),
+                    'payment_method_saved': bool(payment_method.get('saved', False)),
+                    'payment_method_card': payment_card,
+                }
+            )
+
+        return result
+
+    def _receipt_data(
+        self,
+        amount: float,
+        currency: str,
+        description: str,
+        receipt_email: str | None,
+        receipt_phone: str | None,
+    ) -> dict[str, Any] | None:
+        customer_contact_for_receipt = {}
+        if receipt_email:
+            customer_contact_for_receipt['email'] = receipt_email
+        elif receipt_phone:
+            customer_contact_for_receipt['phone'] = receipt_phone
+        elif hasattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL') and settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL:
+            customer_contact_for_receipt['email'] = settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL
+        else:
+            logger.error(
+                'КРИТИЧНО: Не предоставлен email/телефон для чека YooKassa и YOOKASSA_DEFAULT_RECEIPT_EMAIL не установлен.'
+            )
+            return None
+
+        return {
+            'customer': customer_contact_for_receipt,
+            'items': [
+                {
+                    'description': description[:128],
+                    'quantity': '1.00',
+                    'amount': {'value': self._amount_value(amount), 'currency': currency.upper()},
+                    'vat_code': int(getattr(settings, 'YOOKASSA_VAT_CODE', 1)),
+                    'payment_mode': getattr(settings, 'YOOKASSA_PAYMENT_MODE', 'full_payment'),
+                    'payment_subject': getattr(settings, 'YOOKASSA_PAYMENT_SUBJECT', 'service'),
+                }
+            ],
+        }
+
+    async def _post_payment(self, payload: dict[str, Any], idempotence_key: str) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=self._timeout_seconds()) as client:
+            response = await client.post(
+                f'{YOOKASSA_API_BASE_URL}/payments',
+                json=payload,
+                headers={'Idempotence-Key': idempotence_key},
+                auth=self._auth(),
+            )
+            response.raise_for_status()
+            return response.json()
+
     async def create_payment(
         self,
         amount: float,
@@ -196,53 +288,25 @@ class YooKassaService:
             logger.error('YooKassa не сконфигурирован. Невозможно создать платеж.')
             return None
 
-        customer_contact_for_receipt = {}
-        if receipt_email:
-            customer_contact_for_receipt['email'] = receipt_email
-        elif receipt_phone:
-            customer_contact_for_receipt['phone'] = receipt_phone
-        elif hasattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL') and settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL:
-            customer_contact_for_receipt['email'] = settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL
-        else:
-            logger.error(
-                'КРИТИЧНО: Не предоставлен email/телефон для чека YooKassa и YOOKASSA_DEFAULT_RECEIPT_EMAIL не установлен.'
-            )
+        receipt_data_dict = self._receipt_data(amount, currency, description, receipt_email, receipt_phone)
+        if receipt_data_dict is None:
             return {
                 'error': True,
                 'internal_message': 'Отсутствуют контактные данные для чека YooKassa и не настроен email по умолчанию.',
             }
 
         try:
-            builder = PaymentRequestBuilder()
-            builder.set_amount({'value': str(round(amount, 2)), 'currency': currency.upper()})
-            builder.set_capture(True)
-            builder.set_confirmation({'type': ConfirmationType.REDIRECT, 'return_url': return_url or self.return_url})
-            builder.set_description(description)
-            builder.set_metadata(metadata)
-
-            receipt_items_list: list[dict[str, Any]] = [
-                {
-                    'description': description[:128],
-                    'quantity': '1.00',
-                    'amount': {'value': str(round(amount, 2)), 'currency': currency.upper()},
-                    'vat_code': int(getattr(settings, 'YOOKASSA_VAT_CODE', 1)),
-                    'payment_mode': getattr(settings, 'YOOKASSA_PAYMENT_MODE', 'full_payment'),
-                    'payment_subject': getattr(settings, 'YOOKASSA_PAYMENT_SUBJECT', 'service'),
-                }
-            ]
-
-            receipt_data_dict: dict[str, Any] = {'customer': customer_contact_for_receipt, 'items': receipt_items_list}
-
-            builder.set_receipt(receipt_data_dict)
-
-            # Рекуррентные платежи: сохранение карты
-            if settings.YOOKASSA_RECURRENT_ENABLED:
-                if settings.YOOKASSA_RECURRENT_REQUIRED:
-                    builder.set_save_payment_method(True)
-                # Если не required — не устанавливаем, YooKassa покажет чекбокс
-
             idempotence_key = str(uuid.uuid4())
-            payment_request = builder.build()
+            payload: dict[str, Any] = {
+                'amount': {'value': self._amount_value(amount), 'currency': currency.upper()},
+                'capture': True,
+                'confirmation': {'type': 'redirect', 'return_url': return_url or self.return_url},
+                'description': description,
+                'metadata': metadata,
+                'receipt': receipt_data_dict,
+            }
+            if settings.is_yookassa_recurrent_enabled(self.scope) and settings.YOOKASSA_RECURRENT_REQUIRED:
+                payload['save_payment_method'] = True
 
             logger.info(
                 'Создание платежа YooKassa',
@@ -253,35 +317,18 @@ class YooKassaService:
                 receipt_data_dict=receipt_data_dict,
             )
 
-            loop = asyncio.get_running_loop()
-            async with asyncio.timeout(30):
-                response = await loop.run_in_executor(
-                    _yookassa_executor, lambda: YooKassaPayment.create(payment_request, idempotence_key)
-                )
+            response_data = await self._post_payment(payload, idempotence_key)
 
             logger.info(
-                'Ответ YooKassa Payment.create',
-                response_id=response.id,
-                status=response.status,
-                paid=response.paid,
+                'Ответ YooKassa HTTP create payment',
+                response_id=response_data.get('id'),
+                status=response_data.get('status'),
+                paid=response_data.get('paid'),
             )
 
-            return {
-                'id': response.id,
-                'confirmation_url': response.confirmation.confirmation_url if response.confirmation else None,
-                'status': response.status,
-                'metadata': response.metadata,
-                'amount_value': float(response.amount.value),
-                'amount_currency': response.amount.currency,
-                'idempotence_key_used': idempotence_key,
-                'paid': response.paid,
-                'refundable': response.refundable,
-                'created_at': response.created_at.isoformat()
-                if hasattr(response.created_at, 'isoformat')
-                else str(response.created_at),
-                'description_from_yk': response.description,
-                'test_mode': response.test if hasattr(response, 'test') else None,
-            }
+            result = self._payment_response_to_dict(response_data)
+            result['idempotence_key_used'] = idempotence_key
+            return result
         except Exception as e:
             logger.error('Ошибка создания платежа YooKassa', error=e, exc_info=True)
             return None
@@ -300,58 +347,24 @@ class YooKassaService:
             logger.error('YooKassa не сконфигурирован. Невозможно создать платеж через СБП.')
             return None
 
-        customer_contact_for_receipt = {}
-        if receipt_email:
-            customer_contact_for_receipt['email'] = receipt_email
-        elif receipt_phone:
-            customer_contact_for_receipt['phone'] = receipt_phone
-        elif hasattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL') and settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL:
-            customer_contact_for_receipt['email'] = settings.YOOKASSA_DEFAULT_RECEIPT_EMAIL
-        else:
-            logger.error(
-                'КРИТИЧНО: Не предоставлен email/телефон для чека YooKassa и YOOKASSA_DEFAULT_RECEIPT_EMAIL не установлен.'
-            )
+        receipt_data_dict = self._receipt_data(amount, currency, description, receipt_email, receipt_phone)
+        if receipt_data_dict is None:
             return {
                 'error': True,
                 'internal_message': 'Отсутствуют контактные данные для чека YooKassa и не настроен email по умолчанию.',
             }
 
         try:
-            # Создаем один платеж с подтверждением через QR
-            # Это позволит получить QR-код для пользователя
-            builder = PaymentRequestBuilder()
-
-            builder.set_amount({'value': str(round(amount, 2)), 'currency': currency.upper()})
-
-            builder.set_capture(True)
-
-            # Устанавливаем подтверждение через redirect для получения вебхуков
-            builder.set_confirmation({'type': 'redirect', 'return_url': return_url or self.return_url})
-
-            builder.set_description(description)
-
-            builder.set_metadata(metadata)
-
-            builder.set_payment_method_data({'type': 'sbp'})
-
-            receipt_items_list: list[dict[str, Any]] = [
-                {
-                    'description': description[:128],
-                    'quantity': '1.00',
-                    'amount': {'value': str(round(amount, 2)), 'currency': currency.upper()},
-                    'vat_code': int(getattr(settings, 'YOOKASSA_VAT_CODE', 1)),
-                    'payment_mode': getattr(settings, 'YOOKASSA_PAYMENT_MODE', 'full_payment'),
-                    'payment_subject': getattr(settings, 'YOOKASSA_PAYMENT_SUBJECT', 'service'),
-                }
-            ]
-
-            receipt_data_dict: dict[str, Any] = {'customer': customer_contact_for_receipt, 'items': receipt_items_list}
-
-            builder.set_receipt(receipt_data_dict)
-
             idempotence_key = str(uuid.uuid4())
-
-            payment_request = builder.build()
+            payload = {
+                'amount': {'value': self._amount_value(amount), 'currency': currency.upper()},
+                'capture': True,
+                'confirmation': {'type': 'redirect', 'return_url': return_url or self.return_url},
+                'description': description,
+                'metadata': metadata,
+                'payment_method_data': {'type': 'sbp'},
+                'receipt': receipt_data_dict,
+            }
 
             logger.info(
                 'Создание платежа YooKassa СБП с подтверждением redirect',
@@ -362,42 +375,18 @@ class YooKassaService:
                 receipt_data_dict=receipt_data_dict,
             )
 
-            loop = asyncio.get_running_loop()
-            async with asyncio.timeout(30):
-                response = await loop.run_in_executor(
-                    _yookassa_executor, lambda: YooKassaPayment.create(payment_request, idempotence_key)
-                )
+            response_data = await self._post_payment(payload, idempotence_key)
 
             logger.info(
-                'Ответ YooKassa Payment.create (СБП, redirect)',
-                response_id=response.id,
-                status=response.status,
-                paid=response.paid,
+                'Ответ YooKassa HTTP create payment (СБП, redirect)',
+                response_id=response_data.get('id'),
+                status=response_data.get('status'),
+                paid=response_data.get('paid'),
             )
 
-            # Возвращаем данные платежа с redirect-подтверждением
-            # YooKassa покажет QR на десктопе или список банков на мобильном
-            return {
-                'id': response.id,
-                'qr_confirmation_data': response.confirmation.confirmation_data
-                if response.confirmation and hasattr(response.confirmation, 'confirmation_data')
-                else None,
-                'confirmation_url': response.confirmation.confirmation_url
-                if response.confirmation and hasattr(response.confirmation, 'confirmation_url')
-                else None,
-                'status': response.status,
-                'metadata': response.metadata,
-                'amount_value': float(response.amount.value),
-                'amount_currency': response.amount.currency,
-                'idempotence_key_used': idempotence_key,
-                'paid': response.paid,
-                'refundable': response.refundable,
-                'created_at': response.created_at.isoformat()
-                if hasattr(response.created_at, 'isoformat')
-                else str(response.created_at),
-                'description_from_yk': response.description,
-                'test_mode': response.test if hasattr(response, 'test') else None,
-            }
+            result = self._payment_response_to_dict(response_data)
+            result['idempotence_key_used'] = idempotence_key
+            return result
         except Exception as e:
             logger.error('Ошибка создания платежа YooKassa СБП', error=e, exc_info=True)
             return None
@@ -410,61 +399,29 @@ class YooKassaService:
         try:
             logger.info('Получение информации о платеже YooKassa', payment_id_in_yookassa=payment_id_in_yookassa)
 
-            loop = asyncio.get_running_loop()
-            async with asyncio.timeout(30):
-                payment_info_yk = await loop.run_in_executor(
-                    _yookassa_executor, lambda: YooKassaPayment.find_one(payment_id_in_yookassa)
+            async with httpx.AsyncClient(timeout=self._timeout_seconds()) as client:
+                response = await client.get(
+                    f'{YOOKASSA_API_BASE_URL}/payments/{payment_id_in_yookassa}',
+                    auth=self._auth(),
                 )
+                if response.status_code == 404:
+                    logger.warning(
+                        'Платеж не найден в YooKassa (404)',
+                        payment_id_in_yookassa=payment_id_in_yookassa,
+                    )
+                    return None
+                response.raise_for_status()
+                payment_info_yk = response.json()
 
             if payment_info_yk:
                 logger.info(
                     'Информация о платеже YooKassa',
                     payment_id_in_yookassa=payment_id_in_yookassa,
-                    status=payment_info_yk.status,
-                    paid=payment_info_yk.paid,
+                    status=payment_info_yk.get('status'),
+                    paid=payment_info_yk.get('paid'),
                 )
-                return {
-                    'id': payment_info_yk.id,
-                    'status': payment_info_yk.status,
-                    'paid': payment_info_yk.paid,
-                    'amount_value': float(payment_info_yk.amount.value),
-                    'amount_currency': payment_info_yk.amount.currency,
-                    'metadata': payment_info_yk.metadata,
-                    'description': payment_info_yk.description,
-                    'refundable': payment_info_yk.refundable,
-                    'created_at': payment_info_yk.created_at.isoformat()
-                    if hasattr(payment_info_yk.created_at, 'isoformat')
-                    else str(payment_info_yk.created_at),
-                    'captured_at': payment_info_yk.captured_at.isoformat()
-                    if payment_info_yk.captured_at and hasattr(payment_info_yk.captured_at, 'isoformat')
-                    else None,
-                    'payment_method_type': payment_info_yk.payment_method.type
-                    if payment_info_yk.payment_method
-                    else None,
-                    'payment_method_id': payment_info_yk.payment_method.id if payment_info_yk.payment_method else None,
-                    'payment_method_saved': payment_info_yk.payment_method.saved
-                    if payment_info_yk.payment_method and hasattr(payment_info_yk.payment_method, 'saved')
-                    else False,
-                    'payment_method_card': {
-                        'first6': payment_info_yk.payment_method.card.first6,
-                        'last4': payment_info_yk.payment_method.card.last4,
-                        'card_type': payment_info_yk.payment_method.card.card_type,
-                        'expiry_month': payment_info_yk.payment_method.card.expiry_month,
-                        'expiry_year': payment_info_yk.payment_method.card.expiry_year,
-                    }
-                    if payment_info_yk.payment_method
-                    and hasattr(payment_info_yk.payment_method, 'card')
-                    and payment_info_yk.payment_method.card
-                    else None,
-                    'test_mode': payment_info_yk.test if hasattr(payment_info_yk, 'test') else None,
-                }
+                return self._payment_response_to_dict(payment_info_yk)
             logger.warning('Платеж не найден в YooKassa', payment_id_in_yookassa=payment_id_in_yookassa)
-            return None
-        except YooKassaNotFoundError:
-            logger.warning(
-                'Платеж не найден в YooKassa (404)',
-                payment_id_in_yookassa=payment_id_in_yookassa,
-            )
             return None
         except Exception as e:
             logger.error(
@@ -506,30 +463,30 @@ class YooKassaService:
             return None
 
         try:
-            builder = PaymentRequestBuilder()
-            builder.set_amount({'value': str(round(amount, 2)), 'currency': currency.upper()})
-            builder.set_capture(True)
-            builder.set_payment_method_id(payment_method_id)
-            builder.set_description(description)
-            builder.set_metadata(metadata)
-
-            receipt_items_list: list[dict[str, Any]] = [
-                {
-                    'description': description[:128],
-                    'quantity': '1.00',
-                    'amount': {'value': str(round(amount, 2)), 'currency': currency.upper()},
-                    'vat_code': str(getattr(settings, 'YOOKASSA_VAT_CODE', 1)),
-                    'payment_mode': getattr(settings, 'YOOKASSA_PAYMENT_MODE', 'full_payment'),
-                    'payment_subject': getattr(settings, 'YOOKASSA_PAYMENT_SUBJECT', 'service'),
-                }
-            ]
-            receipt_data_dict: dict[str, Any] = {'customer': customer_contact_for_receipt, 'items': receipt_items_list}
-            builder.set_receipt(receipt_data_dict)
-
             if not idempotence_key:
                 sub_id = metadata.get('subscription_id', uuid.uuid4())
                 idempotence_key = f'autopay_{sub_id}_{datetime.now(UTC).strftime("%Y-%m-%d")}'
-            payment_request = builder.build()
+            receipt_data_dict = {
+                'customer': customer_contact_for_receipt,
+                'items': [
+                    {
+                        'description': description[:128],
+                        'quantity': '1.00',
+                        'amount': {'value': self._amount_value(amount), 'currency': currency.upper()},
+                        'vat_code': int(getattr(settings, 'YOOKASSA_VAT_CODE', 1)),
+                        'payment_mode': getattr(settings, 'YOOKASSA_PAYMENT_MODE', 'full_payment'),
+                        'payment_subject': getattr(settings, 'YOOKASSA_PAYMENT_SUBJECT', 'service'),
+                    }
+                ],
+            }
+            payload = {
+                'amount': {'value': self._amount_value(amount), 'currency': currency.upper()},
+                'capture': True,
+                'payment_method_id': payment_method_id,
+                'description': description,
+                'metadata': metadata,
+                'receipt': receipt_data_dict,
+            }
 
             logger.info(
                 'Создание автоплатежа YooKassa',
@@ -540,34 +497,18 @@ class YooKassaService:
                 idempotence_key=idempotence_key,
             )
 
-            loop = asyncio.get_running_loop()
-            async with asyncio.timeout(30):
-                response = await loop.run_in_executor(
-                    _yookassa_executor, lambda: YooKassaPayment.create(payment_request, idempotence_key)
-                )
+            response_data = await self._post_payment(payload, idempotence_key)
 
             logger.info(
                 'Ответ YooKassa автоплатёж',
-                response_id=response.id,
-                status=response.status,
-                paid=response.paid,
+                response_id=response_data.get('id'),
+                status=response_data.get('status'),
+                paid=response_data.get('paid'),
             )
 
-            return {
-                'id': response.id,
-                'status': response.status,
-                'paid': response.paid,
-                'metadata': response.metadata,
-                'amount_value': float(response.amount.value),
-                'amount_currency': response.amount.currency,
-                'idempotence_key_used': idempotence_key,
-                'refundable': response.refundable,
-                'created_at': response.created_at.isoformat()
-                if hasattr(response.created_at, 'isoformat')
-                else str(response.created_at),
-                'description_from_yk': response.description,
-                'test_mode': response.test if hasattr(response, 'test') else None,
-            }
+            result = self._payment_response_to_dict(response_data)
+            result['idempotence_key_used'] = idempotence_key
+            return result
         except Exception as e:
             logger.error(
                 'Ошибка создания автоплатежа YooKassa',

--- a/app/utils/payment_utils.py
+++ b/app/utils/payment_utils.py
@@ -28,8 +28,8 @@ def get_available_payment_methods() -> list[dict[str, str]]:
             }
         )
 
-    if settings.is_yookassa_enabled():
-        if getattr(settings, 'YOOKASSA_SBP_ENABLED', False):
+    if settings.is_yookassa_enabled('bot'):
+        if settings.is_yookassa_sbp_enabled('bot'):
             methods.append(
                 {
                     'id': 'yookassa_sbp',
@@ -461,7 +461,7 @@ def is_payment_method_available(method_id: str) -> bool:
     if method_id == 'stars':
         return settings.TELEGRAM_STARS_ENABLED
     if method_id == 'yookassa':
-        return settings.is_yookassa_enabled()
+        return settings.is_yookassa_enabled('bot')
     if method_id == 'tribute':
         return settings.TRIBUTE_ENABLED
     if method_id == 'mulenpay':
@@ -531,7 +531,7 @@ def get_payment_method_status() -> dict[str, bool]:
     """
     return {
         'stars': settings.TELEGRAM_STARS_ENABLED,
-        'yookassa': settings.is_yookassa_enabled(),
+        'yookassa': settings.is_yookassa_enabled('bot'),
         'tribute': settings.TRIBUTE_ENABLED,
         'mulenpay': settings.is_mulenpay_enabled(),
         'wata': settings.is_wata_enabled(),
@@ -568,7 +568,7 @@ def get_enabled_payment_methods_count() -> int:
     count = 0
     if settings.TELEGRAM_STARS_ENABLED:
         count += 1
-    if settings.is_yookassa_enabled():
+    if settings.is_yookassa_enabled('bot'):
         count += 1
     if settings.TRIBUTE_ENABLED:
         count += 1

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -692,8 +692,8 @@ async def get_payment_methods(
             )
         )
 
-    if settings.is_yookassa_enabled():
-        if getattr(settings, 'YOOKASSA_SBP_ENABLED', False):
+    if settings.is_yookassa_enabled('cabinet'):
+        if settings.is_yookassa_sbp_enabled('cabinet'):
             methods.append(
                 MiniAppPaymentMethod(
                     id='yookassa_sbp',
@@ -973,7 +973,7 @@ async def create_payment_link(
         )
 
     if method == 'yookassa_sbp':
-        if not settings.is_yookassa_enabled() or not getattr(settings, 'YOOKASSA_SBP_ENABLED', False):
+        if not settings.is_yookassa_enabled('cabinet') or not settings.is_yookassa_sbp_enabled('cabinet'):
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Payment method is unavailable')
         if amount_kopeks is None or amount_kopeks <= 0:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Amount must be positive')
@@ -990,6 +990,7 @@ async def create_payment_link(
             description=settings.get_balance_payment_description(
                 amount_kopeks, telegram_user_id=user.telegram_id, user_db_id=user.id
             ),
+            yookassa_scope='cabinet',
         )
         confirmation_url = result.get('confirmation_url') if result else None
         if not result or not confirmation_url:
@@ -1013,7 +1014,7 @@ async def create_payment_link(
         )
 
     if method == 'yookassa':
-        if not settings.is_yookassa_enabled():
+        if not settings.is_yookassa_enabled('cabinet'):
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Payment method is unavailable')
         if amount_kopeks is None or amount_kopeks <= 0:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Amount must be positive')
@@ -1030,6 +1031,7 @@ async def create_payment_link(
             description=settings.get_balance_payment_description(
                 amount_kopeks, telegram_user_id=user.telegram_id, user_db_id=user.id
             ),
+            yookassa_scope='cabinet',
         )
         if not result or not result.get('confirmation_url'):
             raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail='Failed to create payment')

--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -92,6 +92,7 @@ async def _process_payment_service_callback(
     payment_service: PaymentService,
     payload: dict,
     method_name: str,
+    **kwargs,
 ) -> bool:
     db_generator = get_db()
     try:
@@ -101,7 +102,7 @@ async def _process_payment_service_callback(
 
     try:
         process_callback = getattr(payment_service, method_name)
-        return await process_callback(db, payload)
+        return await process_callback(db, payload, **kwargs)
     finally:
         try:
             await db_generator.__anext__()
@@ -333,10 +334,15 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
 
         routes_registered = True
 
-    if settings.is_yookassa_enabled():
+    yookassa_enabled = (
+        settings.is_yookassa_enabled()
+        or settings.is_yookassa_enabled('bot')
+        or settings.is_yookassa_enabled('cabinet')
+    )
 
-        @router.options(settings.YOOKASSA_WEBHOOK_PATH)
-        async def yookassa_options() -> Response:
+    if yookassa_enabled:
+
+        def _yookassa_options_response() -> Response:
             return Response(
                 status_code=status.HTTP_200_OK,
                 headers={
@@ -346,18 +352,20 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
                 },
             )
 
-        @router.get(settings.YOOKASSA_WEBHOOK_PATH)
-        async def yookassa_health() -> JSONResponse:
+        def _yookassa_health_response(yookassa_scope: str | None = None) -> JSONResponse:
             return JSONResponse(
                 {
                     'status': 'ok',
                     'service': 'yookassa_webhook',
-                    'enabled': settings.is_yookassa_enabled(),
+                    'enabled': yookassa_enabled,
+                    'scope': yookassa_scope,
                 }
             )
 
-        @router.post(settings.YOOKASSA_WEBHOOK_PATH)
-        async def yookassa_webhook(request: Request) -> JSONResponse:
+        async def _handle_yookassa_webhook(
+            request: Request,
+            yookassa_scope: str | None = None,
+        ) -> JSONResponse:
             header_ip_candidates = yookassa_webhook_module.collect_yookassa_ip_candidates(
                 request.headers.get('X-Forwarded-For'),
                 request.headers.get('X-Real-IP'),
@@ -420,6 +428,7 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
                     payment_service,
                     webhook_data,
                     'process_yookassa_webhook',
+                    yookassa_scope=yookassa_scope,
                 )
                 if success:
                     return JSONResponse({'status': 'ok'})
@@ -436,6 +445,42 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
                     {'status': 'error', 'reason': 'processing_failed'},
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
+
+        @router.options(settings.YOOKASSA_WEBHOOK_PATH)
+        async def yookassa_options() -> Response:
+            return _yookassa_options_response()
+
+        @router.options(f'{settings.YOOKASSA_WEBHOOK_PATH}/bot')
+        async def yookassa_bot_options() -> Response:
+            return _yookassa_options_response()
+
+        @router.options(f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet')
+        async def yookassa_cabinet_options() -> Response:
+            return _yookassa_options_response()
+
+        @router.get(settings.YOOKASSA_WEBHOOK_PATH)
+        async def yookassa_health() -> JSONResponse:
+            return _yookassa_health_response()
+
+        @router.get(f'{settings.YOOKASSA_WEBHOOK_PATH}/bot')
+        async def yookassa_bot_health() -> JSONResponse:
+            return _yookassa_health_response('bot')
+
+        @router.get(f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet')
+        async def yookassa_cabinet_health() -> JSONResponse:
+            return _yookassa_health_response('cabinet')
+
+        @router.post(settings.YOOKASSA_WEBHOOK_PATH)
+        async def yookassa_webhook(request: Request) -> JSONResponse:
+            return await _handle_yookassa_webhook(request)
+
+        @router.post(f'{settings.YOOKASSA_WEBHOOK_PATH}/bot')
+        async def yookassa_bot_webhook(request: Request) -> JSONResponse:
+            return await _handle_yookassa_webhook(request, 'bot')
+
+        @router.post(f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet')
+        async def yookassa_cabinet_webhook(request: Request) -> JSONResponse:
+            return await _handle_yookassa_webhook(request, 'cabinet')
 
         routes_registered = True
 

--- a/docs/yookassa-bot-cabinet-scope-design.md
+++ b/docs/yookassa-bot-cabinet-scope-design.md
@@ -1,0 +1,869 @@
+# Bot/Cabinet YooKassa Scope Design
+
+Дата исследования: 2026-06-14
+
+Статус: технический дизайн MVP, без реализации.
+
+## Цель
+
+Разделить YooKassa по месту использования в одном backend-инстансе:
+
+- `bot` - Telegram-бот: пополнение баланса, покупка подписок, trial-платежи, recurrent/autopay для bot flows.
+- `cabinet` - Cabinet: пополнение баланса и cabinet flows.
+
+MVP не требует произвольного количества магазинов. Нужны две независимые конфигурации YooKassa, общий backend и обратная совместимость со старым single-shop `YOOKASSA_*`.
+
+## Краткий вывод
+
+Для MVP проще и безопаснее внедрять env-based scopes:
+
+- `YOOKASSA_BOT_*`
+- `YOOKASSA_CABINET_*`
+- старые `YOOKASSA_*` оставить как fallback/default.
+
+DB-based `yookassa_accounts` полезен как следующий этап, но сейчас он требует отдельного решения по хранению секретов, админскому UI и миграции credentials. Существующая `PaymentMethodConfig` в БД управляет отображением/ограничениями методов оплаты в Cabinet, но не является безопасным хранилищем секретов платежных провайдеров.
+
+Официальный YooKassa SDK в текущем виде лучше не использовать для нескольких credentials в одном процессе: код конфигурирует SDK через глобальный `Configuration.configure(shop_id, secret_key)`. Для scoped credentials безопаснее заменить SDK-вызовы на прямые HTTP-запросы с Basic Auth на каждый request. Вариант с lock вокруг SDK возможен только как временный компромисс, но он сериализует вызовы, остается хрупким и легко ломается при новых местах вызова.
+
+Рекомендуемый webhook для MVP:
+
+- `/yookassa-webhook/bot`
+- `/yookassa-webhook/cabinet`
+- старый `/yookassa-webhook` оставить для legacy fallback.
+
+## Текущая реализация
+
+### Глобальная конфигурация
+
+Сейчас настройки YooKassa глобальные:
+
+- `app/config.py:421` - `YOOKASSA_ENABLED`.
+- `app/config.py:424` - `YOOKASSA_SHOP_ID`.
+- `app/config.py:425` - `YOOKASSA_SECRET_KEY`.
+- `app/config.py:426` - `YOOKASSA_RETURN_URL`.
+- `app/config.py:427` - `YOOKASSA_SBP_ENABLED`.
+- `app/config.py:456` - `YOOKASSA_WEBHOOK_PATH`.
+- `app/config.py:460` - `YOOKASSA_RECURRENT_ENABLED`.
+- `app/config.py:2070` - `is_yookassa_enabled()`.
+- `app/config.py:2083` - `get_yookassa_return_url()`.
+
+`settings.is_yookassa_enabled()` сейчас не принимает surface/scope и проверяет только один глобальный магазин.
+
+### YooKassa SDK/service
+
+Основной service:
+
+- `app/services/yookassa_service.py:139` - `YooKassaService.__init__`.
+- `app/services/yookassa_service.py:159` - `Configuration.configure(shop_id, secret_key)`.
+- `app/services/yookassa_service.py:183` - `create_payment()`.
+- `app/services/yookassa_service.py:289` - `create_sbp_payment()`.
+- `app/services/yookassa_service.py:405` - `get_payment_info()`.
+- `app/services/yookassa_service.py:478` - `create_autopayment()`.
+
+Проверка SDK показала, что `Configuration.configure()` пишет credentials в class-level state, а `Payment.create()` / `Payment.find_one()` создают `ApiClient()` из текущей глобальной `Configuration`. Это небезопасно для параллельных запросов разных магазинов.
+
+### Создание YooKassa платежей
+
+Нижний слой создания:
+
+- `app/services/payment/yookassa.py:92` - `create_yookassa_payment()`.
+- `app/services/payment/yookassa.py:196` - `create_yookassa_sbp_payment()`.
+- `app/services/payment_service.py:830` - guest payment routes тоже проходят через YooKassa branch.
+
+Telegram bot balance:
+
+- `app/handlers/balance/yookassa.py:22` - старт оплаты картой.
+- `app/handlers/balance/yookassa.py:69` - старт СБП.
+- `app/handlers/balance/yookassa.py:115` - ввод суммы и создание card payment.
+- `app/handlers/balance/yookassa.py:270` - ввод суммы и создание SBP payment.
+
+Telegram subscription/trial:
+
+- `app/handlers/subscription/purchase.py:735` - trial keyboard показывает YooKassa/SBP по глобальным настройкам.
+- `app/handlers/subscription/purchase.py:3736` - trial SBP payment.
+- `app/handlers/subscription/purchase.py:3774` - trial card payment.
+- `app/handlers/simple_subscription.py:921` - simple subscription YooKassa flow.
+
+Bot keyboards/utilities:
+
+- `app/keyboards/inline.py:1568` - `get_payment_methods_keyboard()`.
+- `app/keyboards/inline.py:1590` - добавление YooKassa в keyboard.
+- `app/keyboards/inline.py:1602` - добавление SBP в keyboard.
+- `app/utils/payment_utils.py:14` - `get_available_payment_methods()`.
+
+Cabinet:
+
+- `app/cabinet/routes/balance.py:138` - `GET /cabinet/balance/payment-methods`.
+- `app/cabinet/routes/balance.py:307` - `POST /cabinet/balance/topup`.
+- `app/cabinet/routes/balance.py:371` - Cabinet вызывает `create_yookassa_sbp_payment()`.
+- `app/cabinet/routes/balance.py:380` - Cabinet вызывает `create_yookassa_payment()`.
+
+Miniapp/web API:
+
+- `app/webapi/routes/miniapp.py:695` - список методов оплаты miniapp.
+- `app/webapi/routes/miniapp.py:975` - miniapp SBP payment.
+- `app/webapi/routes/miniapp.py:1015` - miniapp card payment.
+
+Guest/landing/gift:
+
+- `app/cabinet/routes/landing.py:735` - проверка guest payment method.
+- `app/cabinet/routes/landing.py:840` - создание guest payment.
+- `app/cabinet/routes/gift.py:391` - создание gift gateway payment.
+
+Admin/test:
+
+- `app/handlers/admin/bot_configuration.py:1918` - test payment через глобальную YooKassa.
+
+### Webhook, status check, recovery
+
+Webhook registration:
+
+- `app/webserver/payments.py:336` - registration на `settings.YOOKASSA_WEBHOOK_PATH`.
+- `app/webserver/payments.py:396` - POST handler.
+- `app/external/yookassa_webhook.py:203` - legacy/aiohttp webhook handler.
+
+Webhook processing:
+
+- `app/services/payment/yookassa.py:1364` - `process_yookassa_webhook()`.
+- `app/services/payment/yookassa.py:1397` - текущая remote-проверка статуса через глобальный service.
+- `app/services/payment/yookassa.py:1405` - поиск локального платежа по `yookassa_payment_id`.
+- `app/services/payment/yookassa.py:1472` - восстановление отсутствующей локальной записи из webhook metadata.
+
+Manual status check:
+
+- `app/services/payment/yookassa.py:295` - `get_yookassa_payment_status()`.
+- `app/services/payment_verification_service.py:1512` - manual check вызывает YooKassa status.
+- `app/cabinet/routes/balance.py:1453` - Cabinet manual check endpoint.
+- `app/cabinet/routes/admin_payments.py` - admin manual check uses same verification service.
+
+### Autopay / saved cards
+
+Сохранение payment method:
+
+- `app/services/payment/yookassa.py:1150` - после успешного платежа вызывается `_save_payment_method_if_available()`.
+- `app/services/payment/yookassa.py:1213` - `_save_payment_method_if_available()`.
+- `app/database/crud/saved_payment_method.py:14` - `create_saved_payment_method()`.
+
+Recurrent/autopay:
+
+- `app/services/recurrent_payment_service.py:72` - основной recurrent process.
+- `app/services/recurrent_payment_service.py:233` - обработка одной подписки.
+- `app/services/recurrent_payment_service.py:298` - получение active saved payment methods.
+- `app/services/recurrent_payment_service.py:329` - `create_autopayment()` через YooKassa.
+- `app/services/recurrent_payment_service.py:360` - создание локального `YooKassaPayment` для autopay.
+
+Сейчас `SavedPaymentMethod` не хранит scope/account, хотя `payment_method_id` YooKassa привязан к конкретному магазину.
+
+### Таблицы и модели
+
+YooKassa:
+
+- `app/database/models.py:207` - `YooKassaPayment`.
+- `app/database/models.py:256` - `SavedPaymentMethod`.
+- `app/database/crud/yookassa.py:15` - create local YooKassa payment.
+- `app/database/crud/yookassa.py:82` - get by YooKassa payment id.
+- `app/database/crud/yookassa.py:98` - update status.
+
+Transactions:
+
+- `app/database/models.py:150` - `PaymentMethod.YOOKASSA = 'yookassa'`.
+- `app/database/models.py:2337` - `Transaction`.
+- `app/database/models.py:2360` - unique constraint `(external_id, payment_method)`.
+- `app/database/models.py:2388` - `receipt_uuid`.
+
+Cabinet payment method config:
+
+- `app/database/models.py:3767` - `PaymentMethodConfig`.
+- `app/services/payment_method_config_service.py:18` - `_get_method_defaults()`.
+- `app/services/payment_method_config_service.py:267` - default method order includes `yookassa`.
+- `app/services/payment_method_config_service.py:300` - seed configs.
+- `app/services/payment_method_config_service.py:465` - `get_enabled_methods_for_user()`.
+- `app/cabinet/routes/admin_payment_methods.py:141` - admin list configs.
+- `app/cabinet/routes/admin_payment_methods.py:191` - admin update config.
+
+`PaymentMethodConfig` сейчас выглядит как кабинетная конфигурация отображения методов оплаты. Она не хранит provider credentials.
+
+### Cabinet frontend
+
+Frontend находится в `bedolaga-cabinet`, но backend routes для оплаты находятся в `bedolaga-telegram-bot`.
+
+Релевантные frontend-файлы:
+
+- `src/api/balance.ts` - `getPaymentMethods()`, `createTopUp()`, saved cards endpoints.
+- `src/types/index.ts` - `PaymentMethod`, `PendingPayment`, `SavedCard`, `PaymentMethodConfig`.
+- `src/api/adminPaymentMethods.ts` - admin API для payment method configs.
+
+Для MVP пользовательский Cabinet UI может продолжить показывать метод как `YooKassa`. Разделение `bot`/`cabinet` должно быть внутренним.
+
+## Архитектурное решение MVP
+
+### 1. Ввести scope
+
+Добавить явное понятие YooKassa scope:
+
+```python
+YooKassaScope = Literal["bot", "cabinet"]
+```
+
+Правила:
+
+- Bot handlers всегда запрашивают YooKassa config для `scope='bot'`.
+- Cabinet `/cabinet/balance/payment-methods` и `/cabinet/balance/topup` используют `scope='cabinet'`.
+- Miniapp лучше считать `cabinet` scope, если он является частью Cabinet/user web flows.
+- Landing/gift в MVP можно привязать к `cabinet` scope, потому что эти routes живут в Cabinet backend. Если бизнес хочет отдельную фискализацию/магазин для публичных landing/gift flows, это будущий scope `landing`/`gift`, не часть MVP.
+
+### 2. Env-based config для MVP
+
+Добавить scoped env:
+
+```env
+YOOKASSA_BOT_ENABLED=
+YOOKASSA_BOT_DISPLAY_NAME=
+YOOKASSA_BOT_SHOP_ID=
+YOOKASSA_BOT_SECRET_KEY=
+YOOKASSA_BOT_RETURN_URL=
+YOOKASSA_BOT_SBP_ENABLED=
+YOOKASSA_BOT_RECURRENT_ENABLED=
+
+YOOKASSA_CABINET_ENABLED=
+YOOKASSA_CABINET_DISPLAY_NAME=
+YOOKASSA_CABINET_SHOP_ID=
+YOOKASSA_CABINET_SECRET_KEY=
+YOOKASSA_CABINET_RETURN_URL=
+YOOKASSA_CABINET_SBP_ENABLED=
+YOOKASSA_CABINET_RECURRENT_ENABLED=
+```
+
+Старые env остаются:
+
+```env
+YOOKASSA_ENABLED=
+YOOKASSA_DISPLAY_NAME=
+YOOKASSA_SHOP_ID=
+YOOKASSA_SECRET_KEY=
+YOOKASSA_RETURN_URL=
+YOOKASSA_SBP_ENABLED=
+YOOKASSA_RECURRENT_ENABLED=
+YOOKASSA_WEBHOOK_PATH=
+```
+
+Новые helper methods:
+
+```python
+settings.get_yookassa_config(scope: str) -> YooKassaConfig
+settings.is_yookassa_enabled(scope: str | None = None) -> bool
+settings.get_yookassa_return_url(scope: str | None = None) -> str
+settings.get_yookassa_display_name(scope: str | None = None) -> str
+settings.is_yookassa_sbp_enabled(scope: str | None = None) -> bool
+settings.is_yookassa_recurrent_enabled(scope: str | None = None) -> bool
+```
+
+Fallback rule:
+
+- Если `YOOKASSA_BOT_*` не задан, `bot` использует старый `YOOKASSA_*`.
+- Если `YOOKASSA_CABINET_*` не задан, `cabinet` использует старый `YOOKASSA_*`.
+- Если задан scoped `*_ENABLED=false`, этот scope выключен даже при включенном legacy `YOOKASSA_ENABLED`.
+
+Так старые single-shop установки продолжают работать без изменения `.env`, а новые установки могут разделить Bot и Cabinet.
+
+### 3. Почему не DB-based accounts в MVP
+
+DB-based вариант:
+
+```text
+yookassa_accounts
+  id
+  scope
+  display_name
+  shop_id
+  secret_key
+  enabled
+  sbp_enabled
+  recurrent_enabled
+  return_url
+  default_receipt_email
+  min_amount_kopeks
+  max_amount_kopeks
+```
+
+Плюсы:
+
+- удобно расширять до `landing`, `gift`, `promo`, `default`;
+- можно управлять из админки;
+- можно хранить account id вместо строкового scope в платежах.
+
+Минусы для текущего MVP:
+
+- нужно безопасное хранение `secret_key`, которого сейчас нет в `PaymentMethodConfig`;
+- нужна миграция/админка для credentials;
+- нужно решить аудит, маскирование и запрет логирования секретов;
+- больше blast radius.
+
+Рекомендация: сначала env-based scopes плюс nullable `yookassa_scope` в платежах. Когда потребуется больше двух магазинов или управление из админки, добавить `yookassa_accounts` и мигрировать `yookassa_scope -> yookassa_account_id`.
+
+### 4. Создание платежей через scoped client
+
+`PaymentService` не должен хранить один глобальный `self.yookassa_service`.
+
+Предлагаемый интерфейс:
+
+```python
+await payment_service.create_yookassa_payment(..., scope="bot")
+await payment_service.create_yookassa_sbp_payment(..., scope="cabinet")
+await payment_service.get_yookassa_payment_status(..., scope_from_payment=True)
+```
+
+Внутри:
+
+1. Получить scoped config.
+2. Проверить `enabled`, `shop_id`, `secret_key`.
+3. Создать платеж через scoped HTTP client.
+4. Сохранить `yookassa_scope` в `YooKassaPayment`.
+5. Добавить `yookassa_scope` в YooKassa metadata для отладки/recovery.
+
+Bot flows должны передавать `scope='bot'`.
+
+Cabinet flows должны передавать `scope='cabinet'`.
+
+### 5. Direct HTTP вместо SDK global config
+
+Рекомендуется заменить `app/services/yookassa_service.py` на scoped client поверх прямых HTTP-запросов YooKassa API:
+
+- `POST /v3/payments` для card/SBP/autopayment;
+- `GET /v3/payments/{payment_id}` для status check;
+- Basic Auth на каждый request: `shop_id:secret_key`;
+- `Idempotence-Key` на создание платежей;
+- timeouts и executor больше не нужны, если используется async HTTP client.
+
+Плюсы:
+
+- credentials живут в request context, а не в global SDK state;
+- нет гонки между Bot и Cabinet запросами;
+- легче тестировать разные scopes;
+- проще логировать без секретов.
+
+SDK + lock можно оставить только если прямой HTTP слишком дорог для этапа 1:
+
+```python
+async with yookassa_sdk_lock:
+    Configuration.configure(shop_id, secret_key)
+    YooKassaPayment.create(...)
+```
+
+Но это хуже: один забытый SDK call без lock снова создаст race condition.
+
+### 6. Как Cabinet показывает YooKassa
+
+Для MVP не нужно заводить `yookassa_bot` и `yookassa_cabinet` как отдельные method id.
+
+Оставить внешний method id:
+
+```text
+yookassa
+```
+
+Внутри resolver использует `surface='cabinet'`.
+
+Рекомендуемый минимальный change:
+
+- `PaymentMethodConfig` остается cabinet-facing таблицей.
+- `get_enabled_methods_for_user()` получает или неявно использует `surface='cabinet'`.
+- `_get_method_defaults()` для `yookassa` проверяет `settings.is_yookassa_enabled("cabinet")`.
+- `sub_options.sbp.enabled` проверяет `settings.is_yookassa_sbp_enabled("cabinet")`.
+- `POST /cabinet/balance/topup` принимает прежний `payment_method='yookassa'`, но создает платеж через `scope='cabinet'`.
+
+Не рекомендуется для MVP:
+
+- добавлять `surface` в `PaymentMethodConfig`, если таблица пока используется только Cabinet;
+- заводить method ids `yookassa_bot` / `yookassa_cabinet`, потому что это ухудшит UX и расползется по frontend/types/admin.
+
+Если позже та же таблица будет управлять Bot methods, тогда можно добавить `surface` и unique `(surface, method_id)`.
+
+### 7. Как Bot показывает YooKassa
+
+Bot keyboards/utilities должны проверять только `bot` scope:
+
+- `settings.is_yookassa_enabled("bot")`;
+- `settings.is_yookassa_sbp_enabled("bot")`;
+- `settings.get_yookassa_display_name("bot")`;
+- `settings.get_yookassa_min/max_amount_kopeks("bot")`.
+
+Если Bot YooKassa выключена, бот не показывает YooKassa, даже если Cabinet YooKassa включена.
+
+Если Cabinet YooKassa выключена, Cabinet не показывает YooKassa, даже если Bot YooKassa включена.
+
+### 8. Webhook
+
+Рекомендуемый MVP:
+
+```text
+POST /yookassa-webhook/bot
+POST /yookassa-webhook/cabinet
+POST /yookassa-webhook          # legacy fallback
+```
+
+Scoped path:
+
+1. Router определяет `scope` из path.
+2. Handler извлекает `object.id`.
+3. Backend ищет локальный платеж по `(yookassa_scope, yookassa_payment_id)`.
+4. Backend проверяет статус через credentials этого scope.
+5. Если локальной записи нет, recovery создает ее со scope из path и metadata из webhook.
+
+Legacy path:
+
+1. Backend ищет платеж по `yookassa_payment_id`.
+2. Если у платежа есть `yookassa_scope`, использует его.
+3. Если scope пустой, использует legacy/default config из старых `YOOKASSA_*`.
+4. Если локальной записи нет и scope неизвестен, recovery возможен только через legacy/default config. Поэтому для новых scoped магазинов лучше настраивать scoped webhook paths.
+
+Почему два path лучше одного:
+
+- при потерянной локальной записи понятно, какими credentials проверять платеж;
+- проще отлаживать логи и настройки YooKassa;
+- меньше риск проверить Cabinet payment Bot credentials и наоборот.
+
+Один общий `/yookassa-webhook` можно оставить только как fallback/compatibility, но не как основной вариант для двух магазинов.
+
+### 9. Manual status check
+
+`get_yookassa_payment_status()` должен:
+
+1. загрузить `YooKassaPayment`;
+2. прочитать `yookassa_scope`;
+3. если scope пустой, использовать legacy/default fallback;
+4. проверить remote status через credentials этого scope;
+5. обновить локальный payment и обработать success.
+
+Нельзя выбирать credentials по месту вызова manual check. Например, Cabinet admin может проверять старый Bot платеж, и проверка должна идти через scope самого платежа.
+
+### 10. Autopay and saved payment methods
+
+`SavedPaymentMethod` должен хранить YooKassa scope, потому что `payment_method_id` привязан к магазину.
+
+Правила MVP:
+
+- `_save_payment_method_if_available()` сохраняет scope из успешного `YooKassaPayment`.
+- `create_saved_payment_method()` uniqueness должен учитывать scope.
+- Recurrent service заряжает saved card только credentials того scope, с которым card была сохранена.
+- Для subscription autopay по умолчанию использовать `bot` scope, потому что текущие подписочные flows находятся в боте.
+- Legacy saved cards без scope обрабатывать через legacy/default config.
+
+Если в будущем Cabinet получит отдельные recurring products, нужно явно хранить preferred autopay scope на subscription/order level. До этого нельзя молча брать Cabinet saved card для Bot subscription, если это не согласовано продуктово.
+
+## NaloGO
+
+### Текущее состояние
+
+YooKassa success создает чек NaloGO:
+
+- `app/services/payment/yookassa.py:1299` - `_create_nalogo_receipt()`.
+- `app/services/payment/yookassa.py:1345` - сохранение `transaction.receipt_uuid`.
+- `app/services/nalogo_service.py:303` - `create_receipt()`.
+- `app/services/nalogo_service.py:316` - dedup key `nalogo:created:{payment_id}`.
+- `app/services/nalogo_queue_service.py:156` - queue uses `payment_id`.
+- `app/services/guest_purchase_service.py:190` - guest purchase receipt.
+
+Сейчас NaloGO глобальный.
+
+### MVP-допущение
+
+Для MVP можно оставить один глобальный NaloGO только при бизнес-допущении:
+
+> Bot YooKassa и Cabinet YooKassa принадлежат одному налоговому субъекту, и чеки могут выпускаться через один NaloGO аккаунт.
+
+Это нужно явно подтвердить перед production rollout.
+
+Если магазины YooKassa принадлежат разным юрлицам/самозанятым, глобальный NaloGO неправильный. Тогда NaloGO тоже должен стать scoped:
+
+- `NALOGO_BOT_*`;
+- `NALOGO_CABINET_*`;
+- или DB account, связанный с YooKassa account.
+
+### Изменения NaloGO даже при глобальном аккаунте
+
+Даже если NaloGO остается глобальным, dedup/queue/log context должны учитывать источник:
+
+```text
+nalogo:created:yookassa:{scope}:{payment_id}
+nalogo:queued:yookassa:{scope}:{payment_id}
+```
+
+Минимальный интерфейс:
+
+```python
+create_receipt(
+    ...,
+    payment_provider="yookassa",
+    payment_scope=payment.yookassa_scope or "legacy",
+    external_payment_id=payment.yookassa_payment_id,
+)
+```
+
+В `Transaction` желательно добавить:
+
+- `payment_scope`;
+- `payment_account_id` или будущий `payment_account_slug`;
+- `receipt_uuid`.
+
+Если не менять `Transaction` в MVP, минимум использовать `YooKassaPayment.yookassa_scope` при создании чека и Redis dedup keys.
+
+## Миграции БД
+
+### Обязательные для MVP
+
+1. `yookassa_payments`
+
+Добавить:
+
+```text
+yookassa_scope VARCHAR(32) NULL
+```
+
+Индекс:
+
+```text
+idx_yookassa_payments_scope_payment_id (yookassa_scope, yookassa_payment_id)
+```
+
+Старые строки можно оставить `NULL`. Runtime fallback будет считать `NULL` legacy/default. Массовый backfill в `bot` рискован, потому что часть старых платежей могла прийти из Cabinet.
+
+2. `saved_payment_methods`
+
+Добавить:
+
+```text
+yookassa_scope VARCHAR(32) NULL
+```
+
+Индекс:
+
+```text
+idx_saved_payment_methods_user_scope_active (user_id, yookassa_scope, is_active)
+```
+
+Пересмотреть uniqueness:
+
+Текущий unique только на `yookassa_payment_method_id`. Для multi-scope лучше unique:
+
+```text
+uq_saved_payment_methods_scope_method (yookassa_scope, yookassa_payment_method_id)
+```
+
+Для legacy `NULL` нужно аккуратно учесть поведение конкретной БД по unique nullable columns. Если используется PostgreSQL, лучше сделать partial unique indexes:
+
+```sql
+CREATE UNIQUE INDEX uq_saved_pm_legacy_method
+  ON saved_payment_methods (yookassa_payment_method_id)
+  WHERE yookassa_scope IS NULL;
+
+CREATE UNIQUE INDEX uq_saved_pm_scope_method
+  ON saved_payment_methods (yookassa_scope, yookassa_payment_method_id)
+  WHERE yookassa_scope IS NOT NULL;
+```
+
+3. `transactions` - желательно, но можно отложить
+
+Добавить nullable поля:
+
+```text
+payment_scope VARCHAR(32) NULL
+payment_account_id INTEGER NULL
+```
+
+Для MVP это полезно для админки, аудита и NaloGO. Если нужно минимизировать миграции, можно отложить и читать scope из `YooKassaPayment`.
+
+### Не рекомендуется для MVP
+
+Не добавлять `surface` в `payment_method_configs`, если таблица остается кабинетной.
+
+Если позже нужно управлять методами Bot через ту же таблицу, отдельная миграция:
+
+```text
+payment_method_configs.surface VARCHAR(32) NOT NULL DEFAULT 'cabinet'
+UNIQUE(surface, method_id)
+```
+
+### Future DB accounts
+
+Когда понадобится больше scopes:
+
+```text
+yookassa_accounts
+  id
+  scope
+  display_name
+  shop_id
+  secret_key_encrypted
+  enabled
+  sbp_enabled
+  recurrent_enabled
+  return_url
+  default_receipt_email
+  min_amount_kopeks
+  max_amount_kopeks
+  created_at
+  updated_at
+```
+
+После этого:
+
+- добавить `yookassa_account_id` в `yookassa_payments`;
+- добавить `yookassa_account_id` в `saved_payment_methods`;
+- `yookassa_scope` оставить как denormalized/debug field или убрать после миграции.
+
+## Изменения API, Bot UI, Admin UI
+
+### Backend API
+
+`GET /cabinet/balance/payment-methods`:
+
+- остается прежним по контракту;
+- возвращает `yookassa` только если `settings.is_yookassa_enabled("cabinet")`;
+- SBP option возвращается только если `settings.is_yookassa_sbp_enabled("cabinet")`.
+
+`POST /cabinet/balance/topup`:
+
+- принимает прежний `payment_method='yookassa'`;
+- создает платеж через `scope='cabinet'`;
+- сохраняет scope в локальный payment.
+
+Saved cards endpoints:
+
+- возвращают только карты нужного scope, если endpoint относится к Cabinet;
+- для legacy cards без scope можно показывать только если active config использует legacy/default.
+
+Webhook:
+
+- добавить scoped paths;
+- старый path оставить.
+
+### Bot UI
+
+Bot keyboards не меняют UX:
+
+- пользователю показывается `YooKassa`/display name;
+- технический scope не показывается;
+- Bot видит YooKassa только по `YOOKASSA_BOT_*` или legacy fallback.
+
+### Cabinet Admin UI
+
+Для MVP можно оставить один row `yookassa` в Payment Methods admin. Он означает Cabinet YooKassa.
+
+Что нужно поменять в backend admin response:
+
+- `is_provider_configured` для `yookassa` должен проверять Cabinet scope;
+- display/sub-options должны брать Cabinet scope.
+
+Если нужен админский UI для Bot YooKassa, это отдельный экран/settings section, а не второй method id в Cabinet payment methods.
+
+## Backward compatibility
+
+Обязательные правила:
+
+- Старые `YOOKASSA_*` продолжают работать без изменения `.env`.
+- Если scoped env не задан, `bot` и `cabinet` используют legacy config.
+- Старые `YooKassaPayment.yookassa_scope IS NULL` проверяются через legacy/default config.
+- Старые `SavedPaymentMethod.yookassa_scope IS NULL` заряжаются через legacy/default config.
+- Старый `/yookassa-webhook` остается зарегистрированным.
+- Внешний method id остается `yookassa`.
+- Single-shop installation не требует настройки multi-shop.
+
+Важно: если оператор хочет разделить только Cabinet, он может задать `YOOKASSA_CABINET_*`, а Bot продолжит работать через legacy `YOOKASSA_*`.
+
+## Риски
+
+### YooKassa SDK global config
+
+Риск: параллельные запросы Bot и Cabinet могут использовать не те credentials.
+
+Митигировать: direct HTTP client with per-request Basic Auth. Не логировать `secret_key`.
+
+### Webhook races
+
+Риск: YooKassa webhook и manual check одновременно обрабатывают один платеж.
+
+Текущий код уже использует transaction/lock в success path и проверяет duplicate transaction по `external_id/payment_method`. Scope нужно добавить в lookup/dedup context, но старый unique constraint ломать нельзя без отдельного анализа.
+
+### Duplicate payment id между магазинами
+
+YooKassa payment id скорее всего практически глобален, но на это не нужно опираться.
+
+Митигировать:
+
+- хранить `yookassa_scope`;
+- искать scoped платежи по `(scope, yookassa_payment_id)`;
+- NaloGO keys делать scoped.
+
+### Autopay saved cards
+
+Риск: списать card token через другой магазин.
+
+Митигировать:
+
+- `SavedPaymentMethod.yookassa_scope`;
+- recurrent charge только через scope saved method;
+- не смешивать Bot и Cabinet saved cards без явного product decision.
+
+### NaloGO legal entity mismatch
+
+Риск: чек выпускается не тем налоговым субъектом.
+
+Митигировать:
+
+- MVP допускает global NaloGO только если оба YooKassa магазина принадлежат одному налоговому субъекту;
+- иначе добавить scoped NaloGO credentials.
+
+### Compatibility старых платежей
+
+Риск: старые строки без scope перестают проверяться.
+
+Митигировать:
+
+- nullable scope;
+- legacy fallback;
+- старый webhook path;
+- тесты на старый env-only config.
+
+## План реализации
+
+### Этап 1. Config и compatibility
+
+- Добавить scoped config model/helper methods в `app/config.py`.
+- Оставить старые `YOOKASSA_*` как fallback.
+- Покрыть unit tests для `bot`, `cabinet`, legacy fallback и explicit disabled scoped config.
+
+Verify:
+
+- legacy `.env` включает YooKassa в обоих scopes;
+- `YOOKASSA_CABINET_ENABLED=false` выключает только Cabinet;
+- `YOOKASSA_BOT_ENABLED=false` выключает только Bot.
+
+### Этап 2. DB model/CRUD scope
+
+- Добавить `yookassa_scope` в `YooKassaPayment`.
+- Добавить `yookassa_scope` в `SavedPaymentMethod`.
+- Обновить CRUD create/get/list.
+- Подготовить uniqueness saved methods с учетом scope.
+
+Verify:
+
+- старые записи с `NULL` читаются;
+- новые платежи сохраняют scope;
+- saved card одного scope не используется другим scope.
+
+### Этап 3. Scoped YooKassa client и создание платежей
+
+- Заменить SDK global calls на direct HTTP client или временно обернуть SDK lock.
+- Обновить `create_yookassa_payment()` и `create_yookassa_sbp_payment()` на `scope`.
+- Проставить `scope='bot'` в bot handlers.
+- Проставить `scope='cabinet'` в Cabinet routes.
+- Обновить `PaymentMethodConfig` defaults для Cabinet scope.
+
+Verify:
+
+- Bot создает платеж с Bot shop credentials.
+- Cabinet создает платеж с Cabinet shop credentials.
+- Cabinet methods не показывают YooKassa, если включен только Bot scope.
+- Bot keyboard не показывает YooKassa, если включен только Cabinet scope.
+
+### Этап 4. Webhook/status check
+
+- Добавить `/yookassa-webhook/bot` и `/yookassa-webhook/cabinet`.
+- Старый `/yookassa-webhook` оставить.
+- Передавать scope в `process_yookassa_webhook()`.
+- Manual check выбирать credentials из local payment scope.
+- Recovery missing payment использовать path scope.
+
+Verify:
+
+- webhook `/bot` проверяет Bot credentials;
+- webhook `/cabinet` проверяет Cabinet credentials;
+- legacy webhook работает со старым платежом без scope;
+- manual check старого платежа без scope работает.
+
+### Этап 5. Autopay/saved payment methods
+
+- Сохранять scope вместе с YooKassa saved payment method.
+- Recurrent service выбирать scoped credentials из saved method.
+- Для subscription autopay default scope = `bot`.
+- Legacy saved methods без scope использовать через legacy/default config.
+
+Verify:
+
+- Bot saved card списывается только Bot credentials;
+- Cabinet saved card не используется для Bot subscription без явного правила;
+- legacy saved card продолжает работать.
+
+### Этап 6. NaloGO scope context
+
+- Прокинуть provider/scope/external payment id в NaloGO receipt creation.
+- Обновить Redis dedup keys:
+  - `nalogo:created:yookassa:{scope}:{payment_id}`;
+  - `nalogo:queued:yookassa:{scope}:{payment_id}`.
+- Добавить scope в logs без secret data.
+
+Verify:
+
+- Bot и Cabinet платежи имеют разные NaloGO dedup keys;
+- retry queue не склеивает платежи разных scopes;
+- старые queued receipts можно обработать legacy fallback.
+
+### Этап 7. Admin/frontend/tests
+
+- Cabinet frontend contract оставить прежним.
+- Admin Payment Methods row `yookassa` проверяет Cabinet provider config.
+- Добавить integration tests на `/cabinet/balance/payment-methods`, `/cabinet/balance/topup`, bot keyboard methods, webhook paths и manual status.
+
+Verify:
+
+- пользователь видит обычный `YooKassa`, не `yookassa_bot`;
+- админ не обязан настраивать multi-shop для single-shop installation;
+- secrets не попадают в logs, API response и git.
+
+## Конкретные файлы для реализации
+
+Backend:
+
+- `app/config.py`
+- `app/services/yookassa_service.py`
+- `app/services/payment/yookassa.py`
+- `app/services/payment_service.py`
+- `app/services/payment_method_config_service.py`
+- `app/services/payment_verification_service.py`
+- `app/services/recurrent_payment_service.py`
+- `app/services/nalogo_service.py`
+- `app/services/nalogo_queue_service.py`
+- `app/services/guest_purchase_service.py`
+- `app/webserver/payments.py`
+- `app/external/yookassa_webhook.py`
+- `app/database/models.py`
+- `app/database/crud/yookassa.py`
+- `app/database/crud/saved_payment_method.py`
+- `migrations/alembic/versions/*`
+
+Bot flows:
+
+- `app/handlers/balance/yookassa.py`
+- `app/handlers/subscription/purchase.py`
+- `app/handlers/simple_subscription.py`
+- `app/keyboards/inline.py`
+- `app/utils/payment_utils.py`
+- `app/handlers/admin/bot_configuration.py`
+
+Cabinet/API flows:
+
+- `app/cabinet/routes/balance.py`
+- `app/cabinet/routes/admin_payment_methods.py`
+- `app/cabinet/routes/admin_payments.py`
+- `app/webapi/routes/miniapp.py`
+- `app/cabinet/routes/landing.py`
+- `app/cabinet/routes/gift.py`
+
+Cabinet frontend, если потребуется только текст/типы:
+
+- `bedolaga-cabinet/src/api/balance.ts`
+- `bedolaga-cabinet/src/types/index.ts`
+- `bedolaga-cabinet/src/api/adminPaymentMethods.ts`
+
+Для MVP frontend изменений, скорее всего, не нужно: backend продолжает возвращать method id `yookassa`.

--- a/migrations/alembic/versions/0090_add_yookassa_scopes.py
+++ b/migrations/alembic/versions/0090_add_yookassa_scopes.py
@@ -1,0 +1,40 @@
+"""add YooKassa scope columns
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-06-14
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0090'
+down_revision: Union[str, None] = '0089'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('yookassa_payments', sa.Column('yookassa_scope', sa.String(length=32), nullable=True))
+    op.create_index(
+        'ix_yookassa_payments_scope_payment_id',
+        'yookassa_payments',
+        ['yookassa_scope', 'yookassa_payment_id'],
+        unique=False,
+    )
+    op.add_column('saved_payment_methods', sa.Column('yookassa_scope', sa.String(length=32), nullable=True))
+    op.create_index(
+        'ix_saved_payment_methods_user_scope_active',
+        'saved_payment_methods',
+        ['user_id', 'yookassa_scope', 'is_active'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_saved_payment_methods_user_scope_active', table_name='saved_payment_methods')
+    op.drop_column('saved_payment_methods', 'yookassa_scope')
+    op.drop_index('ix_yookassa_payments_scope_payment_id', table_name='yookassa_payments')
+    op.drop_column('yookassa_payments', 'yookassa_scope')

--- a/tests/crud/test_yookassa_scopes.py
+++ b/tests/crud/test_yookassa_scopes.py
@@ -1,0 +1,136 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from app.database.crud import saved_payment_method as saved_methods, yookassa as yk
+from app.database.models import SavedPaymentMethod, YooKassaPayment
+
+
+def _result(value):
+    res = MagicMock()
+    res.scalar_one_or_none = MagicMock(return_value=value)
+    res.scalars.return_value.all.return_value = value
+    return res
+
+
+def _statement_text(statement) -> str:
+    return str(statement.compile(compile_kwargs={'literal_binds': True}))
+
+
+def test_yookassa_payment_model_stores_scope():
+    payment = YooKassaPayment(
+        user_id=42,
+        yookassa_payment_id='payment-1',
+        amount_kopeks=1000,
+        currency='RUB',
+        description='test',
+        status='pending',
+        yookassa_scope='cabinet',
+    )
+
+    assert payment.yookassa_scope == 'cabinet'
+
+
+async def test_create_yookassa_payment_saves_scope():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(None))
+    db.add = MagicMock()
+
+    payment = await yk.create_yookassa_payment(
+        db=db,
+        user_id=42,
+        yookassa_payment_id='payment-1',
+        amount_kopeks=1000,
+        currency='RUB',
+        description='test',
+        status='pending',
+        yookassa_scope='bot',
+    )
+
+    db.add.assert_called_once()
+    assert payment is not None
+    assert payment.yookassa_scope == 'bot'
+
+
+async def test_get_yookassa_payment_by_id_filters_by_scope_when_passed():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(MagicMock()))
+
+    await yk.get_yookassa_payment_by_id(db, 'payment-1', yookassa_scope='cabinet')
+
+    statement = db.execute.await_args.args[0]
+    statement_text = _statement_text(statement)
+    assert "yookassa_payments.yookassa_payment_id = 'payment-1'" in statement_text
+    assert "yookassa_payments.yookassa_scope = 'cabinet'" in statement_text
+
+
+async def test_get_yookassa_payment_by_id_without_scope_keeps_legacy_lookup():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(MagicMock()))
+
+    await yk.get_yookassa_payment_by_id(db, 'payment-1')
+
+    statement_text = _statement_text(db.execute.await_args.args[0])
+    assert "yookassa_payments.yookassa_payment_id = 'payment-1'" in statement_text
+    assert 'yookassa_payments.yookassa_scope =' not in statement_text
+
+
+def test_saved_payment_method_model_stores_scope():
+    method = SavedPaymentMethod(
+        user_id=42,
+        yookassa_payment_method_id='pm-1',
+        method_type='bank_card',
+        yookassa_scope='cabinet',
+    )
+
+    assert method.yookassa_scope == 'cabinet'
+
+
+async def test_create_saved_payment_method_saves_scope():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(None))
+    db.add = MagicMock()
+
+    method = await saved_methods.create_saved_payment_method(
+        db=db,
+        user_id=42,
+        yookassa_payment_method_id='pm-1',
+        yookassa_scope='bot',
+    )
+
+    db.add.assert_called_once()
+    assert method is not None
+    assert method.yookassa_scope == 'bot'
+
+
+async def test_active_saved_payment_methods_filters_by_scope_when_passed():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result([]))
+
+    await saved_methods.get_active_payment_methods_by_user(db, user_id=42, yookassa_scope='cabinet')
+
+    statement_text = _statement_text(db.execute.await_args.args[0])
+    assert 'saved_payment_methods.user_id = 42' in statement_text
+    assert "saved_payment_methods.yookassa_scope = 'cabinet'" in statement_text
+    assert 'saved_payment_methods.is_active = true' in statement_text
+
+
+async def test_active_saved_payment_methods_without_scope_keeps_legacy_lookup():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result([]))
+
+    await saved_methods.get_active_payment_methods_by_user(db, user_id=42)
+
+    statement_text = _statement_text(db.execute.await_args.args[0])
+    assert 'saved_payment_methods.user_id = 42' in statement_text
+    assert 'saved_payment_methods.yookassa_scope =' not in statement_text
+    assert 'saved_payment_methods.is_active = true' in statement_text
+
+
+async def test_user_ids_with_active_payment_methods_filters_by_scope_when_passed():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result([]))
+
+    await saved_methods.get_user_ids_with_active_payment_methods(db, user_ids=[42, 43], yookassa_scope='bot')
+
+    statement_text = _statement_text(db.execute.await_args.args[0])
+    assert "saved_payment_methods.yookassa_scope = 'bot'" in statement_text
+    assert 'saved_payment_methods.is_active = true' in statement_text

--- a/tests/external/test_yookassa_webhook.py
+++ b/tests/external/test_yookassa_webhook.py
@@ -220,3 +220,26 @@ async def test_handle_webhook_accepts_canceled_event(monkeypatch: pytest.MonkeyP
 
     assert status == 200
     process_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_scoped_webhook_passes_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get_db(monkeypatch)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    app = create_yookassa_webhook_app(service)
+    async with TestClient(TestServer(app)) as client:
+        payload = {'event': 'payment.canceled', 'object': {'id': 'yk_cabinet'}}
+        response = await client.post(
+            f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet',
+            data=json.dumps(payload).encode('utf-8'),
+            headers=_build_headers(),
+        )
+
+        status = response.status
+
+    assert status == 200
+    process_mock.assert_awaited_once()
+    assert process_mock.await_args.kwargs == {'yookassa_scope': 'cabinet'}

--- a/tests/services/test_nalogo_yookassa_scope.py
+++ b/tests/services/test_nalogo_yookassa_scope.py
@@ -1,0 +1,140 @@
+"""NaloGO receipt context for scoped YooKassa payments."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.config import settings
+from app.services import (
+    nalogo_queue_service as nalogo_queue_service_module,
+    nalogo_service as nalogo_service_module,
+)
+from app.services.nalogo_queue_service import NalogoQueueService
+from app.services.nalogo_service import NaloGoService
+
+
+class FakeCache:
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+        self.get_keys: list[str] = []
+        self.set_keys: list[str] = []
+        self.setnx_keys: list[str] = []
+        self.delete_keys: list[str] = []
+        self.lpush_items: list[tuple[str, Any]] = []
+
+    async def get(self, key: str) -> Any:
+        self.get_keys.append(key)
+        return self.values.get(key)
+
+    async def set(self, key: str, value: Any, expire: int | None = None) -> bool:
+        self.set_keys.append(key)
+        self.values[key] = value
+        return True
+
+    async def setnx(self, key: str, value: Any, expire: int | None = None) -> bool:
+        self.setnx_keys.append(key)
+        if key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    async def lpush(self, key: str, value: Any) -> bool:
+        self.lpush_items.append((key, value))
+        return True
+
+    async def llen(self, key: str) -> int:
+        return sum(1 for item_key, _ in self.lpush_items if item_key == key)
+
+    async def delete(self, key: str) -> bool:
+        self.delete_keys.append(key)
+        self.values.pop(key, None)
+        return True
+
+
+@pytest.mark.anyio('asyncio')
+async def test_nalogo_create_receipt_uses_scoped_yookassa_dedup_keys_when_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_cache = FakeCache()
+    monkeypatch.setattr(nalogo_service_module, 'cache', fake_cache)
+
+    service = NaloGoService.__new__(NaloGoService)
+    service.configured = True
+    service.client = SimpleNamespace()
+
+    async def fake_authenticate() -> bool:
+        return False
+
+    service.authenticate = fake_authenticate
+
+    result = await service.create_receipt(
+        name='Пополнение баланса',
+        amount=100.0,
+        quantity=1,
+        payment_id='yk_cabinet_receipt',
+        payment_provider='yookassa',
+        payment_scope='cabinet',
+        external_payment_id='yk_cabinet_receipt',
+    )
+
+    assert result is None
+    created_key = 'nalogo:created:yookassa:cabinet:yk_cabinet_receipt'
+    assert fake_cache.get_keys == [created_key, created_key]
+    assert fake_cache.setnx_keys == ['nalogo:queued:yookassa:cabinet:yk_cabinet_receipt']
+    assert fake_cache.lpush_items[0][0] == nalogo_service_module.NALOGO_QUEUE_KEY
+    queued_receipt = fake_cache.lpush_items[0][1]
+    assert queued_receipt['payment_provider'] == 'yookassa'
+    assert queued_receipt['payment_scope'] == 'cabinet'
+    assert queued_receipt['external_payment_id'] == 'yk_cabinet_receipt'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_nalogo_queue_replays_scoped_receipt_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_cache = FakeCache()
+    monkeypatch.setattr(nalogo_queue_service_module, 'cache', fake_cache)
+    monkeypatch.setattr(settings, 'NALOGO_QUEUE_RECEIPT_DELAY', 0, raising=False)
+
+    create_kwargs: dict[str, Any] = {}
+
+    class FakeNaloGoService:
+        configured = True
+
+        def __init__(self) -> None:
+            self.queue = [
+                {
+                    'name': 'Пополнение баланса',
+                    'amount': 100.0,
+                    'quantity': 1,
+                    'payment_id': 'yk_bot_receipt',
+                    'payment_provider': 'yookassa',
+                    'payment_scope': 'bot',
+                    'external_payment_id': 'yk_bot_receipt',
+                    'attempts': 0,
+                }
+            ]
+
+        async def get_queue_length(self) -> int:
+            return len(self.queue)
+
+        async def pop_receipt_from_queue(self) -> dict[str, Any] | None:
+            return self.queue.pop(0) if self.queue else None
+
+        async def create_receipt(self, **kwargs: Any) -> str:
+            create_kwargs.update(kwargs)
+            return 'receipt-uuid'
+
+        async def requeue_receipt(self, receipt_data: dict[str, Any]) -> bool:
+            self.queue.append(receipt_data)
+            return True
+
+    service = NalogoQueueService(FakeNaloGoService())
+
+    await service._process_pending_receipts()
+
+    assert create_kwargs['payment_provider'] == 'yookassa'
+    assert create_kwargs['payment_scope'] == 'bot'
+    assert create_kwargs['external_payment_id'] == 'yk_bot_receipt'
+    assert fake_cache.delete_keys == ['nalogo:queued:yookassa:bot:yk_bot_receipt']

--- a/tests/services/test_payment_service_webhooks.py
+++ b/tests/services/test_payment_service_webhooks.py
@@ -877,6 +877,143 @@ async def test_process_yookassa_webhook_handles_cancellation(monkeypatch: pytest
 
 
 @pytest.mark.anyio('asyncio')
+async def test_process_yookassa_webhook_uses_path_scope_for_lookup_and_remote_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_ENABLED', True, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SHOP_ID', 'cabinet-shop', raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SECRET_KEY', 'cabinet-secret', raising=False)
+    bot = DummyBot()
+    service = _make_service(bot)
+    fake_session = FakeSession()
+    payment = SimpleNamespace(
+        yookassa_payment_id='yk_cabinet_cancel',
+        yookassa_scope='cabinet',
+        user_id=77,
+        amount_kopeks=5000,
+        transaction_id=None,
+        status='pending',
+        is_paid=False,
+        captured_at=None,
+        payment_method_type=None,
+    )
+    lookup_scopes: list[str | None] = []
+    created_scopes: list[str | None] = []
+
+    async def fake_get_payment(db, payment_id, yookassa_scope=None):
+        lookup_scopes.append(yookassa_scope)
+        return payment
+
+    class ScopedYooKassaService:
+        def __init__(self, scope: str | None = None):
+            created_scopes.append(scope)
+            self.scope = scope
+
+        async def get_payment_info(self, payment_id: str) -> dict[str, Any]:
+            assert payment_id == 'yk_cabinet_cancel'
+            return {
+                'id': payment_id,
+                'status': 'canceled',
+                'paid': False,
+                'amount_value': 50.0,
+                'amount_currency': 'RUB',
+                'payment_method_type': 'bank_card',
+            }
+
+    monkeypatch.setattr(payment_service_module, 'get_yookassa_payment_by_id', fake_get_payment)
+    monkeypatch.setattr('app.services.yookassa_service.YooKassaService', ScopedYooKassaService)
+
+    payload = {
+        'object': {
+            'id': 'yk_cabinet_cancel',
+            'status': 'pending',
+            'paid': False,
+        }
+    }
+
+    result = await service.process_yookassa_webhook(fake_session, payload, yookassa_scope='cabinet')
+
+    assert result is True
+    assert lookup_scopes == ['cabinet']
+    assert created_scopes == ['cabinet']
+    assert payment.status == 'canceled'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_save_payment_method_uses_payment_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(DummyBot())
+    payment = SimpleNamespace(
+        user_id=77,
+        yookassa_payment_id='yk_saved_card',
+        yookassa_scope='cabinet',
+    )
+    existing_lookup_scopes: list[str | None] = []
+    create_kwargs: dict[str, Any] = {}
+
+    async def fake_get_payment_method_by_yookassa_id(
+        db,
+        payment_method_id: str,
+        include_inactive: bool = False,
+        yookassa_scope: str | None = None,
+    ):
+        assert payment_method_id == 'pm_cabinet_card'
+        assert include_inactive is True
+        existing_lookup_scopes.append(yookassa_scope)
+
+    async def fake_create_saved_payment_method(**kwargs: Any):
+        create_kwargs.update(kwargs)
+        return SimpleNamespace(id=123)
+
+    monkeypatch.setattr(
+        'app.database.crud.saved_payment_method.get_payment_method_by_yookassa_id',
+        fake_get_payment_method_by_yookassa_id,
+    )
+    monkeypatch.setattr(
+        'app.database.crud.saved_payment_method.create_saved_payment_method',
+        fake_create_saved_payment_method,
+    )
+
+    await service._save_payment_method_if_available(
+        FakeSession(),
+        payment,
+        {
+            'payment_method': {
+                'id': 'pm_cabinet_card',
+                'type': 'bank_card',
+                'saved': True,
+                'card': {'first6': '411111', 'last4': '1111', 'card_type': 'Visa'},
+            }
+        },
+    )
+
+    assert existing_lookup_scopes == ['cabinet']
+    assert create_kwargs['yookassa_scope'] == 'cabinet'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_create_nalogo_receipt_passes_yookassa_scope() -> None:
+    service = _make_service(DummyBot())
+    create_kwargs: dict[str, Any] = {}
+
+    class FakeNaloGoService:
+        async def create_receipt(self, **kwargs: Any):
+            create_kwargs.update(kwargs)
+
+    service.nalogo_service = FakeNaloGoService()
+    payment = SimpleNamespace(
+        yookassa_payment_id='yk_cabinet_receipt',
+        yookassa_scope='cabinet',
+        amount_kopeks=10000,
+    )
+
+    await service._create_nalogo_receipt(FakeSession(), payment, telegram_user_id=1234)
+
+    assert create_kwargs['payment_provider'] == 'yookassa'
+    assert create_kwargs['payment_scope'] == 'cabinet'
+    assert create_kwargs['external_payment_id'] == 'yk_cabinet_receipt'
+
+
+@pytest.mark.anyio('asyncio')
 async def test_process_yookassa_webhook_restores_missing_payment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/services/test_payment_service_yookassa.py
+++ b/tests/services/test_payment_service_yookassa.py
@@ -132,6 +132,42 @@ async def test_create_yookassa_payment_success(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.anyio('asyncio')
+async def test_create_yookassa_payment_persists_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = {
+        'id': 'yk_bot_123',
+        'status': 'pending',
+        'confirmation_url': 'https://yookassa.ru/confirm',
+        'created_at': '2024-01-01T12:00:00Z',
+    }
+    service = _make_service(StubYooKassaService(response))
+    db = DummySession()
+
+    captured_args: dict[str, Any] = {}
+
+    async def fake_create_yookassa_payment(**kwargs: Any) -> DummyLocalPayment:
+        captured_args.update(kwargs)
+        return DummyLocalPayment(payment_id=556)
+
+    monkeypatch.setattr(
+        payment_service_module,
+        'create_yookassa_payment',
+        fake_create_yookassa_payment,
+        raising=False,
+    )
+
+    result = await service.create_yookassa_payment(
+        db=db,
+        user_id=42,
+        amount_kopeks=14000,
+        description='Пополнение',
+        yookassa_scope='bot',
+    )
+
+    assert result is not None
+    assert captured_args['yookassa_scope'] == 'bot'
+
+
+@pytest.mark.anyio('asyncio')
 async def test_create_yookassa_payment_returns_none_when_service_missing() -> None:
     """Если сервис не настроен, метод должен вернуть None."""
     service = _make_service(None)
@@ -217,6 +253,42 @@ async def test_create_yookassa_sbp_payment_success(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.anyio('asyncio')
+async def test_create_yookassa_sbp_payment_persists_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = {
+        'id': 'yk_sbp_bot_001',
+        'status': 'pending',
+        'confirmation_url': 'https://yookassa.ru/confirm',
+        'confirmation': {'confirmation_token': 'token123'},
+    }
+    service = _make_service(StubYooKassaService(response))
+    db = DummySession()
+
+    captured_args: dict[str, Any] = {}
+
+    async def fake_create_yookassa_payment(**kwargs: Any) -> DummyLocalPayment:
+        captured_args.update(kwargs)
+        return DummyLocalPayment(payment_id=778)
+
+    monkeypatch.setattr(
+        payment_service_module,
+        'create_yookassa_payment',
+        fake_create_yookassa_payment,
+        raising=False,
+    )
+
+    result = await service.create_yookassa_sbp_payment(
+        db=db,
+        user_id=7,
+        amount_kopeks=25000,
+        description='СБП пополнение',
+        yookassa_scope='bot',
+    )
+
+    assert result is not None
+    assert captured_args['yookassa_scope'] == 'bot'
+
+
+@pytest.mark.anyio('asyncio')
 async def test_create_yookassa_sbp_payment_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ошибочный ответ СБП не должен создавать запись."""
     response = {'error': 'invalid'}
@@ -245,3 +317,59 @@ async def test_create_yookassa_sbp_payment_returns_none_on_error(monkeypatch: py
     )
     assert result is None
     assert called is False
+
+
+@pytest.mark.anyio('asyncio')
+async def test_get_yookassa_payment_status_uses_payment_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_ENABLED', True, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SHOP_ID', 'cabinet-shop', raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SECRET_KEY', 'cabinet-secret', raising=False)
+    payment = type(
+        'Payment',
+        (),
+        {
+            'id': 55,
+            'yookassa_payment_id': 'yk_cabinet_status',
+            'yookassa_scope': 'cabinet',
+            'status': 'pending',
+            'is_paid': False,
+            'transaction_id': None,
+        },
+    )()
+    db = DummySession()
+    service = _make_service(None)
+    created_scopes: list[str | None] = []
+
+    class ScopedYooKassaService:
+        def __init__(self, scope: str | None = None):
+            created_scopes.append(scope)
+            self.scope = scope
+
+        async def get_payment_info(self, payment_id: str) -> dict[str, Any]:
+            assert payment_id == 'yk_cabinet_status'
+            return {
+                'status': 'canceled',
+                'paid': False,
+                'payment_method_type': 'bank_card',
+            }
+
+    async def fake_get_local(db, local_payment_id: int):
+        assert local_payment_id == 55
+        return payment
+
+    async def fake_update_status(db, yookassa_payment_id, status, is_paid, is_captured, captured_at, payment_method_type):
+        payment.status = status
+        payment.is_paid = is_paid
+        payment.payment_method_type = payment_method_type
+        return payment
+
+    monkeypatch.setattr(payment_service_module, 'get_yookassa_payment_by_local_id', fake_get_local)
+    monkeypatch.setattr(payment_service_module, 'update_yookassa_payment_status', fake_update_status)
+    monkeypatch.setattr('app.services.yookassa_service.YooKassaService', ScopedYooKassaService)
+
+    result = await service.get_yookassa_payment_status(db, 55)
+
+    assert result is not None
+    assert result['payment'] is payment
+    assert payment.status == 'canceled'
+    assert created_scopes == ['cabinet']

--- a/tests/services/test_recurrent_yookassa_scope.py
+++ b/tests/services/test_recurrent_yookassa_scope.py
@@ -1,0 +1,138 @@
+"""Scoped YooKassa checks for recurrent balance topups."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.config import settings
+from app.database.models import SubscriptionStatus
+from app.services import recurrent_payment_service
+
+
+@pytest.mark.anyio('asyncio')
+async def test_process_recurrent_payments_uses_bot_yookassa_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_ENABLED', False, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_RECURRENT_ENABLED', False, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_ENABLED', True, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_SHOP_ID', 'bot-shop', raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_SECRET_KEY', 'bot-secret', raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_RECURRENT_ENABLED', True, raising=False)
+    monkeypatch.setattr(settings, 'ENABLE_AUTOPAY', True, raising=False)
+
+    async def fake_find_subscriptions(db: Any) -> list[Any]:
+        return []
+
+    monkeypatch.setattr(recurrent_payment_service, '_find_subscriptions_needing_topup', fake_find_subscriptions)
+
+    result = await recurrent_payment_service.process_recurrent_payments(db=SimpleNamespace())
+
+    assert result['checked'] == 0
+    assert result.get('skipped') is None
+
+
+@pytest.mark.anyio('asyncio')
+async def test_recurrent_topup_uses_bot_scope_for_card_client_and_local_payment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = SimpleNamespace(
+        id=42,
+        telegram_id=4242,
+        balance_kopeks=1000,
+        language='ru',
+    )
+    subscription = SimpleNamespace(
+        id=77,
+        user_id=user.id,
+        user=user,
+        tariff=SimpleNamespace(get_shortest_period=lambda: 30),
+        end_date=datetime.now(UTC) + timedelta(hours=1),
+        status=SubscriptionStatus.ACTIVE.value,
+        autopay_days_before=3,
+    )
+    saved_method = SimpleNamespace(
+        id=9,
+        yookassa_payment_method_id='pm_bot_card',
+        card_last4='4242',
+    )
+    active_method_scopes: list[str | None] = []
+    created_payment_kwargs: dict[str, Any] = {}
+
+    class FakeYooKassaService:
+        configured = True
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def create_autopayment(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(kwargs)
+            return {
+                'id': 'yk_bot_recurrent',
+                'status': 'succeeded',
+                'paid': True,
+                'created_at': datetime.now(UTC).isoformat(),
+                'test_mode': True,
+            }
+
+    fake_yookassa_service = FakeYooKassaService()
+
+    class FakePaymentService:
+        yookassa_service = fake_yookassa_service
+
+        def __init__(self) -> None:
+            self.requested_scopes: list[str | None] = []
+
+        def _get_yookassa_service_for_scope(self, scope: str | None) -> FakeYooKassaService:
+            self.requested_scopes.append(scope)
+            return fake_yookassa_service
+
+    class FakePricingEngine:
+        async def calculate_renewal_price(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+            return SimpleNamespace(final_total=5000)
+
+    async def fake_lock_user_for_pricing(db: Any, user_id: int) -> Any:
+        assert user_id == user.id
+        return user
+
+    async def fake_get_active_payment_methods_by_user(
+        db: Any,
+        user_id: int,
+        yookassa_scope: str | None = None,
+    ) -> list[Any]:
+        assert user_id == user.id
+        active_method_scopes.append(yookassa_scope)
+        return [saved_method]
+
+    async def fake_create_yookassa_payment(**kwargs: Any) -> SimpleNamespace:
+        created_payment_kwargs.update(kwargs)
+        return SimpleNamespace(id=123)
+
+    monkeypatch.setattr('app.database.crud.user.lock_user_for_pricing', fake_lock_user_for_pricing)
+    monkeypatch.setattr('app.services.pricing_engine.pricing_engine', FakePricingEngine())
+    monkeypatch.setattr(
+        'app.database.crud.saved_payment_method.get_active_payment_methods_by_user',
+        fake_get_active_payment_methods_by_user,
+    )
+    monkeypatch.setattr('app.database.crud.yookassa.create_yookassa_payment', fake_create_yookassa_payment)
+
+    payment_service = FakePaymentService()
+
+    result = await recurrent_payment_service._process_single_subscription(
+        db=SimpleNamespace(),
+        subscription=subscription,
+        user=user,
+        bot=None,
+        payment_service=payment_service,
+        subscription_service=SimpleNamespace(),
+    )
+
+    assert result == 'created'
+    assert payment_service.requested_scopes == ['bot']
+    assert active_method_scopes == ['bot']
+    assert fake_yookassa_service.calls[0]['metadata']['yookassa_scope'] == 'bot'
+    assert created_payment_kwargs['yookassa_scope'] == 'bot'

--- a/tests/services/test_yookassa_service_adapter.py
+++ b/tests/services/test_yookassa_service_adapter.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, Self
 
 import pytest
 
@@ -15,8 +14,9 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from yookassa import Configuration, Payment as YooKassaPayment  # type: ignore
+from yookassa import Configuration  # type: ignore
 
+import app.services.yookassa_service as yookassa_service_module
 from app.config import settings
 from app.services.yookassa_service import YooKassaService
 
@@ -24,11 +24,6 @@ from app.services.yookassa_service import YooKassaService
 @pytest.fixture
 def anyio_backend() -> str:
     return 'asyncio'
-
-
-class DummyLoop:
-    async def run_in_executor(self, _executor, func):
-        return func()
 
 
 def _prepare_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -52,32 +47,45 @@ def test_init_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_create_payment_success(monkeypatch: pytest.MonkeyPatch) -> None:
     _prepare_config(monkeypatch)
     monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', None, raising=False)
-    monkeypatch.setattr(asyncio, 'get_running_loop', DummyLoop, raising=False)
 
-    captured_config: dict[str, tuple[str, str]] = {}
+    captured_calls: list[dict[str, Any]] = []
 
-    def fake_configure(shop_id: str, secret_key: str) -> None:
-        captured_config['values'] = (shop_id, secret_key)
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
 
-    monkeypatch.setattr(Configuration, 'configure', fake_configure, raising=False)
+        def json(self) -> dict[str, Any]:
+            return {
+                'id': 'yk_1',
+                'status': 'pending',
+                'paid': False,
+                'confirmation': {'confirmation_url': 'https://yk/confirm'},
+                'metadata': {'meta': 'value'},
+                'amount': {'value': '140.00', 'currency': 'RUB'},
+                'refundable': True,
+                'created_at': '2024-01-01T12:00:00+00:00',
+                'description': 'Desc',
+                'test': False,
+            }
 
-    response_obj = SimpleNamespace(
-        id='yk_1',
-        status='pending',
-        paid=False,
-        confirmation=SimpleNamespace(confirmation_url='https://yk/confirm'),
-        metadata={'meta': 'value'},
-        amount=SimpleNamespace(value='140.00', currency='RUB'),
-        refundable=True,
-        created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
-        description='Desc',
-        test=False,
-    )
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+            captured_calls.append({'url': url, **kwargs})
+            return FakeResponse()
 
     monkeypatch.setattr(
-        YooKassaPayment,
-        'create',
-        staticmethod(lambda payload, key: response_obj),
+        yookassa_service_module,
+        'httpx',
+        SimpleNamespace(AsyncClient=FakeAsyncClient, BasicAuth=lambda username, password: (username, password)),
         raising=False,
     )
 
@@ -93,26 +101,20 @@ async def test_create_payment_success(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert service.configured is True
-    assert captured_config['values'] == ('shop123', 'secret123')
     assert result is not None
     assert result['id'] == 'yk_1'
     assert result['confirmation_url'] == 'https://yk/confirm'
     assert result['amount_value'] == 140.0
     assert result['status'] == 'pending'
+    assert captured_calls[0]['auth'] == ('shop123', 'secret123')
+    assert captured_calls[0]['json']['amount']['value'] == '140.00'
+    assert captured_calls[0]['json']['receipt']['items'][0]['amount']['value'] == '140.00'
 
 
 @pytest.mark.anyio('asyncio')
 async def test_create_payment_without_contacts(monkeypatch: pytest.MonkeyPatch) -> None:
     _prepare_config(monkeypatch)
     monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', None, raising=False)
-    monkeypatch.setattr(Configuration, 'configure', lambda *args, **kwargs: None, raising=False)
-    monkeypatch.setattr(asyncio, 'get_running_loop', DummyLoop, raising=False)
-    monkeypatch.setattr(
-        YooKassaPayment,
-        'create',
-        staticmethod(lambda payload, key: SimpleNamespace()),
-        raising=False,
-    )
 
     service = YooKassaService()
     result = await service.create_payment(
@@ -142,27 +144,46 @@ async def test_create_payment_returns_none_when_not_configured(monkeypatch: pyte
 @pytest.mark.anyio('asyncio')
 async def test_create_sbp_payment_success(monkeypatch: pytest.MonkeyPatch) -> None:
     _prepare_config(monkeypatch)
-    monkeypatch.setattr(asyncio, 'get_running_loop', DummyLoop, raising=False)
-    monkeypatch.setattr(Configuration, 'configure', lambda *args, **kwargs: None, raising=False)
     monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', 'fallback@example.com', raising=False)
 
-    response_obj = SimpleNamespace(
-        id='sbp_001',
-        status='pending',
-        paid=False,
-        confirmation=SimpleNamespace(confirmation_url='https://sbp/confirm'),
-        metadata={'meta': 'value'},
-        amount=SimpleNamespace(value='200.00', currency='RUB'),
-        refundable=False,
-        created_at=datetime(2024, 2, 1, 9, 0, 0, tzinfo=UTC),
-        description='SBP payment',
-        test=True,
-    )
+    captured_calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                'id': 'sbp_001',
+                'status': 'pending',
+                'paid': False,
+                'confirmation': {'confirmation_url': 'https://sbp/confirm'},
+                'metadata': {'meta': 'value'},
+                'amount': {'value': '200.00', 'currency': 'RUB'},
+                'refundable': False,
+                'created_at': '2024-02-01T09:00:00+00:00',
+                'description': 'SBP payment',
+                'test': True,
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+            captured_calls.append({'url': url, **kwargs})
+            return FakeResponse()
 
     monkeypatch.setattr(
-        YooKassaPayment,
-        'create',
-        staticmethod(lambda payload, key: response_obj),
+        yookassa_service_module,
+        'httpx',
+        SimpleNamespace(AsyncClient=FakeAsyncClient, BasicAuth=lambda username, password: (username, password)),
         raising=False,
     )
 
@@ -179,3 +200,130 @@ async def test_create_sbp_payment_success(monkeypatch: pytest.MonkeyPatch) -> No
     assert result['id'] == 'sbp_001'
     assert result['confirmation_url'] == 'https://sbp/confirm'
     assert result['status'] == 'pending'
+    assert captured_calls[0]['json']['payment_method_data'] == {'type': 'sbp'}
+
+
+@pytest.mark.anyio('asyncio')
+async def test_create_payment_uses_scoped_basic_auth_without_global_sdk_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_config(monkeypatch)
+    monkeypatch.setattr(Configuration, 'configure', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', 'fallback@example.com', raising=False)
+
+    captured_calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                'id': 'yk_http_1',
+                'status': 'pending',
+                'paid': False,
+                'confirmation': {'confirmation_url': 'https://yk/confirm'},
+                'metadata': {'scope': 'bot'},
+                'amount': {'value': '140.00', 'currency': 'RUB'},
+                'refundable': True,
+                'created_at': '2024-01-01T12:00:00Z',
+                'description': 'Пополнение',
+                'test': False,
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+            captured_calls.append({'url': url, **kwargs})
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        yookassa_service_module,
+        'httpx',
+        SimpleNamespace(AsyncClient=FakeAsyncClient, BasicAuth=lambda username, password: (username, password)),
+        raising=False,
+    )
+
+    service = YooKassaService(shop_id='bot-shop', secret_key='bot-secret')
+    result = await service.create_payment(
+        amount=140.0,
+        currency='RUB',
+        description='Пополнение',
+        metadata={'scope': 'bot'},
+    )
+
+    assert result is not None
+    assert result['id'] == 'yk_http_1'
+    assert captured_calls[0]['auth'] == ('bot-shop', 'bot-secret')
+    assert captured_calls[0]['url'].endswith('/payments')
+
+
+@pytest.mark.anyio('asyncio')
+async def test_scoped_clients_keep_basic_auth_per_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    _prepare_config(monkeypatch)
+    monkeypatch.setattr(Configuration, 'configure', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', 'fallback@example.com', raising=False)
+
+    captured_auth: list[tuple[str, str]] = []
+
+    class FakeResponse:
+        def __init__(self, payment_id: str) -> None:
+            self.payment_id = payment_id
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                'id': self.payment_id,
+                'status': 'pending',
+                'paid': False,
+                'confirmation': {'confirmation_url': f'https://yk/{self.payment_id}'},
+                'metadata': {},
+                'amount': {'value': '10.00', 'currency': 'RUB'},
+                'refundable': False,
+                'created_at': '2024-01-01T12:00:00Z',
+                'description': 'desc',
+                'test': False,
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+            auth = kwargs['auth']
+            captured_auth.append(auth)
+            return FakeResponse(f'payment_{len(captured_auth)}')
+
+    monkeypatch.setattr(
+        yookassa_service_module,
+        'httpx',
+        SimpleNamespace(AsyncClient=FakeAsyncClient, BasicAuth=lambda username, password: (username, password)),
+        raising=False,
+    )
+
+    bot_service = YooKassaService(shop_id='bot-shop', secret_key='bot-secret')
+    cabinet_service = YooKassaService(shop_id='cabinet-shop', secret_key='cabinet-secret')
+
+    await bot_service.create_payment(amount=10, currency='RUB', description='desc', metadata={})
+    await cabinet_service.create_payment(amount=10, currency='RUB', description='desc', metadata={})
+
+    assert captured_auth == [
+        ('bot-shop', 'bot-secret'),
+        ('cabinet-shop', 'cabinet-secret'),
+    ]

--- a/tests/test_yookassa_runtime_scopes.py
+++ b/tests/test_yookassa_runtime_scopes.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.cabinet.routes import balance as cabinet_balance
+from app.cabinet.schemas.balance import TopUpRequest
+from app.config import settings
+from app.handlers.balance import yookassa as bot_yookassa
+from app.keyboards.inline import get_payment_methods_keyboard
+from app.services import payment_method_config_service
+from app.utils.payment_utils import get_available_payment_methods
+from app.webapi.routes import miniapp
+from app.webapi.schemas.miniapp import MiniAppPaymentCreateRequest, MiniAppPaymentMethodsRequest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+def _set_legacy_yookassa(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_ENABLED', enabled, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_SHOP_ID', 'legacy-shop' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_SECRET_KEY', 'legacy-secret' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_SBP_ENABLED', enabled, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_MIN_AMOUNT_KOPEKS', 1000, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_MAX_AMOUNT_KOPEKS', 5000000, raising=False)
+
+
+def _set_bot_yookassa(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_ENABLED', enabled, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_SHOP_ID', 'bot-shop' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_SECRET_KEY', 'bot-secret' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_SBP_ENABLED', enabled, raising=False)
+
+
+def _set_cabinet_yookassa(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_ENABLED', enabled, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SHOP_ID', 'cabinet-shop' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SECRET_KEY', 'cabinet-secret' if enabled else None, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SBP_ENABLED', enabled, raising=False)
+
+
+def _button_callbacks(markup: Any) -> list[str]:
+    callbacks: list[str] = []
+    for row in markup.inline_keyboard:
+        for button in row:
+            callback_data = getattr(button, 'callback_data', None)
+            if callback_data:
+                callbacks.append(callback_data)
+    return callbacks
+
+
+def test_bot_payment_keyboards_use_bot_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_legacy_yookassa(monkeypatch, enabled=False)
+    _set_bot_yookassa(monkeypatch, enabled=True)
+    _set_cabinet_yookassa(monkeypatch, enabled=False)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', False, raising=False)
+
+    available_methods = get_available_payment_methods()
+    callbacks = _button_callbacks(get_payment_methods_keyboard(10000, language='ru'))
+
+    assert {method['id'] for method in available_methods} >= {'yookassa', 'yookassa_sbp'}
+    assert 'topup_amount|yookassa|10000' in callbacks
+    assert 'topup_amount|yookassa_sbp|10000' in callbacks
+
+    _set_bot_yookassa(monkeypatch, enabled=False)
+    _set_cabinet_yookassa(monkeypatch, enabled=True)
+
+    available_methods = get_available_payment_methods()
+    callbacks = _button_callbacks(get_payment_methods_keyboard(10000, language='ru'))
+
+    assert 'yookassa' not in {method['id'] for method in available_methods}
+    assert all('yookassa' not in callback for callback in callbacks)
+
+
+@pytest.mark.anyio('asyncio')
+async def test_cabinet_payment_methods_use_cabinet_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_legacy_yookassa(monkeypatch, enabled=False)
+    _set_bot_yookassa(monkeypatch, enabled=True)
+    _set_cabinet_yookassa(monkeypatch, enabled=False)
+
+    async def fake_get_all_configs(db: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                method_id='yookassa',
+                is_enabled=True,
+                display_name=None,
+                sub_options={'card': True, 'sbp': True},
+                min_amount_kopeks=None,
+                max_amount_kopeks=None,
+                user_type_filter='all',
+                first_topup_filter='any',
+                promo_group_filter_mode='all',
+                sort_order=1,
+                open_url_direct=False,
+            )
+        ]
+
+    monkeypatch.setattr(payment_method_config_service, 'get_all_configs', fake_get_all_configs)
+
+    bot_only_methods = await payment_method_config_service.get_enabled_methods_for_user(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=1, telegram_id=123, promo_group_id=None),
+        is_first_topup=True,
+    )
+    assert [method['id'] for method in bot_only_methods] == []
+
+    _set_bot_yookassa(monkeypatch, enabled=False)
+    _set_cabinet_yookassa(monkeypatch, enabled=True)
+
+    cabinet_methods = await payment_method_config_service.get_enabled_methods_for_user(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=1, telegram_id=123, promo_group_id=None),
+        is_first_topup=True,
+    )
+    assert [method['id'] for method in cabinet_methods] == ['yookassa']
+
+
+@pytest.mark.anyio('asyncio')
+async def test_cabinet_topup_passes_cabinet_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://cabinet.example', raising=False)
+
+    async def fake_get_payment_methods(user: Any, db: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                id='yookassa',
+                is_available=True,
+                min_amount_kopeks=1000,
+                max_amount_kopeks=5000000,
+            )
+        ]
+
+    captured: dict[str, Any] = {}
+
+    class DummyPaymentService:
+        async def create_yookassa_sbp_payment(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                'local_payment_id': 123,
+                'yookassa_payment_id': 'yk_cabinet_sbp',
+                'confirmation_url': 'https://yk/confirm',
+                'status': 'pending',
+            }
+
+    monkeypatch.setattr(cabinet_balance, 'get_payment_methods', fake_get_payment_methods)
+    monkeypatch.setattr(cabinet_balance, 'PaymentService', lambda *args, **kwargs: DummyPaymentService())
+
+    response = await cabinet_balance.create_topup(
+        TopUpRequest(amount_kopeks=25000, payment_method='yookassa', payment_option='sbp'),
+        user=SimpleNamespace(id=7, telegram_id=777, username='user', restriction_topup=False),
+        db=SimpleNamespace(),
+    )
+
+    assert response.payment_id == '123'
+    assert captured['yookassa_scope'] == 'cabinet'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_miniapp_uses_cabinet_scope_for_yookassa(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_legacy_yookassa(monkeypatch, enabled=False)
+    _set_bot_yookassa(monkeypatch, enabled=False)
+    _set_cabinet_yookassa(monkeypatch, enabled=True)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', False, raising=False)
+
+    async def fake_resolve_user(db: Any, init_data: str) -> tuple[Any, dict[str, Any]]:
+        return SimpleNamespace(id=8, telegram_id=888, language='ru'), {}
+
+    captured: dict[str, Any] = {}
+
+    class DummyPaymentService:
+        async def create_yookassa_payment(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                'local_payment_id': 321,
+                'yookassa_payment_id': 'yk_cabinet',
+                'confirmation_url': 'https://yk/confirm',
+                'status': 'pending',
+            }
+
+    monkeypatch.setattr(miniapp, '_resolve_user_from_init_data', fake_resolve_user)
+    monkeypatch.setattr(miniapp, 'PaymentService', lambda *args, **kwargs: DummyPaymentService())
+
+    methods_response = await miniapp.get_payment_methods(
+        MiniAppPaymentMethodsRequest(initData='init'),
+        db=SimpleNamespace(),
+    )
+    assert 'yookassa' in {method.id for method in methods_response.methods}
+
+    create_response = await miniapp.create_payment_link(
+        MiniAppPaymentCreateRequest(initData='init', method='yookassa', amountKopeks=25000),
+        db=SimpleNamespace(),
+    )
+
+    assert create_response.payment_url == 'https://yk/confirm'
+    assert captured['yookassa_scope'] == 'cabinet'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_bot_balance_creation_passes_bot_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_legacy_yookassa(monkeypatch, enabled=True)
+    _set_bot_yookassa(monkeypatch, enabled=True)
+    _set_cabinet_yookassa(monkeypatch, enabled=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_DEFAULT_RECEIPT_EMAIL', 'fallback@example.com', raising=False)
+
+    captured: dict[str, Any] = {}
+
+    class DummyPaymentService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def create_yookassa_payment(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                'local_payment_id': 444,
+                'yookassa_payment_id': 'yk_bot',
+                'confirmation_url': 'https://yk/confirm',
+                'status': 'pending',
+            }
+
+    class DummyMessage:
+        bot = SimpleNamespace()
+        chat = SimpleNamespace(id=777)
+
+        async def answer(self, *args: Any, **kwargs: Any) -> Any:
+            return SimpleNamespace(chat=SimpleNamespace(id=777), message_id=555)
+
+        async def delete(self) -> None:
+            return None
+
+    class DummyState:
+        async def get_data(self) -> dict[str, Any]:
+            return {}
+
+        async def update_data(self, **kwargs: Any) -> None:
+            return None
+
+        async def clear(self) -> None:
+            return None
+
+    monkeypatch.setattr(bot_yookassa, 'PaymentService', DummyPaymentService)
+    monkeypatch.setattr(
+        'app.services.payment_service.get_yookassa_payment_by_local_id',
+        lambda *args, **kwargs: None,
+        raising=False,
+    )
+
+    await bot_yookassa.process_yookassa_payment_amount(
+        message=DummyMessage(),
+        db_user=SimpleNamespace(
+            id=9,
+            telegram_id=999,
+            username='bot_user',
+            language='ru',
+            restriction_topup=False,
+        ),
+        db=SimpleNamespace(),
+        amount_kopeks=25000,
+        state=DummyState(),
+    )
+
+    assert captured['yookassa_scope'] == 'bot'

--- a/tests/test_yookassa_scoped_config.py
+++ b/tests/test_yookassa_scoped_config.py
@@ -1,0 +1,106 @@
+from app.config import Settings
+
+
+def _settings(**overrides):
+    base = {
+        'BOT_TOKEN': 'test-token',
+        'YOOKASSA_ENABLED': True,
+        'YOOKASSA_DISPLAY_NAME': 'Legacy YooKassa',
+        'YOOKASSA_SHOP_ID': 'legacy-shop',
+        'YOOKASSA_SECRET_KEY': 'legacy-secret',
+        'YOOKASSA_RETURN_URL': 'https://legacy.example/return',
+        'YOOKASSA_SBP_ENABLED': True,
+        'YOOKASSA_RECURRENT_ENABLED': True,
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)
+
+
+def test_legacy_yookassa_enables_bot_and_cabinet_when_scoped_env_is_unset():
+    settings = _settings()
+
+    assert settings.is_yookassa_enabled('bot') is True
+    assert settings.is_yookassa_enabled('cabinet') is True
+
+
+def test_cabinet_enabled_false_disables_only_cabinet_with_legacy_enabled():
+    settings = _settings(YOOKASSA_CABINET_ENABLED=False)
+
+    assert settings.is_yookassa_enabled('bot') is True
+    assert settings.is_yookassa_enabled('cabinet') is False
+
+
+def test_bot_enabled_false_disables_only_bot_with_legacy_enabled():
+    settings = _settings(YOOKASSA_BOT_ENABLED=False)
+
+    assert settings.is_yookassa_enabled('bot') is False
+    assert settings.is_yookassa_enabled('cabinet') is True
+
+
+def test_scoped_return_display_sbp_and_recurrent_override_legacy_values():
+    settings = _settings(
+        YOOKASSA_BOT_DISPLAY_NAME='Bot YooKassa',
+        YOOKASSA_BOT_RETURN_URL='https://bot.example/return',
+        YOOKASSA_BOT_SBP_ENABLED=False,
+        YOOKASSA_BOT_RECURRENT_ENABLED=False,
+        YOOKASSA_CABINET_DISPLAY_NAME='Cabinet YooKassa',
+        YOOKASSA_CABINET_RETURN_URL='https://cabinet.example/return',
+        YOOKASSA_CABINET_SBP_ENABLED=False,
+        YOOKASSA_CABINET_RECURRENT_ENABLED=False,
+    )
+
+    assert settings.get_yookassa_display_name('bot') == 'Bot YooKassa'
+    assert settings.get_yookassa_return_url('bot') == 'https://bot.example/return'
+    assert settings.is_yookassa_sbp_enabled('bot') is False
+    assert settings.is_yookassa_recurrent_enabled('bot') is False
+    assert settings.get_yookassa_display_name('cabinet') == 'Cabinet YooKassa'
+    assert settings.get_yookassa_return_url('cabinet') == 'https://cabinet.example/return'
+    assert settings.is_yookassa_sbp_enabled('cabinet') is False
+    assert settings.is_yookassa_recurrent_enabled('cabinet') is False
+
+
+def test_scoped_return_display_sbp_and_recurrent_fallback_to_legacy_values():
+    settings = _settings()
+
+    assert settings.get_yookassa_display_name('bot') == 'Legacy YooKassa'
+    assert settings.get_yookassa_return_url('bot') == 'https://legacy.example/return'
+    assert settings.is_yookassa_sbp_enabled('bot') is True
+    assert settings.is_yookassa_recurrent_enabled('bot') is True
+    assert settings.get_yookassa_display_name('cabinet') == 'Legacy YooKassa'
+    assert settings.get_yookassa_return_url('cabinet') == 'https://legacy.example/return'
+    assert settings.is_yookassa_sbp_enabled('cabinet') is True
+    assert settings.is_yookassa_recurrent_enabled('cabinet') is True
+
+
+def test_partial_scoped_credentials_do_not_mix_with_legacy_credentials():
+    cabinet_shop_only = _settings(
+        YOOKASSA_CABINET_ENABLED=True,
+        YOOKASSA_CABINET_SHOP_ID='cabinet-shop',
+    )
+    cabinet_config = cabinet_shop_only.get_yookassa_config('cabinet')
+
+    assert cabinet_config.enabled is False
+    assert cabinet_config.shop_id == 'cabinet-shop'
+    assert cabinet_config.secret_key is None
+
+    bot_secret_only = _settings(
+        YOOKASSA_BOT_ENABLED=True,
+        YOOKASSA_BOT_SECRET_KEY='bot-secret',
+    )
+    bot_config = bot_secret_only.get_yookassa_config('bot')
+
+    assert bot_config.enabled is False
+    assert bot_config.shop_id is None
+    assert bot_config.secret_key == 'bot-secret'
+
+
+def test_legacy_no_scope_helpers_keep_existing_behavior():
+    settings = _settings(
+        YOOKASSA_BOT_ENABLED=False,
+        YOOKASSA_BOT_RETURN_URL='https://bot.example/return',
+        YOOKASSA_BOT_DISPLAY_NAME='Bot YooKassa',
+    )
+
+    assert settings.is_yookassa_enabled() is True
+    assert settings.get_yookassa_display_name() == 'Legacy YooKassa'
+    assert settings.get_yookassa_return_url() == 'https://legacy.example/return'

--- a/tests/webserver/test_payments.py
+++ b/tests/webserver/test_payments.py
@@ -390,6 +390,42 @@ async def test_yookassa_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.anyio
+async def test_yookassa_scoped_webhook_route_passes_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'YOOKASSA_ENABLED', False, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_BOT_ENABLED', False, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_ENABLED', True, raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SHOP_ID', 'cabinet-shop', raising=False)
+    monkeypatch.setattr(settings, 'YOOKASSA_CABINET_SECRET_KEY', 'cabinet-secret', raising=False)
+
+    async def fake_get_db():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr('app.webserver.payments.get_db', fake_get_db)
+
+    process_mock = AsyncMock(return_value=True)
+    service = SimpleNamespace(process_yookassa_webhook=process_mock)
+
+    router = create_payment_router(DummyBot(), service)
+    assert router is not None
+
+    route = _get_route(router, f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet')
+    payload = {'event': 'payment.succeeded', 'object': {'id': 'yk_cabinet'}}
+    request = _build_request(
+        f'{settings.YOOKASSA_WEBHOOK_PATH}/cabinet',
+        body=json.dumps(payload).encode('utf-8'),
+        headers={},
+    )
+
+    response = await route.endpoint(request)
+
+    assert response.status_code == 200
+    process_mock.assert_awaited_once()
+    _, webhook_payload = process_mock.await_args.args
+    assert webhook_payload == payload
+    assert process_mock.await_args.kwargs == {'yookassa_scope': 'cabinet'}
+
+
+@pytest.mark.anyio
 async def test_yookassa_webhook_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, 'YOOKASSA_ENABLED', True, raising=False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -621,6 +621,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -1241,7 +1242,7 @@ wheels = [
 
 [[package]]
 name = "remnawave-bedolaga-telegram-bot"
-version = "3.54.0"
+version = "3.60.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- split YooKassa runtime configuration into bot and cabinet scopes with legacy single-shop fallback
- persist YooKassa scope on payments and saved payment methods, and route creation/status/webhook/recurrent flows through the scoped account
- keep NaloGO global for one tax subject while including YooKassa scope in queue/dedup context
- add migration, design notes, and focused tests for scoped config/runtime/webhook/NaloGO/recurrent behavior

## Validation
- uv run pytest -q tests/test_yookassa_scoped_config.py tests/test_yookassa_runtime_scopes.py tests/crud/test_yookassa_scopes.py tests/services/test_nalogo_yookassa_scope.py tests/services/test_recurrent_yookassa_scope.py tests/services/test_payment_service_yookassa.py tests/services/test_payment_service_webhooks.py tests/services/test_yookassa_service_adapter.py tests/external/test_yookassa_webhook.py tests/webserver/test_payments.py
- live test stand: bot and cabinet YooKassa test payments completed through checkout and webhooks returned 200 OK

## Notes
- Cabinet frontend repo has no local changes for this task.
- Test stand requires YOOKASSA_TEST_MODE=true when using YooKassa test shops.