### PR TITLE
fix(notifications): email-юзерам уведомления в flow «пополнение → автопокупка» (#2952)

### DIFF
--- a/app/services/payment/common.py
+++ b/app/services/payment/common.py
@@ -318,6 +318,43 @@ class PaymentCommonMixin:
             return False
 
 
+async def notify_email_user_topup(user: Any, amount_kopeks: int) -> None:
+    """«Пополнение успешно» для юзеров без Telegram (#2952).
+
+    Провайдерские webhook-обработчики шлют это сообщение только в Telegram
+    (гейт ``if bot and user.telegram_id``) — email-юзеры (telegram_id IS NULL)
+    не получали ничего. Вызываем мультиканальный роутер ТОЛЬКО для юзеров без
+    telegram_id: telegram-юзерам провайдер уже отправил сообщение напрямую, а
+    роутер сам проверяет email_verified и статус аккаунта. Сбои глотаем —
+    уведомление не должно ронять webhook после зачисления денег.
+    """
+    if user is None or getattr(user, 'telegram_id', None) or not getattr(user, 'email', None):
+        return
+    try:
+        from app.services.notification_delivery_service import (
+            NotificationType,
+            notification_delivery_service,
+        )
+
+        await notification_delivery_service.send_notification(
+            user=user,
+            notification_type=NotificationType.BALANCE_TOPUP,
+            context={
+                'formatted_amount': settings.format_price(amount_kopeks),
+                'formatted_balance': settings.format_price(getattr(user, 'balance_kopeks', 0) or 0),
+                'amount_kopeks': amount_kopeks,
+                'new_balance_kopeks': getattr(user, 'balance_kopeks', 0) or 0,
+            },
+            bot=None,
+        )
+    except Exception as error:
+        logger.error(
+            'Не удалось отправить email-уведомление о пополнении',
+            user_id=getattr(user, 'id', None),
+            error=error,
+        )
+
+
 async def send_cart_notification_after_topup(
     user: Any,
     amount_kopeks: int,
@@ -330,7 +367,12 @@ async def send_cart_notification_after_topup(
     Само сообщение «Баланс пополнен…» больше не шлётся — оно дублировало
     основное «Пополнение успешно!» и ломало MAIN_MENU_MODE=cabinet.
     """
-    del amount_kopeks  # больше не используется после удаления второго сообщения
+    # Единственная общая точка после зачисления во ВСЕХ провайдерах — поэтому
+    # email/WS-канал для юзеров без Telegram подключён здесь, а не в 18+
+    # webhook-обработчиках. Уходит до автопокупки, чтобы уведомления пришли в
+    # хронологическом порядке «пополнение → подписка» (#2952). Для
+    # telegram-юзеров это no-op — им сообщение уже отправил провайдер.
+    await notify_email_user_topup(user, amount_kopeks)
 
     from app.services.subscription_auto_purchase_service import (
         auto_purchase_saved_cart_after_topup,

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -45,6 +45,54 @@ def _format_user_id(user: User) -> str:
     return str(user.telegram_id) if user.telegram_id else f'email:{user.id}'
 
 
+async def _notify_email_user_auto_purchase(
+    user: User,
+    subscription: Subscription | None,
+    tariff_name: str | None,
+    *,
+    renewed: bool,
+) -> None:
+    """Email/WS-уведомление об автопокупке для юзеров без Telegram (#2952).
+
+    Все user-уведомления в этом сервисе гейтятся ``if bot and user.telegram_id``
+    — email-юзеры (авторизация только по email) не узнавали о результате
+    автопокупки вообще. Мультиканальный роутер вызываем ТОЛЬКО для юзеров без
+    telegram_id: telegram-юзерам сообщение уже отправлено ботом напрямую, а
+    роутер сам проверяет email_verified и статус аккаунта. Сбои глотаем —
+    подписка уже оформлена, уведомление не должно ронять flow.
+    """
+    if user is None or getattr(user, 'telegram_id', None) or not getattr(user, 'email', None):
+        return
+    try:
+        from app.services.notification_delivery_service import (
+            NotificationType,
+            notification_delivery_service,
+        )
+
+        end_date = getattr(subscription, 'end_date', None)
+        end_date_str = end_date.strftime('%d.%m.%Y') if end_date else ''
+        await notification_delivery_service.send_notification(
+            user=user,
+            notification_type=(
+                NotificationType.SUBSCRIPTION_RENEWED if renewed else NotificationType.SUBSCRIPTION_ACTIVATED
+            ),
+            context={
+                'expires_at': end_date_str,
+                'new_expires_at': end_date_str,
+                'traffic_limit_gb': getattr(subscription, 'traffic_limit_gb', None),
+                'device_limit': getattr(subscription, 'device_limit', None),
+                'tariff_name': tariff_name or '',
+            },
+            bot=None,
+        )
+    except Exception as error:
+        logger.error(
+            'Не удалось отправить email-уведомление об автопокупке',
+            user_id=getattr(user, 'id', None),
+            error=error,
+        )
+
+
 @dataclass(slots=True)
 class AutoPurchaseContext:
     """Aggregated data prepared for automatic checkout processing."""
@@ -727,6 +775,8 @@ async def _auto_extend_subscription(
                 error=error,
             )
 
+    await _notify_email_user_auto_purchase(user, updated_subscription, prepared.tariff_name, renewed=True)
+
     logger.info(
         '✅ Автопокупка: подписка продлена на дней для пользователя',
         period_days=prepared.period_days,
@@ -1093,6 +1143,10 @@ async def _auto_purchase_tariff(
                 error=error,
             )
 
+    await _notify_email_user_auto_purchase(
+        user, subscription, tariff_name_for_label, renewed=bool(existing_subscription)
+    )
+
     logger.info(
         '✅ Автопокупка тарифа: подписка на тариф (дней) оформлена для пользователя',
         tariff_name=tariff.name,
@@ -1444,6 +1498,8 @@ async def _auto_purchase_daily_tariff(
                 telegram_id=user.telegram_id or user.id,
                 error=error,
             )
+
+    await _notify_email_user_auto_purchase(user, subscription, tariff.name, renewed=bool(existing_subscription))
 
     logger.info(
         '✅ Автопокупка суточного тарифа: тариф активирован для пользователя',
@@ -2535,6 +2591,8 @@ async def try_auto_extend_expired_after_topup(
                 error=error,
             )
 
+    await _notify_email_user_auto_purchase(user, updated_subscription, tariff_name_for_label, renewed=True)
+
     logger.info(
         '✅ Автопродление expired: подписка продлена для пользователя',
         period_days=period_days,
@@ -2912,6 +2970,8 @@ async def try_resume_disabled_daily_after_topup(
                 telegram_id=user.telegram_id or user.id,
                 error=error,
             )
+
+    await _notify_email_user_auto_purchase(user, subscription, tariff.name, renewed=True)
 
     logger.info(
         '✅ Авто-возобновление daily: подписка возобновлена для пользователя',

--- a/tests/services/test_email_topup_notifications.py
+++ b/tests/services/test_email_topup_notifications.py
@@ -1,0 +1,179 @@
+"""Уведомления email-юзерам в flow «пополнение → автопокупка» (#2952).
+
+Оба пользовательских уведомления этого flow («Пополнение успешно!» в 18+
+провайдерах и «Подписка активирована/продлена» в auto-purchase обработчиках)
+гейтились ``if bot and user.telegram_id`` — юзеры без Telegram (авторизация
+по email) не получали вообще ничего и узнавали о результате, только зайдя в
+кабинет.
+
+Фикс подключает мультиканальный роутер ``notification_delivery_service``:
+
+- ``notify_email_user_topup`` вызывается из ЕДИНСТВЕННОЙ общей точки после
+  зачисления — ``send_cart_notification_after_topup`` (её зовут все
+  провайдеры), до автопокупки, чтобы письма шли в порядке
+  «пополнение → подписка»;
+- ``_notify_email_user_auto_purchase`` вызывается из всех пяти подписочных
+  auto-purchase обработчиков после telegram-гейта.
+
+Оба хелпера — no-op для telegram-юзеров (им сообщение уже отправлено ботом)
+и глотают сбои: уведомление не должно ронять webhook после зачисления денег.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.notification_delivery_service import (
+    NotificationType,
+    notification_delivery_service,
+)
+from app.services.payment import common as payment_common
+from app.services.subscription_auto_purchase_service import _notify_email_user_auto_purchase
+
+
+def _email_user(**overrides):
+    defaults = {
+        'id': 7,
+        'telegram_id': None,
+        'email': 'user@test.dev',
+        'email_verified': True,
+        'balance_kopeks': 50000,
+        'language': 'ru',
+        'status': 'active',
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def sent(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Перехватывает send_notification роутера."""
+    calls: list[dict] = []
+
+    async def fake_send_notification(user, notification_type, context, bot=None, **kwargs):
+        calls.append({'user': user, 'type': notification_type, 'context': context, 'bot': bot})
+        return True
+
+    monkeypatch.setattr(notification_delivery_service, 'send_notification', fake_send_notification)
+    return calls
+
+
+# ============ notify_email_user_topup ============
+
+
+async def test_topup_notification_sent_for_email_user(sent) -> None:
+    user = _email_user()
+
+    await payment_common.notify_email_user_topup(user, 25000)
+
+    assert len(sent) == 1
+    call = sent[0]
+    assert call['type'] == NotificationType.BALANCE_TOPUP
+    assert call['bot'] is None
+    assert call['context']['amount_kopeks'] == 25000
+    assert call['context']['new_balance_kopeks'] == 50000
+    assert call['context']['formatted_amount']
+    assert call['context']['formatted_balance']
+
+
+async def test_topup_notification_skipped_for_telegram_user(sent) -> None:
+    # Telegram-юзеру «Пополнение успешно!» уже отправил провайдер напрямую —
+    # роутер вызывать нельзя, иначе будет дубль.
+    await payment_common.notify_email_user_topup(_email_user(telegram_id=12345), 25000)
+
+    assert sent == []
+
+
+async def test_topup_notification_skipped_without_email(sent) -> None:
+    await payment_common.notify_email_user_topup(_email_user(email=None), 25000)
+
+    assert sent == []
+
+
+async def test_topup_notification_swallows_router_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom(*args, **kwargs):
+        raise RuntimeError('smtp down')
+
+    monkeypatch.setattr(notification_delivery_service, 'send_notification', boom)
+
+    # Не должно поднять исключение: деньги уже зачислены, webhook падать не должен.
+    await payment_common.notify_email_user_topup(_email_user(), 25000)
+
+
+async def test_topup_hook_notifies_before_auto_purchase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Порядок каналов: письмо о пополнении уходит ДО автопокупки из корзины,
+    чтобы уведомления пришли в хронологическом порядке «пополнение → подписка»."""
+    import app.services.subscription_auto_purchase_service as auto_mod
+
+    order: list[str] = []
+
+    async def fake_topup_notify(user, amount_kopeks):
+        order.append('topup_email')
+
+    async def fake_daily(db, user, bot=None):
+        order.append('daily')
+        return False
+
+    async def fake_extend(db, user, bot=None):
+        order.append('extend')
+        return False
+
+    async def fake_get_cart(user_id):
+        return None
+
+    monkeypatch.setattr(payment_common, 'notify_email_user_topup', fake_topup_notify)
+    monkeypatch.setattr(auto_mod, 'try_resume_disabled_daily_after_topup', fake_daily)
+    monkeypatch.setattr(auto_mod, 'try_auto_extend_expired_after_topup', fake_extend)
+    monkeypatch.setattr(payment_common.user_cart_service, 'get_user_cart', fake_get_cart)
+
+    await payment_common.send_cart_notification_after_topup(_email_user(), 25000, db=None, bot=None)
+
+    assert order and order[0] == 'topup_email', 'email о пополнении должен уходить до side-effect автопокупки'
+
+
+# ============ _notify_email_user_auto_purchase ============
+
+
+def _subscription():
+    return SimpleNamespace(
+        end_date=datetime(2026, 8, 15, 12, 0, tzinfo=UTC),
+        traffic_limit_gb=100,
+        device_limit=3,
+    )
+
+
+async def test_auto_purchase_notification_activated(sent) -> None:
+    await _notify_email_user_auto_purchase(_email_user(), _subscription(), 'Базовый', renewed=False)
+
+    assert len(sent) == 1
+    call = sent[0]
+    assert call['type'] == NotificationType.SUBSCRIPTION_ACTIVATED
+    assert call['bot'] is None
+    assert call['context']['expires_at'] == '15.08.2026'
+    assert call['context']['tariff_name'] == 'Базовый'
+    assert call['context']['traffic_limit_gb'] == 100
+    assert call['context']['device_limit'] == 3
+
+
+async def test_auto_purchase_notification_renewed(sent) -> None:
+    await _notify_email_user_auto_purchase(_email_user(), _subscription(), 'Базовый', renewed=True)
+
+    assert len(sent) == 1
+    assert sent[0]['type'] == NotificationType.SUBSCRIPTION_RENEWED
+    assert sent[0]['context']['new_expires_at'] == '15.08.2026'
+
+
+async def test_auto_purchase_notification_skipped_for_telegram_user(sent) -> None:
+    await _notify_email_user_auto_purchase(_email_user(telegram_id=12345), _subscription(), 'X', renewed=False)
+
+    assert sent == []
+
+
+async def test_auto_purchase_notification_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom(*args, **kwargs):
+        raise RuntimeError('smtp down')
+
+    monkeypatch.setattr(notification_delivery_service, 'send_notification', boom)
+
+    await _notify_email_user_auto_purchase(_email_user(), _subscription(), 'X', renewed=True)


### PR DESCRIPTION
## 📝 Описание

Закрывает #2952: email-юзеры (`telegram_id IS NULL`, авторизация только по email) не получали **вообще никаких** уведомлений в flow «пополнение → автопокупка из сохранённой корзины» — ни о зачислении баланса, ни об активации подписки. Оба уведомления гейтились `if bot and user.telegram_id`, и для email-юзеров оба пути молча пропускались. Человек, оплативший подписку, узнавал о результате только зайдя в кабинет.

## 🔧 Что сделано

Issue предлагал править гейты в 18 файлах провайдеров + 5 обработчиках. Вместо копипасты по 23 местам email/WS-канал подключён через существующие общие точки — мультиканальным роутером `notification_delivery_service`, который уже используется для этого в cabinet-роутах:

**Уровень 1 — «Пополнение успешно» (все провайдеры одним изменением).** Новый хелпер `notify_email_user_topup` в `payment/common.py` вызывается из `send_cart_notification_after_topup` — это единственная общая точка, которую после зачисления вызывают ВСЕ провайдеры (19+ вызовов: Platega, YooKassa, CryptoBot, Heleket, Lava и т.д., включая apple_iap). Бонус: будущие провайдеры получают email-канал автоматически. Письмо уходит **до** автопокупки — уведомления приходят в хронологическом порядке «пополнение → подписка», ровно по задокументированному в этом же модуле дизайну «ровно два уведомления».

**Уровень 2 — «Подписка активирована/продлена».** Хелпер `_notify_email_user_auto_purchase` вызывается из всех пяти подписочных auto-purchase обработчиков (extend из корзины, периодный тариф, суточный тариф, автопродление expired, возобновление daily) после telegram-гейта. Тип уведомления — `SUBSCRIPTION_RENEWED`/`SUBSCRIPTION_ACTIVATED` по фактическому сценарию (для тарифов — по наличию существующей подписки, как в соседнем WS-уведомлении).

**Гарантии:**
- для telegram-юзеров оба хелпера — no-op: им сообщение уже отправил бот напрямую, дублей нет;
- роутер сам проверяет `email_verified` и статус аккаунта (blocked/deleted);
- сбои SMTP глотаются с логом — уведомление не роняет webhook после зачисления денег.

**Осознанно за скоупом:** автопокупка устройств/трафика осталась на WS-канале — email-шаблонов этих типов (`DEVICES_PURCHASED` и т.п.) не существует, добавление новых шаблонов во все языки — отдельная тема.

## 🧪 Тестирование

- [x] 9 тестов в `tests/services/test_email_topup_notifications.py`: маршрутизация по типу юзера (email — шлём, telegram — no-op, без email — no-op), корректные `NotificationType` и контекст шаблонов (`formatted_amount`, `expires_at`, `tariff_name`, лимиты), порядок «письмо о пополнении до side-effect'ов автопокупки», устойчивость к сбоям роутера
- [x] Полный локальный прогон тестов: 1736 passed
- [x] `ruff format --check` / `ruff check` — чисто

## 🔧 Тип изменений

- [x] Bug fix (исправление)

Fixes #2952
