### PR TITLE
fix(cabinet): возврат средств при сбое покупки тарифа после списания баланса (#3031)

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -31,7 +31,7 @@ from app.database.crud.subscription import (
 )
 from app.database.crud.tariff import get_tariff_by_id, get_tariffs_for_user
 from app.database.crud.transaction import create_transaction
-from app.database.crud.user import add_user_balance, subtract_user_balance
+from app.database.crud.user import add_user_balance, get_user_by_id, subtract_user_balance
 from app.database.models import PaymentMethod, Subscription, Tariff, TransactionType, User
 from app.services.notification_delivery_service import (
     NotificationType,
@@ -863,73 +863,140 @@ async def purchase_tariff(
             payment_method=PaymentMethod.BALANCE,
         )
 
-        # --- Trial cleanup: find and kill all trials BEFORE creating/extending ---
-        from app.database.crud.subscription import deactivate_user_trial_subscriptions
+        # Плоские копии для веток возврата средств ниже: после db.rollback()
+        # ORM-объекты expired, а синхронный доступ к их атрибутам в async-контексте
+        # падает с MissingGreenlet — компенсация обязана работать без живых инстансов.
+        refund_user_id = user.id
+        refund_tariff_id = tariff.id
+        refund_tariff_name = tariff.name
 
-        # Collect remaining trial seconds for TRIAL_ADD_REMAINING_DAYS_TO_PAID
-        _bonus_seconds = 0
-        _now_trial = datetime.now(UTC)
-        killed_trials = await deactivate_user_trial_subscriptions(
-            db,
-            user.id,
-            exclude_subscription_id=subscription.id if subscription else None,
-        )
-        if settings.TRIAL_ADD_REMAINING_DAYS_TO_PAID:
-            for _kt in killed_trials:
-                if _kt.end_date and _kt.end_date > _now_trial:
-                    _bonus_seconds += max(0, (_kt.end_date - _now_trial).total_seconds())
+        async def _refund_charge(reason: str) -> None:
+            """Возврат уже списанной суммы после db.rollback().
 
-        # If existing subscription IS the trial being extended — it's already deactivated
-        # as trial by deactivate_user_trial_subscriptions (is_trial=False, status=DISABLED).
-        # We need to re-activate it for extend to work correctly.
-        if subscription and subscription.id in {kt.id for kt in killed_trials}:
-            subscription.status = 'active'
-            subscription.is_trial = False
-            await db.flush()
-
-        if subscription:
-            # Extend/change tariff — сохраняем докупленные устройства при продлении того же тарифа
-            subscription = await extend_subscription(
-                db=db,
-                subscription=subscription,
-                days=period_days,
-                tariff_id=tariff.id,
-                traffic_limit_gb=traffic_limit_gb,
-                device_limit=effective_device_limit,
-                connected_squads=squads,
-            )
-        else:
-            # Create new subscription
+            Сбои возврата только логируем (CRITICAL): исходную ошибку покупки
+            маскировать нельзя, а двойного списания здесь быть не может.
+            """
             try:
-                subscription = await create_paid_subscription(
-                    db=db,
-                    user_id=user.id,
-                    duration_days=period_days,
-                    traffic_limit_gb=traffic_limit_gb,
-                    device_limit=tariff.device_limit,
-                    connected_squads=squads,
-                    tariff_id=tariff.id,
-                )
-            except IntegrityError:
-                # Partial unique index violation: user already has active subscription for this tariff
-                logger.warning(
-                    'Cabinet purchase: tariff already active (IntegrityError), refunding',
-                    tariff_id=tariff.id,
-                    user_id=user.id,
-                )
-                await db.rollback()
+                refund_user = await get_user_by_id(db, refund_user_id)
+                if refund_user is None:
+                    logger.critical(
+                        'CRITICAL: пользователь не найден для возврата средств после ошибки покупки тарифа',
+                        user_id=refund_user_id,
+                        price_kopeks=price_kopeks,
+                    )
+                    return
                 await add_user_balance(
                     db,
-                    user,
+                    refund_user,
                     price_kopeks,
-                    f"Возврат: тариф '{tariff.name}' уже активен",
+                    reason,
                     create_transaction=True,
                     transaction_type=TransactionType.REFUND,
                 )
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail='You already have an active subscription for this tariff',
+                logger.info(
+                    'Cabinet purchase: средства возвращены после ошибки покупки тарифа',
+                    user_id=refund_user_id,
+                    refund_kopeks=price_kopeks,
                 )
+            except Exception as refund_error:
+                logger.critical(
+                    'CRITICAL: не удалось вернуть средства после ошибки покупки тарифа в кабинете',
+                    user_id=refund_user_id,
+                    price_kopeks=price_kopeks,
+                    refund_error=refund_error,
+                )
+
+        # С этого места деньги уже списаны и закоммичены (subtract_user_balance +
+        # create_transaction). Любая ошибка до успешного сохранения подписки без
+        # компенсации — «тихая» потеря платежа: route-level обработчик отдал бы
+        # HTTP 500 без возврата (#3031: запись в transactions есть, в subscriptions
+        # нет). Пост-persist шаги (bonus_seconds, daily-маркер, синк с панелью)
+        # остаются снаружи guard'а: их сбой не должен возвращать деньги за уже
+        # выданную подписку.
+        try:
+            # --- Trial cleanup: find and kill all trials BEFORE creating/extending ---
+            from app.database.crud.subscription import deactivate_user_trial_subscriptions
+
+            # Collect remaining trial seconds for TRIAL_ADD_REMAINING_DAYS_TO_PAID
+            _bonus_seconds = 0
+            _now_trial = datetime.now(UTC)
+            killed_trials = await deactivate_user_trial_subscriptions(
+                db,
+                user.id,
+                exclude_subscription_id=subscription.id if subscription else None,
+            )
+            if settings.TRIAL_ADD_REMAINING_DAYS_TO_PAID:
+                for _kt in killed_trials:
+                    if _kt.end_date and _kt.end_date > _now_trial:
+                        _bonus_seconds += max(0, (_kt.end_date - _now_trial).total_seconds())
+
+            # Защитная ветка: собственный триал исключён из deactivate выше и сюда
+            # НЕ попадает — его конвертацию (is_trial=False) выполняет
+            # extend_subscription (convert_trial=True по умолчанию). Ветка оживёт,
+            # только если exclude_subscription_id перестанут передавать: тогда
+            # убитый триал нужно реанимировать перед extend, иначе продление
+            # отработает по DISABLED-строке.
+            if subscription and subscription.id in {kt.id for kt in killed_trials}:
+                subscription.status = 'active'
+                subscription.is_trial = False
+                await db.flush()
+
+            if subscription:
+                # Extend/change tariff — сохраняем докупленные устройства при продлении того же тарифа
+                subscription = await extend_subscription(
+                    db=db,
+                    subscription=subscription,
+                    days=period_days,
+                    tariff_id=tariff.id,
+                    traffic_limit_gb=traffic_limit_gb,
+                    device_limit=effective_device_limit,
+                    connected_squads=squads,
+                )
+            else:
+                # Create new subscription
+                try:
+                    subscription = await create_paid_subscription(
+                        db=db,
+                        user_id=user.id,
+                        duration_days=period_days,
+                        traffic_limit_gb=traffic_limit_gb,
+                        device_limit=tariff.device_limit,
+                        connected_squads=squads,
+                        tariff_id=tariff.id,
+                    )
+                except IntegrityError:
+                    # Partial unique index violation: user already has active subscription for this tariff
+                    logger.warning(
+                        'Cabinet purchase: tariff already active (IntegrityError), refunding',
+                        tariff_id=refund_tariff_id,
+                        user_id=refund_user_id,
+                    )
+                    await db.rollback()
+                    await _refund_charge(f"Возврат: тариф '{refund_tariff_name}' уже активен")
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail='You already have an active subscription for this tariff',
+                    )
+        except HTTPException:
+            # 409-ветка выше уже вернула средства; повторная компенсация здесь
+            # превратила бы одиночный возврат в двойной.
+            raise
+        except Exception as purchase_error:
+            # Логируем до rollback — после него атрибуты ORM-объектов недоступны.
+            logger.error(
+                'Cabinet purchase: ошибка между списанием баланса и сохранением подписки — возвращаем средства',
+                user_id=refund_user_id,
+                tariff_id=refund_tariff_id,
+                price_kopeks=price_kopeks,
+                error=purchase_error,
+                exc_info=True,
+            )
+            await db.rollback()
+            await _refund_charge(f"Возврат: ошибка активации тарифа '{refund_tariff_name}'")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail='Failed to process tariff purchase',
+            )
 
         # Add remaining trial time to paid subscription
         if _bonus_seconds > 0 and subscription:

