### PR TITLE
fix(platega): поддержка v2 API — поле url и настраиваемая версия эндпоинта (#2934)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -662,6 +662,10 @@ PLATEGA_ENABLED=false
 PLATEGA_MERCHANT_ID=
 PLATEGA_SECRET=
 PLATEGA_BASE_URL=https://app.platega.io
+# Версия API создания платежа: v1 — /transaction/process (метод задаётся ботом),
+# v2 — /v2/transaction/process. Если карты (метод 11) падают с ошибкой
+# "No available card cascades" — переключитесь на v2
+PLATEGA_API_VERSION=v1
 # Название кнопки в интерфейсе
 PLATEGA_DISPLAY_NAME=Platega
 PLATEGA_RETURN_URL=

--- a/app/config.py
+++ b/app/config.py
@@ -585,6 +585,11 @@ class Settings(BaseSettings):
     PLATEGA_SECRET: str | None = None
     PLATEGA_DISPLAY_NAME: str = 'Platega'
     PLATEGA_BASE_URL: str = 'https://app.platega.io'
+    # 'v1' — документированный POST /transaction/process с обязательным paymentMethod
+    # (ответ несёт ссылку в поле `redirect`); 'v2' — POST /v2/transaction/process
+    # (ссылка в поле `url`), нужен мерчантам, у которых карточные каскады доступны
+    # только в v2 (#2934: v1 отдаёт 400 «No available card cascades» для карт).
+    PLATEGA_API_VERSION: str = 'v1'
     PLATEGA_RETURN_URL: str | None = None
     PLATEGA_FAILED_URL: str | None = None
     PLATEGA_CURRENCY: str = 'RUB'

--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -83,7 +83,7 @@ class PlategaPaymentMixin:
             return None
 
         transaction_id = response.get('transactionId') or response.get('id')
-        redirect_url = response.get('redirect')
+        redirect_url = PlategaService.parse_redirect_url(response)
         status = str(response.get('status') or 'PENDING').upper()
         expires_at = PlategaService.parse_expires_at(response.get('expiresIn'))
 

--- a/app/services/platega_service.py
+++ b/app/services/platega_service.py
@@ -19,8 +19,28 @@ logger = structlog.get_logger(__name__)
 class PlategaService:
     """Обертка над Platega API с базовой повторной отправкой запросов."""
 
+    _SUPPORTED_API_VERSIONS = ('v1', 'v2')
+
     def __init__(self) -> None:
-        self.base_url = (settings.PLATEGA_BASE_URL or 'https://app.platega.io').rstrip('/')
+        base_url = (settings.PLATEGA_BASE_URL or 'https://app.platega.io').rstrip('/')
+        # Совместимость с обходом из #2934: версию дописывали прямо в
+        # PLATEGA_BASE_URL (…/v2). Суффикс срезаем и трактуем как форс версии,
+        # иначе create собрал бы путь /v2/v2/transaction/process, а статусный
+        # GET (неверсионированный по докам Platega) уезжал бы на /v2/transaction/{id}.
+        forced_version: str | None = None
+        for candidate in self._SUPPORTED_API_VERSIONS:
+            suffix = f'/{candidate}'
+            if base_url.endswith(suffix):
+                forced_version = candidate
+                base_url = base_url[: -len(suffix)].rstrip('/')
+                logger.info(
+                    'PLATEGA_BASE_URL содержит суффикс версии — вынесен в версию API',
+                    api_version=candidate,
+                    base_url=base_url,
+                )
+                break
+        self.base_url = base_url
+        self.api_version = forced_version or self._normalize_api_version(settings.PLATEGA_API_VERSION)
         self.merchant_id = settings.PLATEGA_MERCHANT_ID
         self.secret = settings.PLATEGA_SECRET
         self._timeout = aiohttp.ClientTimeout(total=30, connect=10, sock_read=25)
@@ -62,9 +82,15 @@ class PlategaService:
         if payload:
             body['payload'] = payload
 
-        return await self._request('POST', '/transaction/process', json_data=body)
+        # v1 POST /transaction/process — документированный flow с заданным
+        # paymentMethod (ссылка в поле `redirect`). v2 POST /v2/transaction/process
+        # отвечает полем `url` и нужен мерчантам, у которых карточные каскады
+        # работают только в v2 (#2934: v1 отдаёт 400 «No available card cascades»).
+        endpoint = '/v2/transaction/process' if self.api_version == 'v2' else '/transaction/process'
+        return await self._request('POST', endpoint, json_data=body)
 
     async def get_transaction(self, transaction_id: str) -> dict[str, Any] | None:
+        # Статусный GET не версионируется: в доках Platega путь один — /transaction/{id}.
         endpoint = f'/transaction/{transaction_id}'
         return await self._request('GET', endpoint)
 
@@ -191,6 +217,31 @@ class PlategaService:
                 return trimmed_bytes.decode('utf-8')
             except UnicodeDecodeError:
                 trimmed_bytes = trimmed_bytes[:-1]
+
+    @classmethod
+    def _normalize_api_version(cls, raw: str | None) -> str:
+        version = (raw or '').strip().lower()
+        if version in cls._SUPPORTED_API_VERSIONS:
+            return version
+        if version:
+            logger.warning(
+                'Неизвестное значение PLATEGA_API_VERSION, используется v1',
+                configured=raw,
+                supported=cls._SUPPORTED_API_VERSIONS,
+            )
+        return 'v1'
+
+    @staticmethod
+    def parse_redirect_url(response: dict[str, Any] | None) -> str | None:
+        """Ссылка на страницу оплаты из ответа create: v1 отдаёт `redirect`, v2 — `url`.
+
+        Принимаем оба поля независимо от настроенной версии — ответ парсится
+        одинаково и для чужого PLATEGA_BASE_URL, уже указывающего на v2 (#2934).
+        """
+        if not response:
+            return None
+        redirect_url = response.get('redirect') or response.get('url')
+        return str(redirect_url) if redirect_url else None
 
     @staticmethod
     def parse_expires_at(expires_in: str | None) -> datetime | None:

--- a/tests/services/test_platega_service.py
+++ b/tests/services/test_platega_service.py
@@ -1,6 +1,35 @@
+import pytest
 import structlog
 
+from app.config import settings
 from app.services.platega_service import PlategaService
+
+
+def _configure_platega(monkeypatch: pytest.MonkeyPatch, **overrides) -> None:
+    values = {
+        'PLATEGA_ENABLED': True,
+        'PLATEGA_MERCHANT_ID': 'merchant',
+        'PLATEGA_SECRET': 'secret',
+        'PLATEGA_BASE_URL': 'https://app.platega.io',
+        'PLATEGA_API_VERSION': 'v1',
+    }
+    values.update(overrides)
+    for key, value in values.items():
+        monkeypatch.setattr(settings, key, value, raising=False)
+
+
+async def _captured_create_endpoint(monkeypatch: pytest.MonkeyPatch, service: PlategaService) -> str:
+    captured: dict[str, str] = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured['method'] = method
+        captured['endpoint'] = endpoint
+        return {'transactionId': 'tx', 'status': 'PENDING'}
+
+    monkeypatch.setattr(service, '_request', fake_request)
+    await service.create_payment(payment_method=2, amount=100.0, currency='RUB')
+    assert captured['method'] == 'POST'
+    return captured['endpoint']
 
 
 def test_sanitize_description_limits_utf8_bytes() -> None:
@@ -21,3 +50,87 @@ def test_sanitize_description_returns_clean_value() -> None:
 
     assert trimmed == 'Обычное описание'
     assert len(trimmed.encode('utf-8')) <= 64
+
+
+# --- API version selection (#2934) ---
+# Platega v2 (POST /v2/transaction/process) отвечает полем `url`, v1 — `redirect`.
+# У части мерчантов карточный flow (метод 11) в v1 отдаёт 400 «No available card
+# cascades», поэтому версия create-эндпоинта настраивается через PLATEGA_API_VERSION.
+
+
+async def test_create_payment_defaults_to_v1_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_platega(monkeypatch)
+
+    service = PlategaService()
+
+    assert service.api_version == 'v1'
+    assert await _captured_create_endpoint(monkeypatch, service) == '/transaction/process'
+
+
+async def test_create_payment_uses_v2_endpoint_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_platega(monkeypatch, PLATEGA_API_VERSION='v2')
+
+    service = PlategaService()
+
+    assert service.api_version == 'v2'
+    assert await _captured_create_endpoint(monkeypatch, service) == '/v2/transaction/process'
+
+
+async def test_base_url_version_suffix_forces_version_and_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Обход из #2934 (PLATEGA_BASE_URL=…/v2) не должен собирать /v2/v2/… и не
+    должен уводить неверсионированный статусный GET на /v2/transaction/{id}."""
+    _configure_platega(monkeypatch, PLATEGA_BASE_URL='https://app.platega.io/v2', PLATEGA_API_VERSION='v1')
+
+    service = PlategaService()
+
+    assert service.base_url == 'https://app.platega.io'
+    assert service.api_version == 'v2'
+    assert await _captured_create_endpoint(monkeypatch, service) == '/v2/transaction/process'
+
+
+async def test_get_transaction_stays_unversioned(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_platega(monkeypatch, PLATEGA_API_VERSION='v2')
+
+    service = PlategaService()
+    captured: dict[str, str] = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured['method'] = method
+        captured['endpoint'] = endpoint
+        return {'id': 'tx', 'status': 'PENDING'}
+
+    monkeypatch.setattr(service, '_request', fake_request)
+    await service.get_transaction('tx')
+
+    assert captured == {'method': 'GET', 'endpoint': '/transaction/tx'}
+
+
+def test_unknown_api_version_falls_back_to_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_platega(monkeypatch, PLATEGA_API_VERSION='v3')
+
+    with structlog.testing.capture_logs() as logs:
+        service = PlategaService()
+
+    assert service.api_version == 'v1'
+    assert any('PLATEGA_API_VERSION' in entry.get('event', '') for entry in logs)
+
+
+# --- Redirect URL parsing (#2934) ---
+
+
+def test_parse_redirect_url_accepts_v1_field() -> None:
+    response = {'transactionId': 'tx', 'status': 'PENDING', 'redirect': 'https://pay.platega.io?id=tx'}
+
+    assert PlategaService.parse_redirect_url(response) == 'https://pay.platega.io?id=tx'
+
+
+def test_parse_redirect_url_accepts_v2_field() -> None:
+    response = {'transactionId': 'tx', 'status': 'PENDING', 'url': 'https://pay.platega.io?id=tx'}
+
+    assert PlategaService.parse_redirect_url(response) == 'https://pay.platega.io?id=tx'
+
+
+def test_parse_redirect_url_missing_or_empty() -> None:
+    assert PlategaService.parse_redirect_url(None) is None
+    assert PlategaService.parse_redirect_url({}) is None
+    assert PlategaService.parse_redirect_url({'redirect': '', 'url': ''}) is None


### PR DESCRIPTION
## 📝 Описание

Закрывает #2934: при работе через Platega v2 API бот показывал пользователю «Ошибка создания платежа», хотя платёж успешно создавался (и в БД, и на стороне Platega). Причина — v2 возвращает ссылку на оплату в поле `url`, а код читал только `redirect` (поле v1), поэтому `payment_result.redirect_url` был пуст.

## 🔧 Что сделано

- `PlategaService.parse_redirect_url` — парсинг ссылки принимает оба поля (`redirect`/`url`) независимо от настроенной версии; это единственная точка парсинга, поэтому покрыты все потребители: бот, кабинет, miniapp.
- Новая настройка `PLATEGA_API_VERSION` (`v1`/`v2`, дефолт `v1`) выбирает create-эндпоинт: `/transaction/process` или `/v2/transaction/process`. Невалидные значения нормализуются в `v1` с предупреждением в логе.
- Суффикс `/v2` в `PLATEGA_BASE_URL` (воркэраунд из issue) срезается и трактуется как форс версии: иначе собирался бы путь `/v2/v2/transaction/process`, а статусный `GET` уезжал бы на `/v2/transaction/{id}`.
- Статусный `GET /transaction/{id}` намеренно не версионируется — в документации Platega этот путь один и без префикса версии.
- `.env.example` дополнен `PLATEGA_API_VERSION` с подсказкой, когда переключаться на v2.

## ⚠️ Отличие от предложения в issue

В issue предлагался дефолт v2. Сверил с актуальной документацией Platega (docs.platega.io):

- v1 `POST /transaction/process` с обязательным `paymentMethod` **до сих пор официально документирован** как flow «создание платёжной ссылки с заданным методом» и отвечает полем `redirect`;
- v2 `POST /v2/transaction/process` — документированный flow «без заданного метода» (плательщик выбирает способ на странице), `paymentMethod` в его схеме отсутствует; то, что v2 принимает метод — эмпирическое наблюдение, не контракт.

Поэтому дефолт — `v1` (ноль изменений для работающих инсталляций), а v2 включается явно теми, у кого карточные каскады (метод 11) в v1 отдают 400 «No available card cascades». Если Platega окончательно задепрекейтит v1, смена дефолта — одна строка.

## 🧪 Тестирование

- [x] 8 юнит-тестов в `tests/services/test_platega_service.py`: выбор эндпоинта по версии и дефолт, срезание суффикса из base URL, неверсионированный GET, fallback невалидной версии, парсинг обоих полей ссылки
- [x] Полный локальный прогон тестов: 1735 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #2934
