### PR TITLE
fix: исправить идемпотентность Tribute donation webhook

### DIFF
--- a/app/external/tribute.py
+++ b/app/external/tribute.py
@@ -11,6 +11,21 @@ from app.config import settings
 logger = structlog.get_logger(__name__)
 
 
+def _stable_tribute_event_payment_id(event_name: str, webhook_data: dict[str, Any], payload: dict[str, Any]) -> str:
+    raw_id = {
+        'name': event_name,
+        'created_at': webhook_data.get('created_at'),
+        'donation_request_id': payload.get('donation_request_id'),
+        'telegram_user_id': payload.get('telegram_user_id'),
+        'trb_user_id': payload.get('trb_user_id'),
+        'amount': payload.get('amount'),
+        'currency': payload.get('currency'),
+        'period': payload.get('period'),
+    }
+    digest = hashlib.sha256(json.dumps(raw_id, sort_keys=True, ensure_ascii=False).encode()).hexdigest()[:24]
+    return f'trbt_evt_{digest}'
+
+
 class TributeService:
     def __init__(self):
         self.api_key = settings.TRIBUTE_API_KEY
@@ -91,16 +106,18 @@ class TributeService:
             if not payment_id and 'name' in webhook_data:
                 event_name = webhook_data.get('name')
                 data = webhook_data.get('payload', {})
-                payment_id = str(data.get('donation_request_id'))
                 amount_kopeks = data.get('amount', 0)
                 telegram_user_id = data.get('telegram_user_id')
                 trb_user_id = data.get('trb_user_id')
 
                 if event_name in ('new_donation', 'recurrent_donation'):
+                    payment_id = _stable_tribute_event_payment_id(event_name, webhook_data, data)
                     status = 'paid'
                 elif event_name == 'cancelled_subscription':
+                    payment_id = str(data.get('donation_request_id'))
                     status = 'cancelled'
                 else:
+                    payment_id = str(data.get('donation_request_id'))
                     status = 'unknown'
 
             logger.info(
@@ -128,14 +145,15 @@ class TributeService:
                 logger.error('❌ Некорректный telegram_user_id', telegram_user_id=telegram_user_id)
                 return None
 
+            payment_id = payment_id or f'tribute_{telegram_user_id}_{amount_kopeks}'
             result = {
                 'event_type': 'payment',
-                'payment_id': payment_id or f'tribute_{telegram_user_id}_{amount_kopeks}',
+                'payment_id': payment_id,
                 'user_id': telegram_user_id,
                 'trb_user_id': trb_user_id,
                 'amount_kopeks': int(amount_kopeks) if amount_kopeks else 0,
                 'status': status or 'paid',
-                'external_id': f'donation_{payment_id or "unknown"}',
+                'external_id': f'donation_{payment_id}',
                 'payment_system': 'tribute',
             }
 

--- a/tests/external/test_tribute_webhook.py
+++ b/tests/external/test_tribute_webhook.py
@@ -1,0 +1,79 @@
+import pytest
+
+from app.external.tribute import TributeService
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+def _donation_payload(
+    *,
+    created_at: str = '2026-07-01T03:30:40.577825Z',
+    sent_at: str = '2026-07-01T03:30:40.860372362Z',
+    telegram_user_id: int = 123456789,
+    trb_user_id: str = 'T-123456',
+    amount: int = 125000,
+) -> dict:
+    return {
+        'created_at': created_at,
+        'name': 'new_donation',
+        'payload': {
+            'donation_request_id': 135873,
+            'donation_name': 'Example VPN',
+            'period': 'monthly',
+            'amount': amount,
+            'currency': 'rub',
+            'anonymously': False,
+            'web_app_link': 'https://t.me/tribute/app?startapp=example',
+            'user_id': 123456,
+            'trb_user_id': trb_user_id,
+            'telegram_user_id': telegram_user_id,
+            'telegram_username': 'example_user',
+        },
+        'sent_at': sent_at,
+    }
+
+
+@pytest.mark.anyio('asyncio')
+async def test_tribute_donations_with_same_request_get_distinct_payment_ids() -> None:
+    service = TributeService()
+
+    first = await service.process_webhook(
+        _donation_payload(
+            created_at='2026-07-01T03:30:40.577825Z',
+            telegram_user_id=111111111,
+            trb_user_id='T-111111',
+            amount=50000,
+        )
+    )
+    second = await service.process_webhook(
+        _donation_payload(
+            created_at='2026-07-01T04:30:40.577825Z',
+            telegram_user_id=222222222,
+            trb_user_id='T-222222',
+            amount=125000,
+        )
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first['payment_id'].startswith('trbt_evt_')
+    assert second['payment_id'].startswith('trbt_evt_')
+    assert first['payment_id'] != second['payment_id']
+    assert first['external_id'] == f'donation_{first["payment_id"]}'
+    assert second['external_id'] == f'donation_{second["payment_id"]}'
+
+
+@pytest.mark.anyio('asyncio')
+async def test_tribute_retry_keeps_same_payment_id_when_only_sent_at_changes() -> None:
+    service = TributeService()
+
+    first = await service.process_webhook(_donation_payload(sent_at='2026-07-01T03:30:40.860372362Z'))
+    retry = await service.process_webhook(_donation_payload(sent_at='2026-07-01T03:35:40.860372362Z'))
+
+    assert first is not None
+    assert retry is not None
+    assert first['payment_id'] == retry['payment_id']
+    assert first['external_id'] == retry['external_id']


### PR DESCRIPTION
## Описание

- формируем стабильный синтетический `payment_id` для Tribute-событий `new_donation` и `recurrent_donation` вместо прямого использования `donation_request_id`;
- сохраняем идемпотентную обработку повторной доставки webhook-а: `sent_at` не входит в формирование идентификатора;
- добавляем регрессионные тесты для разных донатов с одинаковым `donation_request_id` и для повторной доставки одного webhook-а(тесты нейронку просил написать, но проверил, нормальные). 

Fixes #3021

## Проверки

- `uv run ruff check app/external/tribute.py tests/external/test_tribute_webhook.py`
- `uv run ruff format --check app/external/tribute.py tests/external/test_tribute_webhook.py`
- `TIMEZONE=Europe/Moscow uv run --with tzdata pytest tests/external/test_tribute_webhook.py`
