### PR TITLE
fix(email): не тащить CSS/JS в text/plain версию письма (#2974)

### DIFF
--- a/app/cabinet/services/email_service.py
+++ b/app/cabinet/services/email_service.py
@@ -1,5 +1,6 @@
 """Email service for sending verification and password reset emails."""
 
+import re
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -53,6 +54,28 @@ class EmailService:
     def is_configured(self) -> bool:
         """Check if SMTP is properly configured."""
         return settings.is_smtp_configured()
+
+    @staticmethod
+    def _html_to_plain_text(body_html: str) -> str:
+        """Грубая конвертация HTML в text/plain для multipart/alternative.
+
+        Блоки <style>/<script> удаляются ЦЕЛИКОМ до вырезания тегов: сами теги
+        регулярка убирала и раньше, а их содержимое (CSS/JS-правила) утекало в
+        текстовую версию письма перед основным текстом (#2974).
+
+        &amp; расшифровывается ПОСЛЕДНИМ: иначе "&amp;lt;" проходит двойную
+        расшифровку и превращается в "<" вместо "&lt;".
+        """
+        text = re.sub(r'<(style|script)\b[^>]*>.*?</\1\s*>', '', body_html, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r'<[^>]+>', '', text)
+        text = text.replace('&nbsp;', ' ')
+        text = text.replace('&lt;', '<')
+        text = text.replace('&gt;', '>')
+        text = text.replace('&amp;', '&')
+        # После удаления блоков и тегов остаются простыни пустых строк —
+        # схлопываем, чтобы текст не начинался с десятков переносов.
+        text = re.sub(r'\n\s*\n\s*\n+', '\n\n', text)
+        return text.strip()
 
     def _get_smtp_connection(self) -> smtplib.SMTP:
         """Create and return SMTP connection."""
@@ -119,14 +142,7 @@ class EmailService:
 
             # Plain text version
             if body_text is None:
-                # Simple HTML to text conversion
-                import re
-
-                body_text = re.sub(r'<[^>]+>', '', body_html)
-                body_text = body_text.replace('&nbsp;', ' ')
-                body_text = body_text.replace('&amp;', '&')
-                body_text = body_text.replace('&lt;', '<')
-                body_text = body_text.replace('&gt;', '>')
+                body_text = self._html_to_plain_text(body_html)
 
             part1 = MIMEText(body_text, 'plain', 'utf-8')
             part2 = MIMEText(body_html, 'html', 'utf-8')

--- a/tests/cabinet/test_email_plaintext_conversion.py
+++ b/tests/cabinet/test_email_plaintext_conversion.py
@@ -1,0 +1,90 @@
+"""text/plain версия письма: конвертация HTML не должна тащить CSS/JS (#2974).
+
+Старый конвертер в ``EmailService.send_email`` срезал регуляркой только сами
+теги (``<style>``, ``</style>``), но не их содержимое — CSS-правила базового
+шаблона (``body { font-family: ... }``, ``.container { ... }``) оказывались в
+text/plain части письма ПЕРЕД основным текстом. Почтовики, показывающие
+plain-версию, отдавали пользователю простыню CSS вместо письма.
+
+Фикс: ``EmailService._html_to_plain_text`` — блоки ``<style>``/``<script>``
+удаляются целиком до вырезания тегов; ``&amp;`` расшифровывается последним
+(иначе ``&amp;lt;`` двойной расшифровкой превращается в ``<``); пустые строки
+после удаления блоков схлопываются.
+"""
+
+from app.cabinet.routes.admin_email_templates import SAMPLE_CONTEXTS, _get_default_template
+from app.cabinet.services.email_service import EmailService
+
+
+def test_style_block_content_is_stripped() -> None:
+    html = (
+        '<html><head><style>\n'
+        'body { font-family: Arial, sans-serif; line-height: 1.6; }\n'
+        '.container { max-width: 600px; }\n'
+        '</style></head>'
+        '<body><p>Здравствуйте, user!</p></body></html>'
+    )
+
+    text = EmailService._html_to_plain_text(html)
+
+    assert 'font-family' not in text
+    assert '.container' not in text
+    assert 'Здравствуйте, user!' in text
+
+
+def test_script_block_content_is_stripped() -> None:
+    html = '<body><script type="text/javascript">alert("x");</script><p>Текст письма</p></body>'
+
+    text = EmailService._html_to_plain_text(html)
+
+    assert 'alert' not in text
+    assert 'Текст письма' in text
+
+
+def test_style_block_stripped_case_insensitive_and_multiline() -> None:
+    html = '<STYLE media="all">\n.button {\n  color: red;\n}\n</STYLE >\n<p>Привет</p>'
+
+    text = EmailService._html_to_plain_text(html)
+
+    assert 'color' not in text
+    assert 'Привет' in text
+
+
+def test_entities_unescaped_amp_last() -> None:
+    # &amp;lt; — это экранированная строка "&lt;": расшифровка &amp; первым
+    # давала бы двойную расшифровку в "<".
+    html = '<p>A &amp; B, 5 &lt; 6, x&nbsp;y, &amp;lt;</p>'
+
+    text = EmailService._html_to_plain_text(html)
+
+    assert 'A & B' in text
+    assert '5 < 6' in text
+    assert 'x y' in text
+    assert '&lt;' in text
+
+
+def test_blank_line_runs_are_collapsed() -> None:
+    html = '<style>\nbody { color: #333; }\n</style>\n\n\n\n<p>Первая строка</p>\n\n\n\n\n<p>Вторая строка</p>'
+
+    text = EmailService._html_to_plain_text(html)
+
+    assert '\n\n\n' not in text
+    assert not text.startswith('\n')
+    assert 'Первая строка' in text
+    assert 'Вторая строка' in text
+
+
+def test_real_default_template_produces_clean_plain_text() -> None:
+    """Регрессия на живом шаблоне: дефолтное письмо верификации собирается на
+    базовом шаблоне с большим <style>-блоком — раньше весь этот CSS уезжал в
+    text/plain перед текстом письма."""
+    template = _get_default_template('email_verification', 'ru', SAMPLE_CONTEXTS['email_verification'])
+    assert template is not None
+    body_html = template['body_html']
+    assert '<style' in body_html.lower(), 'тест потерял смысл: в дефолтном шаблоне больше нет <style>'
+
+    text = EmailService._html_to_plain_text(body_html)
+
+    assert 'font-family' not in text
+    assert '{' not in text, 'CSS-правила утекли в text/plain'
+    assert text.strip(), 'plain-версия не должна быть пустой'


### PR DESCRIPTION
## 📝 Описание

Закрывает баг 2 из #2974: CSS из `<style>`-блоков попадает в text/plain версию письма. Конвертер HTML→text в `EmailService.send_email` срезал регуляркой только сами теги (`<style>`, `</style>`), но не их содержимое — CSS-правила базового шаблона (`body { font-family: ... }`, `.container { ... }`) оказывались в текстовой части письма ПЕРЕД основным текстом. Почтовые клиенты, показывающие plain-версию, отдавали пользователю простыню CSS вместо письма.

Баг 1 из того же issue (заголовок `From` внутри MIME encoded-word) уже исправлен в main ранее — `formataddr` используется. Этот PR закрывает оставшуюся часть.

## 🔧 Что сделано

- Конвертация вынесена в `EmailService._html_to_plain_text`: блоки `<style>`/`<script>` удаляются **целиком** до вырезания тегов.
- `&amp;` расшифровывается последним: прежний порядок давал двойную расшифровку — `&amp;lt;` превращался в `<` вместо `&lt;`.
- Простыни пустых строк, остающиеся после удаления блоков, схлопываются — текст не начинается с десятков переносов.

Затронуты все письма с автогенерируемой plain-версией: верификация email, сброс пароля, код смены email, кастомные шаблоны из админки.

## 🧪 Тестирование

- [x] 6 тестов в `tests/cabinet/test_email_plaintext_conversion.py`: вырезание style/script (включая регистр и многострочность), порядок расшифровки entities, схлопывание пустых строк, регрессия на живом дефолтном шаблоне верификации (в нём реальный `<style>`-блок)
- [x] Полный локальный прогон тестов: 1733 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #2974
