### PR TITLE
fix: respect RESET_DEVICES_ON_RENEWAL in Remnawave user sync (#3006)

### DIFF
--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -276,10 +276,11 @@ class SubscriptionService:
             try:
                 existing = await api.get_user_by_uuid(subscription.remnawave_uuid)
                 if existing:
-                    try:
-                        await api.reset_user_devices(existing.uuid)
-                    except Exception as hwid_error:
-                        logger.warning('⚠️ Не удалось сбросить HWID', hwid_error=hwid_error)
+                    if settings.RESET_DEVICES_ON_RENEWAL:
+                        try:
+                            await api.reset_user_devices(existing.uuid)
+                        except Exception as hwid_error:
+                            logger.warning('⚠️ Не удалось сбросить HWID', hwid_error=hwid_error)
 
                     updated = await api.update_user(uuid=existing.uuid, **common_kwargs)
                     if reset_traffic:
@@ -372,11 +373,12 @@ class SubscriptionService:
             logger.info('🔄 Найден существующий пользователь в панели', _format_user_log=self._format_user_log(user))
             remnawave_user = existing_users[0]
 
-            try:
-                await api.reset_user_devices(remnawave_user.uuid)
-                logger.info('🔧 Сброшены HWID устройства', _format_user_log=self._format_user_log(user))
-            except Exception as hwid_error:
-                logger.warning('⚠️ Не удалось сбросить HWID', hwid_error=hwid_error)
+            if settings.RESET_DEVICES_ON_RENEWAL:
+                try:
+                    await api.reset_user_devices(remnawave_user.uuid)
+                    logger.info('🔧 Сброшены HWID устройства', _format_user_log=self._format_user_log(user))
+                except Exception as hwid_error:
+                    logger.warning('⚠️ Не удалось сбросить HWID', hwid_error=hwid_error)
 
             updated_user = await api.update_user(uuid=remnawave_user.uuid, **common_kwargs)
             if reset_traffic:


### PR DESCRIPTION
## Описание
HWID-устройства сбрасывались безусловно в `_create_or_update_remnawave_user_single`
и `_create_or_update_remnawave_user_multi` (`app/services/subscription_service.py`)
при каждом обновлении существующего пользователя в панели Remnawave — настройка
`RESET_DEVICES_ON_RENEWAL` при этом игнорировалась.

Оба вызова `api.reset_user_devices(...)` обёрнуты в `if settings.RESET_DEVICES_ON_RENEWAL:`.

## Мотивация
При `RESET_DEVICES_ON_RENEWAL=false` (значение по умолчанию) пользователи теряли все
привязки устройств при каждом продлении и автопокупке тарифа. Флаг фактически не
работал: он проверялся только в `subscription_renewal_service.py` и гейтил лишь
вторичный сброс, который шёл уже после `update_remnawave_user(...)`, когда устройства
внутри sync уже были стёрты.

Сброс при смене тарифа не затронут — он выполняется отдельным явным блоком в
`tariff_purchase.py` («Гарантированный сброс устройств при смене тарифа»).

Fixes #3006.