### PR TITLE
fix(tickets): писать id реального админа в ticket_messages.user_id (#3029)

### DIFF
--- a/app/cabinet/routes/admin_tickets.py
+++ b/app/cabinet/routes/admin_tickets.py
@@ -483,7 +483,12 @@ async def reply_to_ticket(
 
     message = TicketMessage(
         ticket_id=ticket.id,
-        user_id=ticket.user_id,
+        # Автор сообщения — реально ответивший админ, а не владелец тикета:
+        # иначе при нескольких сотрудниках поддержки невозможно установить,
+        # кто отвечал (#3029). Бот-путь (handlers/admin/tickets.py) пишет id
+        # админа с самого начала — выравниваем семантику. Отображение стороны
+        # сообщения везде идёт по is_from_admin, а не по user_id.
+        user_id=admin.id,
         message_text=request.message,
         is_from_admin=True,
         has_media=has_media,

--- a/app/cabinet/routes/support_ws.py
+++ b/app/cabinet/routes/support_ws.py
@@ -865,7 +865,11 @@ async def _handle_ticket_reply(db: AsyncSession, session: SupportWsSession, payl
         )
     message = TicketMessage(
         ticket_id=ticket.id,
-        user_id=ticket.user_id,
+        # Автор — тот, кто реально отправил: для admin/support это их user id
+        # (session.context.user_id), не владелец тикета (#3029). Иначе
+        # authorUserId в _message_snapshot врёт, а при нескольких сотрудниках
+        # поддержки не установить, кто отвечал. Бот-путь пишет id админа же.
+        user_id=session.context.user_id if is_from_admin else ticket.user_id,
         message_text=body,
         is_from_admin=is_from_admin,
         has_media=bool(primary),

--- a/app/webapi/routes/tickets.py
+++ b/app/webapi/routes/tickets.py
@@ -213,6 +213,9 @@ async def reply_to_ticket(
     message = await TicketMessageCRUD.add_message(
         db,
         ticket_id=ticket_id,
+        # Здесь остаётся id владельца: webapi аутентифицируется сервисным
+        # токеном (require_api_token), личности конкретного админа нет —
+        # в отличие от cabinet- и бот-путей, которые пишут id автора (#3029).
         user_id=ticket.user_id,
         message_text=final_message_text,
         is_from_admin=True,

--- a/tests/cabinet/test_ticket_admin_author.py
+++ b/tests/cabinet/test_ticket_admin_author.py
@@ -1,0 +1,123 @@
+"""ticket_messages.user_id для админ-ответов = id реального автора (#3029).
+
+Ответ администратора на тикет через кабинет (и через mobile support websocket)
+записывался с ``user_id = ticket.user_id`` — id владельца тикета, а не
+ответившего сотрудника. ``is_from_admin`` при этом корректен, но при нескольких
+сотрудниках поддержки невозможно установить, кто именно отвечал. Бот-путь
+(``handlers/admin/tickets.py``) с самого начала пишет id админа — семантика
+поля уже была смешанной.
+
+Фикс выравнивает cabinet- и ws-пути по бот-пути:
+
+- ``admin_tickets.reply_to_ticket`` пишет ``admin.id`` (аутентифицированный
+  админ доступен через ``require_permission('tickets:reply')``);
+- ``support_ws._handle_ticket_reply`` пишет ``session.context.user_id`` для
+  admin/support-ролей и владельца — для владельца;
+- webapi-путь намеренно НЕ меняется: он аутентифицируется сервисным токеном,
+  личности админа там нет.
+
+Отображение стороны сообщения безопасно: все сериализаторы различают стороны
+по ``is_from_admin`` (cabinet-схема ``TicketMessageResponse`` поле ``user_id``
+вообще не отдаёт), а ws-``authorUserId`` начинает говорить правду.
+
+Тесты пинят контракт на уровне AST — интеграционный прогон потребовал бы
+реальную БД и FastAPI-зависимости.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+APP_DIR = Path(__file__).resolve().parents[2] / 'app'
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f'async function {name!r} not found')
+
+
+def _ticket_message_calls(func: ast.AsyncFunctionDef) -> list[ast.Call]:
+    return [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == 'TicketMessage'
+    ]
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    raise AssertionError(f'TicketMessage(...) has no keyword {name!r}')
+
+
+def test_cabinet_admin_reply_stores_admin_id() -> None:
+    """REGRESSION: reply_to_ticket в admin_tickets.py должен писать admin.id,
+    а не ticket.user_id — иначе не установить, кто из сотрудников отвечал."""
+    source = (APP_DIR / 'cabinet' / 'routes' / 'admin_tickets.py').read_text(encoding='utf-8')
+    func = _find_function(ast.parse(source), 'reply_to_ticket')
+
+    calls = _ticket_message_calls(func)
+    assert calls, 'reply_to_ticket должен создавать TicketMessage'
+    user_id = _keyword(calls[0], 'user_id')
+
+    assert isinstance(user_id, ast.Attribute) and user_id.attr == 'id', (
+        'user_id админ-ответа должен быть <admin>.id, а не id владельца тикета'
+    )
+    assert isinstance(user_id.value, ast.Name) and user_id.value.id == 'admin', (
+        'user_id админ-ответа должен браться у аутентифицированного админа '
+        '(зависимость require_permission), а не у владельца тикета (#3029)'
+    )
+
+
+def test_support_ws_reply_stores_actor_id_for_admin() -> None:
+    """REGRESSION: _handle_ticket_reply в support_ws.py должен писать
+    session.context.user_id для admin/support и владельца — для владельца."""
+    source = (APP_DIR / 'cabinet' / 'routes' / 'support_ws.py').read_text(encoding='utf-8')
+    func = _find_function(ast.parse(source), '_handle_ticket_reply')
+
+    calls = _ticket_message_calls(func)
+    assert calls, '_handle_ticket_reply должен создавать TicketMessage'
+    user_id = _keyword(calls[0], 'user_id')
+
+    assert isinstance(user_id, ast.IfExp), (
+        'user_id должен выбираться условно по is_from_admin: '
+        'session.context.user_id для админа, ticket.user_id для владельца'
+    )
+    assert isinstance(user_id.test, ast.Name) and user_id.test.id == 'is_from_admin'
+
+    body_src = ast.unparse(user_id.body)
+    assert 'session.context.user_id' in body_src, (
+        'для admin/support-ролей автором сообщения должен быть '
+        'session.context.user_id (реально ответивший сотрудник, #3029)'
+    )
+    orelse_src = ast.unparse(user_id.orelse)
+    assert 'ticket.user_id' in orelse_src, 'для владельца тикета семантика должна остаться прежней'
+
+
+def test_bot_admin_reply_still_stores_admin_id() -> None:
+    """Пин существующей (корректной) семантики бот-пути: add_message получает
+    db_user.id — id админа, вызвавшего обработчик. Cabinet/ws выровнены по ней;
+    если бот-путь изменится, смешанная семантика вернётся."""
+    source = (APP_DIR / 'handlers' / 'admin' / 'tickets.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == 'add_message'
+        ):
+            continue
+        has_admin_flag = any(
+            kw.arg == 'is_from_admin' and isinstance(kw.value, ast.Constant) and kw.value.value is True
+            for kw in node.keywords
+        )
+        if not has_admin_flag:
+            continue
+        args_src = ', '.join(ast.unparse(a) for a in node.args)
+        assert 'db_user.id' in args_src, 'бот-путь должен продолжать писать id ответившего админа (db_user.id)'
+        return
+    raise AssertionError('в handlers/admin/tickets.py не найден admin-вызов add_message')


### PR DESCRIPTION
## 📝 Описание

Закрывает #3029: при ответе администратора на тикет через кабинет в `ticket_messages.user_id` записывался id владельца тикета, а не реально ответившего сотрудника. `is_from_admin` при этом корректен, но при нескольких сотрудниках поддержки невозможно установить, кто именно отвечал.

Важный контекст: семантика поля уже была смешанной — бот-путь (`handlers/admin/tickets.py`) с самого начала пишет id админа. PR выравнивает остальные пути по нему.

## 🔧 Что сделано

- `cabinet/routes/admin_tickets.py` → `reply_to_ticket`: `user_id = admin.id` — аутентифицированный админ уже доступен через зависимость `require_permission('tickets:reply')`.
- `cabinet/routes/support_ws.py` → `_handle_ticket_reply`: `user_id = session.context.user_id` для admin/support-ролей (владелец — без изменений). Эта точка в issue не упоминалась, найдена при аудите: mobile support websocket воспроизводил тот же баг, и его `authorUserId` в `_message_snapshot` отдавал мобильному клиенту id владельца вместо автора.
- `webapi/routes/tickets.py` намеренно **не** изменён: этот путь аутентифицируется сервисным токеном (`require_api_token`), личности конкретного админа там нет — задокументировано комментарием в коде.

## 🛡️ Безопасность смены семантики

Проверены все читатели `TicketMessage.user_id`:

- отображение стороны сообщения везде идёт по `is_from_admin`; cabinet-схема `TicketMessageResponse` поле `user_id` вообще не отдаёт — UI кабинета изменений не заметит;
- ws-`authorUserId` начинает говорить правду (клиент различает стороны по `isFromAdmin`, который отдаётся рядом);
- merge аккаунтов и очистка данных заблокированных юзеров фильтруют по `user_id` — поведение согласуется с тем, что бот-путь уже годами пишет id админа.

Миграция БД не требуется.

## 🧪 Тестирование

- [x] 3 регрессионных теста в `tests/cabinet/test_ticket_admin_author.py`: cabinet-путь пишет `admin.id`, ws-путь — условно по роли, бот-путь продолжает писать `db_user.id` (пин против возврата смешанной семантики)
- [x] Полный локальный прогон тестов: 1730 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #3029
