### PR TITLE
feat(remnawave): локальная генерация happ crypt4 ссылок (без внешнего API)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -941,7 +941,11 @@ class Settings(BaseSettings):
     CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED: bool = False
     HAPP_CRYPTOLINK_REDIRECT_TEMPLATE: str | None = None
     # Remnawave 2.8.0 удалил /api/system/tools/happ/encrypt — недостающие crypt-ссылки
-    # генерируются через официальный Happ API (crypto.happ.su -> happ://crypt5/...).
+    # генерируются локально (RSA публичным ключом Happ, как на subpage панели ->
+    # happ://crypt4/...). Выключатель на случай ротации ключа Happ: тогда до обновления
+    # бота ссылки поедут через панель/внешний API.
+    HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED: bool = True
+    # Запасной путь — официальный Happ API (crypto.happ.su -> happ://crypt5/...).
     # Выключатель на случай проблем с внешним сервисом.
     HAPP_CRYPTOLINK_API_FALLBACK_ENABLED: bool = True
     HAPP_DOWNLOAD_LINK_IOS: str | None = None

--- a/app/external/remnawave_api.py
+++ b/app/external/remnawave_api.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 import aiohttp
 import structlog
+from Crypto.Cipher import PKCS1_v1_5
+from Crypto.PublicKey import RSA
 
 from app.config import settings
 
@@ -241,8 +243,29 @@ class RemnaWaveTransientError(RemnaWaveAPIError):
     surfaced by the monitoring service, not by per-request error logs."""
 
 
+# Публичный RSA-ключ Happ для crypt4-ссылок — тот же, которым официальная страница
+# подписки Remnawave шифрует ссылку в браузере (@kastov/cryptohapp: JSEncrypt =
+# RSA PKCS#1 v1.5 + base64). Ключ публичный, расшифровать ссылку может только
+# приложение Happ своим приватным ключом.
+HAPP_CRYPTO_V4_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3UZ0M3L4K+WjM3vkbQnz
+ozHg/cRbEXvQ6i4A8RVN4OM3rK9kU01FdjyoIgywve8OEKsFnVwERZAQZ1Trv60B
+hmaM76QQEE+EUlIOL9EpwKWGtTL5lYC1sT9XJMNP3/CI0gP5wwQI88cY/xedpOEB
+W72EmOOShHUm/b/3m+HPmqwc4ugKj5zWV5SyiT829aFA5DxSjmIIFBAms7DafmSq
+LFTYIQL5cShDY2u+/sqyAw9yZIOoqW2TFIgIHhLPWek/ocDU7zyOrlu1E0SmcQQb
+LFqHq02fsnH6IcqTv3N5Adb/CkZDDQ6HvQVBmqbKZKf7ZdXkqsc/Zw27xhG7OfXC
+tUmWsiL7zA+KoTd3avyOh93Q9ju4UQsHthL3Gs4vECYOCS9dsXXSHEY/1ngU/hjO
+WFF8QEE/rYV6nA4PTyUvo5RsctSQL/9DJX7XNh3zngvif8LsCN2MPvx6X+zLouBX
+zgBkQ9DFfZAGLWf9TR7KVjZC/3NsuUCDoAOcpmN8pENBbeB0puiKMMWSvll36+2M
+YR1Xs0MgT8Y9TwhE2+TnnTJOhzmHi/BxiUlY/w2E0s4ax9GHAmX0wyF4zeV7kDkc
+vHuEdc0d7vDmdw0oqCqWj0Xwq86HfORu6tm1A8uRATjb4SzjTKclKuoElVAVa5Jo
+oh/uZMozC65SmDw+N5p6Su8CAwEAAQ==
+-----END PUBLIC KEY-----"""
+
+HAPP_CRYPTO_V4_DEEP_LINK_PREFIX = 'happ://crypt4/'
+
 # Официальный Happ crypto API: POST {"url": ...} -> {"encrypted_link": "happ://crypt5/..."}.
