### PR TITLE
Add mobile cabinet admin contract

### DIFF
--- a/app/cabinet/dependencies.py
+++ b/app/cabinet/dependencies.py
@@ -24,6 +24,8 @@ logger = structlog.get_logger(__name__)
 
 security = HTTPBearer(auto_error=False)
 
+MOBILE_ADMIN_ALLOWED_ROLE_NAMES = frozenset({'Superadmin', 'Admin', 'Moderator'})
+
 
 async def get_cabinet_db() -> AsyncSession:
     """Get database session for cabinet operations."""
@@ -430,6 +432,100 @@ def require_permission(*permissions: str):
             details=details,
         )
         await db.commit()
+        return user
+
+    return dependency
+
+
+async def ensure_mobile_admin_access(
+    db: AsyncSession,
+    user: User,
+    *permissions: str,
+    request: Request | None = None,
+) -> tuple[list[str], list[str], int]:
+    """Verify the versioned mobile cabinet-admin predicate from current DB RBAC state.
+
+    The mobile contract deliberately does not trust RBAC claims embedded in an
+    access token: role names and permissions are reloaded from the database on
+    every request so role downgrades take effect immediately.
+    """
+    from app.database.crud.rbac import UserRoleCRUD
+    from app.services.permission_service import PermissionService
+
+    current_permissions, current_role_names, current_role_level = await UserRoleCRUD.get_user_permissions(db, user.id)
+    allowed_roles = MOBILE_ADMIN_ALLOWED_ROLE_NAMES.intersection(current_role_names)
+    if not allowed_roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='Mobile cabinet admin access requires current Superadmin, Admin, or Moderator role',
+        )
+
+    client_ip = None
+    user_agent = ''
+    request_path = ''
+    request_method = ''
+    if request is not None:
+        try:
+            client_ip = get_client_ip(request)
+        except HTTPException:
+            logger.warning('Unable to determine client IP in ensure_mobile_admin_access')
+            client_ip = 'unknown'
+        user_agent = request.headers.get('user-agent', '')
+        request_path = str(request.url.path)
+        request_method = request.method
+
+    resource_type = None
+    if permissions and ':' in permissions[0]:
+        resource_type = permissions[0].split(':', maxsplit=1)[0]
+
+    for permission in permissions:
+        allowed, reason = await PermissionService.check_permission(db, user, permission, ip_address=client_ip)
+        if not allowed:
+            await PermissionService.log_action(
+                db,
+                user_id=user.id,
+                action=permission,
+                resource_type=resource_type,
+                status='denied',
+                ip_address=client_ip,
+                user_agent=user_agent,
+                request_method=request_method,
+                request_path=request_path,
+                details={'reason': reason, 'contract': 'bedolaga-mobile-cabinet-v1'},
+            )
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f'Mobile cabinet admin permission denied: {reason}',
+            )
+
+    if permissions:
+        await PermissionService.log_action(
+            db,
+            user_id=user.id,
+            action=','.join(permissions),
+            resource_type=resource_type,
+            status='success',
+            ip_address=client_ip,
+            user_agent=user_agent,
+            request_method=request_method,
+            request_path=request_path,
+            details={'contract': 'bedolaga-mobile-cabinet-v1'},
+        )
+        await db.commit()
+
+    return current_permissions, current_role_names, current_role_level
+
+
+def require_mobile_admin_permission(*permissions: str):
+    """FastAPI dependency for the Bedolaga mobile cabinet v1 admin contract."""
+
+    async def dependency(
+        request: Request,
+        user: User = Depends(get_current_cabinet_user),
+        db: AsyncSession = Depends(get_cabinet_db),
+    ) -> User:
+        await ensure_mobile_admin_access(db, user, *permissions, request=request)
         return user
 
     return dependency

--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -18,6 +18,7 @@ from .admin_info_pages import router as admin_info_pages_router
 from .admin_landings import router as admin_landings_router
 from .admin_legal_pages import router as admin_legal_pages_router
 from .admin_menu_layout import router as admin_menu_layout_router
+from .admin_mobile import router as admin_mobile_router
 from .admin_news import router as admin_news_router
 from .admin_news_categories import router as admin_news_categories_router
 from .admin_news_media import router as admin_news_media_router
@@ -120,6 +121,7 @@ router.include_router(gift_router)
 
 # Admin routes (notifications router MUST be before tickets router to avoid route conflict)
 router.include_router(admin_ticket_notifications_router)
+router.include_router(admin_mobile_router)
 router.include_router(admin_tickets_router)
 router.include_router(admin_settings_router)
 router.include_router(admin_wheel_router)

