### PR TITLE
feat(coupons): партии одноразовых купонов на подписку для оптовой продажи (#3042)

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -28,6 +28,7 @@ from app.handlers.admin import (
     bulk_ban as admin_bulk_ban,
     campaigns as admin_campaigns,
     contests as admin_contests,
+    coupons as admin_coupons,
     daily_contests as admin_daily_contests,
     faq as admin_faq,
     main as admin_main,
@@ -199,6 +200,7 @@ async def setup_bot() -> tuple[Bot, Dispatcher]:
     admin_polls.register_handlers(dp)
     admin_promo_groups.register_handlers(dp)
     admin_campaigns.register_handlers(dp)
+    admin_coupons.register_handlers(dp)
     admin_contests.register_handlers(dp)
     admin_daily_contests.register_handlers(dp)
     admin_promo_offers.register_handlers(dp)

--- a/app/database/crud/coupon.py
+++ b/app/database/crud/coupon.py
@@ -1,0 +1,97 @@
+"""CRUD helpers for wholesale coupon batches and their one-time coupons."""
+
+import secrets
+from datetime import datetime
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import Coupon, CouponBatch, CouponStatus
+
+
+def generate_coupon_token() -> str:
+    """128-bit hex token: ``coupon_`` + 32 chars fits Telegram's 64-char start param."""
+    return secrets.token_hex(16)
+
+
+async def create_coupon_batch(
+    db: AsyncSession,
+    *,
+    name: str,
+    tariff_id: int,
+    period_days: int,
+    coupons_count: int,
+    wholesale_price_kopeks: int = 0,
+    valid_until: datetime | None = None,
+    created_by: int | None = None,
+) -> CouponBatch:
+    batch = CouponBatch(
+        name=name,
+        tariff_id=tariff_id,
+        period_days=period_days,
+        coupons_total=coupons_count,
+        wholesale_price_kopeks=wholesale_price_kopeks,
+        valid_until=valid_until,
+        created_by=created_by,
+    )
+    db.add(batch)
+    await db.flush()
+
+    coupons = [Coupon(batch_id=batch.id, token=generate_coupon_token()) for _ in range(coupons_count)]
+    db.add_all(coupons)
+    await db.commit()
+    await db.refresh(batch)
+    return batch
+
+
+async def get_coupon_batch_by_id(db: AsyncSession, batch_id: int) -> CouponBatch | None:
+    result = await db.execute(select(CouponBatch).where(CouponBatch.id == batch_id))
+    return result.scalar_one_or_none()
+
+
+async def get_coupon_batches(db: AsyncSession, *, offset: int = 0, limit: int = 10) -> list[CouponBatch]:
+    result = await db.execute(select(CouponBatch).order_by(CouponBatch.id.desc()).offset(offset).limit(limit))
+    return list(result.scalars().all())
+
+
+async def get_coupon_batches_count(db: AsyncSession) -> int:
+    result = await db.execute(select(func.count(CouponBatch.id)))
+    return result.scalar() or 0
+
+
+async def get_coupon_by_token(db: AsyncSession, token: str) -> Coupon | None:
+    result = await db.execute(select(Coupon).where(Coupon.token == token))
+    return result.scalars().first()
+
+
+async def get_batch_coupon_tokens(db: AsyncSession, batch_id: int, *, status: str | None = None) -> list[str]:
+    """Plain token strings (no entity hydration) — enough for the links export."""
+    query = select(Coupon.token).where(Coupon.batch_id == batch_id)
+    if status is not None:
+        query = query.where(Coupon.status == status)
+    result = await db.execute(query.order_by(Coupon.id))
+    return list(result.scalars().all())
+
+
+async def get_batch_status_counts(db: AsyncSession, batch_id: int) -> dict[str, int]:
+    result = await db.execute(
+        select(Coupon.status, func.count(Coupon.id)).where(Coupon.batch_id == batch_id).group_by(Coupon.status)
+    )
+    return dict(result.all())
+
+
+async def revoke_batch_coupons(db: AsyncSession, batch: CouponBatch) -> int:
+    """Flip all still-active coupons of the batch to REVOKED. Returns how many were revoked.
+
+    Safe against a concurrent redemption: the redeem path holds the coupon row
+    FOR UPDATE and re-checks the status, so whichever transaction commits first
+    wins and the other sees the new status.
+    """
+    result = await db.execute(
+        update(Coupon)
+        .where(Coupon.batch_id == batch.id, Coupon.status == CouponStatus.ACTIVE.value)
+        .values(status=CouponStatus.REVOKED.value)
+    )
+    batch.is_revoked = True
+    await db.commit()
+    return result.rowcount or 0

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2477,6 +2477,69 @@ class PromoCodeUse(Base):
     user = relationship('User')
 
 
+class CouponStatus(StrEnum):
+    ACTIVE = 'active'
+    REDEEMED = 'redeemed'
+    REVOKED = 'revoked'
+
+
+class CouponBatch(Base):
+    """Batch of one-time coupons for wholesale/partner sales.
+
+    The admin generates N coupons for a tariff+period, hands the links to a
+    partner and settles payment outside the bot; ``wholesale_price_kopeks``
+    is bookkeeping only.
+    """
+
+    __tablename__ = 'coupon_batches'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='SET NULL'), nullable=True, index=True)
+    period_days = Column(Integer, nullable=False)
+    coupons_total = Column(Integer, nullable=False)
+    wholesale_price_kopeks = Column(Integer, nullable=False, default=0)  # за купон; 0 — не указана
+    valid_until = Column(AwareDateTime(), nullable=True)
+    # Display-only cache for list views; per-coupon Coupon.status is the
+    # authority (redemption never consults this flag)
+    is_revoked = Column(Boolean, nullable=False, default=False)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+
+    coupons = relationship('Coupon', back_populates='batch', lazy='noload')
+    tariff = relationship('Tariff', lazy='selectin')
+
+    @property
+    def is_expired(self) -> bool:
+        return self.valid_until is not None and _aware(self.valid_until) < datetime.now(UTC)
+
+    def __repr__(self) -> str:
+        return f"<CouponBatch id={self.id} name='{self.name}'>"
+
+
+class Coupon(Base):
+    """One-time coupon redeemed via the ``/start coupon_<token>`` deep link."""
+
+    __tablename__ = 'coupons'
+    __table_args__ = (Index('ix_coupons_batch_status', 'batch_id', 'status'),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    batch_id = Column(Integer, ForeignKey('coupon_batches.id', ondelete='CASCADE'), nullable=False)
+    token = Column(String(64), unique=True, nullable=False, index=True)
+    status = Column(String(20), nullable=False, default=CouponStatus.ACTIVE.value)
+    redeemed_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
+    redeemed_at = Column(AwareDateTime(), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+
+    batch = relationship('CouponBatch', back_populates='coupons', lazy='selectin')
+    user = relationship('User', foreign_keys=[redeemed_by], lazy='noload')
+
+    def __repr__(self) -> str:
+        token_prefix = self.token[:5] if self.token else '?'
+        return f"<Coupon token='{token_prefix}...' status='{self.status}'>"
+
+
 class ReferralEarning(Base):
     __tablename__ = 'referral_earnings'
 

--- a/app/handlers/admin/__init__.py
+++ b/app/handlers/admin/__init__.py
@@ -7,6 +7,7 @@ from . import (
     bulk_ban,
     campaigns,
     contests,
+    coupons,
     daily_contests,
     faq,
     main,

--- a/app/handlers/admin/coupons.py
+++ b/app/handlers/admin/coupons.py
@@ -1,0 +1,512 @@
+import html
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from aiogram import Dispatcher, F, types
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.coupon import (
+    create_coupon_batch,
+    get_batch_coupon_tokens,
+    get_batch_status_counts,
+    get_coupon_batch_by_id,
+    get_coupon_batches,
+    get_coupon_batches_count,
+    revoke_batch_coupons,
+)
+from app.database.crud.tariff import get_all_active_tariffs, get_tariff_by_id
+from app.database.models import CouponBatch, CouponStatus, User
+from app.keyboards.admin import get_admin_pagination_keyboard
+from app.services.coupon_service import COUPON_DEEP_LINK_PREFIX
+from app.states import AdminStates
+from app.utils.decorators import admin_required, error_handler
+from app.utils.formatters import format_datetime
+
+
+logger = structlog.get_logger(__name__)
+
+MAX_COUPONS_PER_BATCH = 500
+MAX_PERIOD_DAYS = 3650
+MAX_WHOLESALE_PRICE_RUBLES = 10_000_000
+
+_CANCEL_KEYBOARD = types.InlineKeyboardMarkup(
+    inline_keyboard=[[types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')]]
+)
+
+
+def _build_coupon_link(bot_username: str, token: str) -> str:
+    return f'https://t.me/{bot_username}?start={COUPON_DEEP_LINK_PREFIX}{token}'
+
+
+def _format_batch_button(batch: CouponBatch) -> str:
+    revoked_mark = '⛔ ' if batch.is_revoked else ''
+    return f'{revoked_mark}#{batch.id} {batch.name} • {batch.period_days} дн. • {batch.coupons_total} шт.'
+
+
+def _format_batch_card(batch: CouponBatch, counts: dict[str, int]) -> str:
+    active = counts.get(CouponStatus.ACTIVE.value, 0)
+    redeemed = counts.get(CouponStatus.REDEEMED.value, 0)
+    revoked = counts.get(CouponStatus.REVOKED.value, 0)
+    tariff_name = html.escape(batch.tariff.name) if batch.tariff else '—'
+
+    text = (
+        f'🎟 <b>Партия купонов #{batch.id}</b>\n\n'
+        f'📌 Название: {html.escape(batch.name)}\n'
+        f'📦 Тариф: {tariff_name} — {batch.period_days} дн.\n'
+        f'🎫 Купонов: {batch.coupons_total}\n'
+    )
+
+    if batch.wholesale_price_kopeks > 0:
+        total_kopeks = batch.wholesale_price_kopeks * batch.coupons_total
+        text += (
+            f'💰 Опт: {settings.format_price(batch.wholesale_price_kopeks)}/шт '
+            f'(итого {settings.format_price(total_kopeks)})\n'
+        )
+
+    text += f'\n📊 <b>Статусы:</b>\n✅ Активных: {active}\n🎫 Погашено: {redeemed}\n⛔ Отозвано: {revoked}\n\n'
+
+    if batch.valid_until:
+        text += f'⏰ Действует до: {format_datetime(batch.valid_until)}\n'
+    else:
+        text += '⏰ Действует: бессрочно\n'
+
+    text += f'📅 Создана: {format_datetime(batch.created_at)}\n'
+
+    if batch.is_revoked:
+        text += '\n⛔ <b>Партия отозвана</b>\n'
+
+    return text
+
+
+def _batch_card_keyboard(batch: CouponBatch, counts: dict[str, int]) -> types.InlineKeyboardMarkup:
+    keyboard = []
+    if counts.get(CouponStatus.ACTIVE.value, 0) > 0:
+        keyboard.append(
+            [types.InlineKeyboardButton(text='📄 Файл со ссылками', callback_data=f'admin_coupon_export_{batch.id}')]
+        )
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text='⛔ Отозвать непогашенные', callback_data=f'admin_coupon_revoke_{batch.id}'
+                )
+            ]
+        )
+    keyboard.append([types.InlineKeyboardButton(text='⬅️ Назад', callback_data='admin_coupons')])
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+async def _load_batch(callback: types.CallbackQuery, db: AsyncSession) -> CouponBatch | None:
+    """Parse the batch id from callback data and fetch the batch, alerting on errors."""
+    try:
+        batch_id = int(callback.data.split('_')[-1])
+    except ValueError:
+        await callback.answer('❌ Ошибка получения ID партии', show_alert=True)
+        return None
+
+    batch = await get_coupon_batch_by_id(db, batch_id)
+    if not batch:
+        await callback.answer('❌ Партия не найдена', show_alert=True)
+        return None
+    return batch
+
+
+async def _show_batch_card(callback: types.CallbackQuery, db: AsyncSession, batch: CouponBatch) -> None:
+    counts = await get_batch_status_counts(db, batch.id)
+    await callback.message.edit_text(
+        _format_batch_card(batch, counts), reply_markup=_batch_card_keyboard(batch, counts)
+    )
+
+
+async def _read_int(message: types.Message, lo: int, hi: int, error_text: str) -> int | None:
+    """Parse an int in [lo, hi] from the message; reply with ``error_text`` and return None otherwise."""
+    try:
+        value = int((message.text or '').strip())
+    except ValueError:
+        value = None
+    if value is None or not lo <= value <= hi:
+        await message.answer(error_text, reply_markup=_CANCEL_KEYBOARD)
+        return None
+    return value
+
+
+async def _render_coupons_menu(
+    db: AsyncSession, language: str, page: int = 1
+) -> tuple[str, types.InlineKeyboardMarkup]:
+    limit = 10
+    offset = (page - 1) * limit
+
+    batches = await get_coupon_batches(db, offset=offset, limit=limit)
+    total_count = await get_coupon_batches_count(db)
+    total_pages = max(1, (total_count + limit - 1) // limit)
+
+    text = (
+        f'🎟 <b>Купоны</b>\n\n'
+        f'Оптовая продажа подписок через партнёров: партия одноразовых ссылок '
+        f'на тариф, каждая выдаёт или продлевает подписку на N дней.\n\n'
+        f'📊 Партий: {total_count}'
+    )
+    if total_pages > 1:
+        text += f' (стр. {page}/{total_pages})'
+
+    keyboard = [
+        [types.InlineKeyboardButton(text=_format_batch_button(batch), callback_data=f'admin_coupon_manage_{batch.id}')]
+        for batch in batches
+    ]
+
+    if total_pages > 1:
+        pagination_row = get_admin_pagination_keyboard(
+            page, total_pages, 'admin_coupon_list', 'admin_coupons', language
+        ).inline_keyboard[0]
+        keyboard.append(pagination_row)
+
+    keyboard.extend(
+        [
+            [types.InlineKeyboardButton(text='➕ Создать партию', callback_data='admin_coupon_create')],
+            [types.InlineKeyboardButton(text='⬅️ Назад', callback_data='admin_submenu_promo')],
+        ]
+    )
+
+    return text, types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+@admin_required
+@error_handler
+async def show_coupons_menu(callback: types.CallbackQuery, db_user: User, db: AsyncSession, state: FSMContext):
+    await state.clear()
+    text, keyboard = await _render_coupons_menu(db, db_user.language)
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def handle_coupon_list_page(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    try:
+        page = int(callback.data.split('_')[-1])
+    except ValueError:
+        page = 1
+    text, keyboard = await _render_coupons_menu(db, db_user.language, page=page)
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def start_coupon_batch_creation(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    tariffs = await get_all_active_tariffs(db)
+    if not tariffs:
+        await callback.answer('❌ Нет активных тарифов. Сначала создайте тариф.', show_alert=True)
+        return
+
+    keyboard = [
+        [types.InlineKeyboardButton(text=tariff.name, callback_data=f'coupon_batch_tariff_{tariff.id}')]
+        for tariff in tariffs
+    ]
+    keyboard.append([types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')])
+
+    await callback.message.edit_text(
+        '🎟 <b>Создание партии купонов</b>\n\nВыберите тариф, который будут выдавать купоны:',
+        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def select_coupon_batch_tariff(callback: types.CallbackQuery, db_user: User, state: FSMContext, db: AsyncSession):
+    try:
+        tariff_id = int(callback.data.split('_')[-1])
+    except ValueError:
+        await callback.answer('❌ Ошибка получения ID тарифа', show_alert=True)
+        return
+
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff or not tariff.is_active:
+        await callback.answer('❌ Тариф не найден или неактивен', show_alert=True)
+        return
+
+    await state.update_data(coupon_tariff_id=tariff.id, coupon_tariff_name=tariff.name)
+
+    await callback.message.edit_text(
+        f'🎟 <b>Создание партии купонов</b>\n\n'
+        f'Тариф: {html.escape(tariff.name)}\n\n'
+        f'📅 Введите количество дней подписки на купон (1-{MAX_PERIOD_DAYS}):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_days)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_days(message: types.Message, db_user: User, state: FSMContext):
+    days = await _read_int(message, 1, MAX_PERIOD_DAYS, f'❌ Введите целое число дней от 1 до {MAX_PERIOD_DAYS}')
+    if days is None:
+        return
+
+    await state.update_data(coupon_period_days=days)
+    await message.answer(
+        f'🎫 Введите количество купонов в партии (1-{MAX_COUPONS_PER_BATCH}):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_count)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_count(message: types.Message, db_user: User, state: FSMContext):
+    count = await _read_int(
+        message, 1, MAX_COUPONS_PER_BATCH, f'❌ Введите целое число купонов от 1 до {MAX_COUPONS_PER_BATCH}'
+    )
+    if count is None:
+        return
+
+    await state.update_data(coupon_count=count)
+    await message.answer(
+        '📌 Введите название партии (например, имя партнёра):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_name)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_name(message: types.Message, db_user: User, state: FSMContext):
+    name = (message.text or '').strip()
+    if not name or len(name) > 255:
+        await message.answer('❌ Название должно быть от 1 до 255 символов', reply_markup=_CANCEL_KEYBOARD)
+        return
+
+    await state.update_data(coupon_batch_name=name)
+    await message.answer(
+        '💰 Введите оптовую цену за купон в рублях — только для учёта (0 — не указывать):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_price)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_price(message: types.Message, db_user: User, state: FSMContext):
+    try:
+        rubles = float((message.text or '').strip().replace(',', '.').replace(' ', ''))
+    except ValueError:
+        await message.answer('❌ Введите цену числом (например, 150 или 99.50)', reply_markup=_CANCEL_KEYBOARD)
+        return
+    # Inverted range check: also rejects NaN (all comparisons with NaN are False)
+    if not 0 <= rubles <= MAX_WHOLESALE_PRICE_RUBLES:
+        await message.answer(
+            f'❌ Цена должна быть от 0 до {MAX_WHOLESALE_PRICE_RUBLES} рублей', reply_markup=_CANCEL_KEYBOARD
+        )
+        return
+
+    await state.update_data(coupon_price_kopeks=int(round(rubles * 100)))
+    await message.answer(
+        '⏰ Введите срок действия купонов в днях (0 — бессрочно):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_expiry)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_expiry(message: types.Message, db_user: User, state: FSMContext):
+    expiry_days = await _read_int(
+        message, 0, MAX_PERIOD_DAYS, f'❌ Введите число дней от 0 до {MAX_PERIOD_DAYS} (0 — бессрочно)'
+    )
+    if expiry_days is None:
+        return
+
+    await state.update_data(coupon_expiry_days=expiry_days)
+
+    data = await state.get_data()
+    price_kopeks = data.get('coupon_price_kopeks', 0)
+    price_line = f'💰 Опт: {settings.format_price(price_kopeks)}/шт\n' if price_kopeks > 0 else ''
+    expiry_line = f'⏰ Срок: {expiry_days} дн.\n' if expiry_days > 0 else '⏰ Срок: бессрочно\n'
+
+    await message.answer(
+        f'🎟 <b>Подтвердите создание партии</b>\n\n'
+        f'📌 Название: {html.escape(data.get("coupon_batch_name", ""))}\n'
+        f'📦 Тариф: {html.escape(data.get("coupon_tariff_name", ""))} — {data.get("coupon_period_days")} дн.\n'
+        f'🎫 Купонов: {data.get("coupon_count")}\n'
+        f'{price_line}'
+        f'{expiry_line}',
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [types.InlineKeyboardButton(text='✅ Создать', callback_data='admin_coupon_create_confirm')],
+                [types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')],
+            ]
+        ),
+    )
+
+
+@admin_required
+@error_handler
+async def confirm_coupon_batch_creation(
+    callback: types.CallbackQuery, db_user: User, state: FSMContext, db: AsyncSession
+):
+    # An old confirmation message keeps a live button: accept it only while the
+    # wizard is actually waiting on this confirmation, otherwise a stale tap
+    # would create a batch from half-entered state of a NEW wizard run.
+    current_state = await state.get_state()
+    if current_state != AdminStates.creating_coupon_batch_expiry.state:
+        await callback.answer('❌ Данные создания устарели, начните заново', show_alert=True)
+        return
+
+    data = await state.get_data()
+    tariff_id = data.get('coupon_tariff_id')
+    period_days = data.get('coupon_period_days')
+    count = data.get('coupon_count')
+    name = data.get('coupon_batch_name')
+    expiry_days = data.get('coupon_expiry_days')
+
+    if not all([tariff_id, period_days, count, name]) or expiry_days is None:
+        await callback.answer('❌ Данные создания устарели, начните заново', show_alert=True)
+        await state.clear()
+        return
+
+    # Consume the wizard state BEFORE the (slow) batch insert — a double-tap on
+    # the confirm button must not create the batch twice.
+    await state.clear()
+
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff or not tariff.is_active:
+        await callback.answer('❌ Тариф не найден или неактивен', show_alert=True)
+        return
+
+    valid_until = datetime.now(UTC) + timedelta(days=expiry_days) if expiry_days else None
+
+    batch = await create_coupon_batch(
+        db,
+        name=name,
+        tariff_id=tariff.id,
+        period_days=period_days,
+        coupons_count=count,
+        wholesale_price_kopeks=data.get('coupon_price_kopeks', 0),
+        valid_until=valid_until,
+        created_by=db_user.id,
+    )
+
+    logger.info(
+        'Создана партия купонов',
+        batch_id=batch.id,
+        tariff_id=tariff.id,
+        period_days=period_days,
+        count=count,
+        created_by=db_user.id,
+    )
+
+    await _show_batch_card(callback, db, batch)
+    await _send_batch_links_file(callback, db, batch)
+    await callback.answer('✅ Партия создана')
+
+
+@admin_required
+@error_handler
+async def show_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+    await _show_batch_card(callback, db, batch)
+    await callback.answer()
+
+
+async def _send_batch_links_file(callback: types.CallbackQuery, db: AsyncSession, batch: CouponBatch) -> None:
+    """Send a .txt with the deep links of all still-active coupons of the batch."""
+    tokens = await get_batch_coupon_tokens(db, batch.id, status=CouponStatus.ACTIVE.value)
+    if not tokens:
+        await callback.answer('❌ В партии нет активных купонов', show_alert=True)
+        return
+
+    # The username is synced into settings at startup; get_me() is a fallback
+    # to avoid an extra Bot API round trip on every export.
+    bot_username = settings.get_bot_username() or (await callback.bot.get_me()).username
+    content = '\n'.join(_build_coupon_link(bot_username, token) for token in tokens) + '\n'
+    file = types.BufferedInputFile(content.encode('utf-8'), filename=f'coupons_batch_{batch.id}.txt')
+    await callback.message.answer_document(
+        document=file,
+        caption=(
+            f'🎟 Партия #{batch.id} «{html.escape(batch.name)}»: '
+            f'{len(tokens)} активных купонов, {batch.period_days} дн. каждый.'
+        ),
+    )
+
+
+@admin_required
+@error_handler
+async def export_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+    await _send_batch_links_file(callback, db, batch)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def ask_revoke_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+
+    counts = await get_batch_status_counts(db, batch.id)
+    active = counts.get(CouponStatus.ACTIVE.value, 0)
+
+    await callback.message.edit_text(
+        f'⛔ <b>Отзыв партии #{batch.id}</b>\n\n'
+        f'«{html.escape(batch.name)}»: будет отозвано {active} непогашенных купонов. '
+        f'Их ссылки перестанут работать. Действие необратимо.\n\n'
+        f'Подтвердить?',
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text='⛔ Да, отозвать', callback_data=f'admin_coupon_revoke_confirm_{batch.id}'
+                    )
+                ],
+                [types.InlineKeyboardButton(text='❌ Отмена', callback_data=f'admin_coupon_manage_{batch.id}')],
+            ]
+        ),
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def confirm_revoke_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+
+    revoked_count = await revoke_batch_coupons(db, batch)
+    logger.info(
+        'Партия купонов отозвана',
+        batch_id=batch.id,
+        revoked_count=revoked_count,
+        admin_id=db_user.id,
+    )
+
+    await _show_batch_card(callback, db, batch)
+    await callback.answer(f'⛔ Отозвано купонов: {revoked_count}')
+
+
+def register_handlers(dp: Dispatcher):
+    dp.callback_query.register(show_coupons_menu, F.data == 'admin_coupons')
+    dp.callback_query.register(handle_coupon_list_page, F.data.startswith('admin_coupon_list_page_'))
+    dp.callback_query.register(start_coupon_batch_creation, F.data == 'admin_coupon_create')
+    dp.callback_query.register(confirm_coupon_batch_creation, F.data == 'admin_coupon_create_confirm')
+    dp.callback_query.register(select_coupon_batch_tariff, F.data.startswith('coupon_batch_tariff_'))
+    dp.callback_query.register(show_coupon_batch, F.data.startswith('admin_coupon_manage_'))
+    dp.callback_query.register(export_coupon_batch, F.data.startswith('admin_coupon_export_'))
+    # NB: register the *_revoke_confirm_ handler before the *_revoke_ one —
+    # the shorter prefix also matches confirmation callbacks.
+    dp.callback_query.register(confirm_revoke_coupon_batch, F.data.startswith('admin_coupon_revoke_confirm_'))
+    dp.callback_query.register(ask_revoke_coupon_batch, F.data.startswith('admin_coupon_revoke_'))
+
+    dp.message.register(process_coupon_batch_days, AdminStates.creating_coupon_batch_days)
+    dp.message.register(process_coupon_batch_count, AdminStates.creating_coupon_batch_count)
+    dp.message.register(process_coupon_batch_name, AdminStates.creating_coupon_batch_name)
+    dp.message.register(process_coupon_batch_price, AdminStates.creating_coupon_batch_price)
+    dp.message.register(process_coupon_batch_expiry, AdminStates.creating_coupon_batch_expiry)

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -42,6 +42,12 @@ from app.middlewares.channel_checker import (
 from app.services.admin_notification_service import AdminNotificationService
 from app.services.campaign_service import AdvertisingCampaignService
 from app.services.channel_subscription_service import channel_subscription_service
+from app.services.coupon_service import (
+    COUPON_DEEP_LINK_PREFIX,
+    CouponRedemptionError,
+    is_coupon_token,
+    redeem_coupon,
+)
 from app.services.guest_purchase_service import GIFT_TOKEN_MIN_PREFIX_LENGTH
 from app.services.main_menu_button_service import MainMenuButtonService
 from app.services.phantom_service import claim_phantom, merge_phantom_into_user
@@ -220,6 +226,66 @@ async def _activate_pending_gift_after_registration(
             )
         except Exception:
             pass
+
+
+_COUPON_ERROR_TEXTS = {
+    'invalid': '❌ Купон не найден или уже использован.',
+    'expired': '⌛ Срок действия купона истёк.',
+    'already_redeemed_by_you': 'ℹ️ Вы уже активировали этот купон.',
+    'internal': '❌ Произошла ошибка при активации купона. Попробуйте позже или обратитесь в поддержку.',
+}
+
+
+async def _redeem_pending_coupon(
+    db: AsyncSession,
+    state: FSMContext,
+    user: 'User',
+    answer_func: Callable[..., Any],
+) -> None:
+    """Extract pending_coupon_token from FSM state and redeem it for ``user``.
+
+    Must be called BEFORE state.clear() to preserve the token.
+    """
+    coupon_token: str | None = None
+    try:
+        fresh_state = await state.get_data()
+        coupon_token = fresh_state.get('pending_coupon_token')
+        if not coupon_token:
+            return
+
+        try:
+            result = await redeem_coupon(db, coupon_token, user)
+        except CouponRedemptionError as error:
+            await answer_func(
+                _COUPON_ERROR_TEXTS.get(error.code, _COUPON_ERROR_TEXTS['invalid']),
+                parse_mode=ParseMode.HTML,
+            )
+            return
+    except Exception:
+        logger.exception(
+            'Failed to redeem coupon deep link',
+            token_prefix=(coupon_token or '')[:5],
+        )
+        try:
+            await answer_func(_COUPON_ERROR_TEXTS['internal'], parse_mode=ParseMode.HTML)
+        except Exception:
+            pass
+        return
+
+    # Redemption is committed at this point — a failed confirmation send must
+    # not claim the activation failed (the coupon IS consumed).
+    try:
+        tariff_name = html.escape(result.tariff_name)
+        await answer_func(
+            f'🎟 <b>Купон активирован!</b>\n{tariff_name} — {result.period_days} дн.\n\nВаша подписка обновлена.',
+            parse_mode=ParseMode.HTML,
+        )
+    except Exception:
+        logger.exception(
+            'Coupon redeemed but the confirmation message failed to send',
+            token_prefix=(coupon_token or '')[:5],
+            user_id=user.id,
+        )
 
 
 async def _claim_phantom_user(
@@ -815,6 +881,28 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             await state.update_data(pending_gift_token=gift_token)
             start_parameter = None  # Don't treat as campaign or referral
 
+    # Handle coupon deep links: /start coupon_{token} — one-time wholesale coupons
+    if start_parameter and start_parameter.startswith(COUPON_DEEP_LINK_PREFIX):
+        coupon_token = start_parameter.removeprefix(COUPON_DEEP_LINK_PREFIX).lower()
+        # The payload fits Telegram's 64-char start param untruncated, so the
+        # lookup is exact-match. Swallow the parameter only for coupons that
+        # actually exist — a campaign start_parameter may legitimately begin
+        # with 'coupon_' (even coupon_<32 hex>) and must fall through to the
+        # campaign lookup below.
+        if is_coupon_token(coupon_token):
+            from app.database.crud.coupon import get_coupon_by_token
+
+            if await get_coupon_by_token(db, coupon_token) is not None:
+                logger.info(
+                    'Coupon deep link detected',
+                    token_prefix=coupon_token[:5],
+                    telegram_id=message.from_user.id,
+                )
+                # Redeemed via _redeem_pending_coupon(): immediately below for
+                # registered users, after registration for new ones.
+                await state.update_data(pending_coupon_token=coupon_token)
+                start_parameter = None  # Don't treat as campaign or referral
+
     # Handle web auth deep links: /start webauth_{token}
     if start_parameter and start_parameter.startswith('webauth_'):
         web_auth_token = start_parameter.removeprefix('webauth_')
@@ -1065,12 +1153,12 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             except Exception as e:
                 logger.error('Ошибка отправки уведомления о рекламной кампании', error=e)
 
-        # Auto-activate pending gift if deep link contained GIFT_
+        # Auto-activate pending gift/coupon if deep link contained GIFT_/coupon_
         if user:
             await _activate_pending_gift_after_registration(db, state, user, message.answer)
-            await state.update_data(pending_gift_token=None)
+            await _redeem_pending_coupon(db, state, user, message.answer)
             await _persist_pending_subid_after_registration(db, state, user)
-            await state.update_data(pending_subid=None)
+            await state.update_data(pending_gift_token=None, pending_coupon_token=None, pending_subid=None)
             # Refresh user to pick up newly created subscriptions
             await db.refresh(user, attribute_names=['subscriptions'])
 
@@ -1930,9 +2018,20 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
         telegram_id=user.telegram_id,
     )
 
-    # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
+    # Auto-activate pending gift/coupon for newly registered user (before state.clear() wipes the tokens)
     await _activate_pending_gift_after_registration(db, state, user, callback.message.answer)
+    await _redeem_pending_coupon(db, state, user, callback.message.answer)
     await _persist_pending_subid_after_registration(db, state, user)
+    # Gift/coupon may have just created a subscription — reload it, otherwise the
+    # stale empty list below offers the trial on top of the granted subscription
+    try:
+        await db.refresh(user, ['subscriptions'])
+    except Exception as refresh_error:
+        logger.error(
+            'Ошибка обновления подписок после активации подарка/купона',
+            telegram_id=user.telegram_id,
+            refresh_error=refresh_error,
+        )
 
     await state.clear()
 
@@ -2278,9 +2377,20 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
         '🗑️ COMPLETE: Redis payload удален после успешной регистрации пользователя', telegram_id=user.telegram_id
     )
 
-    # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
+    # Auto-activate pending gift/coupon for newly registered user (before state.clear() wipes the tokens)
     await _activate_pending_gift_after_registration(db, state, user, message.answer)
+    await _redeem_pending_coupon(db, state, user, message.answer)
     await _persist_pending_subid_after_registration(db, state, user)
+    # Gift/coupon may have just created a subscription — reload it, otherwise the
+    # stale empty list below offers the trial on top of the granted subscription
+    try:
+        await db.refresh(user, ['subscriptions'])
+    except Exception as refresh_error:
+        logger.error(
+            'Ошибка обновления подписок после активации подарка/купона',
+            telegram_id=user.telegram_id,
+            refresh_error=refresh_error,
+        )
 
     await state.clear()
 

--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -103,6 +103,12 @@ def get_admin_promo_submenu_keyboard(language: str = 'ru') -> InlineKeyboardMark
             [InlineKeyboardButton(text=texts.ADMIN_CAMPAIGNS, callback_data='admin_campaigns')],
             [
                 InlineKeyboardButton(
+                    text=_t(texts, 'ADMIN_COUPONS', '🎟 Купоны'),
+                    callback_data='admin_coupons',
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text=_t(texts, 'ADMIN_CONTESTS', '🏆 Конкурсы'),
                     callback_data='admin_contests',
                 )

--- a/app/services/coupon_service.py
+++ b/app/services/coupon_service.py
@@ -1,0 +1,213 @@
+"""Wholesale coupons: batch-generated one-time links that grant subscription days.
+
+The admin creates a batch of coupons for a tariff+period and hands the deep
+links (``https://t.me/<bot>?start=coupon_<token>``) to a partner. Redeeming a
+link grants the batch tariff for N days, or extends an existing subscription
+by N days — mirroring gift activation semantics
+(:func:`app.services.guest_purchase_service.activate_purchase`).
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.coupon import get_coupon_by_token
+from app.database.crud.subscription import (
+    create_paid_subscription,
+    extend_subscription,
+    get_subscription_by_user_id,
+    replace_subscription,
+)
+from app.database.models import Coupon, CouponStatus, Subscription, Tariff, User, _aware
+from app.services.subscription_service import SubscriptionService
+
+
+logger = structlog.get_logger(__name__)
+
+COUPON_DEEP_LINK_PREFIX = 'coupon_'
+
+# 32 hex chars = 128 bits: unguessable, and the full deep-link payload
+# (`coupon_` + token = 39 chars) fits Telegram's 64-char start param without
+# truncation, so lookups are always exact-match (no prefix matching at all).
+_COUPON_TOKEN_RE = re.compile(r'[0-9a-f]{32}')
+
+
+def is_coupon_token(value: str) -> bool:
+    """True if ``value`` has the exact coupon-token format (no DB hit)."""
+    return bool(_COUPON_TOKEN_RE.fullmatch(value))
+
+
+class CouponRedemptionError(Exception):
+    """Coupon cannot be redeemed; ``code`` selects the user-facing message.
+
+    Codes: ``invalid`` (unknown / revoked / redeemed by someone else —
+    deliberately uniform so the response is not an oracle), ``expired``,
+    ``already_redeemed_by_you``, ``internal``.
+    """
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(slots=True)
+class CouponRedemptionResult:
+    tariff_name: str
+    period_days: int
+
+
+def _check_redeemable(coupon: Coupon, user: User) -> None:
+    """Raise CouponRedemptionError unless the coupon can be redeemed by ``user``.
+
+    Pure checks only — safe to run both before and after the row lock is taken.
+    """
+    if coupon.status == CouponStatus.REDEEMED.value:
+        if coupon.redeemed_by == user.id:
+            raise CouponRedemptionError('already_redeemed_by_you')
+        raise CouponRedemptionError('invalid')
+    if coupon.status != CouponStatus.ACTIVE.value:
+        # REVOKED (or any future state): same uniform answer as "not found"
+        raise CouponRedemptionError('invalid')
+
+    batch = coupon.batch
+    if batch is None:
+        raise CouponRedemptionError('invalid')
+    if batch.is_expired:
+        raise CouponRedemptionError('expired')
+
+
+async def redeem_coupon(db: AsyncSession, token: str, user: User) -> CouponRedemptionResult:
+    """Atomically redeem a one-time coupon for ``user``.
+
+    All validation runs on an unlocked read, so a rejected link never holds a
+    row lock for the rest of the caller's handler. The claim itself re-reads
+    the row with SELECT ... FOR UPDATE and re-checks it, and the status flip
+    to REDEEMED is set BEFORE the Remnawave sync — which commits the session
+    internally — so claim and grant land in one transaction and a coupon can
+    never pay out twice.
+    """
+    normalized = (token or '').strip().lower()
+    if not is_coupon_token(normalized):
+        raise CouponRedemptionError('invalid')
+
+    coupon = await get_coupon_by_token(db, normalized)
+    if coupon is None:
+        raise CouponRedemptionError('invalid')
+
+    _check_redeemable(coupon, user)
+
+    tariff = coupon.batch.tariff
+    if tariff is None:
+        logger.error('Купон ссылается на отсутствующий тариф', coupon_id=coupon.id, batch_id=coupon.batch_id)
+        raise CouponRedemptionError('internal')
+
+    tariff_name = tariff.name
+    period_days = coupon.batch.period_days
+    batch_id = coupon.batch_id
+    coupon_id = coupon.id
+
+    # Claim under row lock: reload the row FOR UPDATE and re-check — a
+    # concurrent redemption or batch revoke may have won between the two reads.
+    await db.refresh(coupon, with_for_update=True)
+    _check_redeemable(coupon, user)
+
+    try:
+        subscription = await _grant_subscription_days(db, user, tariff, period_days)
+
+        coupon.status = CouponStatus.REDEEMED.value
+        coupon.redeemed_by = user.id
+        coupon.redeemed_at = datetime.now(UTC)
+
+        # create_remnawave_user() commits the session internally on success
+        # (persisting claim+grant atomically) and swallows panel/API errors,
+        # returning None WITHOUT committing — treat that as a failure so the
+        # rollback below keeps the coupon ACTIVE and the link retryable.
+        remnawave_user = await SubscriptionService().create_remnawave_user(db, subscription)
+        if remnawave_user is None:
+            raise RuntimeError('Remnawave sync failed')
+        await db.commit()
+    except Exception:
+        logger.exception('Не удалось погасить купон', coupon_id=coupon_id, user_id=user.id)
+        await db.rollback()
+        raise CouponRedemptionError('internal') from None
+
+    logger.info(
+        'Купон погашен',
+        coupon_id=coupon_id,
+        batch_id=batch_id,
+        user_id=user.id,
+        days=period_days,
+    )
+    return CouponRedemptionResult(tariff_name=tariff_name, period_days=period_days)
+
+
+async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff, period_days: int) -> Subscription:
+    """Create/extend/replace a subscription for ``period_days`` of ``tariff``.
+
+    Mirrors the gift-activation branches in ``activate_purchase``. All CRUD
+    calls use ``commit=False`` — the caller owns the transaction.
+    """
+    squads = list(tariff.allowed_squads or [])
+    if not squads:
+        from app.database.crud.server_squad import get_all_server_squads
+
+        # Explicit high limit: the default (50) silently truncates deployments
+        # with more available squads.
+        all_servers, _ = await get_all_server_squads(db, available_only=True, limit=10_000)
+        squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
+
+    if settings.is_multi_tariff_enabled():
+        from app.database.crud.subscription import get_subscription_by_user_and_tariff
+
+        existing = await get_subscription_by_user_and_tariff(db, user.id, tariff.id)
+    else:
+        existing = await get_subscription_by_user_id(db, user.id)
+
+    has_time = existing is not None and existing.end_date is not None and _aware(existing.end_date) > datetime.now(UTC)
+
+    if existing is not None and has_time:
+        # In multi-tariff mode the subscription already belongs to this tariff,
+        # so passing tariff_id is a no-op; in single mode it switches the
+        # subscription to the batch tariff (same as gift activation).
+        return await extend_subscription(
+            db,
+            existing,
+            period_days,
+            tariff_id=tariff.id,
+            traffic_limit_gb=tariff.traffic_limit_gb,
+            device_limit=tariff.device_limit,
+            connected_squads=squads,
+            commit=False,
+        )
+
+    if existing is not None:
+        # Expired subscription — replace with fresh dates
+        subscription = await replace_subscription(
+            db,
+            existing,
+            duration_days=period_days,
+            traffic_limit_gb=tariff.traffic_limit_gb,
+            device_limit=tariff.device_limit,
+            connected_squads=squads,
+            is_trial=False,
+            update_server_counters=True,
+            commit=False,
+        )
+        subscription.tariff_id = tariff.id
+        return subscription
+
+    return await create_paid_subscription(
+        db=db,
+        user_id=user.id,
+        duration_days=period_days,
+        traffic_limit_gb=tariff.traffic_limit_gb,
+        device_limit=tariff.device_limit,
+        connected_squads=squads,
+        tariff_id=tariff.id,
+        update_server_counters=True,
+        commit=False,
+    )

--- a/app/states.py
+++ b/app/states.py
@@ -67,6 +67,12 @@ class AdminStates(StatesGroup):
     setting_discount_hours = State()  # Для DISCOUNT: ввод срока действия скидки в часах
     selecting_promo_group = State()
 
+    creating_coupon_batch_days = State()
+    creating_coupon_batch_count = State()
+    creating_coupon_batch_name = State()
+    creating_coupon_batch_price = State()
+    creating_coupon_batch_expiry = State()
+
     creating_campaign_name = State()
     creating_campaign_start = State()
     creating_campaign_bonus = State()

--- a/migrations/alembic/versions/0095_add_coupons.py
+++ b/migrations/alembic/versions/0095_add_coupons.py
@@ -1,0 +1,85 @@
+"""add coupon_batches and coupons tables
+
+Wholesale/partner sales: the admin batch-generates one-time coupons
+(``coupon_batches`` holds tariff+period+bookkeeping, ``coupons`` holds the
+per-link secret token). Redeeming a coupon via the ``/start coupon_<token>``
+deep link grants a new subscription for the batch period or extends an
+existing one. ON DELETE CASCADE ties coupons to their batch.
+
+Revision ID: 0095
+Revises: 0094
+Create Date: 2026-07-11
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '0095'
+down_revision: Union[str, None] = '0094'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if 'coupon_batches' not in tables:
+        op.create_table(
+            'coupon_batches',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('name', sa.String(length=255), nullable=False),
+            sa.Column('tariff_id', sa.Integer(), nullable=True),
+            sa.Column('period_days', sa.Integer(), nullable=False),
+            sa.Column('coupons_total', sa.Integer(), nullable=False),
+            sa.Column('wholesale_price_kopeks', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('valid_until', sa.DateTime(timezone=True), nullable=True),
+            sa.Column('is_revoked', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+            sa.Column('created_by', sa.Integer(), nullable=True),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(['tariff_id'], ['tariffs.id'], ondelete='SET NULL'),
+            sa.ForeignKeyConstraint(['created_by'], ['users.id'], ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+        op.create_index('ix_coupon_batches_tariff_id', 'coupon_batches', ['tariff_id'])
+
+    if 'coupons' not in tables:
+        op.create_table(
+            'coupons',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('batch_id', sa.Integer(), nullable=False),
+            sa.Column('token', sa.String(length=64), nullable=False),
+            sa.Column('status', sa.String(length=20), nullable=False, server_default='active'),
+            sa.Column('redeemed_by', sa.Integer(), nullable=True),
+            sa.Column('redeemed_at', sa.DateTime(timezone=True), nullable=True),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(['batch_id'], ['coupon_batches.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['redeemed_by'], ['users.id'], ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+        # Column(unique=True, index=True) in the model → a single unique index
+        op.create_index('ix_coupons_token', 'coupons', ['token'], unique=True)
+        op.create_index('ix_coupons_redeemed_by', 'coupons', ['redeemed_by'])
+        op.create_index('ix_coupons_batch_status', 'coupons', ['batch_id', 'status'])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if 'coupons' in tables:
+        op.drop_index('ix_coupons_batch_status', table_name='coupons')
+        op.drop_index('ix_coupons_redeemed_by', table_name='coupons')
+        op.drop_index('ix_coupons_token', table_name='coupons')
+        op.drop_table('coupons')
+
+    if 'coupon_batches' in tables:
+        op.drop_index('ix_coupon_batches_tariff_id', table_name='coupon_batches')
+        op.drop_table('coupon_batches')

--- a/tests/services/test_coupon_service.py
+++ b/tests/services/test_coupon_service.py
@@ -1,0 +1,351 @@
+"""Tests for the wholesale coupon service (batches of one-time links).
+
+Coupons are the fourth "grant subscription days" mechanism (after promocodes,
+gifts and campaigns): the admin batch-generates one-time tokens, a user
+redeems one via the ``/start coupon_<token>`` deep link. These tests pin the
+redemption contract:
+
+- token format is validated before any DB access;
+- responses are uniform for unknown / revoked / redeemed-by-someone-else
+  coupons (no oracle for enumeration), while redeemed-by-you is friendly;
+- validation runs on an unlocked read; the claim re-reads the row FOR UPDATE
+  and re-checks it, and the REDEEMED flip happens BEFORE the Remnawave sync
+  (which commits the session internally), so claim and grant land in one
+  transaction;
+- a failed Remnawave sync (the method swallows errors and returns None)
+  aborts the redemption: rollback, ``internal`` error, coupon stays ACTIVE
+  and the link retryable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.database.crud.coupon import generate_coupon_token
+from app.database.models import CouponStatus
+from app.services.coupon_service import (
+    COUPON_DEEP_LINK_PREFIX,
+    CouponRedemptionError,
+    _grant_subscription_days,
+    is_coupon_token,
+    redeem_coupon,
+)
+
+
+VALID_TOKEN = 'a1' * 16  # 32 hex chars
+
+
+def _user(user_id: int = 7) -> SimpleNamespace:
+    return SimpleNamespace(id=user_id)
+
+
+def _tariff() -> SimpleNamespace:
+    return SimpleNamespace(id=3, name='Basic', allowed_squads=['sq-1'], traffic_limit_gb=100, device_limit=2)
+
+
+def _batch(**overrides) -> SimpleNamespace:
+    base = {'id': 1, 'tariff_id': 3, 'period_days': 30, 'is_expired': False, 'tariff': _tariff()}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _coupon(status: str = CouponStatus.ACTIVE.value, redeemed_by: int | None = None, batch=None) -> SimpleNamespace:
+    if batch is None:
+        batch = _batch()
+    return SimpleNamespace(
+        id=11, batch_id=batch.id, status=status, redeemed_by=redeemed_by, redeemed_at=None, batch=batch
+    )
+
+
+# --- Token format ---------------------------------------------------------
+
+
+def test_generated_token_matches_format_and_fits_start_param() -> None:
+    for _ in range(100):
+        token = generate_coupon_token()
+        assert is_coupon_token(token)
+        # Telegram truncates start params longer than 64 chars; the coupon flow
+        # relies on exact-match lookups, so the payload must never be truncated.
+        assert len(COUPON_DEEP_LINK_PREFIX + token) <= 64
+
+
+def test_generated_tokens_are_unique() -> None:
+    tokens = {generate_coupon_token() for _ in range(1000)}
+    assert len(tokens) == 1000
+
+
+def test_is_coupon_token_rejects_wrong_shapes() -> None:
+    assert not is_coupon_token('')
+    assert not is_coupon_token('abc')
+    assert not is_coupon_token('g' * 32)  # non-hex
+    assert not is_coupon_token('a' * 31)
+    assert not is_coupon_token('a' * 33)
+    # redeem_coupon lowercases before validating, the matcher itself is strict
+    assert not is_coupon_token('A' * 32)
+
+
+# --- Redemption: validation and status handling ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_format_never_touches_db() -> None:
+    db = AsyncMock()
+    with pytest.raises(CouponRedemptionError) as err:
+        await redeem_coupon(db, 'not-a-token', _user())
+    assert err.value.code == 'invalid'
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_is_invalid() -> None:
+    db = AsyncMock()
+    lookup = AsyncMock(return_value=None)
+    with patch('app.services.coupon_service.get_coupon_by_token', lookup):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+    lookup.assert_awaited_once_with(db, VALID_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_token_is_normalized_before_lookup() -> None:
+    db = AsyncMock()
+    lookup = AsyncMock(return_value=None)
+    with patch('app.services.coupon_service.get_coupon_by_token', lookup):
+        with pytest.raises(CouponRedemptionError):
+            await redeem_coupon(db, f'  {VALID_TOKEN.upper()} ', _user())
+    lookup.assert_awaited_once_with(db, VALID_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_rejection_never_takes_the_row_lock() -> None:
+    """Failed links must not hold FOR UPDATE for the rest of the /start handler."""
+    db = AsyncMock()
+    coupon = _coupon(status=CouponStatus.REVOKED.value)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError):
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    db.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redeemed_by_same_user_is_distinguishable() -> None:
+    coupon = _coupon(status=CouponStatus.REDEEMED.value, redeemed_by=7)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user(7))
+    assert err.value.code == 'already_redeemed_by_you'
+
+
+@pytest.mark.asyncio
+async def test_redeemed_by_other_user_is_uniform_invalid() -> None:
+    coupon = _coupon(status=CouponStatus.REDEEMED.value, redeemed_by=8)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user(7))
+    assert err.value.code == 'invalid'
+
+
+@pytest.mark.asyncio
+async def test_revoked_coupon_is_uniform_invalid() -> None:
+    coupon = _coupon(status=CouponStatus.REVOKED.value)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+
+
+@pytest.mark.asyncio
+async def test_expired_batch_raises_expired() -> None:
+    coupon = _coupon(batch=_batch(is_expired=True))
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'expired'
+    assert coupon.status == CouponStatus.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_missing_tariff_is_internal_error() -> None:
+    coupon = _coupon(batch=_batch(tariff=None))
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'internal'
+    assert coupon.status == CouponStatus.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claim_lost_after_lock_is_rejected() -> None:
+    """The locked re-read must re-check the status — a concurrent redemption may win."""
+    coupon = _coupon()
+    db = AsyncMock()
+
+    async def refresh_reveals_concurrent_redeem(instance, **kwargs):
+        instance.status = CouponStatus.REDEEMED.value
+        instance.redeemed_by = 999
+
+    db.refresh = AsyncMock(side_effect=refresh_reveals_concurrent_redeem)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+    db.commit.assert_not_called()
+
+
+# --- Redemption: happy path and failure atomicity -------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_claims_under_lock_and_flips_before_remnawave_sync() -> None:
+    coupon = _coupon()
+    user = _user()
+    db = AsyncMock()
+    subscription = SimpleNamespace(id=99)
+
+    status_at_sync: list[str] = []
+
+    async def fake_sync(self, db_arg, sub):
+        # create_remnawave_user() commits the session internally, so by this
+        # point the coupon MUST already be claimed — otherwise the grant could
+        # commit while the coupon is still ACTIVE (double-payout window).
+        status_at_sync.append(coupon.status)
+        return SimpleNamespace(uuid='rw-uuid')
+
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=subscription)),
+        patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=fake_sync),
+    ):
+        result = await redeem_coupon(db, VALID_TOKEN, user)
+
+    db.refresh.assert_awaited_once_with(coupon, with_for_update=True)
+    assert status_at_sync == [CouponStatus.REDEEMED.value]
+    assert coupon.redeemed_by == user.id
+    assert coupon.redeemed_at is not None
+    db.commit.assert_awaited_once()
+    db.rollback.assert_not_called()
+    assert result.tariff_name == 'Basic'
+    assert result.period_days == 30
+
+
+@pytest.mark.asyncio
+async def test_failed_remnawave_sync_aborts_redemption() -> None:
+    """create_remnawave_user swallows API errors and returns None WITHOUT
+    committing — the redemption must roll back so the coupon is not burned
+    while the user got no working panel account."""
+    coupon = _coupon()
+    db = AsyncMock()
+
+    async def failing_sync(self, db_arg, sub):
+        return None
+
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=SimpleNamespace(id=99))),
+        patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=failing_sync),
+    ):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+
+    assert err.value.code == 'internal'
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_grant_failure_rolls_back_and_raises_internal() -> None:
+    coupon = _coupon()
+    db = AsyncMock()
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch(
+            'app.services.coupon_service._grant_subscription_days',
+            AsyncMock(side_effect=RuntimeError('boom')),
+        ),
+    ):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'internal'
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_called()
+    assert coupon.status == CouponStatus.ACTIVE.value, 'failed redemption must not consume the coupon'
+
+
+# --- Grant branches (single-tariff mode mirrors gift activation) ----------
+
+
+@pytest.mark.asyncio
+async def test_grant_extends_active_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    existing = SimpleNamespace(end_date=datetime.now(UTC) + timedelta(days=5), tariff_id=3)
+    extend = AsyncMock(return_value='extended')
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
+        patch('app.services.coupon_service.extend_subscription', extend),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+
+    assert result == 'extended'
+    assert extend.await_args.args[2] == 30
+    kwargs = extend.await_args.kwargs
+    assert kwargs['commit'] is False, 'the caller owns the transaction'
+    assert kwargs['tariff_id'] == 3
+
+
+@pytest.mark.asyncio
+async def test_grant_replaces_expired_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    existing = SimpleNamespace(end_date=datetime.now(UTC) - timedelta(days=1), tariff_id=99)
+    replaced = SimpleNamespace(tariff_id=99)
+    replace = AsyncMock(return_value=replaced)
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
+        patch('app.services.coupon_service.replace_subscription', replace),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+
+    kwargs = replace.await_args.kwargs
+    assert kwargs['is_trial'] is False
+    assert kwargs['commit'] is False
+    assert kwargs['duration_days'] == 30
+    assert result.tariff_id == 3, 'replaced subscription must be reassigned to the batch tariff'
+
+
+@pytest.mark.asyncio
+async def test_grant_creates_subscription_when_none_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    create = AsyncMock(return_value='created')
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=None)),
+        patch('app.services.coupon_service.create_paid_subscription', create),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+
+    assert result == 'created'
+    kwargs = create.await_args.kwargs
+    assert kwargs['user_id'] == 9
+    assert kwargs['duration_days'] == 30
+    assert kwargs['tariff_id'] == 3
+    assert kwargs['commit'] is False
+
+
+@pytest.mark.asyncio
+async def test_grant_multi_tariff_looks_up_by_tariff(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: True)
+    lookup = AsyncMock(return_value=None)
+    create = AsyncMock(return_value='created')
+    with (
+        patch('app.database.crud.subscription.get_subscription_by_user_and_tariff', lookup),
+        patch('app.services.coupon_service.create_paid_subscription', create),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+
+    lookup.assert_awaited_once()
+    assert lookup.await_args.args[1:] == (9, 3)
+    assert result == 'created'

--- a/tests/test_coupon_deeplink_pins.py
+++ b/tests/test_coupon_deeplink_pins.py
@@ -1,0 +1,118 @@
+"""Source-level pins for the coupon deep-link wiring.
+
+The /start flow is huge and heavily branched, and the coupon feature relies on
+a few ordering invariants that are easy to break silently during refactors:
+
+- the coupon branch must swallow ``start_parameter`` ONLY for exact-format
+  tokens that exist in the DB (a campaign start_parameter may legitimately
+  begin with ``coupon_``, even ``coupon_<32 hex>``);
+- every gift-activation call site must also redeem pending coupons;
+- in the service, validation runs unlocked, the claim happens under a
+  FOR UPDATE re-read, the REDEEMED flip precedes the Remnawave sync (which
+  commits the session internally), and the sync's None error-return aborts
+  the redemption;
+- in the admin module, the ``*_revoke_confirm_`` handler must be registered
+  before the ``*_revoke_`` one (the shorter prefix matches both), and the
+  create-confirmation callback must be guarded against stale buttons and
+  double taps.
+"""
+
+import inspect
+
+import app.handlers.start as start_module
+from app.handlers.admin import coupons as admin_coupons
+from app.services import coupon_service
+from app.states import AdminStates
+
+
+START_SOURCE = inspect.getsource(start_module)
+
+
+def test_cmd_start_parses_coupon_deep_link() -> None:
+    assert 'startswith(COUPON_DEEP_LINK_PREFIX)' in START_SOURCE
+    assert 'pending_coupon_token=coupon_token' in START_SOURCE
+
+
+def test_coupon_redeem_called_at_every_gift_activation_site() -> None:
+    gift_calls = START_SOURCE.count('await _activate_pending_gift_after_registration(')
+    coupon_calls = START_SOURCE.count('await _redeem_pending_coupon(')
+    assert gift_calls == 3, 'gift activation call sites moved — re-check coupon redemption wiring'
+    assert coupon_calls == gift_calls, 'every gift activation site must also redeem pending coupons'
+
+
+def test_coupon_branch_only_swallows_existing_coupons() -> None:
+    """`start_parameter = None` must sit INSIDE the is_coupon_token() guard AND
+    require a DB hit — otherwise a campaign whose start_parameter is
+    'coupon_<32 hex>' silently loses its attribution."""
+    source = inspect.getsource(start_module.cmd_start)
+    branch_start = source.index('startswith(COUPON_DEEP_LINK_PREFIX)')
+    branch_end = source.index('webauth_', branch_start)
+    branch = source[branch_start:branch_end]
+
+    guard_pos = branch.index('if is_coupon_token(')
+    exists_pos = branch.index('get_coupon_by_token(db, coupon_token)')
+    null_pos = branch.index('start_parameter = None')
+    assert guard_pos < exists_pos < null_pos
+
+    guard_indent = len(branch[:guard_pos].split('\n')[-1])
+    null_indent = len(branch[:null_pos].split('\n')[-1])
+    assert null_indent > guard_indent, (
+        'start_parameter must be swallowed only for real coupon tokens, '
+        'otherwise campaigns whose start_parameter begins with "coupon_" break'
+    )
+
+
+def test_redeem_flips_status_before_remnawave_sync() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    flip = source.index('coupon.status = CouponStatus.REDEEMED.value')
+    sync = source.index('create_remnawave_user')
+    commit = source.index('await db.commit()')
+    assert flip < sync < commit, (
+        'create_remnawave_user() commits the session internally: the claim must '
+        'already be part of that transaction, or the coupon can pay out twice'
+    )
+
+
+def test_redeem_claims_under_row_lock_and_rechecks() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    assert 'with_for_update=True' in source
+    assert source.count('_check_redeemable(coupon, user)') == 2, (
+        'validation must run both unlocked (no lock held on rejection paths) '
+        'and again after the FOR UPDATE re-read (concurrent claim may have won)'
+    )
+
+
+def test_redeem_aborts_when_remnawave_sync_returns_none() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    assert 'remnawave_user is None' in source, (
+        'create_remnawave_user swallows errors and returns None without '
+        'committing — ignoring that burns the coupon during any panel outage'
+    )
+
+
+def test_revoke_confirm_registered_before_revoke_prefix() -> None:
+    source = inspect.getsource(admin_coupons.register_handlers)
+    confirm = source.index("'admin_coupon_revoke_confirm_'")
+    revoke = source.index("'admin_coupon_revoke_'")
+    assert confirm < revoke, "startswith('admin_coupon_revoke_') also matches confirmation callbacks"
+
+
+def test_create_confirm_is_guarded_against_stale_buttons_and_double_taps() -> None:
+    source = inspect.getsource(admin_coupons.confirm_coupon_batch_creation)
+    # Stale confirm buttons from old messages must be rejected by FSM state
+    assert 'creating_coupon_batch_expiry.state' in source
+    # The wizard state must be consumed BEFORE the slow batch insert
+    clear = source.index('await state.clear()')
+    create = source.index('await create_coupon_batch(')
+    assert clear < create, 'a double-tap on the confirm button must not create the batch twice'
+
+
+def test_admin_states_for_coupon_creation_exist() -> None:
+    for name in (
+        'creating_coupon_batch_days',
+        'creating_coupon_batch_count',
+        'creating_coupon_batch_name',
+        'creating_coupon_batch_price',
+        'creating_coupon_batch_expiry',
+    ):
+        assert hasattr(AdminStates, name)


### PR DESCRIPTION
## Описание

Механизм оптовой продажи подписок через партнёров (партнёрские боты, каналы, реселлеры): админ пакетом создаёт N одноразовых купонов на выбранный тариф и срок, передаёт файл со ссылками партнёру по договорной цене, партнёр продаёт ссылки своим пользователям.

Closes #3042

Это первый этап из описанных в issue (бот целиком). Второй этап — управление в cabinet + публичная страница активации — сделаю отдельным PR, чтобы этот не разрастался.

## Что добавлено

**Модели и миграция 0095** — `coupon_batches` (тариф, дни, количество, название/партнёр, учётная оптовая цена, срок годности) и `coupons` (токен, статус `active/redeemed/revoked`, кем и когда погашен). Сами деньги ходят вне бота — цена в партии только для учёта.

**Активация** — переход по `https://t.me/<bot>?start=coupon_<token>`:
- подписки нет → создаётся на тариф партии на N дней;
- подписка есть → продлевается на N дней (семантика gift-активации: extend/replace/create, триал конвертируется в платную);
- незарегистрированному купон гасится сразу после регистрации (как pending gift, все три точки завершения регистрации).

**Админ-раздел «🎟 Купоны»** в подменю промо: создание партии мастером (тариф → дни → количество → название → цена → срок → подтверждение), файл `.txt` со ссылками, карточка партии со статистикой погашений, повторный экспорт актуальных ссылок, отзыв непогашенных купонов (например, партнёр не оплатил).

## Безопасность и корректность

- Токен 128 бит (32 hex): ссылка целиком влезает в лимит 64 символа start-параметра, поэтому поиск только exact-match — без префиксных выборок и перебора.
- Валидация купона идёт на незалоченном чтении (отказ по ссылке не держит row lock до конца `/start`), сам клейм — повторное чтение `FOR UPDATE` с ре-проверкой статуса: конкурентное погашение одного токена невозможно.
- Флаг погашения выставляется до Remnawave-синка, а результат синка проверяется: панель недоступна → откат, купон остаётся активным и ссылка рабочей (не сгорает без доставки).
- Единый ответ для несуществующего/чужого/отозванного купона (никакого оракула), «вы уже активировали» — только самому погасившему.
- `start_parameter` глушится только для реально существующих купонов — рекламная кампания со start-параметром вида `coupon_...` продолжает работать.
- Подтверждение создания защищено от дабл-клика и от «живых» кнопок из старых сообщений (проверка FSM-состояния + очистка стейта до вставки).
- После гашения на путях регистрации подписки пользователя перечитываются — без этого сразу после активации купона предлагался триал.

## Тестирование

- 29 новых тестов: формат/уникальность токенов, все статусные ветки и единообразие ошибок, порядок «клейм под локом → синк → коммит», откат при падении синка/выдачи, ветки extend/replace/create и multi-tariff, пины на разбор deep link в `/start`, порядок регистрации хендлеров и гварды подтверждения.
- Полный прогон: 1791 passed (ruff format + ruff check чистые).

## Чек-лист

- [x] Код отформатирован (`ruff format .`)
- [x] Линтер проходит (`ruff check .`)
- [x] Тесты проходят
- [x] Ветка от `dev`, PR в `dev`
