### PR TITLE
fix(backup): одиночный scheduler-цикл и BACKUP_TIME в локальной таймзоне (#3030)

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -12,6 +12,7 @@ from datetime import UTC, date as dt_date, datetime, time as dt_time, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import aiofiles
 import pyzipper
@@ -193,6 +194,14 @@ class BackupService:
         self.data_dir = self.backup_dir.parent
         self.archive_format_version = '2.0'
         self._auto_backup_task = None
+        # Сериализует start/stop scheduler-таски. На холодном старте
+        # start_auto_backup зовут конкурентно до 6 раз (по одному на каждую
+        # BACKUP_* настройку из _apply_to_settings + вызов из main.py): без
+        # лока два вызова одновременно проходят cancel-await старой таски,
+        # оба создают новые циклы, второй перезаписывает _auto_backup_task —
+        # первый цикл осиротевает и живёт параллельно. Осиротевшие циклы
+        # одновременно пишут один gzip-архив и рвут его (#3030).
+        self._scheduler_lock = asyncio.Lock()
         self._settings = self._load_settings()
 
         self._base_backup_models = [
@@ -391,15 +400,33 @@ class BackupService:
             self._settings.backup_time = '03:00'
             return default_hours, default_minutes
 
+    def _get_timezone(self) -> ZoneInfo:
+        tz_name = settings.TIMEZONE or 'UTC'
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            logger.warning('Некорректная TIMEZONE, для расчёта бекапов используется UTC', timezone=tz_name)
+            return ZoneInfo('UTC')
+
     def _calculate_next_backup_datetime(self, reference: datetime | None = None) -> datetime:
+        """Ближайший запуск по BACKUP_TIME, интерпретированному в settings.TIMEZONE.
+
+        Раньше часы/минуты из настроек подставлялись напрямую в UTC-«сейчас»:
+        TZ контейнера игнорировался, и бекап уезжал на разницу с UTC (для MSK —
+        на 3 часа, #3030). settings.TIMEZONE наследует env TZ, так что
+        BACKUP_TIME теперь означает локальное время оператора. Возвращается
+        aware-datetime в UTC — сам цикл продолжает жить в UTC.
+        """
         reference = reference or datetime.now(UTC)
         hours, minutes = self._parse_backup_time()
 
-        next_run = reference.replace(hour=hours, minute=minutes, second=0, microsecond=0)
-        if next_run <= reference:
-            next_run += timedelta(days=1)
+        tz = self._get_timezone()
+        local_reference = reference.astimezone(tz)
+        next_local = local_reference.replace(hour=hours, minute=minutes, second=0, microsecond=0)
+        if next_local <= local_reference:
+            next_local += timedelta(days=1)
 
-        return next_run
+        return next_local.astimezone(UTC)
 
     def _get_backup_interval(self) -> timedelta:
         hours = self._settings.backup_interval_hours
@@ -1948,33 +1975,39 @@ class BackupService:
             return False
 
     async def start_auto_backup(self):
-        # Дожидаемся отмены старой таски, чтобы не было двух циклов параллельно
-        # во время рестарта scheduler'а после изменения BACKUP_TIME из кабинета.
-        if self._auto_backup_task and not self._auto_backup_task.done():
-            self._auto_backup_task.cancel()
-            import contextlib
+        # Лок обязателен: без него конкурентные вызовы (6 штук на холодном
+        # старте) интерливятся на await отмены старой таски, каждый создаёт
+        # свой цикл, а ссылку _auto_backup_task получает только последний —
+        # остальные циклы осиротевают и параллельно пишут один архив (#3030).
+        async with self._scheduler_lock:
+            # Дожидаемся отмены старой таски, чтобы не было двух циклов параллельно
+            # во время рестарта scheduler'а после изменения BACKUP_TIME из кабинета.
+            if self._auto_backup_task and not self._auto_backup_task.done():
+                self._auto_backup_task.cancel()
+                import contextlib
 
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._auto_backup_task
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._auto_backup_task
 
-        if self._settings.auto_backup_enabled:
-            next_run = self._calculate_next_backup_datetime()
-            interval = self._get_backup_interval()
-            self._auto_backup_task = asyncio.create_task(self._auto_backup_loop(next_run))
-            logger.info(
-                '📄 Автобекапы включены, интервал: ч, ближайший запуск',
-                total_seconds=interval.total_seconds() / 3600,
-                next_run=next_run.strftime('%d.%m.%Y %H:%M:%S'),
-            )
+            if self._settings.auto_backup_enabled:
+                next_run = self._calculate_next_backup_datetime()
+                interval = self._get_backup_interval()
+                self._auto_backup_task = asyncio.create_task(self._auto_backup_loop(next_run))
+                logger.info(
+                    '📄 Автобекапы включены, интервал: ч, ближайший запуск',
+                    total_seconds=interval.total_seconds() / 3600,
+                    next_run=next_run.astimezone(self._get_timezone()).strftime('%d.%m.%Y %H:%M:%S %Z'),
+                )
 
     async def stop_auto_backup(self):
-        if self._auto_backup_task and not self._auto_backup_task.done():
-            self._auto_backup_task.cancel()
-            import contextlib
+        async with self._scheduler_lock:
+            if self._auto_backup_task and not self._auto_backup_task.done():
+                self._auto_backup_task.cancel()
+                import contextlib
 
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._auto_backup_task
-            logger.info('ℹ️ Автобекапы остановлены')
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._auto_backup_task
+                logger.info('ℹ️ Автобекапы остановлены')
 
     async def _auto_backup_loop(self, next_run: datetime | None = None):
         # Перечитываем настройки в начале цикла — на случай если admin изменил

--- a/tests/services/test_backup_scheduler.py
+++ b/tests/services/test_backup_scheduler.py
@@ -1,0 +1,112 @@
+"""Планировщик автобэкапов: одиночный цикл и таймзона BACKUP_TIME (#3030).
+
+Две проблемы, которые пинят эти тесты:
+
+1. Гонка рестартов. На холодном старте ``start_auto_backup`` вызывается
+   конкурентно до 6 раз (по одному на каждую BACKUP_* настройку из
+   ``_apply_to_settings`` + вызов из main.py). Без лока вызовы интерливились
+   на ``await`` отмены старой таски: каждый создавал свой ``_auto_backup_loop``,
+   ссылку ``_auto_backup_task`` получал только последний, остальные циклы
+   осиротевали. В назначенный час 4-5 циклов одновременно писали один
+   gzip-архив — на выходе битый файл (``zlib.error: invalid stored block
+   lengths``) и 3-4 дублирующих уведомления в Telegram.
+
+2. Таймзона. ``_calculate_next_backup_datetime`` подставлял BACKUP_TIME
+   напрямую в UTC-«сейчас», игнорируя TZ контейнера: для Europe/Moscow бекап
+   уезжал на 3 часа. Теперь BACKUP_TIME интерпретируется в settings.TIMEZONE
+   (наследует env TZ), наружу возвращается UTC.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from app.config import settings
+from app.services.backup_service import BackupService
+
+
+@pytest.fixture
+def service() -> BackupService:
+    return BackupService()
+
+
+# ============ Таймзона BACKUP_TIME ============
+
+
+def test_backup_time_interpreted_in_configured_timezone(service, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'TIMEZONE', 'Europe/Moscow', raising=False)
+    service._settings.backup_time = '21:00'
+
+    reference = datetime(2026, 7, 2, 11, 36, tzinfo=UTC)  # 14:36 MSK
+    next_run = service._calculate_next_backup_datetime(reference)
+
+    # 21:00 MSK == 18:00 UTC того же дня
+    assert next_run == datetime(2026, 7, 2, 18, 0, tzinfo=UTC)
+
+
+def test_backup_time_rolls_to_next_day_by_local_clock(service, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'TIMEZONE', 'Europe/Moscow', raising=False)
+    service._settings.backup_time = '21:00'
+
+    reference = datetime(2026, 7, 2, 19, 0, tzinfo=UTC)  # 22:00 MSK — сегодняшний слот прошёл
+    next_run = service._calculate_next_backup_datetime(reference)
+
+    assert next_run == datetime(2026, 7, 3, 18, 0, tzinfo=UTC)
+
+
+def test_utc_timezone_keeps_legacy_behavior(service, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, 'TIMEZONE', 'UTC', raising=False)
+    service._settings.backup_time = '03:00'
+
+    reference = datetime(2026, 7, 2, 11, 0, tzinfo=UTC)
+    next_run = service._calculate_next_backup_datetime(reference)
+
+    assert next_run == datetime(2026, 7, 3, 3, 0, tzinfo=UTC)
+
+
+def test_invalid_timezone_falls_back_to_utc(service, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Валидатор конфига отсекает мусор при старте, но настройка может прийти
+    # из БД/окружения мимо валидатора — расчёт не должен падать.
+    monkeypatch.setattr(settings, 'TIMEZONE', 'Neverland/Nope', raising=False)
+    service._settings.backup_time = '03:00'
+
+    reference = datetime(2026, 7, 2, 11, 0, tzinfo=UTC)
+    next_run = service._calculate_next_backup_datetime(reference)
+
+    assert next_run == datetime(2026, 7, 3, 3, 0, tzinfo=UTC)
+
+
+# ============ Гонка конкурентных рестартов ============
+
+
+async def test_concurrent_starts_leave_exactly_one_loop(service, monkeypatch: pytest.MonkeyPatch) -> None:
+    """РЕГРЕССИЯ #3030: 6 конкурентных start_auto_backup (холодный старт) не
+    должны оставлять осиротевших циклов — выживает ровно один."""
+    service._settings.auto_backup_enabled = True
+
+    alive: set[object] = set()
+
+    async def fake_loop(next_run=None):
+        token = object()
+        alive.add(token)
+        try:
+            await asyncio.Event().wait()  # живём до отмены
+        finally:
+            alive.discard(token)
+
+    monkeypatch.setattr(service, '_auto_backup_loop', fake_loop)
+
+    await asyncio.gather(*(service.start_auto_backup() for _ in range(6)))
+    await asyncio.sleep(0)
+
+    assert len(alive) == 1, f'осиротевшие циклы автобэкапа: живо {len(alive)}, должен быть ровно 1'
+    assert service._auto_backup_task is not None and not service._auto_backup_task.done()
+
+    await service.stop_auto_backup()
+    assert len(alive) == 0, 'stop_auto_backup должен останавливать единственный цикл'
+
+
+async def test_stop_without_running_task_is_noop(service) -> None:
+    await service.stop_auto_backup()
+    assert service._auto_backup_task is None


### PR DESCRIPTION
## 📝 Описание

Закрывает обе части #3030: множественная инициализация scheduler-тасок автобэкапа на холодном старте (битые gzip-архивы + дублирующие уведомления) и расчёт времени запуска строго в UTC (игнорирование TZ контейнера).

## 🎯 Корень проблемы

**Гонка рестартов.** На холодном старте `start_auto_backup` вызывается конкурентно до 6 раз: по одному на каждую BACKUP_* настройку из `_apply_to_settings` (`system_settings_service`) + прямой вызов из `main.py`. Внутри метода уже был cancel-await старой таски, но от конкуренции он не защищал: вызовы интерливились на `await`, каждый создавал свой `_auto_backup_loop`, ссылку `_auto_backup_task` получал только последний — остальные циклы осиротевали. В назначенный час 4-5 циклов одновременно писали один архив: `zlib.error: Error -3 ... invalid stored block lengths` при чтении метаданных и 3-4 дублирующих уведомления в Telegram.

**Таймзона.** `_calculate_next_backup_datetime` подставлял часы/минуты из BACKUP_TIME напрямую в UTC-«сейчас» — для `TZ: Europe/Moscow` бекап уезжал на 3 часа относительно ожидания оператора.

## 🔧 Что сделано

- `asyncio.Lock` сериализует `start_auto_backup`/`stop_auto_backup`: связка cancel-await-create атомарна, из N конкурентных рестартов выживает ровно один цикл (последний). Дедлок исключён — `_auto_backup_loop` не вызывает start/stop.
- `BACKUP_TIME` интерпретируется в `settings.TIMEZONE` — она наследует env `TZ`, так что у пользователей с `TZ: Europe/Moscow` из docker-compose всё чинится без новой конфигурации. Наружу по-прежнему возвращается aware-datetime в UTC, весь цикл продолжает жить в UTC. `_get_timezone` с fallback на UTC — по образцу `contest_rotation_service`.
- В лог «ближайший запуск» теперь пишется в локальной зоне с меткой `%Z` — оператор видит время, совпадающее с его BACKUP_TIME.

## 🧪 Тестирование

- [x] 6 тестов в `tests/services/test_backup_scheduler.py`: таймзонная математика (MSK → UTC, rollover через локальную полночь, `TIMEZONE=UTC` сохраняет прежнее поведение, fallback на мусорной зоне), гоночный тест — 6 конкурентных `start_auto_backup` оставляют ровно один живой цикл (без лока тест ловит все 6), no-op `stop` без запущенной таски
- [x] Полный локальный прогон тестов: 1733 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #3030