-# Fallback-источник crypt-ссылок после того, как Remnawave 2.8.0 удалил свой encrypt-эндпоинт.
+# Запасной источник crypt-ссылок, если локальное шифрование выключено/не удалось.
 HAPP_CRYPTO_API_URL = 'https://crypto.happ.su/api-v2.php'
 HAPP_CRYPTO_API_COOLDOWN_SECONDS = 600
 HAPP_CRYPTO_API_CACHE_MAX = 512
@@ -1407,10 +1430,37 @@ class RemnaWaveAPI:
         return True
 
     async def encrypt_happ_crypto_link(self, link_to_encrypt: str) -> str | None:
+        encrypted = self._encrypt_locally(link_to_encrypt)
+        if encrypted:
+            return encrypted
         encrypted = await self._encrypt_via_panel(link_to_encrypt)
         if encrypted:
             return encrypted
         return await self._encrypt_via_happ_api(link_to_encrypt)
+
+    @staticmethod
+    def _encrypt_locally(link_to_encrypt: str) -> str | None:
+        """Шифрует ссылку подписки в happ://crypt4/... локально, без сети.
+
+        Повторяет алгоритм официальной страницы подписки Remnawave
+        (@kastov/cryptohapp): RSA PKCS#1 v1.5 публичным ключом Happ + base64.
+        В отличие от панельного эндпоинта (удалён в 2.8.0) и внешнего Happ API
+        (лимиты, cooldown, утечка URL подписки вовне) работает всегда и бесплатно.
+        """
+        if not settings.HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED:
+            return None
+        try:
+            key = RSA.import_key(HAPP_CRYPTO_V4_PUBLIC_KEY)
+            payload = link_to_encrypt.encode('utf-8')
+            # Лимит PKCS#1 v1.5 — размер ключа минус 11 байт (501 для RSA-4096)
+            if len(payload) > key.size_in_bytes() - 11:
+                logger.warning('Ссылка слишком длинная для happ crypt4', length=len(payload))
+                return None
+            encrypted = PKCS1_v1_5.new(key).encrypt(payload)
+            return HAPP_CRYPTO_V4_DEEP_LINK_PREFIX + base64.b64encode(encrypted).decode('ascii')
+        except Exception as e:
+            logger.warning('Не удалось локально зашифровать happ ссылку', error=e)
+            return None
 
     async def _encrypt_via_panel(self, link_to_encrypt: str) -> str | None:
         # Эндпоинт удалён в Remnawave 2.8.0 — после первого 404 больше не дёргаем.
@@ -1515,12 +1565,15 @@ class RemnaWaveAPI:
 
     async def enrich_user_with_happ_link(self, user: RemnaWaveUser) -> RemnaWaveUser:
         if not user.happ_crypto_link and user.subscription_url:
-            # Панельный эндпоинт (2.7.x) — локальный и бесплатный. Внешний Happ API
-            # на этом горячем пути (enrich зовётся на каждом get_user_by_*) дёргаем
-            # только когда crypt-ссылки реально нужны боту (happ_cryptolink-режим);
-            # кабинет генерирует недостающие ссылки сам — по факту CRYPT-шаблона
-            # в app-config, — так что URL подписок не утекают вовне без надобности.
-            encrypted = await self._encrypt_via_panel(user.subscription_url)
+            # Сначала локальное шифрование (мгновенно, без сети), затем панельный
+            # эндпоинт (2.7.x). Внешний Happ API на этом горячем пути (enrich зовётся
+            # на каждом get_user_by_*) дёргаем только когда crypt-ссылки реально нужны
+            # боту (happ_cryptolink-режим); кабинет генерирует недостающие ссылки сам —
+            # по факту CRYPT-шаблона в app-config, — так что URL подписок не утекают
+            # вовне без надобности.
+            encrypted = self._encrypt_locally(user.subscription_url) or await self._encrypt_via_panel(
+                user.subscription_url
+            )
             if not encrypted and settings.is_happ_cryptolink_mode():
                 encrypted = await self._encrypt_via_happ_api(user.subscription_url)
             if encrypted:

--- a/tests/external/test_remnawave_2_8_0.py
+++ b/tests/external/test_remnawave_2_8_0.py
@@ -11,13 +11,26 @@ remains valid; the response-side rename is consumed in ``admin_traffic`` routes.
 
 from __future__ import annotations
 