--- a/tests/cabinet/test_purchase_tariff_refund_on_failure.py
+++ b/tests/cabinet/test_purchase_tariff_refund_on_failure.py
@@ -1,0 +1,239 @@
+"""Source-level pin: cabinet ``/purchase-tariff`` must compensate (refund) when
+the subscription fails to persist AFTER the balance charge is committed.
+
+Background — the bug this defends against (#3031)
+-------------------------------------------------
+``subtract_user_balance`` and ``create_transaction`` commit immediately; the
+subscription is created/extended afterwards. Any failure in between — an
+IntegrityError from a tariff-switch race that the narrow create-branch handler
+does not catch (e.g. raised by ``extend_subscription``), a transient DB/driver
+error ("Single-row INSERT ... did not produce a new primary key result"), a
+FlushError — used to bubble into the route-level ``except Exception``, which
+returns HTTP 500 WITHOUT compensation. Prod evidence: ``transactions`` has the
+``subscription_payment`` row, ``subscriptions`` has nothing — the user paid and
+got nothing.
+
+Fix shape
+---------
+The charge→persist section is wrapped in a guard inside ``purchase_tariff``:
+
+- ``except HTTPException: raise`` — the 409 "already active" branch refunds
+  itself; re-raising prevents a double refund;
+- ``except Exception`` — log, ``db.rollback()``, refund via ``_refund_charge``,
+  re-raise as HTTP 500.
+
+``_refund_charge`` re-fetches the user with ``get_user_by_id`` because after
+``db.rollback()`` ORM instances are expired and synchronous attribute access in
+an async context dies with MissingGreenlet — a refund path must never depend on
+live instances.
+
+Post-persist steps (trial bonus seconds, daily-charge marker, panel sync) stay
+OUTSIDE the guard on purpose: once the subscription is committed the product is
+delivered, and a later failure must not hand the money back on top of it.
+
+A full integration test would need a real DB + FastAPI deps; these tests pin
+the SOURCE-LEVEL structure via AST so the guard can't silently disappear.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PURCHASE_PATH = (
+    Path(__file__).resolve().parents[2] / 'app' / 'cabinet' / 'routes' / 'subscription_modules' / 'purchase.py'
+)
+
+
+def _find_async_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f'async function {name!r} not found in cabinet purchase.py')
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    """Collect the names of all calls (plain and attribute) under ``node``."""
+    names: set[str] = set()
+    for n in ast.walk(node):
+        if isinstance(n, ast.Call):
+            func = n.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _handler_type_names(handler: ast.ExceptHandler) -> set[str]:
+    if handler.type is None:
+        return set()
+    if isinstance(handler.type, ast.Name):
+        return {handler.type.id}
+    if isinstance(handler.type, ast.Tuple):
+        return {elt.id for elt in handler.type.elts if isinstance(elt, ast.Name)}
+    return set()
+
+
+def _find_refund_guard(func: ast.AsyncFunctionDef) -> ast.Try:
+    """The Try whose ``except Exception`` handler performs the compensation.
+
+    Distinguished from the route-level Try (whose Exception handler only logs
+    and re-raises 500) by the ``_refund_charge`` call inside the handler.
+    """
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Try):
+            continue
+        for handler in node.handlers:
+            if 'Exception' in _handler_type_names(handler) and '_refund_charge' in _call_names(handler):
+                return node
+    raise AssertionError(
+        'purchase_tariff must wrap the charge→persist section in a guard whose '
+        'except Exception handler calls _refund_charge — without it any failure '
+        'between the committed balance charge and the subscription commit loses '
+        "the user's money (#3031)"
+    )
+
+
+def test_persistence_wrapped_in_refund_guard() -> None:
+    """REGRESSION: both persistence branches (extend + create) must sit inside
+    the refund guard, and the guard must re-raise HTTPException untouched so the
+    self-refunding 409 branch is not compensated twice.
+    """
+    tree = ast.parse(PURCHASE_PATH.read_text(encoding='utf-8'))
+    func = _find_async_function(tree, 'purchase_tariff')
+    guard = _find_refund_guard(func)
+
+    body_calls = _call_names(ast.Module(body=guard.body, type_ignores=[]))
+    assert 'extend_subscription' in body_calls, (
+        'extend_subscription must run inside the refund guard: an IntegrityError '
+        'from a tariff-switch race there is NOT caught by the create-branch '
+        'handler and previously lost the charge'
+    )
+    assert 'create_paid_subscription' in body_calls, (
+        'create_paid_subscription must run inside the refund guard: non-'
+        'IntegrityError failures (FlushError, driver errors) previously lost the charge'
+    )
+
+    http_handlers = [h for h in guard.handlers if 'HTTPException' in _handler_type_names(h)]
+    assert http_handlers, 'the refund guard must have an "except HTTPException: raise" handler'
+    assert all(
+        len(h.body) == 1 and isinstance(h.body[0], ast.Raise) and h.body[0].exc is None for h in http_handlers
+    ), (
+        'the HTTPException handler must be a bare re-raise: the 409 "already '
+        'active" branch refunds itself, compensating again would double-refund'
+    )
+
+    exception_handler = next(h for h in guard.handlers if 'Exception' in _handler_type_names(h))
+    handler_calls = _call_names(exception_handler)
+    assert 'rollback' in handler_calls, (
+        'the except Exception handler must roll back the broken transaction before refunding'
+    )
+    raises_http = any(
+        isinstance(n, ast.Raise)
+        and isinstance(n.exc, ast.Call)
+        and isinstance(n.exc.func, ast.Name)
+        and n.exc.func.id == 'HTTPException'
+        for n in ast.walk(exception_handler)
+    )
+    assert raises_http, 'after refunding, the guard must surface the failure as an HTTPException (500)'
+
+
+def test_refund_helper_uses_fresh_user_and_refund_transaction() -> None:
+    """REGRESSION: ``_refund_charge`` must re-fetch the user via
+    ``get_user_by_id`` (post-rollback ORM instances are expired → MissingGreenlet
+    on attribute access) and must credit via ``add_user_balance`` with a REFUND
+    transaction so the compensation is visible in the transaction history.
+    """
+    tree = ast.parse(PURCHASE_PATH.read_text(encoding='utf-8'))
+    func = _find_async_function(tree, 'purchase_tariff')
+    helper = _find_async_function(func, '_refund_charge')
+
+    helper_calls = _call_names(helper)
+    assert 'get_user_by_id' in helper_calls, (
+        '_refund_charge must re-fetch the user with get_user_by_id — the closure '
+        'User instance is expired after db.rollback() and dies with MissingGreenlet'
+    )
+
+    add_balance_calls = [
+        n
+        for n in ast.walk(helper)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == 'add_user_balance'
+    ]
+    assert add_balance_calls, '_refund_charge must credit the user via add_user_balance'
+    call = add_balance_calls[0]
+    keywords = {kw.arg: kw.value for kw in call.keywords}
+    assert 'transaction_type' in keywords, 'refund must set an explicit transaction_type'
+    tx_type = keywords['transaction_type']
+    assert isinstance(tx_type, ast.Attribute) and tx_type.attr == 'REFUND', (
+        'refund must be recorded as TransactionType.REFUND'
+    )
+    create_tx = keywords.get('create_transaction')
+    assert isinstance(create_tx, ast.Constant) and create_tx.value is True, (
+        'refund must create a transaction record (create_transaction=True)'
+    )
+
+
+def test_charge_precedes_guard_and_delivery_steps_stay_outside() -> None:
+    """REGRESSION: the guard must start AFTER the committed charge (so it covers
+    everything that can lose it) and must end BEFORE the daily-charge marker —
+    once the subscription is committed the product is delivered, and a failure
+    in post-persist bookkeeping must NOT refund a delivered subscription.
+    """
+    tree = ast.parse(PURCHASE_PATH.read_text(encoding='utf-8'))
+    func = _find_async_function(tree, 'purchase_tariff')
+    guard = _find_refund_guard(func)
+
+    charge_calls = [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == 'subtract_user_balance'
+    ]
+    assert charge_calls, 'purchase_tariff must charge the balance via subtract_user_balance'
+    assert charge_calls[0].lineno < guard.lineno, (
+        'the balance charge must happen before the refund guard: the guard exists '
+        'to compensate the already-committed charge'
+    )
+
+    daily_marker_assigns = [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Attribute) and t.attr == 'last_daily_charge_at' for t in n.targets)
+    ]
+    assert daily_marker_assigns, 'daily tariffs must still set last_daily_charge_at after purchase'
+    guard_end = guard.end_lineno or guard.lineno
+    assert all(a.lineno > guard_end for a in daily_marker_assigns), (
+        'post-persist bookkeeping (last_daily_charge_at) must stay OUTSIDE the '
+        'refund guard: the subscription is already committed at that point, '
+        'refunding there would hand back money for a delivered product'
+    )
+
+
+def test_trial_conversion_stays_enabled_in_extend_branch() -> None:
+    """REGRESSION: the ``extend_subscription`` call must NOT pass
+    ``convert_trial=False``. The purchase flow deliberately EXCLUDES the resolved
+    subscription from ``deactivate_user_trial_subscriptions``; that is only safe
+    because ``extend_subscription`` (convert_trial=True by default) converts the
+    trial to paid in place. Disabling the conversion here would leave a paying
+    user flagged as trial (#3031's report scenario).
+    """
+    tree = ast.parse(PURCHASE_PATH.read_text(encoding='utf-8'))
+    func = _find_async_function(tree, 'purchase_tariff')
+
+    extend_calls = [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == 'extend_subscription'
+    ]
+    assert extend_calls, 'purchase_tariff must extend the resolved subscription via extend_subscription'
+    for call in extend_calls:
+        for kw in call.keywords:
+            if kw.arg == 'convert_trial':
+                assert isinstance(kw.value, ast.Constant) and kw.value.value is True, (
+                    'extend_subscription in purchase_tariff must keep trial '
+                    'conversion enabled — the trial is excluded from '
+                    'deactivate_user_trial_subscriptions and relies on this call '
+                    'to drop the is_trial flag'
+                )


### PR DESCRIPTION
## 📝 Описание

Закрывает сценарий из #3031: деньги списываются с баланса при покупке тарифа через кабинет, но подписка не создаётся — пользователь теряет платёж без компенсации.

## 🎯 Корень проблемы

`subtract_user_balance` и `create_transaction` коммитят сразу, а подписка создаётся/продлевается после. Любая ошибка между этими точками — `IntegrityError` из `extend_subscription` при гонке смены тарифа (узкий `except IntegrityError` покрывает только create-ветку), `FlushError`/сбои драйвера (ровно «did not produce a new primary key result» из отчёта) — улетала в route-level `except Exception` и превращалась в HTTP 500 **без возврата денег**. Картина из issue: в `transactions` запись есть, в `subscriptions` — нет.

## 🔧 Что сделано

- Секция «списание → сохранение подписки» в `purchase_tariff` обёрнута в компенсирующий guard: лог, `rollback`, возврат суммы транзакцией `REFUND`, HTTP 500 — зеркалит компенсацию из auto-purchase сервиса.
- `except HTTPException: raise` перед общим обработчиком: 409-ветка «тариф уже активен» возвращает деньги сама, повторная компенсация дала бы двойной возврат.
- Возврат через `_refund_charge`: пользователь перечитывается свежим `get_user_by_id`, имя тарифа — из заранее сохранённой строки. После `rollback()` ORM-объекты expired, и синхронный доступ к их атрибутам в async-контексте падает с `MissingGreenlet` — этой же миной страдала существующая 409-ветка, тоже вылечена.
- Пост-persist шаги (bonus seconds, daily-маркер, синк с панелью) осознанно вне guard: подписка уже выдана, возвращать за неё деньги нельзя.

## ⚠️ Почему не однострочник из issue

Предложенная в issue замена `exclude_subscription_id=subscription.id if (subscription and not subscription.is_trial) else None` не применена:

1. По коду v3.62.0 заявленная цепочка не воспроизводится: если резолвнутая подписка — собственный триал пользователя, поток идёт в `extend_subscription`, которая сама конвертирует триал в платную (`convert_trial=True` по умолчанию), INSERT там не выполняется. А при `subscription is None` триал и так не исключается из деактивации.
2. При `TRIAL_ADD_REMAINING_DAYS_TO_PAID=true` однострочник давал бы двойное начисление остатка триала: остаток сохраняется в `end_date` веткой extend и добавлялся бы второй раз через `_bonus_seconds`.

Комментарий у защитной ветки реактивации приведён в соответствие с реальностью — именно вводящий в заблуждение комментарий и породил диагноз из issue.

## 🧪 Тестирование

- [x] 4 регрессионных теста в `tests/cabinet/test_purchase_tariff_refund_on_failure.py` (source-level пины по образцу `test_purchase_tariff_expired_trial_reuse.py`): guard покрывает обе ветки persistence; bare re-raise `HTTPException`; refund свежим инстансом юзера транзакцией `TransactionType.REFUND`; пост-persist шаги вне guard
- [x] Полный локальный прогон тестов: 1731 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #3031
