### PR TITLE
fix: hide trial offer when TRIAL_DURATION_DAYS=0

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1140,6 +1140,20 @@ async def get_trial_info(
     """Get trial subscription info and availability."""
     await db.refresh(user, ['subscriptions'])
 
+    # When trial is globally disabled (TRIAL_DURATION_DAYS=0 and no paid trial),
+    # return is_available=False immediately — same gate as the miniapp.
+    if settings.TRIAL_DURATION_DAYS <= 0 and not settings.TRIAL_PAYMENT_ENABLED:
+        return TrialInfoResponse(
+            is_available=False,
+            duration_days=0,
+            traffic_limit_gb=settings.TRIAL_TRAFFIC_LIMIT_GB,
+            device_limit=settings.TRIAL_DEVICE_LIMIT,
+            requires_payment=False,
+            price_kopeks=0,
+            price_rubles=0,
+            reason_unavailable='Trial is disabled',
+        )
+
     # Проверяем, отключён ли триал для этого типа пользователя
     if settings.is_trial_disabled_for_user(getattr(user, 'auth_type', 'telegram')):
         return TrialInfoResponse(


### PR DESCRIPTION
## Problem

`GET /cabinet/subscription/trial` returned `is_available: true` for new users even when `TRIAL_DURATION_DAYS=0` (trials globally disabled). The dashboard rendered a `TrialOfferCard` showing **0 days** — an empty/broken trial UI.

The miniapp correctly guards this in `_is_trial_available_for_user`:
```python
if settings.TRIAL_DURATION_DAYS <= 0:
    return False
```
The cabinet endpoint was missing the equivalent check.

## Fix

Add early return in `GET /subscription/trial` when `TRIAL_DURATION_DAYS <= 0` and `TRIAL_PAYMENT_ENABLED=false`, matching the miniapp behaviour.

## Files changed

- `app/cabinet/routes/subscription_modules/purchase.py` — `get_trial_info()` early return