### PR TITLE
feat(coupons): cabinet API — партии, экспорт ссылок, погашение (#3042, этап 2)

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -28,6 +28,7 @@ from app.handlers.admin import (
     bulk_ban as admin_bulk_ban,
     campaigns as admin_campaigns,
     contests as admin_contests,
+    coupons as admin_coupons,
     daily_contests as admin_daily_contests,
     faq as admin_faq,
     main as admin_main,
@@ -199,6 +200,7 @@ async def setup_bot() -> tuple[Bot, Dispatcher]:
     admin_polls.register_handlers(dp)
     admin_promo_groups.register_handlers(dp)
     admin_campaigns.register_handlers(dp)
+    admin_coupons.register_handlers(dp)
     admin_contests.register_handlers(dp)
     admin_daily_contests.register_handlers(dp)
     admin_promo_offers.register_handlers(dp)

--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -13,6 +13,7 @@ from .admin_bulk_actions import router as admin_bulk_actions_router
 from .admin_button_styles import router as admin_button_styles_router
 from .admin_campaigns import router as admin_campaigns_router
 from .admin_channels import router as admin_channels_router
+from .admin_coupons import router as admin_coupons_router
 from .admin_email_templates import router as admin_email_templates_router
 from .admin_info_pages import router as admin_info_pages_router
 from .admin_landings import router as admin_landings_router
@@ -48,6 +49,7 @@ from .auth import router as auth_router
 from .balance import router as balance_router
 from .branding import router as branding_router
 from .contests import router as contests_router
+from .coupon import router as coupon_router
 from .gift import router as gift_router
 from .info import router as info_router
 from .info_pages import router as info_pages_router
@@ -102,6 +104,7 @@ router.include_router(withdrawal_router)
 router.include_router(ticket_notifications_router)
 router.include_router(tickets_router)
 router.include_router(promocode_router)
+router.include_router(coupon_router)
 router.include_router(contests_router)
 router.include_router(polls_router)
 router.include_router(promo_router)
@@ -133,6 +136,7 @@ router.include_router(admin_ban_system_router)
 router.include_router(admin_broadcasts_router)
 router.include_router(admin_promocodes_router)
 router.include_router(admin_promo_groups_router)
+router.include_router(admin_coupons_router)
 router.include_router(admin_campaigns_router)
 router.include_router(admin_partners_router)
 router.include_router(admin_withdrawals_router)

--- a/app/cabinet/routes/admin_coupons.py
+++ b/app/cabinet/routes/admin_coupons.py
@@ -1,0 +1,182 @@
+"""Admin cabinet API for wholesale coupon batches (RBAC: coupons:*)."""
+
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.coupon import (
+    create_coupon_batch,
+    get_batch_coupon_tokens,
+    get_batch_status_counts,
+    get_coupon_batch_by_id,
+    get_coupon_batches,
+    get_coupon_batches_count,
+    get_status_counts_for_batches,
+    revoke_batch_coupons,
+)
+from app.database.crud.tariff import get_tariff_by_id
+from app.database.models import CouponBatch, CouponStatus, User
+from app.services.coupon_service import COUPON_DEEP_LINK_PREFIX
+
+from ..dependencies import get_cabinet_db, require_permission
+from ..schemas.coupons import (
+    CouponBatchCreatedResponse,
+    CouponBatchCreateRequest,
+    CouponBatchLinksResponse,
+    CouponBatchListResponse,
+    CouponBatchResponse,
+    CouponBatchRevokeResponse,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/admin/coupons', tags=['Admin Coupons'])
+
+
+def _build_links(tokens: list[str]) -> list[str]:
+    """Deep links for the tokens; empty when the bot username is not synced yet."""
+    bot_username = settings.get_bot_username()
+    if not bot_username:
+        return []
+    return [f'https://t.me/{bot_username}?start={COUPON_DEEP_LINK_PREFIX}{token}' for token in tokens]
+
+
+def _serialize_batch(batch: CouponBatch, counts: dict[str, int]) -> CouponBatchResponse:
+    return CouponBatchResponse(
+        id=batch.id,
+        name=batch.name,
+        tariff_id=batch.tariff_id,
+        tariff_name=batch.tariff.name if batch.tariff else None,
+        period_days=batch.period_days,
+        coupons_total=batch.coupons_total,
+        wholesale_price_kopeks=batch.wholesale_price_kopeks,
+        valid_until=batch.valid_until,
+        is_revoked=batch.is_revoked,
+        created_at=batch.created_at,
+        active_count=counts.get(CouponStatus.ACTIVE.value, 0),
+        redeemed_count=counts.get(CouponStatus.REDEEMED.value, 0),
+        revoked_count=counts.get(CouponStatus.REVOKED.value, 0),
+    )
+
+
+async def _get_batch_or_404(db: AsyncSession, batch_id: int) -> CouponBatch:
+    batch = await get_coupon_batch_by_id(db, batch_id)
+    if batch is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, 'Coupon batch not found')
+    return batch
+
+
+@router.get('', response_model=CouponBatchListResponse)
+async def list_coupon_batches(
+    admin: User = Depends(require_permission('coupons:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> CouponBatchListResponse:
+    """List coupon batches with redemption stats."""
+    total = await get_coupon_batches_count(db) or 0
+    batches = await get_coupon_batches(db, offset=offset, limit=limit)
+    counts_by_batch = await get_status_counts_for_batches(db, [batch.id for batch in batches])
+
+    return CouponBatchListResponse(
+        items=[_serialize_batch(batch, counts_by_batch.get(batch.id, {})) for batch in batches],
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post('', response_model=CouponBatchCreatedResponse, status_code=status.HTTP_201_CREATED)
+async def create_coupon_batch_endpoint(
+    payload: CouponBatchCreateRequest,
+    admin: User = Depends(require_permission('coupons:create')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponBatchCreatedResponse:
+    """Create a batch of one-time coupons and return the generated links."""
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, 'Batch name must not be blank')
+
+    tariff = await get_tariff_by_id(db, payload.tariff_id)
+    if not tariff or not tariff.is_active:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, 'Tariff not found or inactive')
+
+    valid_until = datetime.now(UTC) + timedelta(days=payload.valid_days) if payload.valid_days else None
+
+    batch = await create_coupon_batch(
+        db,
+        name=name,
+        tariff_id=tariff.id,
+        period_days=payload.period_days,
+        coupons_count=payload.coupons_count,
+        wholesale_price_kopeks=payload.wholesale_price_kopeks,
+        valid_until=valid_until,
+        created_by=admin.id,
+    )
+
+    logger.info(
+        'Создана партия купонов (cabinet)',
+        batch_id=batch.id,
+        tariff_id=tariff.id,
+        count=payload.coupons_count,
+        created_by=admin.id,
+    )
+
+    tokens = await get_batch_coupon_tokens(db, batch.id, status=CouponStatus.ACTIVE.value)
+    counts = await get_batch_status_counts(db, batch.id)
+    base = _serialize_batch(batch, counts)
+    return CouponBatchCreatedResponse(**base.model_dump(), links=_build_links(tokens), tokens=tokens)
+
+
+@router.get('/{batch_id}', response_model=CouponBatchResponse)
+async def get_coupon_batch(
+    batch_id: int,
+    admin: User = Depends(require_permission('coupons:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponBatchResponse:
+    """Batch card with redemption stats."""
+    batch = await _get_batch_or_404(db, batch_id)
+    counts = await get_batch_status_counts(db, batch.id)
+    return _serialize_batch(batch, counts)
+
+
+@router.get('/{batch_id}/links', response_model=CouponBatchLinksResponse)
+async def export_coupon_batch_links(
+    batch_id: int,
+    admin: User = Depends(require_permission('coupons:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponBatchLinksResponse:
+    """Still-active coupon links of the batch (for handing to the partner)."""
+    batch = await _get_batch_or_404(db, batch_id)
+    tokens = await get_batch_coupon_tokens(db, batch.id, status=CouponStatus.ACTIVE.value)
+    return CouponBatchLinksResponse(
+        batch_id=batch.id,
+        count=len(tokens),
+        links=_build_links(tokens),
+        tokens=tokens,
+    )
+
+
+@router.post('/{batch_id}/revoke', response_model=CouponBatchRevokeResponse)
+async def revoke_coupon_batch(
+    batch_id: int,
+    admin: User = Depends(require_permission('coupons:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponBatchRevokeResponse:
+    """Revoke all still-active coupons of the batch (e.g. the partner did not pay)."""
+    batch = await _get_batch_or_404(db, batch_id)
+    revoked_count = await revoke_batch_coupons(db, batch)
+
+    logger.info(
+        'Партия купонов отозвана (cabinet)',
+        batch_id=batch.id,
+        revoked_count=revoked_count,
+        admin_id=admin.id,
+    )
+
+    counts = await get_batch_status_counts(db, batch.id)
+    return CouponBatchRevokeResponse(revoked_count=revoked_count, batch=_serialize_batch(batch, counts))

--- a/app/cabinet/routes/coupon.py
+++ b/app/cabinet/routes/coupon.py
@@ -1,0 +1,121 @@
+"""Cabinet coupon redemption: authorized redeem + public status by token.
+
+Coupons are one-time wholesale links (see app/services/coupon_service.py).
+Telegram users normally redeem them via the bot deep link; this route is the
+redemption path for email-auth cabinet users and the data source for the
+public "you've got a coupon" page.
+"""
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cabinet.ip_utils import get_client_ip
+from app.config import settings
+from app.database.crud.coupon import get_coupon_by_token
+from app.database.models import CouponStatus, User
+from app.services.coupon_service import (
+    COUPON_DEEP_LINK_PREFIX,
+    CouponRedemptionError,
+    is_coupon_token,
+    redeem_coupon,
+)
+from app.services.notification_delivery_service import NotificationType, notification_delivery_service
+from app.utils.cache import RateLimitCache
+
+from ..dependencies import get_cabinet_db, get_current_cabinet_user
+from ..schemas.coupons import CouponRedeemRequest, CouponRedeemResponse, CouponStatusResponse
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/coupon', tags=['Cabinet Coupon'])
+
+# Stable machine codes → English messages; the frontend maps codes to localized
+# strings (same contract as promocode activation).
+_ERROR_MESSAGES = {
+    'invalid': 'Coupon not found or already used',
+    'expired': 'Coupon has expired',
+    'already_redeemed_by_you': 'You have already redeemed this coupon',
+    'internal': 'Server error occurred',
+}
+
+
+@router.post('/redeem', response_model=CouponRedeemResponse)
+async def redeem_coupon_endpoint(
+    request: CouponRedeemRequest,
+    user: User = Depends(get_current_cabinet_user),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponRedeemResponse:
+    """Redeem a one-time coupon for the current cabinet user."""
+    try:
+        result = await redeem_coupon(db, request.token, user)
+    except CouponRedemptionError as error:
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR if error.code == 'internal' else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(
+            status_code=status_code,
+            detail={'code': error.code, 'message': _ERROR_MESSAGES.get(error.code, _ERROR_MESSAGES['invalid'])},
+        ) from None
+
+    # Email-only users get the email + cabinet-WS notification; telegram users
+    # are notified by the bot flows (mirrors subscription_modules/purchase.py)
+    if not user.telegram_id and user.email and user.email_verified:
+        try:
+            notification_type = (
+                NotificationType.SUBSCRIPTION_RENEWED if result.renewed else NotificationType.SUBSCRIPTION_ACTIVATED
+            )
+            end_date_str = result.end_date.strftime('%d.%m.%Y') if result.end_date else ''
+            await notification_delivery_service.send_notification(
+                user=user,
+                notification_type=notification_type,
+                context={
+                    'expires_at': end_date_str,  # for SUBSCRIPTION_ACTIVATED
+                    'new_expires_at': end_date_str,  # for SUBSCRIPTION_RENEWED
+                    'traffic_limit_gb': result.traffic_limit_gb,
+                    'device_limit': result.device_limit,
+                    'tariff_name': result.tariff_name,
+                },
+                bot=None,
+            )
+        except Exception as notif_error:
+            logger.warning('Failed to send coupon redemption notification', email=user.email, notif_error=notif_error)
+
+    return CouponRedeemResponse(
+        success=True,
+        tariff_name=result.tariff_name,
+        period_days=result.period_days,
+        renewed=result.renewed,
+        end_date=result.end_date,
+    )
+
+
+@router.get('/{token}/status', response_model=CouponStatusResponse)
+async def coupon_status(
+    token: str,
+    raw_request: Request,
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> CouponStatusResponse:
+    """Public info about a still-redeemable coupon (no authentication).
+
+    The token itself is the secret. Missing, redeemed, revoked and expired
+    coupons all answer the same 404 — the endpoint is not an oracle.
+    """
+    client_ip = get_client_ip(raw_request)
+    if await RateLimitCache.is_ip_rate_limited(client_ip, 'coupon_status', limit=30, window=60, fail_closed=True):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail='Too many requests')
+
+    normalized = token.strip().lower()
+    if not is_coupon_token(normalized):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Coupon not found')
+
+    coupon = await get_coupon_by_token(db, normalized)
+    if coupon is None or coupon.status != CouponStatus.ACTIVE.value or coupon.batch is None or coupon.batch.is_expired:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Coupon not found')
+
+    bot_username = settings.get_bot_username()
+    return CouponStatusResponse(
+        tariff_name=coupon.batch.tariff.name if coupon.batch.tariff else '',
+        period_days=coupon.batch.period_days,
+        valid_until=coupon.batch.valid_until,
+        bot_link=(f'https://t.me/{bot_username}?start={COUPON_DEEP_LINK_PREFIX}{normalized}' if bot_username else None),
+    )

--- a/app/cabinet/schemas/coupons.py
+++ b/app/cabinet/schemas/coupons.py
@@ -1,0 +1,83 @@
+"""Schemas for wholesale coupon batches management in cabinet."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CouponBatchResponse(BaseModel):
+    """Coupon batch with redemption stats."""
+
+    id: int
+    name: str
+    tariff_id: int | None
+    tariff_name: str | None
+    period_days: int
+    coupons_total: int
+    wholesale_price_kopeks: int
+    valid_until: datetime | None
+    is_revoked: bool
+    created_at: datetime
+    active_count: int = 0
+    redeemed_count: int = 0
+    revoked_count: int = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CouponBatchListResponse(BaseModel):
+    items: list[CouponBatchResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class CouponBatchCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255, description='Batch label, e.g. the partner name')
+    tariff_id: int = Field(..., ge=1)
+    period_days: int = Field(..., ge=1, le=3650)
+    coupons_count: int = Field(..., ge=1, le=500)
+    wholesale_price_kopeks: int = Field(0, ge=0, description='Bookkeeping-only price per coupon')
+    valid_days: int = Field(0, ge=0, le=3650, description='Coupon lifetime in days; 0 — perpetual')
+
+
+class CouponBatchCreatedResponse(CouponBatchResponse):
+    """Creation response: batch card plus the generated one-time links."""
+
+    links: list[str] = Field(default_factory=list)
+    tokens: list[str] = Field(default_factory=list)
+
+
+class CouponBatchLinksResponse(BaseModel):
+    """Export of still-active coupon links of a batch."""
+
+    batch_id: int
+    count: int
+    links: list[str] = Field(default_factory=list)
+    tokens: list[str] = Field(default_factory=list)
+
+
+class CouponBatchRevokeResponse(BaseModel):
+    revoked_count: int
+    batch: CouponBatchResponse
+
+
+class CouponRedeemRequest(BaseModel):
+    token: str = Field(..., min_length=1, max_length=64, description='Coupon token from the one-time link')
+
+
+class CouponRedeemResponse(BaseModel):
+    success: bool = True
+    tariff_name: str
+    period_days: int
+    renewed: bool
+    end_date: datetime | None
+
+
+class CouponStatusResponse(BaseModel):
+    """Public info about a still-redeemable coupon."""
+
+    tariff_name: str
+    period_days: int
+    valid_until: datetime | None
+    bot_link: str | None

--- a/app/database/crud/coupon.py
+++ b/app/database/crud/coupon.py
@@ -80,6 +80,21 @@ async def get_batch_status_counts(db: AsyncSession, batch_id: int) -> dict[str, 
     return dict(result.all())
 
 
+async def get_status_counts_for_batches(db: AsyncSession, batch_ids: list[int]) -> dict[int, dict[str, int]]:
+    """Status counts for many batches in one query (list views)."""
+    if not batch_ids:
+        return {}
+    result = await db.execute(
+        select(Coupon.batch_id, Coupon.status, func.count(Coupon.id))
+        .where(Coupon.batch_id.in_(batch_ids))
+        .group_by(Coupon.batch_id, Coupon.status)
+    )
+    counts: dict[int, dict[str, int]] = {}
+    for batch_id, coupon_status, count in result.all():
+        counts.setdefault(batch_id, {})[coupon_status] = count
+    return counts
+
+
 async def revoke_batch_coupons(db: AsyncSession, batch: CouponBatch) -> int:
     """Flip all still-active coupons of the batch to REVOKED. Returns how many were revoked.
 

--- a/app/database/crud/coupon.py
+++ b/app/database/crud/coupon.py
@@ -1,0 +1,97 @@
+"""CRUD helpers for wholesale coupon batches and their one-time coupons."""
+
+import secrets
+from datetime import datetime
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import Coupon, CouponBatch, CouponStatus
+
+
+def generate_coupon_token() -> str:
+    """128-bit hex token: ``coupon_`` + 32 chars fits Telegram's 64-char start param."""
+    return secrets.token_hex(16)
+
+
+async def create_coupon_batch(
+    db: AsyncSession,
+    *,
+    name: str,
+    tariff_id: int,
+    period_days: int,
+    coupons_count: int,
+    wholesale_price_kopeks: int = 0,
+    valid_until: datetime | None = None,
+    created_by: int | None = None,
+) -> CouponBatch:
+    batch = CouponBatch(
+        name=name,
+        tariff_id=tariff_id,
+        period_days=period_days,
+        coupons_total=coupons_count,
+        wholesale_price_kopeks=wholesale_price_kopeks,
+        valid_until=valid_until,
+        created_by=created_by,
+    )
+    db.add(batch)
+    await db.flush()
+
+    coupons = [Coupon(batch_id=batch.id, token=generate_coupon_token()) for _ in range(coupons_count)]
+    db.add_all(coupons)
+    await db.commit()
+    await db.refresh(batch)
+    return batch
+
+
+async def get_coupon_batch_by_id(db: AsyncSession, batch_id: int) -> CouponBatch | None:
+    result = await db.execute(select(CouponBatch).where(CouponBatch.id == batch_id))
+    return result.scalar_one_or_none()
+
+
+async def get_coupon_batches(db: AsyncSession, *, offset: int = 0, limit: int = 10) -> list[CouponBatch]:
+    result = await db.execute(select(CouponBatch).order_by(CouponBatch.id.desc()).offset(offset).limit(limit))
+    return list(result.scalars().all())
+
+
+async def get_coupon_batches_count(db: AsyncSession) -> int:
+    result = await db.execute(select(func.count(CouponBatch.id)))
+    return result.scalar() or 0
+
+
+async def get_coupon_by_token(db: AsyncSession, token: str) -> Coupon | None:
+    result = await db.execute(select(Coupon).where(Coupon.token == token))
+    return result.scalars().first()
+
+
+async def get_batch_coupon_tokens(db: AsyncSession, batch_id: int, *, status: str | None = None) -> list[str]:
+    """Plain token strings (no entity hydration) — enough for the links export."""
+    query = select(Coupon.token).where(Coupon.batch_id == batch_id)
+    if status is not None:
+        query = query.where(Coupon.status == status)
+    result = await db.execute(query.order_by(Coupon.id))
+    return list(result.scalars().all())
+
+
+async def get_batch_status_counts(db: AsyncSession, batch_id: int) -> dict[str, int]:
+    result = await db.execute(
+        select(Coupon.status, func.count(Coupon.id)).where(Coupon.batch_id == batch_id).group_by(Coupon.status)
+    )
+    return dict(result.all())
+
+
+async def revoke_batch_coupons(db: AsyncSession, batch: CouponBatch) -> int:
+    """Flip all still-active coupons of the batch to REVOKED. Returns how many were revoked.
+
+    Safe against a concurrent redemption: the redeem path holds the coupon row
+    FOR UPDATE and re-checks the status, so whichever transaction commits first
+    wins and the other sees the new status.
+    """
+    result = await db.execute(
+        update(Coupon)
+        .where(Coupon.batch_id == batch.id, Coupon.status == CouponStatus.ACTIVE.value)
+        .values(status=CouponStatus.REVOKED.value)
+    )
+    batch.is_revoked = True
+    await db.commit()
+    return result.rowcount or 0

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2477,6 +2477,69 @@ class PromoCodeUse(Base):
     user = relationship('User')
 
 
+class CouponStatus(StrEnum):
+    ACTIVE = 'active'
+    REDEEMED = 'redeemed'
+    REVOKED = 'revoked'
+
+
+class CouponBatch(Base):
+    """Batch of one-time coupons for wholesale/partner sales.
+
+    The admin generates N coupons for a tariff+period, hands the links to a
+    partner and settles payment outside the bot; ``wholesale_price_kopeks``
+    is bookkeeping only.
+    """
+
+    __tablename__ = 'coupon_batches'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    tariff_id = Column(Integer, ForeignKey('tariffs.id', ondelete='SET NULL'), nullable=True, index=True)
+    period_days = Column(Integer, nullable=False)
+    coupons_total = Column(Integer, nullable=False)
+    wholesale_price_kopeks = Column(Integer, nullable=False, default=0)  # за купон; 0 — не указана
+    valid_until = Column(AwareDateTime(), nullable=True)
+    # Display-only cache for list views; per-coupon Coupon.status is the
+    # authority (redemption never consults this flag)
+    is_revoked = Column(Boolean, nullable=False, default=False)
+    created_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+    updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now())
+
+    coupons = relationship('Coupon', back_populates='batch', lazy='noload')
+    tariff = relationship('Tariff', lazy='selectin')
+
+    @property
+    def is_expired(self) -> bool:
+        return self.valid_until is not None and _aware(self.valid_until) < datetime.now(UTC)
+
+    def __repr__(self) -> str:
+        return f"<CouponBatch id={self.id} name='{self.name}'>"
+
+
+class Coupon(Base):
+    """One-time coupon redeemed via the ``/start coupon_<token>`` deep link."""
+
+    __tablename__ = 'coupons'
+    __table_args__ = (Index('ix_coupons_batch_status', 'batch_id', 'status'),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    batch_id = Column(Integer, ForeignKey('coupon_batches.id', ondelete='CASCADE'), nullable=False)
+    token = Column(String(64), unique=True, nullable=False, index=True)
+    status = Column(String(20), nullable=False, default=CouponStatus.ACTIVE.value)
+    redeemed_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)
+    redeemed_at = Column(AwareDateTime(), nullable=True)
+    created_at = Column(AwareDateTime(), server_default=func.now())
+
+    batch = relationship('CouponBatch', back_populates='coupons', lazy='selectin')
+    user = relationship('User', foreign_keys=[redeemed_by], lazy='noload')
+
+    def __repr__(self) -> str:
+        token_prefix = self.token[:5] if self.token else '?'
+        return f"<Coupon token='{token_prefix}...' status='{self.status}'>"
+
+
 class ReferralEarning(Base):
     __tablename__ = 'referral_earnings'
 

--- a/app/handlers/admin/__init__.py
+++ b/app/handlers/admin/__init__.py
@@ -7,6 +7,7 @@ from . import (
     bulk_ban,
     campaigns,
     contests,
+    coupons,
     daily_contests,
     faq,
     main,

--- a/app/handlers/admin/coupons.py
+++ b/app/handlers/admin/coupons.py
@@ -1,0 +1,512 @@
+import html
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from aiogram import Dispatcher, F, types
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.coupon import (
+    create_coupon_batch,
+    get_batch_coupon_tokens,
+    get_batch_status_counts,
+    get_coupon_batch_by_id,
+    get_coupon_batches,
+    get_coupon_batches_count,
+    revoke_batch_coupons,
+)
+from app.database.crud.tariff import get_all_active_tariffs, get_tariff_by_id
+from app.database.models import CouponBatch, CouponStatus, User
+from app.keyboards.admin import get_admin_pagination_keyboard
+from app.services.coupon_service import COUPON_DEEP_LINK_PREFIX
+from app.states import AdminStates
+from app.utils.decorators import admin_required, error_handler
+from app.utils.formatters import format_datetime
+
+
+logger = structlog.get_logger(__name__)
+
+MAX_COUPONS_PER_BATCH = 500
+MAX_PERIOD_DAYS = 3650
+MAX_WHOLESALE_PRICE_RUBLES = 10_000_000
+
+_CANCEL_KEYBOARD = types.InlineKeyboardMarkup(
+    inline_keyboard=[[types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')]]
+)
+
+
+def _build_coupon_link(bot_username: str, token: str) -> str:
+    return f'https://t.me/{bot_username}?start={COUPON_DEEP_LINK_PREFIX}{token}'
+
+
+def _format_batch_button(batch: CouponBatch) -> str:
+    revoked_mark = '⛔ ' if batch.is_revoked else ''
+    return f'{revoked_mark}#{batch.id} {batch.name} • {batch.period_days} дн. • {batch.coupons_total} шт.'
+
+
+def _format_batch_card(batch: CouponBatch, counts: dict[str, int]) -> str:
+    active = counts.get(CouponStatus.ACTIVE.value, 0)
+    redeemed = counts.get(CouponStatus.REDEEMED.value, 0)
+    revoked = counts.get(CouponStatus.REVOKED.value, 0)
+    tariff_name = html.escape(batch.tariff.name) if batch.tariff else '—'
+
+    text = (
+        f'🎟 <b>Партия купонов #{batch.id}</b>\n\n'
+        f'📌 Название: {html.escape(batch.name)}\n'
+        f'📦 Тариф: {tariff_name} — {batch.period_days} дн.\n'
+        f'🎫 Купонов: {batch.coupons_total}\n'
+    )
+
+    if batch.wholesale_price_kopeks > 0:
+        total_kopeks = batch.wholesale_price_kopeks * batch.coupons_total
+        text += (
+            f'💰 Опт: {settings.format_price(batch.wholesale_price_kopeks)}/шт '
+            f'(итого {settings.format_price(total_kopeks)})\n'
+        )
+
+    text += f'\n📊 <b>Статусы:</b>\n✅ Активных: {active}\n🎫 Погашено: {redeemed}\n⛔ Отозвано: {revoked}\n\n'
+
+    if batch.valid_until:
+        text += f'⏰ Действует до: {format_datetime(batch.valid_until)}\n'
+    else:
+        text += '⏰ Действует: бессрочно\n'
+
+    text += f'📅 Создана: {format_datetime(batch.created_at)}\n'
+
+    if batch.is_revoked:
+        text += '\n⛔ <b>Партия отозвана</b>\n'
+
+    return text
+
+
+def _batch_card_keyboard(batch: CouponBatch, counts: dict[str, int]) -> types.InlineKeyboardMarkup:
+    keyboard = []
+    if counts.get(CouponStatus.ACTIVE.value, 0) > 0:
+        keyboard.append(
+            [types.InlineKeyboardButton(text='📄 Файл со ссылками', callback_data=f'admin_coupon_export_{batch.id}')]
+        )
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text='⛔ Отозвать непогашенные', callback_data=f'admin_coupon_revoke_{batch.id}'
+                )
+            ]
+        )
+    keyboard.append([types.InlineKeyboardButton(text='⬅️ Назад', callback_data='admin_coupons')])
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+async def _load_batch(callback: types.CallbackQuery, db: AsyncSession) -> CouponBatch | None:
+    """Parse the batch id from callback data and fetch the batch, alerting on errors."""
+    try:
+        batch_id = int(callback.data.split('_')[-1])
+    except ValueError:
+        await callback.answer('❌ Ошибка получения ID партии', show_alert=True)
+        return None
+
+    batch = await get_coupon_batch_by_id(db, batch_id)
+    if not batch:
+        await callback.answer('❌ Партия не найдена', show_alert=True)
+        return None
+    return batch
+
+
+async def _show_batch_card(callback: types.CallbackQuery, db: AsyncSession, batch: CouponBatch) -> None:
+    counts = await get_batch_status_counts(db, batch.id)
+    await callback.message.edit_text(
+        _format_batch_card(batch, counts), reply_markup=_batch_card_keyboard(batch, counts)
+    )
+
+
+async def _read_int(message: types.Message, lo: int, hi: int, error_text: str) -> int | None:
+    """Parse an int in [lo, hi] from the message; reply with ``error_text`` and return None otherwise."""
+    try:
+        value = int((message.text or '').strip())
+    except ValueError:
+        value = None
+    if value is None or not lo <= value <= hi:
+        await message.answer(error_text, reply_markup=_CANCEL_KEYBOARD)
+        return None
+    return value
+
+
+async def _render_coupons_menu(
+    db: AsyncSession, language: str, page: int = 1
+) -> tuple[str, types.InlineKeyboardMarkup]:
+    limit = 10
+    offset = (page - 1) * limit
+
+    batches = await get_coupon_batches(db, offset=offset, limit=limit)
+    total_count = await get_coupon_batches_count(db)
+    total_pages = max(1, (total_count + limit - 1) // limit)
+
+    text = (
+        f'🎟 <b>Купоны</b>\n\n'
+        f'Оптовая продажа подписок через партнёров: партия одноразовых ссылок '
+        f'на тариф, каждая выдаёт или продлевает подписку на N дней.\n\n'
+        f'📊 Партий: {total_count}'
+    )
+    if total_pages > 1:
+        text += f' (стр. {page}/{total_pages})'
+
+    keyboard = [
+        [types.InlineKeyboardButton(text=_format_batch_button(batch), callback_data=f'admin_coupon_manage_{batch.id}')]
+        for batch in batches
+    ]
+
+    if total_pages > 1:
+        pagination_row = get_admin_pagination_keyboard(
+            page, total_pages, 'admin_coupon_list', 'admin_coupons', language
+        ).inline_keyboard[0]
+        keyboard.append(pagination_row)
+
+    keyboard.extend(
+        [
+            [types.InlineKeyboardButton(text='➕ Создать партию', callback_data='admin_coupon_create')],
+            [types.InlineKeyboardButton(text='⬅️ Назад', callback_data='admin_submenu_promo')],
+        ]
+    )
+
+    return text, types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+@admin_required
+@error_handler
+async def show_coupons_menu(callback: types.CallbackQuery, db_user: User, db: AsyncSession, state: FSMContext):
+    await state.clear()
+    text, keyboard = await _render_coupons_menu(db, db_user.language)
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def handle_coupon_list_page(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    try:
+        page = int(callback.data.split('_')[-1])
+    except ValueError:
+        page = 1
+    text, keyboard = await _render_coupons_menu(db, db_user.language, page=page)
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def start_coupon_batch_creation(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    tariffs = await get_all_active_tariffs(db)
+    if not tariffs:
+        await callback.answer('❌ Нет активных тарифов. Сначала создайте тариф.', show_alert=True)
+        return
+
+    keyboard = [
+        [types.InlineKeyboardButton(text=tariff.name, callback_data=f'coupon_batch_tariff_{tariff.id}')]
+        for tariff in tariffs
+    ]
+    keyboard.append([types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')])
+
+    await callback.message.edit_text(
+        '🎟 <b>Создание партии купонов</b>\n\nВыберите тариф, который будут выдавать купоны:',
+        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def select_coupon_batch_tariff(callback: types.CallbackQuery, db_user: User, state: FSMContext, db: AsyncSession):
+    try:
+        tariff_id = int(callback.data.split('_')[-1])
+    except ValueError:
+        await callback.answer('❌ Ошибка получения ID тарифа', show_alert=True)
+        return
+
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff or not tariff.is_active:
+        await callback.answer('❌ Тариф не найден или неактивен', show_alert=True)
+        return
+
+    await state.update_data(coupon_tariff_id=tariff.id, coupon_tariff_name=tariff.name)
+
+    await callback.message.edit_text(
+        f'🎟 <b>Создание партии купонов</b>\n\n'
+        f'Тариф: {html.escape(tariff.name)}\n\n'
+        f'📅 Введите количество дней подписки на купон (1-{MAX_PERIOD_DAYS}):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_days)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_days(message: types.Message, db_user: User, state: FSMContext):
+    days = await _read_int(message, 1, MAX_PERIOD_DAYS, f'❌ Введите целое число дней от 1 до {MAX_PERIOD_DAYS}')
+    if days is None:
+        return
+
+    await state.update_data(coupon_period_days=days)
+    await message.answer(
+        f'🎫 Введите количество купонов в партии (1-{MAX_COUPONS_PER_BATCH}):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_count)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_count(message: types.Message, db_user: User, state: FSMContext):
+    count = await _read_int(
+        message, 1, MAX_COUPONS_PER_BATCH, f'❌ Введите целое число купонов от 1 до {MAX_COUPONS_PER_BATCH}'
+    )
+    if count is None:
+        return
+
+    await state.update_data(coupon_count=count)
+    await message.answer(
+        '📌 Введите название партии (например, имя партнёра):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_name)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_name(message: types.Message, db_user: User, state: FSMContext):
+    name = (message.text or '').strip()
+    if not name or len(name) > 255:
+        await message.answer('❌ Название должно быть от 1 до 255 символов', reply_markup=_CANCEL_KEYBOARD)
+        return
+
+    await state.update_data(coupon_batch_name=name)
+    await message.answer(
+        '💰 Введите оптовую цену за купон в рублях — только для учёта (0 — не указывать):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_price)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_price(message: types.Message, db_user: User, state: FSMContext):
+    try:
+        rubles = float((message.text or '').strip().replace(',', '.').replace(' ', ''))
+    except ValueError:
+        await message.answer('❌ Введите цену числом (например, 150 или 99.50)', reply_markup=_CANCEL_KEYBOARD)
+        return
+    # Inverted range check: also rejects NaN (all comparisons with NaN are False)
+    if not 0 <= rubles <= MAX_WHOLESALE_PRICE_RUBLES:
+        await message.answer(
+            f'❌ Цена должна быть от 0 до {MAX_WHOLESALE_PRICE_RUBLES} рублей', reply_markup=_CANCEL_KEYBOARD
+        )
+        return
+
+    await state.update_data(coupon_price_kopeks=int(round(rubles * 100)))
+    await message.answer(
+        '⏰ Введите срок действия купонов в днях (0 — бессрочно):',
+        reply_markup=_CANCEL_KEYBOARD,
+    )
+    await state.set_state(AdminStates.creating_coupon_batch_expiry)
+
+
+@admin_required
+@error_handler
+async def process_coupon_batch_expiry(message: types.Message, db_user: User, state: FSMContext):
+    expiry_days = await _read_int(
+        message, 0, MAX_PERIOD_DAYS, f'❌ Введите число дней от 0 до {MAX_PERIOD_DAYS} (0 — бессрочно)'
+    )
+    if expiry_days is None:
+        return
+
+    await state.update_data(coupon_expiry_days=expiry_days)
+
+    data = await state.get_data()
+    price_kopeks = data.get('coupon_price_kopeks', 0)
+    price_line = f'💰 Опт: {settings.format_price(price_kopeks)}/шт\n' if price_kopeks > 0 else ''
+    expiry_line = f'⏰ Срок: {expiry_days} дн.\n' if expiry_days > 0 else '⏰ Срок: бессрочно\n'
+
+    await message.answer(
+        f'🎟 <b>Подтвердите создание партии</b>\n\n'
+        f'📌 Название: {html.escape(data.get("coupon_batch_name", ""))}\n'
+        f'📦 Тариф: {html.escape(data.get("coupon_tariff_name", ""))} — {data.get("coupon_period_days")} дн.\n'
+        f'🎫 Купонов: {data.get("coupon_count")}\n'
+        f'{price_line}'
+        f'{expiry_line}',
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [types.InlineKeyboardButton(text='✅ Создать', callback_data='admin_coupon_create_confirm')],
+                [types.InlineKeyboardButton(text='❌ Отмена', callback_data='admin_coupons')],
+            ]
+        ),
+    )
+
+
+@admin_required
+@error_handler
+async def confirm_coupon_batch_creation(
+    callback: types.CallbackQuery, db_user: User, state: FSMContext, db: AsyncSession
+):
+    # An old confirmation message keeps a live button: accept it only while the
+    # wizard is actually waiting on this confirmation, otherwise a stale tap
+    # would create a batch from half-entered state of a NEW wizard run.
+    current_state = await state.get_state()
+    if current_state != AdminStates.creating_coupon_batch_expiry.state:
+        await callback.answer('❌ Данные создания устарели, начните заново', show_alert=True)
+        return
+
+    data = await state.get_data()
+    tariff_id = data.get('coupon_tariff_id')
+    period_days = data.get('coupon_period_days')
+    count = data.get('coupon_count')
+    name = data.get('coupon_batch_name')
+    expiry_days = data.get('coupon_expiry_days')
+
+    if not all([tariff_id, period_days, count, name]) or expiry_days is None:
+        await callback.answer('❌ Данные создания устарели, начните заново', show_alert=True)
+        await state.clear()
+        return
+
+    # Consume the wizard state BEFORE the (slow) batch insert — a double-tap on
+    # the confirm button must not create the batch twice.
+    await state.clear()
+
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff or not tariff.is_active:
+        await callback.answer('❌ Тариф не найден или неактивен', show_alert=True)
+        return
+
+    valid_until = datetime.now(UTC) + timedelta(days=expiry_days) if expiry_days else None
+
+    batch = await create_coupon_batch(
+        db,
+        name=name,
+        tariff_id=tariff.id,
+        period_days=period_days,
+        coupons_count=count,
+        wholesale_price_kopeks=data.get('coupon_price_kopeks', 0),
+        valid_until=valid_until,
+        created_by=db_user.id,
+    )
+
+    logger.info(
+        'Создана партия купонов',
+        batch_id=batch.id,
+        tariff_id=tariff.id,
+        period_days=period_days,
+        count=count,
+        created_by=db_user.id,
+    )
+
+    await _show_batch_card(callback, db, batch)
+    await _send_batch_links_file(callback, db, batch)
+    await callback.answer('✅ Партия создана')
+
+
+@admin_required
+@error_handler
+async def show_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+    await _show_batch_card(callback, db, batch)
+    await callback.answer()
+
+
+async def _send_batch_links_file(callback: types.CallbackQuery, db: AsyncSession, batch: CouponBatch) -> None:
+    """Send a .txt with the deep links of all still-active coupons of the batch."""
+    tokens = await get_batch_coupon_tokens(db, batch.id, status=CouponStatus.ACTIVE.value)
+    if not tokens:
+        await callback.answer('❌ В партии нет активных купонов', show_alert=True)
+        return
+
+    # The username is synced into settings at startup; get_me() is a fallback
+    # to avoid an extra Bot API round trip on every export.
+    bot_username = settings.get_bot_username() or (await callback.bot.get_me()).username
+    content = '\n'.join(_build_coupon_link(bot_username, token) for token in tokens) + '\n'
+    file = types.BufferedInputFile(content.encode('utf-8'), filename=f'coupons_batch_{batch.id}.txt')
+    await callback.message.answer_document(
+        document=file,
+        caption=(
+            f'🎟 Партия #{batch.id} «{html.escape(batch.name)}»: '
+            f'{len(tokens)} активных купонов, {batch.period_days} дн. каждый.'
+        ),
+    )
+
+
+@admin_required
+@error_handler
+async def export_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+    await _send_batch_links_file(callback, db, batch)
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def ask_revoke_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+
+    counts = await get_batch_status_counts(db, batch.id)
+    active = counts.get(CouponStatus.ACTIVE.value, 0)
+
+    await callback.message.edit_text(
+        f'⛔ <b>Отзыв партии #{batch.id}</b>\n\n'
+        f'«{html.escape(batch.name)}»: будет отозвано {active} непогашенных купонов. '
+        f'Их ссылки перестанут работать. Действие необратимо.\n\n'
+        f'Подтвердить?',
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    types.InlineKeyboardButton(
+                        text='⛔ Да, отозвать', callback_data=f'admin_coupon_revoke_confirm_{batch.id}'
+                    )
+                ],
+                [types.InlineKeyboardButton(text='❌ Отмена', callback_data=f'admin_coupon_manage_{batch.id}')],
+            ]
+        ),
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def confirm_revoke_coupon_batch(callback: types.CallbackQuery, db_user: User, db: AsyncSession):
+    batch = await _load_batch(callback, db)
+    if batch is None:
+        return
+
+    revoked_count = await revoke_batch_coupons(db, batch)
+    logger.info(
+        'Партия купонов отозвана',
+        batch_id=batch.id,
+        revoked_count=revoked_count,
+        admin_id=db_user.id,
+    )
+
+    await _show_batch_card(callback, db, batch)
+    await callback.answer(f'⛔ Отозвано купонов: {revoked_count}')
+
+
+def register_handlers(dp: Dispatcher):
+    dp.callback_query.register(show_coupons_menu, F.data == 'admin_coupons')
+    dp.callback_query.register(handle_coupon_list_page, F.data.startswith('admin_coupon_list_page_'))
+    dp.callback_query.register(start_coupon_batch_creation, F.data == 'admin_coupon_create')
+    dp.callback_query.register(confirm_coupon_batch_creation, F.data == 'admin_coupon_create_confirm')
+    dp.callback_query.register(select_coupon_batch_tariff, F.data.startswith('coupon_batch_tariff_'))
+    dp.callback_query.register(show_coupon_batch, F.data.startswith('admin_coupon_manage_'))
+    dp.callback_query.register(export_coupon_batch, F.data.startswith('admin_coupon_export_'))
+    # NB: register the *_revoke_confirm_ handler before the *_revoke_ one —
+    # the shorter prefix also matches confirmation callbacks.
+    dp.callback_query.register(confirm_revoke_coupon_batch, F.data.startswith('admin_coupon_revoke_confirm_'))
+    dp.callback_query.register(ask_revoke_coupon_batch, F.data.startswith('admin_coupon_revoke_'))
+
+    dp.message.register(process_coupon_batch_days, AdminStates.creating_coupon_batch_days)
+    dp.message.register(process_coupon_batch_count, AdminStates.creating_coupon_batch_count)
+    dp.message.register(process_coupon_batch_name, AdminStates.creating_coupon_batch_name)
+    dp.message.register(process_coupon_batch_price, AdminStates.creating_coupon_batch_price)
+    dp.message.register(process_coupon_batch_expiry, AdminStates.creating_coupon_batch_expiry)

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -42,6 +42,12 @@ from app.middlewares.channel_checker import (
 from app.services.admin_notification_service import AdminNotificationService
 from app.services.campaign_service import AdvertisingCampaignService
 from app.services.channel_subscription_service import channel_subscription_service
+from app.services.coupon_service import (
+    COUPON_DEEP_LINK_PREFIX,
+    CouponRedemptionError,
+    is_coupon_token,
+    redeem_coupon,
+)
 from app.services.guest_purchase_service import GIFT_TOKEN_MIN_PREFIX_LENGTH
 from app.services.main_menu_button_service import MainMenuButtonService
 from app.services.phantom_service import claim_phantom, merge_phantom_into_user
@@ -220,6 +226,66 @@ async def _activate_pending_gift_after_registration(
             )
         except Exception:
             pass
+
+
+_COUPON_ERROR_TEXTS = {
+    'invalid': '❌ Купон не найден или уже использован.',
+    'expired': '⌛ Срок действия купона истёк.',
+    'already_redeemed_by_you': 'ℹ️ Вы уже активировали этот купон.',
+    'internal': '❌ Произошла ошибка при активации купона. Попробуйте позже или обратитесь в поддержку.',
+}
+
+
+async def _redeem_pending_coupon(
+    db: AsyncSession,
+    state: FSMContext,
+    user: 'User',
+    answer_func: Callable[..., Any],
+) -> None:
+    """Extract pending_coupon_token from FSM state and redeem it for ``user``.
+
+    Must be called BEFORE state.clear() to preserve the token.
+    """
+    coupon_token: str | None = None
+    try:
+        fresh_state = await state.get_data()
+        coupon_token = fresh_state.get('pending_coupon_token')
+        if not coupon_token:
+            return
+
+        try:
+            result = await redeem_coupon(db, coupon_token, user)
+        except CouponRedemptionError as error:
+            await answer_func(
+                _COUPON_ERROR_TEXTS.get(error.code, _COUPON_ERROR_TEXTS['invalid']),
+                parse_mode=ParseMode.HTML,
+            )
+            return
+    except Exception:
+        logger.exception(
+            'Failed to redeem coupon deep link',
+            token_prefix=(coupon_token or '')[:5],
+        )
+        try:
+            await answer_func(_COUPON_ERROR_TEXTS['internal'], parse_mode=ParseMode.HTML)
+        except Exception:
+            pass
+        return
+
+    # Redemption is committed at this point — a failed confirmation send must
+    # not claim the activation failed (the coupon IS consumed).
+    try:
+        tariff_name = html.escape(result.tariff_name)
+        await answer_func(
+            f'🎟 <b>Купон активирован!</b>\n{tariff_name} — {result.period_days} дн.\n\nВаша подписка обновлена.',
+            parse_mode=ParseMode.HTML,
+        )
+    except Exception:
+        logger.exception(
+            'Coupon redeemed but the confirmation message failed to send',
+            token_prefix=(coupon_token or '')[:5],
+            user_id=user.id,
+        )
 
 
 async def _claim_phantom_user(
@@ -815,6 +881,28 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             await state.update_data(pending_gift_token=gift_token)
             start_parameter = None  # Don't treat as campaign or referral
 
+    # Handle coupon deep links: /start coupon_{token} — one-time wholesale coupons
+    if start_parameter and start_parameter.startswith(COUPON_DEEP_LINK_PREFIX):
+        coupon_token = start_parameter.removeprefix(COUPON_DEEP_LINK_PREFIX).lower()
+        # The payload fits Telegram's 64-char start param untruncated, so the
+        # lookup is exact-match. Swallow the parameter only for coupons that
+        # actually exist — a campaign start_parameter may legitimately begin
+        # with 'coupon_' (even coupon_<32 hex>) and must fall through to the
+        # campaign lookup below.
+        if is_coupon_token(coupon_token):
+            from app.database.crud.coupon import get_coupon_by_token
+
+            if await get_coupon_by_token(db, coupon_token) is not None:
+                logger.info(
+                    'Coupon deep link detected',
+                    token_prefix=coupon_token[:5],
+                    telegram_id=message.from_user.id,
+                )
+                # Redeemed via _redeem_pending_coupon(): immediately below for
+                # registered users, after registration for new ones.
+                await state.update_data(pending_coupon_token=coupon_token)
+                start_parameter = None  # Don't treat as campaign or referral
+
     # Handle web auth deep links: /start webauth_{token}
     if start_parameter and start_parameter.startswith('webauth_'):
         web_auth_token = start_parameter.removeprefix('webauth_')
@@ -1065,12 +1153,12 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
             except Exception as e:
                 logger.error('Ошибка отправки уведомления о рекламной кампании', error=e)
 
-        # Auto-activate pending gift if deep link contained GIFT_
+        # Auto-activate pending gift/coupon if deep link contained GIFT_/coupon_
         if user:
             await _activate_pending_gift_after_registration(db, state, user, message.answer)
-            await state.update_data(pending_gift_token=None)
+            await _redeem_pending_coupon(db, state, user, message.answer)
             await _persist_pending_subid_after_registration(db, state, user)
-            await state.update_data(pending_subid=None)
+            await state.update_data(pending_gift_token=None, pending_coupon_token=None, pending_subid=None)
             # Refresh user to pick up newly created subscriptions
             await db.refresh(user, attribute_names=['subscriptions'])
 
@@ -1930,9 +2018,20 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
         telegram_id=user.telegram_id,
     )
 
-    # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
+    # Auto-activate pending gift/coupon for newly registered user (before state.clear() wipes the tokens)
     await _activate_pending_gift_after_registration(db, state, user, callback.message.answer)
+    await _redeem_pending_coupon(db, state, user, callback.message.answer)
     await _persist_pending_subid_after_registration(db, state, user)
+    # Gift/coupon may have just created a subscription — reload it, otherwise the
+    # stale empty list below offers the trial on top of the granted subscription
+    try:
+        await db.refresh(user, ['subscriptions'])
+    except Exception as refresh_error:
+        logger.error(
+            'Ошибка обновления подписок после активации подарка/купона',
+            telegram_id=user.telegram_id,
+            refresh_error=refresh_error,
+        )
 
     await state.clear()
 
@@ -2278,9 +2377,20 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
         '🗑️ COMPLETE: Redis payload удален после успешной регистрации пользователя', telegram_id=user.telegram_id
     )
 
-    # Auto-activate pending gift for newly registered user (before state.clear() wipes the token)
+    # Auto-activate pending gift/coupon for newly registered user (before state.clear() wipes the tokens)
     await _activate_pending_gift_after_registration(db, state, user, message.answer)
+    await _redeem_pending_coupon(db, state, user, message.answer)
     await _persist_pending_subid_after_registration(db, state, user)
+    # Gift/coupon may have just created a subscription — reload it, otherwise the
+    # stale empty list below offers the trial on top of the granted subscription
+    try:
+        await db.refresh(user, ['subscriptions'])
+    except Exception as refresh_error:
+        logger.error(
+            'Ошибка обновления подписок после активации подарка/купона',
+            telegram_id=user.telegram_id,
+            refresh_error=refresh_error,
+        )
 
     await state.clear()
 

--- a/app/keyboards/admin.py
+++ b/app/keyboards/admin.py
@@ -103,6 +103,12 @@ def get_admin_promo_submenu_keyboard(language: str = 'ru') -> InlineKeyboardMark
             [InlineKeyboardButton(text=texts.ADMIN_CAMPAIGNS, callback_data='admin_campaigns')],
             [
                 InlineKeyboardButton(
+                    text=_t(texts, 'ADMIN_COUPONS', '🎟 Купоны'),
+                    callback_data='admin_coupons',
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text=_t(texts, 'ADMIN_CONTESTS', '🏆 Конкурсы'),
                     callback_data='admin_contests',
                 )

--- a/app/services/coupon_service.py
+++ b/app/services/coupon_service.py
@@ -1,0 +1,213 @@
+"""Wholesale coupons: batch-generated one-time links that grant subscription days.
+
+The admin creates a batch of coupons for a tariff+period and hands the deep
+links (``https://t.me/<bot>?start=coupon_<token>``) to a partner. Redeeming a
+link grants the batch tariff for N days, or extends an existing subscription
+by N days — mirroring gift activation semantics
+(:func:`app.services.guest_purchase_service.activate_purchase`).
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.crud.coupon import get_coupon_by_token
+from app.database.crud.subscription import (
+    create_paid_subscription,
+    extend_subscription,
+    get_subscription_by_user_id,
+    replace_subscription,
+)
+from app.database.models import Coupon, CouponStatus, Subscription, Tariff, User, _aware
+from app.services.subscription_service import SubscriptionService
+
+
+logger = structlog.get_logger(__name__)
+
+COUPON_DEEP_LINK_PREFIX = 'coupon_'
+
+# 32 hex chars = 128 bits: unguessable, and the full deep-link payload
+# (`coupon_` + token = 39 chars) fits Telegram's 64-char start param without
+# truncation, so lookups are always exact-match (no prefix matching at all).
+_COUPON_TOKEN_RE = re.compile(r'[0-9a-f]{32}')
+
+
+def is_coupon_token(value: str) -> bool:
+    """True if ``value`` has the exact coupon-token format (no DB hit)."""
+    return bool(_COUPON_TOKEN_RE.fullmatch(value))
+
+
+class CouponRedemptionError(Exception):
+    """Coupon cannot be redeemed; ``code`` selects the user-facing message.
+
+    Codes: ``invalid`` (unknown / revoked / redeemed by someone else —
+    deliberately uniform so the response is not an oracle), ``expired``,
+    ``already_redeemed_by_you``, ``internal``.
+    """
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(slots=True)
+class CouponRedemptionResult:
+    tariff_name: str
+    period_days: int
+
+
+def _check_redeemable(coupon: Coupon, user: User) -> None:
+    """Raise CouponRedemptionError unless the coupon can be redeemed by ``user``.
+
+    Pure checks only — safe to run both before and after the row lock is taken.
+    """
+    if coupon.status == CouponStatus.REDEEMED.value:
+        if coupon.redeemed_by == user.id:
+            raise CouponRedemptionError('already_redeemed_by_you')
+        raise CouponRedemptionError('invalid')
+    if coupon.status != CouponStatus.ACTIVE.value:
+        # REVOKED (or any future state): same uniform answer as "not found"
+        raise CouponRedemptionError('invalid')
+
+    batch = coupon.batch
+    if batch is None:
+        raise CouponRedemptionError('invalid')
+    if batch.is_expired:
+        raise CouponRedemptionError('expired')
+
+
+async def redeem_coupon(db: AsyncSession, token: str, user: User) -> CouponRedemptionResult:
+    """Atomically redeem a one-time coupon for ``user``.
+
+    All validation runs on an unlocked read, so a rejected link never holds a
+    row lock for the rest of the caller's handler. The claim itself re-reads
+    the row with SELECT ... FOR UPDATE and re-checks it, and the status flip
+    to REDEEMED is set BEFORE the Remnawave sync — which commits the session
+    internally — so claim and grant land in one transaction and a coupon can
+    never pay out twice.
+    """
+    normalized = (token or '').strip().lower()
+    if not is_coupon_token(normalized):
+        raise CouponRedemptionError('invalid')
+
+    coupon = await get_coupon_by_token(db, normalized)
+    if coupon is None:
+        raise CouponRedemptionError('invalid')
+
+    _check_redeemable(coupon, user)
+
+    tariff = coupon.batch.tariff
+    if tariff is None:
+        logger.error('Купон ссылается на отсутствующий тариф', coupon_id=coupon.id, batch_id=coupon.batch_id)
+        raise CouponRedemptionError('internal')
+
+    tariff_name = tariff.name
+    period_days = coupon.batch.period_days
+    batch_id = coupon.batch_id
+    coupon_id = coupon.id
+
+    # Claim under row lock: reload the row FOR UPDATE and re-check — a
+    # concurrent redemption or batch revoke may have won between the two reads.
+    await db.refresh(coupon, with_for_update=True)
+    _check_redeemable(coupon, user)
+
+    try:
+        subscription = await _grant_subscription_days(db, user, tariff, period_days)
+
+        coupon.status = CouponStatus.REDEEMED.value
+        coupon.redeemed_by = user.id
+        coupon.redeemed_at = datetime.now(UTC)
+
+        # create_remnawave_user() commits the session internally on success
+        # (persisting claim+grant atomically) and swallows panel/API errors,
+        # returning None WITHOUT committing — treat that as a failure so the
+        # rollback below keeps the coupon ACTIVE and the link retryable.
+        remnawave_user = await SubscriptionService().create_remnawave_user(db, subscription)
+        if remnawave_user is None:
+            raise RuntimeError('Remnawave sync failed')
+        await db.commit()
+    except Exception:
+        logger.exception('Не удалось погасить купон', coupon_id=coupon_id, user_id=user.id)
+        await db.rollback()
+        raise CouponRedemptionError('internal') from None
+
+    logger.info(
+        'Купон погашен',
+        coupon_id=coupon_id,
+        batch_id=batch_id,
+        user_id=user.id,
+        days=period_days,
+    )
+    return CouponRedemptionResult(tariff_name=tariff_name, period_days=period_days)
+
+
+async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff, period_days: int) -> Subscription:
+    """Create/extend/replace a subscription for ``period_days`` of ``tariff``.
+
+    Mirrors the gift-activation branches in ``activate_purchase``. All CRUD
+    calls use ``commit=False`` — the caller owns the transaction.
+    """
+    squads = list(tariff.allowed_squads or [])
+    if not squads:
+        from app.database.crud.server_squad import get_all_server_squads
+
+        # Explicit high limit: the default (50) silently truncates deployments
+        # with more available squads.
+        all_servers, _ = await get_all_server_squads(db, available_only=True, limit=10_000)
+        squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
+
+    if settings.is_multi_tariff_enabled():
+        from app.database.crud.subscription import get_subscription_by_user_and_tariff
+
+        existing = await get_subscription_by_user_and_tariff(db, user.id, tariff.id)
+    else:
+        existing = await get_subscription_by_user_id(db, user.id)
+
+    has_time = existing is not None and existing.end_date is not None and _aware(existing.end_date) > datetime.now(UTC)
+
+    if existing is not None and has_time:
+        # In multi-tariff mode the subscription already belongs to this tariff,
+        # so passing tariff_id is a no-op; in single mode it switches the
+        # subscription to the batch tariff (same as gift activation).
+        return await extend_subscription(
+            db,
+            existing,
+            period_days,
+            tariff_id=tariff.id,
+            traffic_limit_gb=tariff.traffic_limit_gb,
+            device_limit=tariff.device_limit,
+            connected_squads=squads,
+            commit=False,
+        )
+
+    if existing is not None:
+        # Expired subscription — replace with fresh dates
+        subscription = await replace_subscription(
+            db,
+            existing,
+            duration_days=period_days,
+            traffic_limit_gb=tariff.traffic_limit_gb,
+            device_limit=tariff.device_limit,
+            connected_squads=squads,
+            is_trial=False,
+            update_server_counters=True,
+            commit=False,
+        )
+        subscription.tariff_id = tariff.id
+        return subscription
+
+    return await create_paid_subscription(
+        db=db,
+        user_id=user.id,
+        duration_days=period_days,
+        traffic_limit_gb=tariff.traffic_limit_gb,
+        device_limit=tariff.device_limit,
+        connected_squads=squads,
+        tariff_id=tariff.id,
+        update_server_counters=True,
+        commit=False,
+    )

--- a/app/services/coupon_service.py
+++ b/app/services/coupon_service.py
@@ -58,6 +58,10 @@ class CouponRedemptionError(Exception):
 class CouponRedemptionResult:
     tariff_name: str
     period_days: int
+    renewed: bool  # True — продлили действующую подписку, False — выдали новую/заменили истёкшую
+    end_date: datetime | None
+    traffic_limit_gb: int | None
+    device_limit: int | None
 
 
 def _check_redeemable(coupon: Coupon, user: User) -> None:
@@ -116,7 +120,10 @@ async def redeem_coupon(db: AsyncSession, token: str, user: User) -> CouponRedem
     _check_redeemable(coupon, user)
 
     try:
-        subscription = await _grant_subscription_days(db, user, tariff, period_days)
+        subscription, renewed = await _grant_subscription_days(db, user, tariff, period_days)
+        end_date = subscription.end_date
+        traffic_limit_gb = subscription.traffic_limit_gb
+        device_limit = subscription.device_limit
 
         coupon.status = CouponStatus.REDEEMED.value
         coupon.redeemed_by = user.id
@@ -142,14 +149,25 @@ async def redeem_coupon(db: AsyncSession, token: str, user: User) -> CouponRedem
         user_id=user.id,
         days=period_days,
     )
-    return CouponRedemptionResult(tariff_name=tariff_name, period_days=period_days)
+    return CouponRedemptionResult(
+        tariff_name=tariff_name,
+        period_days=period_days,
+        renewed=renewed,
+        end_date=end_date,
+        traffic_limit_gb=traffic_limit_gb,
+        device_limit=device_limit,
+    )
 
 
-async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff, period_days: int) -> Subscription:
+async def _grant_subscription_days(
+    db: AsyncSession, user: User, tariff: Tariff, period_days: int
+) -> tuple[Subscription, bool]:
     """Create/extend/replace a subscription for ``period_days`` of ``tariff``.
 
-    Mirrors the gift-activation branches in ``activate_purchase``. All CRUD
-    calls use ``commit=False`` — the caller owns the transaction.
+    Returns ``(subscription, renewed)``: ``renewed`` is True when an active
+    subscription was extended, False when a new one was created or an expired
+    one replaced. Mirrors the gift-activation branches in ``activate_purchase``.
+    All CRUD calls use ``commit=False`` — the caller owns the transaction.
     """
     squads = list(tariff.allowed_squads or [])
     if not squads:
@@ -173,7 +191,7 @@ async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff,
         # In multi-tariff mode the subscription already belongs to this tariff,
         # so passing tariff_id is a no-op; in single mode it switches the
         # subscription to the batch tariff (same as gift activation).
-        return await extend_subscription(
+        subscription = await extend_subscription(
             db,
             existing,
             period_days,
@@ -183,6 +201,7 @@ async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff,
             connected_squads=squads,
             commit=False,
         )
+        return subscription, True
 
     if existing is not None:
         # Expired subscription — replace with fresh dates
@@ -198,9 +217,9 @@ async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff,
             commit=False,
         )
         subscription.tariff_id = tariff.id
-        return subscription
+        return subscription, False
 
-    return await create_paid_subscription(
+    subscription = await create_paid_subscription(
         db=db,
         user_id=user.id,
         duration_days=period_days,
@@ -211,3 +230,4 @@ async def _grant_subscription_days(db: AsyncSession, user: User, tariff: Tariff,
         update_server_counters=True,
         commit=False,
     )
+    return subscription, False

--- a/app/services/permission_service.py
+++ b/app/services/permission_service.py
@@ -60,6 +60,7 @@ PERMISSION_REGISTRY: dict[str, list[str]] = {
     'broadcasts': ['read', 'create', 'edit', 'delete', 'send'],
     'tariffs': ['read', 'create', 'edit', 'delete'],
     'promocodes': ['read', 'create', 'edit', 'delete', 'stats'],
+    'coupons': ['read', 'create', 'edit'],
     'promo_groups': ['read', 'create', 'edit', 'delete'],
     'promo_offers': ['read', 'create', 'edit', 'send'],
     'campaigns': ['read', 'create', 'edit', 'delete', 'stats'],

--- a/app/states.py
+++ b/app/states.py
@@ -67,6 +67,12 @@ class AdminStates(StatesGroup):
     setting_discount_hours = State()  # Для DISCOUNT: ввод срока действия скидки в часах
     selecting_promo_group = State()
 
+    creating_coupon_batch_days = State()
+    creating_coupon_batch_count = State()
+    creating_coupon_batch_name = State()
+    creating_coupon_batch_price = State()
+    creating_coupon_batch_expiry = State()
+
     creating_campaign_name = State()
     creating_campaign_start = State()
     creating_campaign_bonus = State()

--- a/migrations/alembic/versions/0095_add_coupons.py
+++ b/migrations/alembic/versions/0095_add_coupons.py
@@ -1,0 +1,85 @@
+"""add coupon_batches and coupons tables
+
+Wholesale/partner sales: the admin batch-generates one-time coupons
+(``coupon_batches`` holds tariff+period+bookkeeping, ``coupons`` holds the
+per-link secret token). Redeeming a coupon via the ``/start coupon_<token>``
+deep link grants a new subscription for the batch period or extends an
+existing one. ON DELETE CASCADE ties coupons to their batch.
+
+Revision ID: 0095
+Revises: 0094
+Create Date: 2026-07-11
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '0095'
+down_revision: Union[str, None] = '0094'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if 'coupon_batches' not in tables:
+        op.create_table(
+            'coupon_batches',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('name', sa.String(length=255), nullable=False),
+            sa.Column('tariff_id', sa.Integer(), nullable=True),
+            sa.Column('period_days', sa.Integer(), nullable=False),
+            sa.Column('coupons_total', sa.Integer(), nullable=False),
+            sa.Column('wholesale_price_kopeks', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('valid_until', sa.DateTime(timezone=True), nullable=True),
+            sa.Column('is_revoked', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+            sa.Column('created_by', sa.Integer(), nullable=True),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(['tariff_id'], ['tariffs.id'], ondelete='SET NULL'),
+            sa.ForeignKeyConstraint(['created_by'], ['users.id'], ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+        op.create_index('ix_coupon_batches_tariff_id', 'coupon_batches', ['tariff_id'])
+
+    if 'coupons' not in tables:
+        op.create_table(
+            'coupons',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('batch_id', sa.Integer(), nullable=False),
+            sa.Column('token', sa.String(length=64), nullable=False),
+            sa.Column('status', sa.String(length=20), nullable=False, server_default='active'),
+            sa.Column('redeemed_by', sa.Integer(), nullable=True),
+            sa.Column('redeemed_at', sa.DateTime(timezone=True), nullable=True),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(['batch_id'], ['coupon_batches.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['redeemed_by'], ['users.id'], ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+        # Column(unique=True, index=True) in the model → a single unique index
+        op.create_index('ix_coupons_token', 'coupons', ['token'], unique=True)
+        op.create_index('ix_coupons_redeemed_by', 'coupons', ['redeemed_by'])
+        op.create_index('ix_coupons_batch_status', 'coupons', ['batch_id', 'status'])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if 'coupons' in tables:
+        op.drop_index('ix_coupons_batch_status', table_name='coupons')
+        op.drop_index('ix_coupons_redeemed_by', table_name='coupons')
+        op.drop_index('ix_coupons_token', table_name='coupons')
+        op.drop_table('coupons')
+
+    if 'coupon_batches' in tables:
+        op.drop_index('ix_coupon_batches_tariff_id', table_name='coupon_batches')
+        op.drop_table('coupon_batches')

--- a/tests/cabinet/test_coupon_routes.py
+++ b/tests/cabinet/test_coupon_routes.py
@@ -1,0 +1,339 @@
+"""Tests for the cabinet coupons API (phase 2 of the wholesale coupons feature).
+
+Follows the house pattern for admin-route tests: a route-registration smoke
+test on the aggregate router plus direct handler calls with hand-built fakes
+(`admin=SimpleNamespace(...)`, `db=AsyncMock()`) — `require_permission` and
+`get_cabinet_db` are bypassed by passing the already-resolved arguments.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.config import settings
+from app.services.coupon_service import CouponRedemptionError, CouponRedemptionResult
+
+
+VALID_TOKEN = 'a1' * 16
+
+
+def _batch(**overrides) -> SimpleNamespace:
+    base = {
+        'id': 5,
+        'name': 'OptTG Partner',
+        'tariff_id': 3,
+        'tariff': SimpleNamespace(name='Basic'),
+        'period_days': 30,
+        'coupons_total': 50,
+        'wholesale_price_kopeks': 15000,
+        'valid_until': None,
+        'is_revoked': False,
+        'created_at': datetime.now(UTC),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# --- Wiring ----------------------------------------------------------------
+
+
+def test_coupon_routes_registered() -> None:
+    from app.cabinet.routes import router
+
+    methods_by_path: dict[str, set[str]] = {}
+    for route in router.routes:
+        if 'coupon' in route.path:
+            methods_by_path.setdefault(route.path, set()).update(route.methods)
+
+    assert methods_by_path.get('/cabinet/admin/coupons') == {'GET', 'POST'}
+    assert methods_by_path.get('/cabinet/admin/coupons/{batch_id}') == {'GET'}
+    assert methods_by_path.get('/cabinet/admin/coupons/{batch_id}/links') == {'GET'}
+    assert methods_by_path.get('/cabinet/admin/coupons/{batch_id}/revoke') == {'POST'}
+    assert methods_by_path.get('/cabinet/coupon/redeem') == {'POST'}
+    assert methods_by_path.get('/cabinet/coupon/{token}/status') == {'GET'}
+
+
+def test_coupons_permissions_registered() -> None:
+    from app.services.permission_service import PERMISSION_REGISTRY, get_all_permissions
+
+    assert 'coupons' in PERMISSION_REGISTRY
+    all_permissions = get_all_permissions()
+    for permission in ('coupons:read', 'coupons:create', 'coupons:edit'):
+        assert permission in all_permissions
+
+
+# --- Admin: create batch ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_batch_returns_links_and_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.cabinet.routes import admin_coupons
+    from app.cabinet.schemas.coupons import CouponBatchCreateRequest
+
+    monkeypatch.setattr(type(settings), 'get_bot_username', lambda self: 'testbot')
+    tariff = SimpleNamespace(id=3, name='Basic', is_active=True)
+    batch = _batch()
+
+    with (
+        patch.object(admin_coupons, 'get_tariff_by_id', AsyncMock(return_value=tariff)),
+        patch.object(admin_coupons, 'create_coupon_batch', AsyncMock(return_value=batch)) as create_mock,
+        patch.object(admin_coupons, 'get_batch_coupon_tokens', AsyncMock(return_value=[VALID_TOKEN])),
+        patch.object(admin_coupons, 'get_batch_status_counts', AsyncMock(return_value={'active': 50})),
+    ):
+        response = await admin_coupons.create_coupon_batch_endpoint(
+            payload=CouponBatchCreateRequest(
+                name='  OptTG Partner  ', tariff_id=3, period_days=30, coupons_count=50, valid_days=90
+            ),
+            admin=SimpleNamespace(id=1),
+            db=AsyncMock(),
+        )
+
+    assert response.links == [f'https://t.me/testbot?start=coupon_{VALID_TOKEN}']
+    assert response.tokens == [VALID_TOKEN]
+    assert response.active_count == 50
+    kwargs = create_mock.await_args.kwargs
+    assert kwargs['name'] == 'OptTG Partner', 'name must be stripped before persisting'
+    assert kwargs['created_by'] == 1
+    assert kwargs['valid_until'] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_batch_rejects_inactive_tariff() -> None:
+    from app.cabinet.routes import admin_coupons
+    from app.cabinet.schemas.coupons import CouponBatchCreateRequest
+
+    tariff = SimpleNamespace(id=3, name='Basic', is_active=False)
+    with patch.object(admin_coupons, 'get_tariff_by_id', AsyncMock(return_value=tariff)):
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_coupons.create_coupon_batch_endpoint(
+                payload=CouponBatchCreateRequest(name='X', tariff_id=3, period_days=30, coupons_count=1),
+                admin=SimpleNamespace(id=1),
+                db=AsyncMock(),
+            )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_batch_rejects_blank_name() -> None:
+    from app.cabinet.routes import admin_coupons
+    from app.cabinet.schemas.coupons import CouponBatchCreateRequest
+
+    with pytest.raises(HTTPException) as exc_info:
+        await admin_coupons.create_coupon_batch_endpoint(
+            payload=CouponBatchCreateRequest(name='   ', tariff_id=3, period_days=30, coupons_count=1),
+            admin=SimpleNamespace(id=1),
+            db=AsyncMock(),
+        )
+    assert exc_info.value.status_code == 400
+
+
+# --- Admin: card / links / revoke -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_404_when_missing() -> None:
+    from app.cabinet.routes import admin_coupons
+
+    with patch.object(admin_coupons, 'get_coupon_batch_by_id', AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_coupons.get_coupon_batch(batch_id=999, admin=SimpleNamespace(id=1), db=AsyncMock())
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_links_export_counts_active_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.cabinet.routes import admin_coupons
+
+    monkeypatch.setattr(type(settings), 'get_bot_username', lambda self: 'testbot')
+    tokens_mock = AsyncMock(return_value=[VALID_TOKEN, 'b2' * 16])
+    with (
+        patch.object(admin_coupons, 'get_coupon_batch_by_id', AsyncMock(return_value=_batch())),
+        patch.object(admin_coupons, 'get_batch_coupon_tokens', tokens_mock),
+    ):
+        response = await admin_coupons.export_coupon_batch_links(
+            batch_id=5, admin=SimpleNamespace(id=1), db=AsyncMock()
+        )
+
+    assert response.count == 2
+    assert len(response.links) == 2
+    assert tokens_mock.await_args.kwargs.get('status') == 'active', 'export must include only still-active coupons'
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_count_and_updated_card() -> None:
+    from app.cabinet.routes import admin_coupons
+
+    batch = _batch(is_revoked=True)
+    with (
+        patch.object(admin_coupons, 'get_coupon_batch_by_id', AsyncMock(return_value=batch)),
+        patch.object(admin_coupons, 'revoke_batch_coupons', AsyncMock(return_value=37)),
+        patch.object(admin_coupons, 'get_batch_status_counts', AsyncMock(return_value={'revoked': 37, 'redeemed': 13})),
+    ):
+        response = await admin_coupons.revoke_coupon_batch(batch_id=5, admin=SimpleNamespace(id=1), db=AsyncMock())
+
+    assert response.revoked_count == 37
+    assert response.batch.revoked_count == 37
+    assert response.batch.is_revoked is True
+
+
+# --- User: redeem ----------------------------------------------------------
+
+
+def _redeem_result(renewed: bool = False) -> CouponRedemptionResult:
+    return CouponRedemptionResult(
+        tariff_name='Basic',
+        period_days=30,
+        renewed=renewed,
+        end_date=datetime.now(UTC) + timedelta(days=30),
+        traffic_limit_gb=100,
+        device_limit=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_redeem_success_for_telegram_user_sends_no_email() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+    from app.cabinet.schemas.coupons import CouponRedeemRequest
+
+    user = SimpleNamespace(id=5, telegram_id=123, email=None, email_verified=False)
+    send_mock = AsyncMock()
+    with (
+        patch.object(coupon_routes, 'redeem_coupon', AsyncMock(return_value=_redeem_result())),
+        patch.object(coupon_routes.notification_delivery_service, 'send_notification', send_mock),
+    ):
+        response = await coupon_routes.redeem_coupon_endpoint(
+            request=CouponRedeemRequest(token=VALID_TOKEN), user=user, db=AsyncMock()
+        )
+
+    assert response.success is True
+    assert response.tariff_name == 'Basic'
+    assert response.period_days == 30
+    send_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redeem_notifies_email_only_user() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+    from app.cabinet.schemas.coupons import CouponRedeemRequest
+    from app.services.notification_delivery_service import NotificationType
+
+    user = SimpleNamespace(id=5, telegram_id=None, email='user@example.com', email_verified=True)
+    send_mock = AsyncMock()
+    with (
+        patch.object(coupon_routes, 'redeem_coupon', AsyncMock(return_value=_redeem_result(renewed=True))),
+        patch.object(coupon_routes.notification_delivery_service, 'send_notification', send_mock),
+    ):
+        response = await coupon_routes.redeem_coupon_endpoint(
+            request=CouponRedeemRequest(token=VALID_TOKEN), user=user, db=AsyncMock()
+        )
+
+    assert response.renewed is True
+    send_mock.assert_awaited_once()
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs['notification_type'] == NotificationType.SUBSCRIPTION_RENEWED
+    assert kwargs['context']['tariff_name'] == 'Basic'
+    assert kwargs['context']['new_expires_at']
+
+
+@pytest.mark.asyncio
+async def test_redeem_maps_service_errors_to_structured_contract() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+    from app.cabinet.schemas.coupons import CouponRedeemRequest
+
+    user = SimpleNamespace(id=5, telegram_id=123, email=None, email_verified=False)
+
+    for code, expected_status in (
+        ('invalid', 400),
+        ('expired', 400),
+        ('already_redeemed_by_you', 400),
+        ('internal', 500),
+    ):
+        with patch.object(coupon_routes, 'redeem_coupon', AsyncMock(side_effect=CouponRedemptionError(code))):
+            with pytest.raises(HTTPException) as exc_info:
+                await coupon_routes.redeem_coupon_endpoint(
+                    request=CouponRedeemRequest(token=VALID_TOKEN), user=user, db=AsyncMock()
+                )
+        assert exc_info.value.status_code == expected_status
+        assert exc_info.value.detail['code'] == code
+        assert exc_info.value.detail['message']
+
+
+# --- Public: status --------------------------------------------------------
+
+
+def _status_request() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_public_status_returns_offer_for_active_coupon(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+
+    monkeypatch.setattr(type(settings), 'get_bot_username', lambda self: 'testbot')
+    coupon = SimpleNamespace(
+        status='active',
+        batch=SimpleNamespace(is_expired=False, period_days=30, valid_until=None, tariff=SimpleNamespace(name='Basic')),
+    )
+    with (
+        patch.object(coupon_routes, 'get_client_ip', lambda request: '1.2.3.4'),
+        patch.object(coupon_routes.RateLimitCache, 'is_ip_rate_limited', AsyncMock(return_value=False)),
+        patch.object(coupon_routes, 'get_coupon_by_token', AsyncMock(return_value=coupon)),
+    ):
+        response = await coupon_routes.coupon_status(
+            token=VALID_TOKEN.upper(), raw_request=_status_request(), db=AsyncMock()
+        )
+
+    assert response.tariff_name == 'Basic'
+    assert response.period_days == 30
+    assert response.bot_link == f'https://t.me/testbot?start=coupon_{VALID_TOKEN}'
+
+
+@pytest.mark.asyncio
+async def test_public_status_is_uniform_404_for_consumed_coupon() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+
+    coupon = SimpleNamespace(status='redeemed', batch=SimpleNamespace(is_expired=False))
+    with (
+        patch.object(coupon_routes, 'get_client_ip', lambda request: '1.2.3.4'),
+        patch.object(coupon_routes.RateLimitCache, 'is_ip_rate_limited', AsyncMock(return_value=False)),
+        patch.object(coupon_routes, 'get_coupon_by_token', AsyncMock(return_value=coupon)),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coupon_routes.coupon_status(token=VALID_TOKEN, raw_request=_status_request(), db=AsyncMock())
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_public_status_rate_limited() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+
+    with (
+        patch.object(coupon_routes, 'get_client_ip', lambda request: '1.2.3.4'),
+        patch.object(coupon_routes.RateLimitCache, 'is_ip_rate_limited', AsyncMock(return_value=True)),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coupon_routes.coupon_status(token=VALID_TOKEN, raw_request=_status_request(), db=AsyncMock())
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_public_status_rejects_malformed_token_without_db_hit() -> None:
+    from app.cabinet.routes import coupon as coupon_routes
+
+    lookup = AsyncMock()
+    with (
+        patch.object(coupon_routes, 'get_client_ip', lambda request: '1.2.3.4'),
+        patch.object(coupon_routes.RateLimitCache, 'is_ip_rate_limited', AsyncMock(return_value=False)),
+        patch.object(coupon_routes, 'get_coupon_by_token', lookup),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coupon_routes.coupon_status(
+                token='definitely-not-a-token', raw_request=_status_request(), db=AsyncMock()
+            )
+    assert exc_info.value.status_code == 404
+    lookup.assert_not_called()

--- a/tests/services/test_coupon_service.py
+++ b/tests/services/test_coupon_service.py
@@ -1,0 +1,351 @@
+"""Tests for the wholesale coupon service (batches of one-time links).
+
+Coupons are the fourth "grant subscription days" mechanism (after promocodes,
+gifts and campaigns): the admin batch-generates one-time tokens, a user
+redeems one via the ``/start coupon_<token>`` deep link. These tests pin the
+redemption contract:
+
+- token format is validated before any DB access;
+- responses are uniform for unknown / revoked / redeemed-by-someone-else
+  coupons (no oracle for enumeration), while redeemed-by-you is friendly;
+- validation runs on an unlocked read; the claim re-reads the row FOR UPDATE
+  and re-checks it, and the REDEEMED flip happens BEFORE the Remnawave sync
+  (which commits the session internally), so claim and grant land in one
+  transaction;
+- a failed Remnawave sync (the method swallows errors and returns None)
+  aborts the redemption: rollback, ``internal`` error, coupon stays ACTIVE
+  and the link retryable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.database.crud.coupon import generate_coupon_token
+from app.database.models import CouponStatus
+from app.services.coupon_service import (
+    COUPON_DEEP_LINK_PREFIX,
+    CouponRedemptionError,
+    _grant_subscription_days,
+    is_coupon_token,
+    redeem_coupon,
+)
+
+
+VALID_TOKEN = 'a1' * 16  # 32 hex chars
+
+
+def _user(user_id: int = 7) -> SimpleNamespace:
+    return SimpleNamespace(id=user_id)
+
+
+def _tariff() -> SimpleNamespace:
+    return SimpleNamespace(id=3, name='Basic', allowed_squads=['sq-1'], traffic_limit_gb=100, device_limit=2)
+
+
+def _batch(**overrides) -> SimpleNamespace:
+    base = {'id': 1, 'tariff_id': 3, 'period_days': 30, 'is_expired': False, 'tariff': _tariff()}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _coupon(status: str = CouponStatus.ACTIVE.value, redeemed_by: int | None = None, batch=None) -> SimpleNamespace:
+    if batch is None:
+        batch = _batch()
+    return SimpleNamespace(
+        id=11, batch_id=batch.id, status=status, redeemed_by=redeemed_by, redeemed_at=None, batch=batch
+    )
+
+
+# --- Token format ---------------------------------------------------------
+
+
+def test_generated_token_matches_format_and_fits_start_param() -> None:
+    for _ in range(100):
+        token = generate_coupon_token()
+        assert is_coupon_token(token)
+        # Telegram truncates start params longer than 64 chars; the coupon flow
+        # relies on exact-match lookups, so the payload must never be truncated.
+        assert len(COUPON_DEEP_LINK_PREFIX + token) <= 64
+
+
+def test_generated_tokens_are_unique() -> None:
+    tokens = {generate_coupon_token() for _ in range(1000)}
+    assert len(tokens) == 1000
+
+
+def test_is_coupon_token_rejects_wrong_shapes() -> None:
+    assert not is_coupon_token('')
+    assert not is_coupon_token('abc')
+    assert not is_coupon_token('g' * 32)  # non-hex
+    assert not is_coupon_token('a' * 31)
+    assert not is_coupon_token('a' * 33)
+    # redeem_coupon lowercases before validating, the matcher itself is strict
+    assert not is_coupon_token('A' * 32)
+
+
+# --- Redemption: validation and status handling ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_format_never_touches_db() -> None:
+    db = AsyncMock()
+    with pytest.raises(CouponRedemptionError) as err:
+        await redeem_coupon(db, 'not-a-token', _user())
+    assert err.value.code == 'invalid'
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_is_invalid() -> None:
+    db = AsyncMock()
+    lookup = AsyncMock(return_value=None)
+    with patch('app.services.coupon_service.get_coupon_by_token', lookup):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+    lookup.assert_awaited_once_with(db, VALID_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_token_is_normalized_before_lookup() -> None:
+    db = AsyncMock()
+    lookup = AsyncMock(return_value=None)
+    with patch('app.services.coupon_service.get_coupon_by_token', lookup):
+        with pytest.raises(CouponRedemptionError):
+            await redeem_coupon(db, f'  {VALID_TOKEN.upper()} ', _user())
+    lookup.assert_awaited_once_with(db, VALID_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_rejection_never_takes_the_row_lock() -> None:
+    """Failed links must not hold FOR UPDATE for the rest of the /start handler."""
+    db = AsyncMock()
+    coupon = _coupon(status=CouponStatus.REVOKED.value)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError):
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    db.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redeemed_by_same_user_is_distinguishable() -> None:
+    coupon = _coupon(status=CouponStatus.REDEEMED.value, redeemed_by=7)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user(7))
+    assert err.value.code == 'already_redeemed_by_you'
+
+
+@pytest.mark.asyncio
+async def test_redeemed_by_other_user_is_uniform_invalid() -> None:
+    coupon = _coupon(status=CouponStatus.REDEEMED.value, redeemed_by=8)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user(7))
+    assert err.value.code == 'invalid'
+
+
+@pytest.mark.asyncio
+async def test_revoked_coupon_is_uniform_invalid() -> None:
+    coupon = _coupon(status=CouponStatus.REVOKED.value)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+
+
+@pytest.mark.asyncio
+async def test_expired_batch_raises_expired() -> None:
+    coupon = _coupon(batch=_batch(is_expired=True))
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'expired'
+    assert coupon.status == CouponStatus.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_missing_tariff_is_internal_error() -> None:
+    coupon = _coupon(batch=_batch(tariff=None))
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(AsyncMock(), VALID_TOKEN, _user())
+    assert err.value.code == 'internal'
+    assert coupon.status == CouponStatus.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claim_lost_after_lock_is_rejected() -> None:
+    """The locked re-read must re-check the status — a concurrent redemption may win."""
+    coupon = _coupon()
+    db = AsyncMock()
+
+    async def refresh_reveals_concurrent_redeem(instance, **kwargs):
+        instance.status = CouponStatus.REDEEMED.value
+        instance.redeemed_by = 999
+
+    db.refresh = AsyncMock(side_effect=refresh_reveals_concurrent_redeem)
+    with patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'invalid'
+    db.commit.assert_not_called()
+
+
+# --- Redemption: happy path and failure atomicity -------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_claims_under_lock_and_flips_before_remnawave_sync() -> None:
+    coupon = _coupon()
+    user = _user()
+    db = AsyncMock()
+    subscription = SimpleNamespace(id=99)
+
+    status_at_sync: list[str] = []
+
+    async def fake_sync(self, db_arg, sub):
+        # create_remnawave_user() commits the session internally, so by this
+        # point the coupon MUST already be claimed — otherwise the grant could
+        # commit while the coupon is still ACTIVE (double-payout window).
+        status_at_sync.append(coupon.status)
+        return SimpleNamespace(uuid='rw-uuid')
+
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=subscription)),
+        patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=fake_sync),
+    ):
+        result = await redeem_coupon(db, VALID_TOKEN, user)
+
+    db.refresh.assert_awaited_once_with(coupon, with_for_update=True)
+    assert status_at_sync == [CouponStatus.REDEEMED.value]
+    assert coupon.redeemed_by == user.id
+    assert coupon.redeemed_at is not None
+    db.commit.assert_awaited_once()
+    db.rollback.assert_not_called()
+    assert result.tariff_name == 'Basic'
+    assert result.period_days == 30
+
+
+@pytest.mark.asyncio
+async def test_failed_remnawave_sync_aborts_redemption() -> None:
+    """create_remnawave_user swallows API errors and returns None WITHOUT
+    committing — the redemption must roll back so the coupon is not burned
+    while the user got no working panel account."""
+    coupon = _coupon()
+    db = AsyncMock()
+
+    async def failing_sync(self, db_arg, sub):
+        return None
+
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=SimpleNamespace(id=99))),
+        patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=failing_sync),
+    ):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+
+    assert err.value.code == 'internal'
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_grant_failure_rolls_back_and_raises_internal() -> None:
+    coupon = _coupon()
+    db = AsyncMock()
+    with (
+        patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
+        patch(
+            'app.services.coupon_service._grant_subscription_days',
+            AsyncMock(side_effect=RuntimeError('boom')),
+        ),
+    ):
+        with pytest.raises(CouponRedemptionError) as err:
+            await redeem_coupon(db, VALID_TOKEN, _user())
+    assert err.value.code == 'internal'
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_called()
+    assert coupon.status == CouponStatus.ACTIVE.value, 'failed redemption must not consume the coupon'
+
+
+# --- Grant branches (single-tariff mode mirrors gift activation) ----------
+
+
+@pytest.mark.asyncio
+async def test_grant_extends_active_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    existing = SimpleNamespace(end_date=datetime.now(UTC) + timedelta(days=5), tariff_id=3)
+    extend = AsyncMock(return_value='extended')
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
+        patch('app.services.coupon_service.extend_subscription', extend),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+
+    assert result == 'extended'
+    assert extend.await_args.args[2] == 30
+    kwargs = extend.await_args.kwargs
+    assert kwargs['commit'] is False, 'the caller owns the transaction'
+    assert kwargs['tariff_id'] == 3
+
+
+@pytest.mark.asyncio
+async def test_grant_replaces_expired_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    existing = SimpleNamespace(end_date=datetime.now(UTC) - timedelta(days=1), tariff_id=99)
+    replaced = SimpleNamespace(tariff_id=99)
+    replace = AsyncMock(return_value=replaced)
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
+        patch('app.services.coupon_service.replace_subscription', replace),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+
+    kwargs = replace.await_args.kwargs
+    assert kwargs['is_trial'] is False
+    assert kwargs['commit'] is False
+    assert kwargs['duration_days'] == 30
+    assert result.tariff_id == 3, 'replaced subscription must be reassigned to the batch tariff'
+
+
+@pytest.mark.asyncio
+async def test_grant_creates_subscription_when_none_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    create = AsyncMock(return_value='created')
+    with (
+        patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=None)),
+        patch('app.services.coupon_service.create_paid_subscription', create),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+
+    assert result == 'created'
+    kwargs = create.await_args.kwargs
+    assert kwargs['user_id'] == 9
+    assert kwargs['duration_days'] == 30
+    assert kwargs['tariff_id'] == 3
+    assert kwargs['commit'] is False
+
+
+@pytest.mark.asyncio
+async def test_grant_multi_tariff_looks_up_by_tariff(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: True)
+    lookup = AsyncMock(return_value=None)
+    create = AsyncMock(return_value='created')
+    with (
+        patch('app.database.crud.subscription.get_subscription_by_user_and_tariff', lookup),
+        patch('app.services.coupon_service.create_paid_subscription', create),
+    ):
+        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+
+    lookup.assert_awaited_once()
+    assert lookup.await_args.args[1:] == (9, 3)
+    assert result == 'created'

--- a/tests/services/test_coupon_service.py
+++ b/tests/services/test_coupon_service.py
@@ -206,7 +206,8 @@ async def test_success_claims_under_lock_and_flips_before_remnawave_sync() -> No
     coupon = _coupon()
     user = _user()
     db = AsyncMock()
-    subscription = SimpleNamespace(id=99)
+    end_date = datetime.now(UTC) + timedelta(days=30)
+    subscription = SimpleNamespace(id=99, end_date=end_date, traffic_limit_gb=100, device_limit=2)
 
     status_at_sync: list[str] = []
 
@@ -219,7 +220,7 @@ async def test_success_claims_under_lock_and_flips_before_remnawave_sync() -> No
 
     with (
         patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
-        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=subscription)),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=(subscription, True))),
         patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=fake_sync),
     ):
         result = await redeem_coupon(db, VALID_TOKEN, user)
@@ -232,6 +233,10 @@ async def test_success_claims_under_lock_and_flips_before_remnawave_sync() -> No
     db.rollback.assert_not_called()
     assert result.tariff_name == 'Basic'
     assert result.period_days == 30
+    assert result.renewed is True
+    assert result.end_date == end_date
+    assert result.traffic_limit_gb == 100
+    assert result.device_limit == 2
 
 
 @pytest.mark.asyncio
@@ -245,9 +250,10 @@ async def test_failed_remnawave_sync_aborts_redemption() -> None:
     async def failing_sync(self, db_arg, sub):
         return None
 
+    granted = (SimpleNamespace(id=99, end_date=None, traffic_limit_gb=0, device_limit=None), False)
     with (
         patch('app.services.coupon_service.get_coupon_by_token', AsyncMock(return_value=coupon)),
-        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=SimpleNamespace(id=99))),
+        patch('app.services.coupon_service._grant_subscription_days', AsyncMock(return_value=granted)),
         patch('app.services.coupon_service.SubscriptionService.create_remnawave_user', new=failing_sync),
     ):
         with pytest.raises(CouponRedemptionError) as err:
@@ -289,9 +295,10 @@ async def test_grant_extends_active_subscription(monkeypatch: pytest.MonkeyPatch
         patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
         patch('app.services.coupon_service.extend_subscription', extend),
     ):
-        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+        subscription, renewed = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
 
-    assert result == 'extended'
+    assert subscription == 'extended'
+    assert renewed is True
     assert extend.await_args.args[2] == 30
     kwargs = extend.await_args.kwargs
     assert kwargs['commit'] is False, 'the caller owns the transaction'
@@ -308,13 +315,14 @@ async def test_grant_replaces_expired_subscription(monkeypatch: pytest.MonkeyPat
         patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=existing)),
         patch('app.services.coupon_service.replace_subscription', replace),
     ):
-        result = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
+        subscription, renewed = await _grant_subscription_days(AsyncMock(), _user(), _tariff(), 30)
 
     kwargs = replace.await_args.kwargs
     assert kwargs['is_trial'] is False
     assert kwargs['commit'] is False
     assert kwargs['duration_days'] == 30
-    assert result.tariff_id == 3, 'replaced subscription must be reassigned to the batch tariff'
+    assert renewed is False, 'replacing an expired subscription is an activation, not a renewal'
+    assert subscription.tariff_id == 3, 'replaced subscription must be reassigned to the batch tariff'
 
 
 @pytest.mark.asyncio
@@ -325,9 +333,10 @@ async def test_grant_creates_subscription_when_none_exists(monkeypatch: pytest.M
         patch('app.services.coupon_service.get_subscription_by_user_id', AsyncMock(return_value=None)),
         patch('app.services.coupon_service.create_paid_subscription', create),
     ):
-        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+        subscription, renewed = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
 
-    assert result == 'created'
+    assert subscription == 'created'
+    assert renewed is False
     kwargs = create.await_args.kwargs
     assert kwargs['user_id'] == 9
     assert kwargs['duration_days'] == 30
@@ -344,8 +353,8 @@ async def test_grant_multi_tariff_looks_up_by_tariff(monkeypatch: pytest.MonkeyP
         patch('app.database.crud.subscription.get_subscription_by_user_and_tariff', lookup),
         patch('app.services.coupon_service.create_paid_subscription', create),
     ):
-        result = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
+        subscription, _renewed = await _grant_subscription_days(AsyncMock(), _user(9), _tariff(), 30)
 
     lookup.assert_awaited_once()
     assert lookup.await_args.args[1:] == (9, 3)
-    assert result == 'created'
+    assert subscription == 'created'

--- a/tests/test_coupon_deeplink_pins.py
+++ b/tests/test_coupon_deeplink_pins.py
@@ -1,0 +1,118 @@
+"""Source-level pins for the coupon deep-link wiring.
+
+The /start flow is huge and heavily branched, and the coupon feature relies on
+a few ordering invariants that are easy to break silently during refactors:
+
+- the coupon branch must swallow ``start_parameter`` ONLY for exact-format
+  tokens that exist in the DB (a campaign start_parameter may legitimately
+  begin with ``coupon_``, even ``coupon_<32 hex>``);
+- every gift-activation call site must also redeem pending coupons;
+- in the service, validation runs unlocked, the claim happens under a
+  FOR UPDATE re-read, the REDEEMED flip precedes the Remnawave sync (which
+  commits the session internally), and the sync's None error-return aborts
+  the redemption;
+- in the admin module, the ``*_revoke_confirm_`` handler must be registered
+  before the ``*_revoke_`` one (the shorter prefix matches both), and the
+  create-confirmation callback must be guarded against stale buttons and
+  double taps.
+"""
+
+import inspect
+
+import app.handlers.start as start_module
+from app.handlers.admin import coupons as admin_coupons
+from app.services import coupon_service
+from app.states import AdminStates
+
+
+START_SOURCE = inspect.getsource(start_module)
+
+
+def test_cmd_start_parses_coupon_deep_link() -> None:
+    assert 'startswith(COUPON_DEEP_LINK_PREFIX)' in START_SOURCE
+    assert 'pending_coupon_token=coupon_token' in START_SOURCE
+
+
+def test_coupon_redeem_called_at_every_gift_activation_site() -> None:
+    gift_calls = START_SOURCE.count('await _activate_pending_gift_after_registration(')
+    coupon_calls = START_SOURCE.count('await _redeem_pending_coupon(')
+    assert gift_calls == 3, 'gift activation call sites moved — re-check coupon redemption wiring'
+    assert coupon_calls == gift_calls, 'every gift activation site must also redeem pending coupons'
+
+
+def test_coupon_branch_only_swallows_existing_coupons() -> None:
+    """`start_parameter = None` must sit INSIDE the is_coupon_token() guard AND
+    require a DB hit — otherwise a campaign whose start_parameter is
+    'coupon_<32 hex>' silently loses its attribution."""
+    source = inspect.getsource(start_module.cmd_start)
+    branch_start = source.index('startswith(COUPON_DEEP_LINK_PREFIX)')
+    branch_end = source.index('webauth_', branch_start)
+    branch = source[branch_start:branch_end]
+
+    guard_pos = branch.index('if is_coupon_token(')
+    exists_pos = branch.index('get_coupon_by_token(db, coupon_token)')
+    null_pos = branch.index('start_parameter = None')
+    assert guard_pos < exists_pos < null_pos
+
+    guard_indent = len(branch[:guard_pos].split('\n')[-1])
+    null_indent = len(branch[:null_pos].split('\n')[-1])
+    assert null_indent > guard_indent, (
+        'start_parameter must be swallowed only for real coupon tokens, '
+        'otherwise campaigns whose start_parameter begins with "coupon_" break'
+    )
+
+
+def test_redeem_flips_status_before_remnawave_sync() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    flip = source.index('coupon.status = CouponStatus.REDEEMED.value')
+    sync = source.index('create_remnawave_user')
+    commit = source.index('await db.commit()')
+    assert flip < sync < commit, (
+        'create_remnawave_user() commits the session internally: the claim must '
+        'already be part of that transaction, or the coupon can pay out twice'
+    )
+
+
+def test_redeem_claims_under_row_lock_and_rechecks() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    assert 'with_for_update=True' in source
+    assert source.count('_check_redeemable(coupon, user)') == 2, (
+        'validation must run both unlocked (no lock held on rejection paths) '
+        'and again after the FOR UPDATE re-read (concurrent claim may have won)'
+    )
+
+
+def test_redeem_aborts_when_remnawave_sync_returns_none() -> None:
+    source = inspect.getsource(coupon_service.redeem_coupon)
+    assert 'remnawave_user is None' in source, (
+        'create_remnawave_user swallows errors and returns None without '
+        'committing — ignoring that burns the coupon during any panel outage'
+    )
+
+
+def test_revoke_confirm_registered_before_revoke_prefix() -> None:
+    source = inspect.getsource(admin_coupons.register_handlers)
+    confirm = source.index("'admin_coupon_revoke_confirm_'")
+    revoke = source.index("'admin_coupon_revoke_'")
+    assert confirm < revoke, "startswith('admin_coupon_revoke_') also matches confirmation callbacks"
+
+
+def test_create_confirm_is_guarded_against_stale_buttons_and_double_taps() -> None:
+    source = inspect.getsource(admin_coupons.confirm_coupon_batch_creation)
+    # Stale confirm buttons from old messages must be rejected by FSM state
+    assert 'creating_coupon_batch_expiry.state' in source
+    # The wizard state must be consumed BEFORE the slow batch insert
+    clear = source.index('await state.clear()')
+    create = source.index('await create_coupon_batch(')
+    assert clear < create, 'a double-tap on the confirm button must not create the batch twice'
+
+
+def test_admin_states_for_coupon_creation_exist() -> None:
+    for name in (
+        'creating_coupon_batch_days',
+        'creating_coupon_batch_count',
+        'creating_coupon_batch_name',
+        'creating_coupon_batch_price',
+        'creating_coupon_batch_expiry',
+    ):
+        assert hasattr(AdminStates, name)


### PR DESCRIPTION
## Описание

Второй этап купонов из #3042: управление партиями и активация через cabinet.

> ⚠️ Основан на #3043 (купоны в боте) — мержить после него. После мержа #3043 диф этого PR автоматически сожмётся до одного коммита.

## Что добавлено

**Админ-API `/cabinet/admin/coupons`** (новая RBAC-секция `coupons: read/create/edit` в `PERMISSION_REGISTRY` — сама появляется в редакторе ролей и в `GET /admin/rbac/permissions`):

- `GET /` — список партий со статистикой погашений (подсчёт статусов по всем партиям страницы одним GROUP BY-запросом);
- `POST /` — создание партии, в ответе сразу сгенерированные ссылки и токены;
- `GET /{id}` — карточка со статистикой;
- `GET /{id}/links` — экспорт только непогашенных ссылок (для передачи партнёру);
- `POST /{id}/revoke` — отзыв непогашенных.

**Активация в кабинете** — `POST /cabinet/coupon/redeem` (авторизованный пользователь): это путь погашения для email-пользователей, которым бот недоступен. Ошибки — в структурированном контракте `{code, message}` со стабильными машинными кодами (как у активации промокодов). Email-пользователям после погашения уходит письмо + WebSocket-уведомление «подписка активирована/продлена» — по образцу `subscription_modules/purchase.py`; telegram-пользователей уведомляют бот-флоу.

**Публичный статус** — `GET /cabinet/coupon/{token}/status` (без авторизации, данные для страницы «вам подарили подписку»): тариф/дни/срок + deep link на активацию в боте. Rate limit 30/60 fail-closed (как у landing/gift), единый 404 для несуществующего/погашенного/отозванного/истёкшего купона — эндпоинт не является оракулом, формат токена проверяется до обращения к БД.

**Сервис**: `redeem_coupon` теперь возвращает `renewed`/`end_date`/лимиты (нужны для уведомлений и ответа API); `_grant_subscription_days` отдаёт признак «продление действующей vs новая/замена истёкшей».

## Тестирование

- 15 новых тестов в стиле `tests/cabinet` (smoke регистрации роутов и методов, прямые вызовы хендлеров с фейками, контракт ошибок по всем кодам, реестр прав, публичный статус: единый 404, rate limit, отсутствие обращения к БД при кривом токене).
- Полный прогон: 1806 passed, `ruff format`/`ruff check` чистые.

## Чек-лист

- [x] Код отформатирован (`ruff format .`)
- [x] Линтер проходит (`ruff check .`)
- [x] Тесты проходят
- [x] Ветка от `dev` (через #3043), PR в `dev`