+import base64
 from unittest.mock import AsyncMock
+
+import pytest
 
 from app.external.remnawave_api import RemnaWaveAPI, RemnaWaveAPIError
 
 
 def _api() -> RemnaWaveAPI:
     return RemnaWaveAPI('http://panel.local', 'key')
+
+
+@pytest.fixture(autouse=True)
+def _local_happ_encryption_off(monkeypatch):
+    """Тесты fallback-цепочки ниже проверяют путь панель -> внешний Happ API;
+    локальное RSA-шифрование (основной путь по умолчанию) закоротило бы их,
+    поэтому здесь оно выключено и включается явно в тестах локального шифрования."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED', False)
 
 
 async def test_restart_node_sends_force_restart_body_default_false():
@@ -259,6 +272,87 @@ async def test_happ_api_fallback_disabled_by_setting(monkeypatch):
     api._call_happ_crypto_api = AsyncMock(return_value='happ://crypt5/encrypted')
     try:
         assert await api.encrypt_happ_crypto_link('https://sub.example/x') is None
+        api._call_happ_crypto_api.assert_not_called()
+    finally:
+        _reset_happ_state()
+
+
+async def test_happ_local_encryption_roundtrip(monkeypatch):
+    """Локальное шифрование должно давать happ://crypt4/<base64>, расшифровываемый
+    приватным ключом (та же схема PKCS#1 v1.5, что у subpage панели). Настоящий
+    приватный ключ есть только у Happ, поэтому roundtrip — на тестовой паре."""
+    from Crypto.Cipher import PKCS1_v1_5
+    from Crypto.PublicKey import RSA
+
+    import app.external.remnawave_api as rw
+    from app.config import settings
+
+    keypair = RSA.generate(2048)
+    monkeypatch.setattr(rw, 'HAPP_CRYPTO_V4_PUBLIC_KEY', keypair.publickey().export_key().decode())
+    monkeypatch.setattr(settings, 'HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED', True)
+
+    api = _api()
+    api._make_request = AsyncMock()
+    api._call_happ_crypto_api = AsyncMock()
+
+    link = await api.encrypt_happ_crypto_link('https://sub.example/x')
+
+    assert link is not None and link.startswith('happ://crypt4/')
+    blob = base64.b64decode(link.removeprefix('happ://crypt4/'))
+    assert PKCS1_v1_5.new(keypair).decrypt(blob, None) == b'https://sub.example/x'
+    # Локальный путь не должен трогать ни панель, ни внешний сервис.
+    api._make_request.assert_not_called()
+    api._call_happ_crypto_api.assert_not_called()
+
+
+async def test_happ_local_encryption_real_key_single_rsa4096_block(monkeypatch):
+    """Со вшитым ключом Happ v4 (RSA-4096) шифртекст — один блок в 512 байт,
+    как у ссылок, которые генерирует официальная страница подписки."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED', True)
+
+    link = RemnaWaveAPI._encrypt_locally('https://sub.example/x')
+
+    assert link is not None and link.startswith('happ://crypt4/')
+    assert len(base64.b64decode(link.removeprefix('happ://crypt4/'))) == 512
+
+
+async def test_happ_local_encryption_rejects_oversized_payload(monkeypatch):
+    """PKCS#1 v1.5 вмещает size_in_bytes()-11: слишком длинная ссылка -> None,
+    а не исключение (дальше цепочка уйдёт в панель/внешний API)."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED', True)
+
+    assert RemnaWaveAPI._encrypt_locally('https://sub.example/' + 'x' * 600) is None
+
+
+async def test_happ_local_encryption_disabled_by_setting():
+    """HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED=false должен пропустить локальный
+    путь (fixture уже выключила флаг) — цепочка идёт в панель/внешний API."""
+    assert RemnaWaveAPI._encrypt_locally('https://sub.example/x') is None
+
+
+async def test_enrich_uses_local_encryption_without_network(monkeypatch):
+    """С локальным шифрованием enrich заполняет crypt-ссылку в любом режиме бота,
+    не делая ни одного сетевого вызова (ни в панель, ни во внешний Happ API)."""
+    from types import SimpleNamespace
+
+    from app.config import settings
+
+    _reset_happ_state()
+    monkeypatch.setattr(settings, 'HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED', True)
+    monkeypatch.setattr(type(settings), 'is_happ_cryptolink_mode', lambda self: False)
+    api = _api()
+    api._make_request = AsyncMock()
+    api._call_happ_crypto_api = AsyncMock()
+    user = SimpleNamespace(happ_crypto_link=None, subscription_url='https://sub.example/x')
+    try:
+        enriched = await api.enrich_user_with_happ_link(user)
+        assert enriched.happ_crypto_link is not None
+        assert enriched.happ_crypto_link.startswith('happ://crypt4/')
+        api._make_request.assert_not_called()
         api._call_happ_crypto_api.assert_not_called()
     finally:
         _reset_happ_state()


### PR DESCRIPTION
## 📝 Описание

Локальная генерация `happ://crypt4/...` ссылок — тем же алгоритмом, которым их создаёт официальная страница подписки Remnawave в браузере (`@kastov/cryptohapp`: RSA PKCS#1 v1.5 публичным ключом Happ v4 + base64). Локальное шифрование встаёт первым в существующую цепочку: **локально → панельный эндпоинт (<2.8.0) → внешний Happ API**.

## 🎯 Мотивация

Remnawave 2.8.0 удалила `POST /api/system/tools/happ/encrypt`, и единственным источником недостающих crypt-ссылок остался внешний сервис `crypto.happ.su` со всеми его ограничениями, от которых текущий код вынужден защищаться: лимиты/429, cooldown при сбоях, per-URL баны, кэш, плюс URL подписок пользователей уходят на сторонний сервис (из-за чего в `enrich_user_with_happ_link` fallback ограничен режимом `happ_cryptolink`).

При этом ключ шифрования — публичный, он вшит в JS официальной subpage панели. Шифровать можно локально: мгновенно, без сети, без лимитов и без утечки URL. Расшифровать ссылку по-прежнему может только приложение Happ своим приватным ключом.

## 🔧 Изменения

- `app/external/remnawave_api.py`: константа с публичным ключом Happ v4, статический метод `_encrypt_locally()`, вызов первым в `encrypt_happ_crypto_link()` и в `enrich_user_with_happ_link()` (горячий путь теперь заполняет crypt-ссылку в любом режиме бота, без сети).
- `app/config.py`: флаг `HAPP_CRYPTOLINK_LOCAL_ENCRYPTION_ENABLED=true` — выключатель на случай ротации ключа Happ (тогда до обновления бота ссылки поедут по прежним путям: панель/внешний API).
- `tests/external/test_remnawave_2_8_0.py`: autouse-фикстура отключает локальное шифрование в тестах fallback-цепочки (они по-прежнему проверяют панель → внешний API), + 5 новых тестов: roundtrip-расшифровка на тестовой RSA-паре, формат ссылки с реальным ключом (один блок RSA-4096 = 512 байт), переполнение payload, выключатель, enrich без сетевых вызовов.

## 🧪 Тестирование

- `uv run pytest` — 1707 passed (весь сьют).
- `uv run ruff check` / `ruff format --check` — чисто.
- Формат ссылки сверен с живой subpage панели: перехваченный `happ://crypt4/...` из браузера и локально сгенерированный дают идентичную структуру (RSA-4096, 512 байт, base64 684 символа); содержимое различается только случайным паддингом PKCS#1 v1.5.

## ⚠️ Замечания

- Если Happ введёт новый формат (crypt5 уже отдаёт их API v2), локальный ключ можно дополнить/заменить; до тех пор v4 — то, что сегодня генерирует официальная subpage Remnawave.
- Поведение по умолчанию меняется: crypt-ссылки начнут заполняться и вне `happ_cryptolink`-режима (раньше в enrich внешний API дёргался только в нём). Это дёшево (локальная операция) и полезно кабинету/miniapp, но если считаете лишним — могу ограничить локальный путь теми же условиями.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
