### PR TITLE
feat: настраиваемое описание метода оплаты (скрытие имени провайдера)

### DIFF
--- a/app/cabinet/routes/admin_payment_methods.py
+++ b/app/cabinet/routes/admin_payment_methods.py
@@ -41,6 +41,7 @@ class PaymentMethodConfigResponse(BaseModel):
     is_enabled: bool
     display_name: str | None = None
     default_display_name: str
+    description: str | None = None
     sub_options: dict | None = None
     available_sub_options: list[SubOptionInfo] | None = None
     quick_amounts: list[int] | None = None
@@ -94,8 +95,10 @@ class PaymentMethodConfigUpdateRequest(BaseModel):
     promo_group_filter_mode: str | None = Field(default=None, pattern='^(all|selected)$')
     allowed_promo_group_ids: list[int] | None = None
     open_url_direct: bool | None = None
+    description: str | None = Field(default=None, description='Null to reset to default')
     # Allow explicitly resetting display_name to null
     reset_display_name: bool = False
+    reset_description: bool = False
     reset_min_amount: bool = False
     reset_max_amount: bool = False
 
@@ -129,6 +132,7 @@ def _enrich_config(config, defaults: dict) -> PaymentMethodConfigResponse:
         sort_order=config.sort_order,
         is_enabled=config.is_enabled,
         display_name=config.display_name,
+        description=config.description,
         default_display_name=method_def.get('default_display_name', config.method_id),
         sub_options=config.sub_options,
         available_sub_options=available_sub_options,
@@ -219,6 +223,11 @@ async def update_payment_method(
         data['display_name'] = None
     elif request.display_name is not None:
         data['display_name'] = request.display_name.strip() or None
+
+    if request.reset_description:
+        data['description'] = None
+    elif request.description is not None:
+        data['description'] = request.description.strip() or None
 
     if request.sub_options is not None:
         data['sub_options'] = request.sub_options

--- a/app/cabinet/routes/balance.py
+++ b/app/cabinet/routes/balance.py
@@ -207,7 +207,7 @@ async def get_payment_methods(
             PaymentMethodResponse(
                 id=method_id,
                 name=method_data['name'],
-                description=None,
+                description=method_data.get('description'),
                 min_amount_kopeks=method_data['min_amount_kopeks'],
                 max_amount_kopeks=method_data['max_amount_kopeks'],
                 is_available=True,

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3796,6 +3796,7 @@ class PaymentMethodConfig(Base):
 
     # Переопределение отображаемого имени (null = использовать из env)
     display_name = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
 
     # Под-опции включения/выключения (JSON): {"card": true, "sbp": false}
     # Для методов с вариантами: yookassa, pal24, platega

--- a/app/services/payment_method_config_service.py
+++ b/app/services/payment_method_config_service.py
@@ -487,6 +487,7 @@ async def update_config(
     updatable_fields = (
         'is_enabled',
         'display_name',
+        'description',
         'sub_options',
         'quick_amounts',
         'min_amount_kopeks',
@@ -634,6 +635,7 @@ async def get_enabled_methods_for_user(
             {
                 'id': method_id,
                 'name': display_name,
+                'description': config.description,
                 'min_amount_kopeks': min_amount,
                 'max_amount_kopeks': max_amount,
                 'options': options,

--- a/migrations/alembic/versions/0096_payment_method_description.py
+++ b/migrations/alembic/versions/0096_payment_method_description.py
@@ -1,0 +1,43 @@
+"""payment_method_configs: per-method description override
+
+Revision ID: 0096
+Revises: 0095
+Create Date: 2026-06-26
+
+Adds ``description`` to ``payment_method_configs`` so admins can set a custom
+per-method description shown on the cabinet balance page. When empty, the
+cabinet falls back to its default localized description.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0096'
+down_revision: Union[str, None] = '0095'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'payment_method_configs' not in inspector.get_table_names():
+        return
+    existing = {col['name'] for col in inspector.get_columns('payment_method_configs')}
+    if 'description' not in existing:
+        op.add_column(
+            'payment_method_configs',
+            sa.Column('description', sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'payment_method_configs' not in inspector.get_table_names():
+        return
+    existing = {col['name'] for col in inspector.get_columns('payment_method_configs')}
+    if 'description' in existing:
+        op.drop_column('payment_method_configs', 'description')


### PR DESCRIPTION
## Что

Добавляет настраиваемое поле «Описание» для каждого метода оплаты, редактируемое в админ-кабинете. Описание показывается под названием метода на странице баланса.

## Зачем

Позволяет **скрыть имя платёжного провайдера от клиента** (white-label).

Например, для метода EtoPlatezhi вместо дефолтного «Оплата через Etoplatezhi» можно вывести «Оплата картой, СБП, SberPay и ЮMoney» — без упоминания провайдера. Это требование некоторых провайдеров (не показывать их бренд конечному пользователю).

Раньше текст описания был захардкожен в локалях фронтенда и при обновлении возвращался к дефолту с именем провайдера.

## Логика

- Описание задано в админке → показываем его
- Описание пусто → fallback на текст по умолчанию (локаль)

## Изменения (backend)

- migration 0096 — колонка `description` в `payment_method_configs`
- `PaymentMethodConfig.description` (nullable)
- admin API: поля `description` / `reset_description` (зеркало `display_name`)
- эндпоинт методов отдаёт `description`-override клиенту

Фронтенд-часть — отдельным PR в bedolaga-cabinet.---

### 🔗 Связанные PR (EtoPlatezhi / платежи)

Части общей работы над платежами/рекуррентами EtoPlatezhi, ревьюятся независимо:

**Бот:** #2949 (recurring движок + EtoPlatezhi) · #3014 (white-label описание метода) · #3015 (причина отклонения)
**Кабинет:** smediainfo/bedolaga-cabinet#433 (recurring consent gate) · #465 (white-label UI) · #466 (причина отклонения UI)