### PR TITLE
feat(cabinet): add /branding/footer-enabled GET+PATCH endpoint

### DIFF
--- a/app/cabinet/routes/branding.py
+++ b/app/cabinet/routes/branding.py
@@ -1118,3 +1118,43 @@ async def update_gift_enabled(
     await set_setting_value(db, GIFT_ENABLED_KEY, str(payload.enabled).lower())
     logger.info('Admin set gift enabled', telegram_id=admin.telegram_id, enabled=payload.enabled)
     return GiftEnabledResponse(enabled=payload.enabled)
+
+
+# ============ Legal Footer Routes (custom patch) ============
+
+FOOTER_ENABLED_KEY = 'CABINET_FOOTER_ENABLED'  # Stores "true" or "false"
+
+
+class FooterEnabledResponse(BaseModel):
+    """Legal footer enabled setting."""
+
+    enabled: bool = True
+
+
+class FooterEnabledUpdate(BaseModel):
+    """Request to update legal footer setting."""
+
+    enabled: bool
+
+
+@router.get('/footer-enabled', response_model=FooterEnabledResponse)
+async def get_footer_enabled(
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Get legal footer enabled setting. Public endpoint - no authentication required."""
+    value = await get_setting_value(db, FOOTER_ENABLED_KEY)
+    if value is not None:
+        return FooterEnabledResponse(enabled=value.lower() == 'true')
+    return FooterEnabledResponse(enabled=True)
+
+
+@router.patch('/footer-enabled', response_model=FooterEnabledResponse)
+async def update_footer_enabled(
+    payload: FooterEnabledUpdate,
+    admin: User = Depends(require_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Update legal footer enabled setting. Admin only."""
+    await set_setting_value(db, FOOTER_ENABLED_KEY, str(payload.enabled).lower())
+    logger.info('Admin set footer enabled', telegram_id=admin.telegram_id, enabled=payload.enabled)
+    return FooterEnabledResponse(enabled=payload.enabled)


### PR DESCRIPTION
Backend for the cabinet legal footer — pairs with cabinet PR BEDOLAGA-DEV/bedolaga-cabinet#464.

The cabinet frontend renders a legal footer (Public Offer / Privacy / Recurring) on the login page, gated by a `CABINET_FOOTER_ENABLED` setting. This adds the backend endpoint it calls:

- `GET /cabinet/branding/footer-enabled` — public, returns `{enabled}` (default true)
- `PATCH /cabinet/branding/footer-enabled` — admin-only (`settings:edit`), stores `CABINET_FOOTER_ENABLED` in system_settings

Follows the existing `/branding/animation` + `/branding/email-auth` pattern. Single file, +40 lines.