--- a/app/cabinet/routes/admin_mobile.py
+++ b/app/cabinet/routes/admin_mobile.py
@@ -1,0 +1,535 @@
+"""Mobile cabinet-admin facade for Wave Machine integrations.
+
+This router freezes the `bedolaga-mobile-cabinet-v1` backend contract. It is
+intentionally narrow and never depends on the legacy root Web API token guard.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.cabinet.routes.admin_settings import SettingUpdateRequest, bot_configuration_service, update_setting
+from app.cabinet.routes.admin_tickets import (
+    AdminReplyRequest,
+    AdminStatusUpdateRequest,
+    get_all_tickets,
+    get_ticket_detail,
+    reply_to_ticket,
+    update_ticket_status,
+)
+from app.cabinet.routes.admin_users import (
+    get_user_by_telegram,
+    get_user_detail,
+    list_users,
+    reset_user_subscription,
+    update_user_balance,
+)
+from app.cabinet.routes.media import MediaUploadResponse, upload_media
+from app.cabinet.schemas.admin_mobile import (
+    CONTRACT_VERSION,
+    MobileContractInfoResponse,
+    MobileDashboardStatsResponse,
+    MobileDisabledFeatureResponse,
+    MobileIncomeResponse,
+    MobileSettingsCorsContractResponse,
+    MobileSettingsCorsKey,
+    MobileSubscriptionResponse,
+    MobileTransactionItem,
+    MobileTransactionListResponse,
+)
+from app.database.crud.referral import get_referral_statistics
+from app.database.crud.subscription import get_subscriptions_statistics, get_trial_statistics
+from app.database.crud.transaction import REAL_PAYMENT_METHODS, get_transactions_statistics
+from app.database.crud.user import get_users_statistics
+from app.database.models import (
+    Subscription,
+    SubscriptionStatus,
+    Ticket,
+    TicketStatus,
+    Transaction,
+    TransactionType,
+    User,
+    UserStatus,
+)
+
+from ..dependencies import get_cabinet_db, require_mobile_admin_permission
+from ..schemas.users import ResetSubscriptionRequest, SortByEnum, UpdateBalanceRequest, UserStatusEnum
+
+
+router = APIRouter(prefix='/admin/mobile', tags=['Cabinet Admin Mobile'])
+
+_CORS_KEYS = ('WEB_API_ALLOWED_ORIGINS', 'CABINET_ALLOWED_ORIGINS')
+
+
+def _kopeks_to_rubles(value: float | None) -> float:
+    return round((value or 0) / 100, 2)
+
+
+async def _get_mobile_overview(db: AsyncSession) -> dict[str, object]:
+    total_users = await db.scalar(select(func.count()).select_from(User)) or 0
+    active_users = (
+        await db.scalar(select(func.count()).select_from(User).where(User.status == UserStatus.ACTIVE.value)) or 0
+    )
+    blocked_users = (
+        await db.scalar(select(func.count()).select_from(User).where(User.status == UserStatus.BLOCKED.value)) or 0
+    )
+    total_balance_kopeks = await db.scalar(select(func.coalesce(func.sum(User.balance_kopeks), 0))) or 0
+    active_subscriptions = (
+        await db.scalar(
+            select(func.count())
+            .select_from(Subscription)
+            .where(Subscription.status == SubscriptionStatus.ACTIVE.value)
+        )
+        or 0
+    )
+    expired_subscriptions = (
+        await db.scalar(
+            select(func.count())
+            .select_from(Subscription)
+            .where(Subscription.status == SubscriptionStatus.EXPIRED.value)
+        )
+        or 0
+    )
+    pending_tickets = (
+        await db.scalar(
+            select(func.count())
+            .select_from(Ticket)
+            .where(Ticket.status.in_([TicketStatus.OPEN.value, TicketStatus.ANSWERED.value]))
+        )
+        or 0
+    )
+    today = datetime.now(UTC).date()
+    today_transactions = (
+        await db.scalar(
+            select(func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)).where(
+                func.date(Transaction.created_at) == today,
+                Transaction.type == TransactionType.DEPOSIT.value,
+                Transaction.payment_method.in_(REAL_PAYMENT_METHODS),
+            )
+        )
+        or 0
+    )
+    return {
+        'users': {
+            'total': total_users,
+            'active': active_users,
+            'blocked': blocked_users,
+            'balance_kopeks': int(total_balance_kopeks),
+            'balance_rubles': _kopeks_to_rubles(total_balance_kopeks),
+        },
+        'subscriptions': {
+            'active': active_subscriptions,
+            'expired': expired_subscriptions,
+        },
+        'support': {
+            'open_tickets': pending_tickets,
+        },
+        'payments': {
+            'today_kopeks': int(today_transactions),
+            'today_rubles': _kopeks_to_rubles(today_transactions),
+        },
+    }
+
+
+def _serialize_subscription(subscription: Subscription) -> MobileSubscriptionResponse:
+    """Serialize a subscription without importing root Web API auth dependencies."""
+    return MobileSubscriptionResponse(
+        id=subscription.id,
+        user_id=subscription.user_id,
+        status=subscription.status,
+        actual_status=subscription.actual_status,
+        is_trial=subscription.is_trial,
+        start_date=subscription.start_date,
+        end_date=subscription.end_date,
+        traffic_limit_gb=subscription.traffic_limit_gb,
+        traffic_used_gb=subscription.traffic_used_gb or 0,
+        device_limit=subscription.device_limit or 0,
+        autopay_enabled=subscription.autopay_enabled,
+        autopay_days_before=subscription.autopay_days_before,
+        subscription_url=subscription.subscription_url,
+        subscription_crypto_link=subscription.subscription_crypto_link,
+        connected_squads=list(subscription.connected_squads or []),
+        created_at=subscription.created_at,
+        updated_at=subscription.updated_at,
+    )
+
+
+def _serialize_transaction(transaction: Transaction) -> MobileTransactionItem:
+    return MobileTransactionItem(
+        id=transaction.id,
+        user_id=transaction.user_id,
+        type=transaction.type,
+        amount_kopeks=transaction.amount_kopeks,
+        amount_rubles=round(transaction.amount_kopeks / 100, 2),
+        description=transaction.description,
+        payment_method=transaction.payment_method,
+        external_id=transaction.external_id,
+        is_completed=transaction.is_completed,
+        created_at=transaction.created_at,
+        completed_at=transaction.completed_at,
+    )
+
+
+def _month_bounds(year: int, month: int) -> tuple[datetime, datetime]:
+    if month < 1 or month > 12:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, 'month must be between 1 and 12')
+    start = datetime(year, month, 1, tzinfo=UTC)
+    end = datetime(year + int(month == 12), 1 if month == 12 else month + 1, 1, tzinfo=UTC)
+    return start, end
+
+
+@router.get('/contract', response_model=MobileContractInfoResponse)
+async def get_mobile_contract(
+    _: User = Depends(require_mobile_admin_permission('users:read')),
+) -> MobileContractInfoResponse:
+    """Return the frozen mobile cabinet contract metadata."""
+    return MobileContractInfoResponse()
+
+
+@router.get('/tickets')
+async def get_mobile_tickets(
+    page: int = Query(1, ge=1, description='Page number'),
+    per_page: int = Query(20, ge=1, le=100, description='Items per page'),
+    status_filter: str | None = Query(None, alias='status', description='Filter by status'),
+    priority_filter: str | None = Query(None, alias='priority', description='Filter by priority'),
+    user_id: int | None = Query(None, description='Filter by user ID'),
+    admin: User = Depends(require_mobile_admin_permission('tickets:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for the admin ticket list."""
+    return await get_all_tickets(
+        page=page,
+        per_page=per_page,
+        status_filter=status_filter,
+        priority_filter=priority_filter,
+        user_id=user_id,
+        admin=admin,
+        db=db,
+    )
+
+
+@router.get('/tickets/{ticket_id}')
+async def get_mobile_ticket_detail(
+    ticket_id: int,
+    admin: User = Depends(require_mobile_admin_permission('tickets:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for admin ticket detail."""
+    return await get_ticket_detail(ticket_id=ticket_id, admin=admin, db=db)
+
+
+@router.post('/tickets/{ticket_id}/reply')
+async def reply_to_mobile_ticket(
+    ticket_id: int,
+    request: AdminReplyRequest,
+    admin: User = Depends(require_mobile_admin_permission('tickets:reply')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for replying to a ticket."""
+    return await reply_to_ticket(ticket_id=ticket_id, request=request, admin=admin, db=db)
+
+
+@router.post('/tickets/{ticket_id}/status')
+async def update_mobile_ticket_status(
+    ticket_id: int,
+    request: AdminStatusUpdateRequest,
+    admin: User = Depends(require_mobile_admin_permission('tickets:close')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for ticket status updates."""
+    return await update_ticket_status(ticket_id=ticket_id, request=request, admin=admin, db=db)
+
+
+@router.get('/users')
+async def list_mobile_users(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    search: str | None = Query(None, max_length=255),
+    email: str | None = Query(None, max_length=255),
+    status_filter: UserStatusEnum | None = Query(None, alias='status'),
+    subscription_status: str | None = Query(None, max_length=20),
+    tariff_id: str | None = Query(None, max_length=255),
+    promo_group_id: int | None = Query(None),
+    campaign_id: int | None = Query(None),
+    partner_id: int | None = Query(None),
+    sort_by: SortByEnum = Query(SortByEnum.CREATED_AT),
+    admin: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for user search/list."""
+    return await list_users(
+        offset=offset,
+        limit=limit,
+        search=search,
+        email=email,
+        status=status_filter,
+        subscription_status=subscription_status,
+        tariff_id=tariff_id,
+        promo_group_id=promo_group_id,
+        campaign_id=campaign_id,
+        partner_id=partner_id,
+        sort_by=sort_by,
+        admin=admin,
+        db=db,
+    )
+
+
+@router.get('/users/by-telegram/{telegram_id}')
+async def get_mobile_user_by_telegram(
+    telegram_id: int,
+    admin: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for Telegram ID user lookup."""
+    return await get_user_by_telegram(telegram_id=telegram_id, admin=admin, db=db)
+
+
+@router.get('/users/{user_id}')
+async def get_mobile_user_detail(
+    user_id: int,
+    admin: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for user detail."""
+    return await get_user_detail(user_id=user_id, admin=admin, db=db)
+
+
+@router.post('/users/{user_id}/balance')
+async def update_mobile_user_balance(
+    user_id: int,
+    request: UpdateBalanceRequest,
+    admin: User = Depends(require_mobile_admin_permission('users:balance')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Mobile role-gated wrapper for user balance updates."""
+    return await update_user_balance(user_id=user_id, request=request, admin=admin, db=db)
+
+
+@router.post('/media/upload', response_model=MediaUploadResponse, status_code=status.HTTP_201_CREATED)
+async def upload_mobile_media(
+    request: Request,
+    admin: User = Depends(require_mobile_admin_permission('tickets:reply')),
+    file: UploadFile = File(...),
+    media_type: str = Form('photo', description='File type: photo, video, or document'),
+) -> MediaUploadResponse:
+    """Mobile role-gated media upload for ticket replies."""
+    return await upload_media(request=request, user=admin, file=file, media_type=media_type)
+
+
+@router.get('/subscriptions/lookup', response_model=MobileSubscriptionResponse)
+async def lookup_subscription_by_url(
+    subscription_url: str = Query(..., min_length=1, max_length=4096),
+    _: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> MobileSubscriptionResponse:
+    """Find a subscription by URL using cabinet JWT auth."""
+    result = await db.execute(
+        select(Subscription)
+        .options(selectinload(Subscription.user))
+        .where(
+            or_(
+                Subscription.subscription_url == subscription_url,
+                Subscription.subscription_crypto_link == subscription_url,
+            )
+        )
+        .order_by(Subscription.created_at.desc())
+        .limit(1)
+    )
+    subscription = result.scalar_one_or_none()
+    if not subscription:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, 'Subscription not found')
+    return _serialize_subscription(subscription)
+
+
+@router.get('/subscriptions/{subscription_id}', response_model=MobileSubscriptionResponse)
+async def get_mobile_subscription(
+    subscription_id: int,
+    _: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> MobileSubscriptionResponse:
+    """Return subscription detail by internal subscription ID."""
+    result = await db.execute(
+        select(Subscription).options(selectinload(Subscription.user)).where(Subscription.id == subscription_id)
+    )
+    subscription = result.scalar_one_or_none()
+    if not subscription:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, 'Subscription not found')
+    return _serialize_subscription(subscription)
+
+
+@router.get('/transactions/monthly-income', response_model=MobileIncomeResponse)
+async def get_mobile_monthly_income(
+    year: int = Query(..., ge=2020, le=2100),
+    month: int = Query(..., ge=1, le=12),
+    _: User = Depends(require_mobile_admin_permission('stats:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> MobileIncomeResponse:
+    """Return completed real-payment income for a calendar month."""
+    period_start, period_end = _month_bounds(year, month)
+    amount_expr = func.coalesce(func.sum(func.abs(Transaction.amount_kopeks)), 0)
+    count_expr = func.count(Transaction.id)
+    result = await db.execute(
+        select(amount_expr, count_expr).where(
+            Transaction.created_at >= period_start,
+            Transaction.created_at < period_end,
+            Transaction.type == TransactionType.DEPOSIT.value,
+            Transaction.is_completed.is_(True),
+            Transaction.payment_method.in_(REAL_PAYMENT_METHODS),
+        )
+    )
+    income_kopeks, transaction_count = result.one()
+    income_kopeks = int(income_kopeks or 0)
+    return MobileIncomeResponse(
+        period_start=period_start,
+        period_end=period_end,
+        income_kopeks=income_kopeks,
+        income_rubles=round(income_kopeks / 100, 2),
+        transaction_count=int(transaction_count or 0),
+        payment_methods=sorted(REAL_PAYMENT_METHODS),
+    )
+
+
+@router.get('/users/{user_id}/transactions', response_model=MobileTransactionListResponse)
+async def get_mobile_user_transactions(
+    user_id: int,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    _: User = Depends(require_mobile_admin_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> MobileTransactionListResponse:
+    """Return completed real-payment user transactions for mobile spending views."""
+    filters = [
+        Transaction.user_id == user_id,
+        Transaction.type == TransactionType.DEPOSIT.value,
+        Transaction.is_completed.is_(True),
+        Transaction.payment_method.in_(REAL_PAYMENT_METHODS),
+    ]
+    total = await db.scalar(select(func.count()).select_from(Transaction).where(and_(*filters))) or 0
+    result = await db.execute(
+        select(Transaction).where(and_(*filters)).order_by(Transaction.created_at.desc()).offset(offset).limit(limit)
+    )
+    transactions = result.scalars().all()
+    return MobileTransactionListResponse(
+        items=[_serialize_transaction(tx) for tx in transactions],
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post('/users/{user_id}/reset-subscription')
+async def reset_mobile_user_subscription(
+    user_id: int,
+    request: ResetSubscriptionRequest = ResetSubscriptionRequest(),
+    admin: User = Depends(require_mobile_admin_permission('users:subscription')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Cabinet-JWT equivalent of the legacy mobile delete-subscription action."""
+    response = await reset_user_subscription(user_id=user_id, request=request, admin=admin, db=db)
+    if hasattr(response, 'model_dump'):
+        data = response.model_dump()
+    else:
+        data = dict(response)
+    return {'contract_version': CONTRACT_VERSION, **data}
+
+
+@router.get('/stats/full', response_model=MobileDashboardStatsResponse)
+async def get_mobile_stats_full(
+    _: User = Depends(require_mobile_admin_permission('stats:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> MobileDashboardStatsResponse:
+    """Cabinet-JWT replacement for legacy root `/stats/full` mobile consumers."""
+    overview = await _get_mobile_overview(db)
+    users_stats = await get_users_statistics(db)
+    subscriptions_stats = await get_subscriptions_statistics(db)
+    trial_stats = await get_trial_statistics(db)
+    transactions_stats = await get_transactions_statistics(
+        db, start_date=datetime(2020, 1, 1, tzinfo=UTC), end_date=datetime.now(UTC)
+    )
+    referral_stats = await get_referral_statistics(db)
+
+    transactions_totals = transactions_stats.get('totals', {})
+    transactions_today = transactions_stats.get('today', {})
+    transactions_totals = {
+        **transactions_totals,
+        'income_rubles': _kopeks_to_rubles(transactions_totals.get('income_kopeks')),
+        'expenses_rubles': _kopeks_to_rubles(transactions_totals.get('expenses_kopeks')),
+        'profit_rubles': _kopeks_to_rubles(transactions_totals.get('profit_kopeks')),
+        'subscription_income_kopeks': abs(transactions_totals.get('subscription_income_kopeks', 0)),
+        'subscription_income_rubles': _kopeks_to_rubles(abs(transactions_totals.get('subscription_income_kopeks', 0))),
+    }
+    transactions_today = {
+        **transactions_today,
+        'income_rubles': _kopeks_to_rubles(transactions_today.get('income_kopeks')),
+    }
+    referral_stats = {
+        **referral_stats,
+        'total_paid_rubles': _kopeks_to_rubles(referral_stats.get('total_paid_kopeks')),
+        'today_earnings_rubles': _kopeks_to_rubles(referral_stats.get('today_earnings_kopeks')),
+        'week_earnings_rubles': _kopeks_to_rubles(referral_stats.get('week_earnings_kopeks')),
+        'month_earnings_rubles': _kopeks_to_rubles(referral_stats.get('month_earnings_kopeks')),
+    }
+    return MobileDashboardStatsResponse(
+        overview=overview,
+        users=users_stats,
+        subscriptions={**subscriptions_stats, 'trial_statistics': trial_stats},
+        transactions={**transactions_stats, 'totals': transactions_totals, 'today': transactions_today},
+        referrals=referral_stats,
+    )
+
+
+@router.get('/realtime', response_model=MobileDisabledFeatureResponse)
+async def get_mobile_realtime_contract(
+    _: User = Depends(require_mobile_admin_permission('tickets:read')),
+) -> MobileDisabledFeatureResponse:
+    """Make realtime disablement explicit for mobile v1."""
+    return MobileDisabledFeatureResponse(
+        feature='realtime_tickets',
+        reason='Mobile v1 must not use /ws?api_key=... or /cabinet/ws?token=... query-token websockets.',
+    )
+
+
+@router.get('/settings/cors', response_model=MobileSettingsCorsContractResponse)
+async def get_mobile_cors_contract(
+    _: User = Depends(require_mobile_admin_permission('settings:read')),
+) -> MobileSettingsCorsContractResponse:
+    """Describe post-auth CORS settings exposure for mobile."""
+    keys: list[MobileSettingsCorsKey] = []
+    for key in _CORS_KEYS:
+        try:
+            bot_configuration_service.get_definition(key)
+        except KeyError:
+            keys.append(MobileSettingsCorsKey(key=key, mode='operator-guidance', env_locked=True))
+            continue
+        env_locked = bot_configuration_service.is_env_locked(key)
+        keys.append(
+            MobileSettingsCorsKey(
+                key=key,
+                mode='read-only/operator-guidance' if env_locked else 'editable-after-auth',
+                env_locked=env_locked,
+                secret=bot_configuration_service.is_secret_key(key),
+            )
+        )
+    return MobileSettingsCorsContractResponse(
+        pre_auth_behavior='local/operator-guidance-only',
+        server_side_edit='allowed only after cabinet JWT, mobile role allowlist, settings:edit, and env-lock checks',
+        allowed_keys=keys,
+    )
+
+
+@router.put('/settings/cors/{key}')
+async def update_mobile_cors_setting(
+    key: str,
+    payload: SettingUpdateRequest,
+    admin: User = Depends(require_mobile_admin_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Post-auth server-side edit for the approved CORS keys only."""
+    if key not in _CORS_KEYS:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, 'CORS setting is not part of the mobile contract')
+    return await update_setting(key=key, payload=payload, admin=admin, db=db)

--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -160,12 +160,14 @@ async def _create_auth_response(user: User, db: AsyncSession) -> AuthResponse:
     )
     refresh_token = create_refresh_token(user.id)
     expires_in = settings.get_cabinet_access_token_expire_minutes() * 60
+    refresh_expires_in = settings.get_cabinet_refresh_token_expire_days() * 24 * 60 * 60
 
     return AuthResponse(
         access_token=access_token,
         refresh_token=refresh_token,
         token_type='bearer',
         expires_in=expires_in,
+        refresh_expires_in=refresh_expires_in,
         user=_user_to_response(user),
     )
 
@@ -1761,12 +1763,14 @@ async def refresh_token(
         role_level=user_role_level,
     )
     expires_in = settings.get_cabinet_access_token_expire_minutes() * 60
+    refresh_expires_in = max(0, int((token_record.expires_at - datetime.now(UTC)).total_seconds()))
 
     return TokenResponse(
         access_token=access_token,
         refresh_token=request.refresh_token,
         token_type='bearer',
         expires_in=expires_in,
+        refresh_expires_in=refresh_expires_in,
     )
 
 

--- a/app/cabinet/schemas/admin_mobile.py
+++ b/app/cabinet/schemas/admin_mobile.py
@@ -1,0 +1,126 @@
+"""Stable response schemas for the Bedolaga mobile cabinet v1 contract."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+CONTRACT_VERSION = 'bedolaga-mobile-cabinet-v1'
+MOBILE_ALLOWED_ROLE_NAMES = ['Superadmin', 'Admin', 'Moderator']
+
+
+class MobileContractMetadata(BaseModel):
+    """Common contract metadata returned by mobile facade endpoints."""
+
+    contract_version: str = CONTRACT_VERSION
+    required_role_names: list[str] = Field(default_factory=lambda: MOBILE_ALLOWED_ROLE_NAMES.copy())
+    auth: str = 'cabinet_jwt_allowed_role'
+    legacy_auth: str = 'rejected'
+
+
+class MobileContractInfoResponse(MobileContractMetadata):
+    """Machine-readable contract summary."""
+
+    realtime: str = 'disabled'
+    media_download_auth: str = 'signed_media_token'
+    refresh_validity_method: str = 'explicit-fields'
+    refresh_fields: list[str] = Field(default_factory=lambda: ['expires_in', 'refresh_expires_in'])
+
+
+class MobileSubscriptionResponse(MobileContractMetadata):
+    """Subscription detail exposed to Wave Machine mobile clients."""
+
+    id: int
+    user_id: int
+    status: str
+    actual_status: str
+    is_trial: bool
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    traffic_limit_gb: int = 0
+    traffic_used_gb: float = 0
+    device_limit: int = 0
+    autopay_enabled: bool = False
+    autopay_days_before: int | None = None
+    subscription_url: str | None = None
+    subscription_crypto_link: str | None = None
+    connected_squads: list[str] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class MobileTransactionItem(BaseModel):
+    """Transaction shape used by mobile spending and income screens."""
+
+    id: int
+    user_id: int
+    type: str
+    amount_kopeks: int
+    amount_rubles: float
+    description: str | None = None
+    payment_method: str | None = None
+    external_id: str | None = None
+    is_completed: bool
+    created_at: datetime
+    completed_at: datetime | None = None
+
+
+class MobileTransactionListResponse(MobileContractMetadata):
+    """Paginated mobile transaction response."""
+
+    items: list[MobileTransactionItem]
+    total: int
+    limit: int
+    offset: int
+    completed_real_payment_only: bool = True
+
+
+class MobileIncomeResponse(MobileContractMetadata):
+    """Income aggregate for a calendar month."""
+
+    period_start: datetime
+    period_end: datetime
+    income_kopeks: int
+    income_rubles: float
+    transaction_count: int
+    payment_methods: list[str]
+    completed_real_payment_only: bool = True
+
+
+class MobileDashboardStatsResponse(MobileContractMetadata):
+    """Cabinet-JWT replacement for legacy /stats/full mobile usage."""
+
+    overview: dict[str, Any]
+    users: dict[str, Any]
+    subscriptions: dict[str, Any]
+    transactions: dict[str, Any]
+    referrals: dict[str, Any]
+
+
+class MobileDisabledFeatureResponse(MobileContractMetadata):
+    """Explicit disabled-feature contract response."""
+
+    feature: str
+    enabled: bool = False
+    replacement: str | None = None
+    reason: str
+
+
+class MobileSettingsCorsKey(BaseModel):
+    """Server-side CORS setting key exposed after auth."""
+
+    key: str
+    mode: str
+    env_locked: bool
+    secret: bool = False
+
+
+class MobileSettingsCorsContractResponse(MobileContractMetadata):
+    """CORS contract for mobile setup/settings screens."""
+
+    pre_auth_behavior: str
+    server_side_edit: str
+    allowed_keys: list[MobileSettingsCorsKey]

--- a/app/cabinet/schemas/auth.py
+++ b/app/cabinet/schemas/auth.py
@@ -105,6 +105,7 @@ class TokenResponse(BaseModel):
     refresh_token: str
     token_type: str = 'bearer'
     expires_in: int = Field(..., description='Access token expiration in seconds')
+    refresh_expires_in: int = Field(..., description='Refresh token remaining lifetime in seconds')
 
 
 class UserResponse(BaseModel):
@@ -160,6 +161,7 @@ class AuthResponse(BaseModel):
     refresh_token: str
     token_type: str = 'bearer'
     expires_in: int
+    refresh_expires_in: int = Field(..., description='Refresh token remaining lifetime in seconds')
     user: UserResponse
     campaign_bonus: CampaignBonusInfo | None = None
 

--- a/docs/mobile-cabinet-contract.md
+++ b/docs/mobile-cabinet-contract.md
@@ -1,0 +1,72 @@
+# Bedolaga Mobile Cabinet Contract
+
+## Contract Version
+
+Version: bedolaga-mobile-cabinet-v1
+Owner: K2SO
+Consumers: R2D2 iOS, C3PO Android
+Stability rule: response fields used by mobile must not change without a new contract version and updated fixtures.
+Legacy auth rule: contract endpoints must reject WebApiToken-only credentials and must not require `X-API-Key`.
+Mobile auth predicate: valid cabinet JWT + role name in `Superadmin`, `Admin`, `Moderator` + endpoint permission when required.
+Refresh validity rule: mobile receives deterministic refresh-token validity evidence through explicit `refresh_expires_in` on login and refresh responses.
+
+## Endpoint Audit
+
+| Capability | Current root endpoint | Cabinet endpoint/facade | Auth | Permission | Response contract | Decision | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Health check | `GET /health` | `GET /health` | none | none | Existing health reachability. | use-existing-cabinet-route | Root and cabinet share unauthenticated health behavior; no admin data. |
+| Email login | none | `POST /cabinet/auth/email/login` | none | none | Existing auth response plus `expires_in` and `refresh_expires_in`. | use-existing-cabinet-route | `app/cabinet/routes/auth.py` issues cabinet JWTs and stores refresh token rows. |
+| OAuth providers | none | `GET /cabinet/auth/oauth/providers` | none | none | Mobile must hide Telegram and only expose configured native-safe providers. | use-existing-cabinet-route | OAuth remains outside admin-token migration; Telegram is excluded by mobile contract. |
+| OAuth authorize | none | `GET /cabinet/auth/oauth/{provider}/authorize` | none | none | Provider state/PKCE/deep-link rules are platform-gated before mobile enables OAuth. | use-existing-cabinet-route | Existing cabinet OAuth routes own state/callback validation. |
+| OAuth callback | none | `POST /cabinet/auth/oauth/{provider}/callback` | none | none | Invalid state/verifier is rejected by cabinet OAuth flow. | use-existing-cabinet-route | Existing cabinet OAuth routes; no root Web API fallback. |
+| Token refresh | `POST /cabinet/auth/refresh` | same | refresh JWT + stored token row | none | Returns `access_token`, original `refresh_token`, `expires_in`, `refresh_expires_in`; revoked/expired/inactive user returns 401. | use-existing-cabinet-route | `app/cabinet/routes/auth.py` verifies JWT type, token row, expiry/revocation, and active user. |
+| Permission check | none | `GET /cabinet/auth/me/permissions` | cabinet JWT | authenticated user | Current roles/permissions from backend so mobile can allow only exact role names. | use-existing-cabinet-route | `PermissionService.get_user_permissions` reloads DB RBAC. |
+| Ticket list/detail/reply/status | `/tickets*` | `/cabinet/admin/mobile/tickets*` | cabinet JWT + mobile allowed role | `tickets:read`, `tickets:reply`, `tickets:close` | Existing cabinet ticket shapes behind mobile role-gated wrappers. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`; wrappers compose mobile role allowlist with existing permission service behavior. |
+| User search/detail/by Telegram ID | `/users*` | `/cabinet/admin/mobile/users*` | cabinet JWT + mobile allowed role | `users:read` | Existing cabinet user shapes behind mobile role-gated wrappers; Telegram ID path is `/users/by-telegram/{telegram_id}`. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`; wrappers compose mobile role allowlist with existing permission service behavior. |
+| Subscription lookup by URL | `GET /subscriptions` paging/search | `GET /cabinet/admin/mobile/subscriptions/lookup?subscription_url=...` | cabinet JWT + mobile allowed role | `users:read` | `MobileSubscriptionResponse`. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`. |
+| Subscription detail | `GET /subscriptions/{id}` | `GET /cabinet/admin/mobile/subscriptions/{subscription_id}` | cabinet JWT + mobile allowed role | `users:read` | `MobileSubscriptionResponse`. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`. |
+| Monthly income/global transactions | `GET /transactions` | `GET /cabinet/admin/mobile/transactions/monthly-income` | cabinet JWT + mobile allowed role | `stats:read` | Completed deposit transactions filtered to `REAL_PAYMENT_METHODS`, calendar-month bounds. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`. |
+| User transactions/spending | `GET /transactions?user_id=...` | `GET /cabinet/admin/mobile/users/{user_id}/transactions` | cabinet JWT + mobile allowed role | `users:read` | `MobileTransactionListResponse`, completed real-payment deposits only. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`. |
+| Balance update | `POST /users/{id}/balance` | `POST /cabinet/admin/mobile/users/{user_id}/balance` | cabinet JWT + mobile allowed role | `users:balance` | Existing response returns balance delta; mobile should refresh user detail after success if it needs a full user. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`; wrapper composes mobile role allowlist with existing permission service behavior. |
+| Delete/reset subscription | `DELETE /users/{id}/subscription` | `POST /cabinet/admin/mobile/users/{user_id}/reset-subscription` | cabinet JWT + mobile allowed role | `users:subscription` | Existing reset-subscription semantics wrapped with `contract_version`. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`; deletes all user subscriptions and optionally disables panel user. |
+| Media upload/download | `POST /upload`, `GET /media/{file_id}` | `POST /cabinet/admin/mobile/media/upload`, `GET /cabinet/media/{file_id}?token=...` | upload: cabinet JWT + mobile allowed role; download: signed media token | upload: `tickets:reply` | Downloads use expiring HMAC token bound to file ID; no admin-token header. Scriptable uploads are rejected. | add-mobile-facade | Upload wrapper is implemented in `app/cabinet/routes/admin_mobile.py`; signed download remains token-only in `app/cabinet/routes/media.py`. |
+| Dashboard/widget stats | `GET /stats/full` | `GET /cabinet/admin/mobile/stats/full` | cabinet JWT + mobile allowed role | `stats:read` | `MobileDashboardStatsResponse`, cabinet-JWT replacement of root stats shape. | add-mobile-facade | Implemented in `app/cabinet/routes/admin_mobile.py`. |
+| Realtime tickets | `GET /ws?api_key=...` | `GET /cabinet/admin/mobile/realtime` | cabinet JWT + mobile allowed role | `tickets:read` | Explicit disabled feature response; mobile must not connect to root or cabinet query-token WebSockets. | disable-mobile-feature | Mobile v1 disables realtime until a non-query-token WS contract is reviewed. |
+| CORS settings | `PUT /settings/{key}` | `GET /cabinet/admin/mobile/settings/cors`, `PUT /cabinet/admin/mobile/settings/cors/{key}` | cabinet JWT + mobile allowed role | read: `settings:read`, edit: `settings:edit` | Pre-auth local/operator guidance only; server edit limited to `WEB_API_ALLOWED_ORIGINS` and `CABINET_ALLOWED_ORIGINS` after env-lock checks. | operator-guidance-only | Implemented CORS contract wrapper delegates env-lock and secret masking to cabinet settings service. |
+
+## Mobile Auth Predicate
+
+Every authenticated endpoint under `/cabinet/admin/mobile` requires:
+
+1. a valid cabinet JWT access token,
+2. current database role name exactly `Superadmin`, `Admin`, or `Moderator`,
+3. matching current database RBAC permission when the endpoint requires one.
+
+The predicate reloads roles and permissions from the database on each request. JWT-embedded roles or permissions are not accepted as authority for mobile admin access, so downgraded users are rejected on the next request.
+
+## Refresh-Token Validity
+
+Method: `explicit-fields`.
+
+Login and refresh responses include:
+
+- `expires_in`: access-token lifetime in seconds.
+- `refresh_expires_in`: refresh-token remaining lifetime in seconds.
+
+Refresh still returns 401 for invalid JWT type/signature, expired refresh JWT, missing or revoked refresh-token row, expired token row, or inactive/deleted user. Mobile must schedule foreground/background refresh from `expires_in`, then stop on refresh 401 or failed role revalidation.
+
+## WebSocket Decision
+
+Decision: `disable-realtime-for-mobile-v1`.
+
+R2D2/C3PO must not use `GET /ws?api_key=...` and must not use existing `/cabinet/ws?token=...` query-token WebSocket for the mobile contract. A future realtime contract must use a non-query bearer mechanism and the same current-state role predicate.
+
+## Media Auth Model
+
+Uploads use `POST /cabinet/admin/mobile/media/upload` with cabinet JWT, mobile role allowlist, and `tickets:reply`. Downloads use `GET /cabinet/media/{file_id}?token=<signed_media_token>`. The token is HMAC-signed, file-bound, expiring, and does not require `X-API-Key` or an Authorization header. Scriptable upload extensions and content types are rejected.
+
+## Fixtures
+
+Fixture directory: `tests/fixtures/bedolaga-mobile-cabinet-v1`.
+
+Each fixture includes `contract_version`, method/path/status, auth mode, required role names, required permissions, response schema, and fixture kind.

--- a/tests/cabinet/test_mobile_admin_contract.py
+++ b/tests/cabinet/test_mobile_admin_contract.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.cabinet import dependencies as cabinet_dependencies
+from app.cabinet.routes import admin_mobile
+from app.cabinet.schemas.admin_mobile import CONTRACT_VERSION
+from app.cabinet.schemas.auth import AuthResponse, TokenResponse, UserResponse
+from app.services.permission_service import permission_matches
+
+
+class _User:
+    id = 42
+    telegram_id = 4242
+    email = 'admin@example.test'
+    email_verified = True
+
+
+class _Db:
+    def __init__(self) -> None:
+        self.commit = AsyncMock()
+
+
+async def _set_current_roles(monkeypatch: pytest.MonkeyPatch, roles: list[str], permissions: list[str]) -> None:
+    async def fake_get_user_permissions(_db, user_id: int):
+        assert user_id == _User.id
+        return permissions, roles, 100 if roles else 0
+
+    async def fake_check_permission(_db, _user, required_permission: str, *, ip_address=None):
+        if any(permission_matches(current_permission, required_permission) for current_permission in permissions):
+            return True, 'Granted by RBAC'
+        return False, 'Permission not granted by any role'
+
+    async def fake_log_action(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        'app.database.crud.rbac.UserRoleCRUD.get_user_permissions',
+        fake_get_user_permissions,
+    )
+    monkeypatch.setattr('app.services.permission_service.PermissionService.check_permission', fake_check_permission)
+    monkeypatch.setattr('app.services.permission_service.PermissionService.log_action', fake_log_action)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('role_name', ['Superadmin', 'Admin', 'Moderator'])
+async def test_mobile_admin_allowed_roles_with_required_permission_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+    role_name: str,
+) -> None:
+    await _set_current_roles(monkeypatch, [role_name], ['users:*'])
+
+    permissions, roles, _level = await cabinet_dependencies.ensure_mobile_admin_access(_Db(), _User(), 'users:read')
+
+    assert permissions == ['users:*']
+    assert roles == [role_name]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('role_name', ['Support', 'Marketer'])
+async def test_mobile_admin_disallowed_roles_are_rejected_even_with_matching_permissions(
+    monkeypatch: pytest.MonkeyPatch,
+    role_name: str,
+) -> None:
+    await _set_current_roles(monkeypatch, [role_name], ['users:*', 'stats:*', 'tickets:*'])
+
+    with pytest.raises(HTTPException) as exc:
+        await cabinet_dependencies.ensure_mobile_admin_access(_Db(), _User(), 'users:read')
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert 'Superadmin, Admin, or Moderator' in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_mobile_admin_no_role_user_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    await _set_current_roles(monkeypatch, [], ['*:*'])
+
+    with pytest.raises(HTTPException) as exc:
+        await cabinet_dependencies.ensure_mobile_admin_access(_Db(), _User(), 'users:read')
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_mobile_admin_downgraded_user_uses_current_database_roles_not_stale_token_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = _User()
+    user.stale_token_roles = ['Admin']
+    user.stale_token_permissions = ['users:*']
+    await _set_current_roles(monkeypatch, ['Support'], ['users:*'])
+
+    with pytest.raises(HTTPException) as exc:
+        await cabinet_dependencies.ensure_mobile_admin_access(_Db(), user, 'users:read')
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_mobile_admin_permission_is_still_enforced_for_allowed_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    await _set_current_roles(monkeypatch, ['Moderator'], ['tickets:*'])
+
+    with pytest.raises(HTTPException) as exc:
+        await cabinet_dependencies.ensure_mobile_admin_access(_Db(), _User(), 'settings:edit')
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert 'Permission not granted by any role' in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_mobile_admin_uses_permission_service_for_abac_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    await _set_current_roles(monkeypatch, ['Admin'], ['settings:*'])
+    calls: list[dict] = []
+
+    async def fake_check_permission(_db, _user, required_permission: str, *, ip_address=None):
+        assert required_permission == 'settings:edit'
+        return False, 'Denied by policy: office-hours'
+
+    async def fake_log_action(*_args, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr('app.services.permission_service.PermissionService.check_permission', fake_check_permission)
+    monkeypatch.setattr('app.services.permission_service.PermissionService.log_action', fake_log_action)
+    db = _Db()
+
+    with pytest.raises(HTTPException) as exc:
+        await cabinet_dependencies.ensure_mobile_admin_access(db, _User(), 'settings:edit')
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert 'Denied by policy: office-hours' in str(exc.value.detail)
+    assert calls[-1]['status'] == 'denied'
+    db.commit.assert_awaited()
+
+
+def test_mobile_facade_does_not_import_or_require_legacy_root_web_api_auth() -> None:
+    source = inspect.getsource(admin_mobile)
+
+    assert 'require_api_token' not in source
+    assert 'X-API-Key' not in source
+    assert 'WEB_API_DEFAULT_TOKEN' not in source
+    assert 'query_params.get' not in source
+
+
+def test_mobile_facade_wraps_authenticated_mobile_consumed_routes_with_mobile_guard() -> None:
+    source = inspect.getsource(admin_mobile)
+
+    expected = [
+        "require_mobile_admin_permission('tickets:read')",
+        "require_mobile_admin_permission('tickets:reply')",
+        "require_mobile_admin_permission('tickets:close')",
+        "require_mobile_admin_permission('users:read')",
+        "require_mobile_admin_permission('users:balance')",
+        "require_mobile_admin_permission('users:subscription')",
+        "require_mobile_admin_permission('stats:read')",
+        "require_mobile_admin_permission('settings:edit')",
+    ]
+    for needle in expected:
+        assert needle in source
+
+
+def test_mobile_subscription_fixture_shape() -> None:
+    now = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+    subscription = SimpleNamespace(
+        id=7,
+        user_id=42,
+        status='active',
+        actual_status='active',
+        is_trial=False,
+        start_date=now,
+        end_date=now,
+        traffic_limit_gb=100,
+        traffic_used_gb=12.5,
+        device_limit=3,
+        autopay_enabled=False,
+        autopay_days_before=None,
+        subscription_url='https://example.test/sub/abc',
+        subscription_crypto_link=None,
+        connected_squads=['squad-a'],
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = admin_mobile._serialize_subscription(subscription)
+
+    assert response.contract_version == CONTRACT_VERSION
+    assert response.required_role_names == ['Superadmin', 'Admin', 'Moderator']
+    assert response.id == 7
+    assert response.subscription_url == 'https://example.test/sub/abc'
+
+
+def test_month_bounds_are_utc_and_exclusive() -> None:
+    start, end = admin_mobile._month_bounds(2026, 12)
+
+    assert start == datetime(2026, 12, 1, tzinfo=UTC)
+    assert end == datetime(2027, 1, 1, tzinfo=UTC)
+
+
+def test_auth_and_refresh_responses_expose_refresh_lifetime() -> None:
+    user = UserResponse(id=42, created_at=datetime(2026, 7, 3, tzinfo=UTC))
+
+    auth = AuthResponse(
+        access_token='access',
+        refresh_token='refresh',
+        expires_in=900,
+        refresh_expires_in=2_592_000,
+        user=user,
+    )
+    refresh = TokenResponse(
+        access_token='new-access',
+        refresh_token='refresh',
+        expires_in=900,
+        refresh_expires_in=2_500_000,
+    )
+
+    assert auth.refresh_expires_in == 2_592_000
+    assert refresh.refresh_expires_in == 2_500_000

--- a/tests/cabinet/test_mobile_realtime_and_media_contract.py
+++ b/tests/cabinet/test_mobile_realtime_and_media_contract.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import inspect
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_mobile
+from app.cabinet.routes.media import (
+    _BLOCKED_UPLOAD_CONTENT_TYPES,
+    _BLOCKED_UPLOAD_EXTENSIONS,
+    _media_signature,
+    _verify_media_token,
+    make_media_token,
+)
+
+
+FID = 'BAADAgADabcdef_-1234567890'
+
+
+@pytest.mark.asyncio
+async def test_mobile_realtime_contract_is_explicitly_disabled() -> None:
+    response = await admin_mobile.get_mobile_realtime_contract()
+
+    assert response.enabled is False
+    assert response.feature == 'realtime_tickets'
+    assert '/ws?api_key=' in response.reason
+    assert '/cabinet/ws?token=' in response.reason
+
+
+def test_mobile_router_does_not_ship_query_token_websocket_contract() -> None:
+    source = inspect.getsource(admin_mobile)
+
+    assert '@router.websocket' not in source
+    assert 'query_params' not in source
+    assert 'websocket.accept' not in source
+
+
+def test_signed_media_token_is_required_bound_and_expiring_for_mobile_downloads() -> None:
+    token = make_media_token(FID)
+
+    assert _verify_media_token(FID, token) is True
+    assert _verify_media_token('BQADdifferent_-9876543210zy', token) is False
+
+    exp = int(time.time()) - 10
+    assert _verify_media_token(FID, f'{exp}.{_media_signature(FID, exp)}') is False
+
+
+def test_media_contract_rejects_scriptable_upload_types() -> None:
+    assert '.svg' in _BLOCKED_UPLOAD_EXTENSIONS
+    assert '.html' in _BLOCKED_UPLOAD_EXTENSIONS
+    assert 'image/svg+xml' in _BLOCKED_UPLOAD_CONTENT_TYPES
+    assert 'text/html' in _BLOCKED_UPLOAD_CONTENT_TYPES
+
+
+def test_mobile_media_contract_source_has_no_admin_token_download_requirement() -> None:
+    source = inspect.getsource(admin_mobile)
+
+    assert 'X-API-Key' not in source
+    assert 'WEB_API_DEFAULT_TOKEN' not in source
+    assert 'require_api_token' not in source
+
+
+@pytest.mark.asyncio
+async def test_realtime_response_does_not_enable_admin_event_subscription_for_downgraded_users(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def rejected_dependency(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail='downgraded')
+
+    monkeypatch.setattr(admin_mobile, 'get_mobile_realtime_contract', rejected_dependency)
+
+    with pytest.raises(HTTPException) as exc:
+        await admin_mobile.get_mobile_realtime_contract()
+
+    assert exc.value.status_code == 403

--- a/tests/cabinet/test_mobile_settings_contract.py
+++ b/tests/cabinet/test_mobile_settings_contract.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.cabinet.routes import admin_mobile
+from app.cabinet.routes.admin_settings import SettingUpdateRequest
+
+
+class _FakeConfigService:
+    SECRET_MASK = '********'
+
+    def __init__(self, env_locked: bool = False) -> None:
+        self.env_locked = env_locked
+
+    def get_definition(self, key: str):
+        if key not in {'WEB_API_ALLOWED_ORIGINS', 'CABINET_ALLOWED_ORIGINS'}:
+            raise KeyError(key)
+        return SimpleNamespace(key=key)
+
+    def is_env_locked(self, key: str) -> bool:
+        return self.env_locked and key == 'WEB_API_ALLOWED_ORIGINS'
+
+    def is_secret_key(self, _key: str) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_cors_contract_marks_pre_auth_as_operator_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin_mobile, 'bot_configuration_service', _FakeConfigService(env_locked=True))
+
+    response = await admin_mobile.get_mobile_cors_contract()
+
+    assert response.pre_auth_behavior == 'local/operator-guidance-only'
+    assert response.server_side_edit.startswith('allowed only after cabinet JWT')
+    by_key = {item.key: item for item in response.allowed_keys}
+    assert by_key['WEB_API_ALLOWED_ORIGINS'].mode == 'read-only/operator-guidance'
+    assert by_key['CABINET_ALLOWED_ORIGINS'].mode == 'editable-after-auth'
+
+
+@pytest.mark.asyncio
+async def test_mobile_cors_update_rejects_keys_outside_contract() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await admin_mobile.update_mobile_cors_setting(
+            key='BOT_TOKEN',
+            payload=SettingUpdateRequest(value='secret'),
+            admin=SimpleNamespace(telegram_id=1),
+            db=object(),
+        )
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_mobile_cors_update_delegates_env_lock_and_secret_handling(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def fake_update_setting(key, payload, admin, db):
+        calls.append((key, payload.value))
+        return {'key': key, 'current': payload.value, 'env_locked': False, 'is_secret': False}
+
+    monkeypatch.setattr(admin_mobile, 'update_setting', fake_update_setting)
+
+    response = await admin_mobile.update_mobile_cors_setting(
+        key='CABINET_ALLOWED_ORIGINS',
+        payload=SettingUpdateRequest(value='https://mobile.example.test'),
+        admin=SimpleNamespace(telegram_id=1),
+        db=object(),
+    )
+
+    assert calls == [('CABINET_ALLOWED_ORIGINS', 'https://mobile.example.test')]
+    assert response['key'] == 'CABINET_ALLOWED_ORIGINS'

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/balance_update_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/balance_update_success.json
@@ -1,0 +1,17 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/admin/mobile/users/42/balance",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:balance"],
+  "response_schema": "UpdateBalanceResponse",
+  "fixture_kind": "success",
+  "body": {
+    "success": true,
+    "old_balance_kopeks": 0,
+    "new_balance_kopeks": 50000,
+    "message": "Balance updated"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/cors_contract_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/cors_contract_success.json
@@ -1,0 +1,20 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/settings/cors",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["settings:read"],
+  "response_schema": "MobileSettingsCorsContractResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "pre_auth_behavior": "local/operator-guidance-only",
+    "server_side_edit": "allowed only after cabinet JWT, mobile role allowlist, settings:edit, and env-lock checks",
+    "allowed_keys": [
+      {"key": "WEB_API_ALLOWED_ORIGINS", "mode": "editable-after-auth", "env_locked": false, "secret": false},
+      {"key": "CABINET_ALLOWED_ORIGINS", "mode": "editable-after-auth", "env_locked": false, "secret": false}
+    ]
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/login_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/login_success.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/email/login",
+  "status": 200,
+  "auth": "email_password",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "AuthResponse",
+  "fixture_kind": "success",
+  "body": {
+    "access_token": "<cabinet-access-jwt>",
+    "refresh_token": "<cabinet-refresh-jwt>",
+    "token_type": "bearer",
+    "expires_in": 900,
+    "refresh_expires_in": 2592000
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/media_download_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/media_download_success.json
@@ -1,0 +1,16 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/media/{file_id}?token={signed_media_token}",
+  "status": 200,
+  "auth": "signed_media_download_token",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "BinaryMediaResponse",
+  "fixture_kind": "success",
+  "body": {
+    "download_auth_model": "signed_media_token",
+    "no_admin_token_headers": true,
+    "token_properties": ["hmac_signed", "file_bound", "expiring"]
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/media_upload_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/media_upload_success.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/admin/mobile/media/upload",
+  "status": 201,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["tickets:reply"],
+  "response_schema": "MediaUploadResponse",
+  "fixture_kind": "success",
+  "body": {
+    "media_type": "photo",
+    "file_id": "BAADAgADabcdef_-1234567890",
+    "media_url": "https://example.test/cabinet/media/BAADAgADabcdef_-1234567890?token=<signed_media_token>",
+    "download_auth_model": "signed_media_token",
+    "no_admin_token_headers": true
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/mobile_auth_forbidden_support.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/mobile_auth_forbidden_support.json
@@ -1,0 +1,14 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/subscriptions/lookup?subscription_url=https%3A%2F%2Fexample.test%2Fsub%2Fabc",
+  "status": 403,
+  "auth": "cabinet_jwt_disallowed_current_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:read"],
+  "response_schema": "HTTPError",
+  "fixture_kind": "error",
+  "body": {
+    "detail": "Mobile cabinet admin access requires current Superadmin, Admin, or Moderator role"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/monthly_income_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/monthly_income_success.json
@@ -1,0 +1,20 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/transactions/monthly-income?year=2026&month=7",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["stats:read"],
+  "response_schema": "MobileIncomeResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "period_start": "2026-07-01T00:00:00Z",
+    "period_end": "2026-08-01T00:00:00Z",
+    "income_kopeks": 129900,
+    "income_rubles": 1299.0,
+    "transaction_count": 3,
+    "completed_real_payment_only": true
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/permissions_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/permissions_success.json
@@ -1,0 +1,16 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/auth/me/permissions",
+  "status": 200,
+  "auth": "cabinet_jwt",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": [],
+  "response_schema": "PermissionService.get_user_permissions",
+  "fixture_kind": "success",
+  "body": {
+    "roles": ["Admin"],
+    "permissions": ["users:*", "tickets:*", "stats:*"],
+    "role_level": 100
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/realtime_disabled.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/realtime_disabled.json
@@ -1,0 +1,17 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/realtime",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["tickets:read"],
+  "response_schema": "MobileDisabledFeatureResponse",
+  "fixture_kind": "disabled",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "feature": "realtime_tickets",
+    "enabled": false,
+    "reason": "Mobile v1 must not use /ws?api_key=... or /cabinet/ws?token=... query-token websockets."
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_expired_error.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_expired_error.json
@@ -1,0 +1,14 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/refresh",
+  "status": 401,
+  "auth": "expired_refresh_token",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "HTTPError",
+  "fixture_kind": "error",
+  "body": {
+    "detail": "Invalid or expired refresh token"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_inactive_user_error.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_inactive_user_error.json
@@ -1,0 +1,14 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/refresh",
+  "status": 401,
+  "auth": "inactive_user_refresh_token",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "HTTPError",
+  "fixture_kind": "error",
+  "body": {
+    "detail": "User not found or inactive"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_near_expiry_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_near_expiry_success.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/refresh",
+  "status": 200,
+  "auth": "refresh_jwt_and_stored_token_row",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "TokenResponse",
+  "fixture_kind": "success",
+  "body": {
+    "access_token": "<cabinet-access-jwt>",
+    "refresh_token": "<same-refresh-jwt>",
+    "token_type": "bearer",
+    "expires_in": 900,
+    "refresh_expires_in": 3600
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_revoked_error.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_revoked_error.json
@@ -1,0 +1,14 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/refresh",
+  "status": 401,
+  "auth": "revoked_refresh_token",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "HTTPError",
+  "fixture_kind": "error",
+  "body": {
+    "detail": "Refresh token not found or revoked"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_valid_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/refresh_valid_success.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/auth/refresh",
+  "status": 200,
+  "auth": "refresh_jwt_and_stored_token_row",
+  "required_role_names": [],
+  "required_permissions": [],
+  "response_schema": "TokenResponse",
+  "fixture_kind": "success",
+  "body": {
+    "access_token": "<cabinet-access-jwt>",
+    "refresh_token": "<same-refresh-jwt>",
+    "token_type": "bearer",
+    "expires_in": 900,
+    "refresh_expires_in": 2500000
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/reset_subscription_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/reset_subscription_success.json
@@ -1,0 +1,17 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "POST",
+  "path": "/cabinet/admin/mobile/users/42/reset-subscription",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:subscription"],
+  "response_schema": "ResetSubscriptionResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "success": true,
+    "message": "Subscription reset successfully",
+    "subscription_deleted": true
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/stats_full_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/stats_full_success.json
@@ -1,0 +1,19 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/stats/full",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["stats:read"],
+  "response_schema": "MobileDashboardStatsResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "overview": {},
+    "users": {},
+    "subscriptions": {},
+    "transactions": {},
+    "referrals": {}
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/subscription_detail_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/subscription_detail_success.json
@@ -1,0 +1,19 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/subscriptions/7",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:read"],
+  "response_schema": "MobileSubscriptionResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "id": 7,
+    "user_id": 42,
+    "status": "active",
+    "actual_status": "active",
+    "is_trial": false
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/subscription_lookup_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/subscription_lookup_success.json
@@ -1,0 +1,28 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/subscriptions/lookup?subscription_url=https%3A%2F%2Fexample.test%2Fsub%2Fabc",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:read"],
+  "response_schema": "MobileSubscriptionResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "id": 7,
+    "user_id": 42,
+    "status": "active",
+    "actual_status": "active",
+    "is_trial": false,
+    "traffic_limit_gb": 100,
+    "traffic_used_gb": 12.5,
+    "device_limit": 3,
+    "autopay_enabled": false,
+    "subscription_url": "https://example.test/sub/abc",
+    "connected_squads": ["squad-a"],
+    "required_role_names": ["Superadmin", "Admin", "Moderator"],
+    "auth": "cabinet_jwt_allowed_role",
+    "legacy_auth": "rejected"
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/tickets_list_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/tickets_list_success.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/tickets",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["tickets:read"],
+  "response_schema": "AdminTicketListResponse",
+  "fixture_kind": "success",
+  "body": {
+    "items": [],
+    "total": 0,
+    "page": 1,
+    "per_page": 20,
+    "pages": 1
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/user_detail_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/user_detail_success.json
@@ -1,0 +1,17 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/users/42",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:read"],
+  "response_schema": "UserDetailResponse",
+  "fixture_kind": "success",
+  "body": {
+    "id": 42,
+    "telegram_id": 4242,
+    "status": "active",
+    "balance_kopeks": 0
+  }
+}

--- a/tests/fixtures/bedolaga-mobile-cabinet-v1/user_transactions_success.json
+++ b/tests/fixtures/bedolaga-mobile-cabinet-v1/user_transactions_success.json
@@ -1,0 +1,30 @@
+{
+  "contract_version": "bedolaga-mobile-cabinet-v1",
+  "method": "GET",
+  "path": "/cabinet/admin/mobile/users/42/transactions",
+  "status": 200,
+  "auth": "cabinet_jwt_allowed_role",
+  "required_role_names": ["Superadmin", "Admin", "Moderator"],
+  "required_permissions": ["users:read"],
+  "response_schema": "MobileTransactionListResponse",
+  "fixture_kind": "success",
+  "body": {
+    "contract_version": "bedolaga-mobile-cabinet-v1",
+    "items": [
+      {
+        "id": 9001,
+        "user_id": 42,
+        "type": "deposit",
+        "amount_kopeks": 49900,
+        "amount_rubles": 499.0,
+        "payment_method": "yookassa",
+        "is_completed": true,
+        "created_at": "2026-07-03T12:00:00Z"
+      }
+    ],
+    "total": 1,
+    "limit": 50,
+    "offset": 0,
+    "completed_real_payment_only": true
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "remnawave-bedolaga-telegram-bot"
-version = "3.54.0"
+version = "3.62.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- add bedolaga-mobile-cabinet-v1 under /cabinet/admin/mobile for Wave Machine mobile cabinet JWT migration
- enforce current DB role names Superadmin/Admin/Moderator plus PermissionService-backed endpoint permissions
- add explicit refresh_expires_in, realtime disablement, signed-media/CORS contract docs, and versioned fixtures

## Verification
- .venv/bin/pytest tests/cabinet/test_mobile_admin_contract.py tests/cabinet/test_mobile_realtime_and_media_contract.py tests/cabinet/test_mobile_settings_contract.py -q
- uv run ruff check app/cabinet/dependencies.py app/cabinet/routes/admin_mobile.py app/cabinet/routes/auth.py app/cabinet/routes/__init__.py app/cabinet/schemas/admin_mobile.py app/cabinet/schemas/auth.py tests/cabinet/test_mobile_admin_contract.py tests/cabinet/test_mobile_realtime_and_media_contract.py tests/cabinet/test_mobile_settings_contract.py
- rg -n "X-API-Key|WEB_API_DEFAULT_TOKEN|require_api_token|api_key=" app/cabinet tests/cabinet docs/mobile-cabinet-contract.md
- rg -n "/cabinet/admin/(tickets|users)|/cabinet/media/upload" docs/mobile-cabinet-contract.md tests/fixtures/bedolaga-mobile-cabinet-v1 || true

## Review Gate
Chewbacca implementation review: APPROVED. Non-blocking follow-ups: audit logging for role-allowlist denials, one error fixture per facade endpoint, and live DB/API integration coverage.