### PR TITLE
fix(bot): тексты длиннее лимита Telegram роняли показ правил и политики (MESSAGE_TOO_LONG)

### DIFF
--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -288,16 +288,58 @@ async def show_service_rules(callback: types.CallbackQuery, db_user: User, db: A
         )
         return
 
+    raw_page = 1
+    if callback.data and ':' in callback.data:
+        try:
+            raw_page = int(callback.data.split(':', 1)[1])
+        except ValueError:
+            raw_page = 1
+    raw_page = max(raw_page, 1)
+
     rules_text = await get_current_rules_content(db, db_user.language)
 
     if not rules_text:
         rules_text = await get_rules(db_user.language)
 
+    # Правила могут быть длиннее лимита Telegram (4096) — пагинация как у
+    # политики конфиденциальности и оферты
+    pages = split_telegram_text(rules_text, max_length=3500) or ['']
+    total_pages = len(pages)
+    current_page = min(raw_page, total_pages)
+
+    message_text = f'{texts.t("RULES_HEADER", "📋 <b>Правила сервиса</b>")}\n\n{pages[current_page - 1]}'
+
+    keyboard_rows: list[list[types.InlineKeyboardButton]] = []
+
+    if total_pages > 1:
+        nav_row: list[types.InlineKeyboardButton] = []
+        if current_page > 1:
+            nav_row.append(
+                types.InlineKeyboardButton(
+                    text=texts.t('PAGINATION_PREV', '⬅️'),
+                    callback_data=f'menu_rules:{current_page - 1}',
+                )
+            )
+        nav_row.append(
+            types.InlineKeyboardButton(
+                text=f'{current_page}/{total_pages}',
+                callback_data='noop',
+            )
+        )
+        if current_page < total_pages:
+            nav_row.append(
+                types.InlineKeyboardButton(
+                    text=texts.t('PAGINATION_NEXT', '➡️'),
+                    callback_data=f'menu_rules:{current_page + 1}',
+                )
+            )
+        keyboard_rows.append(nav_row)
+
+    keyboard_rows.append([types.InlineKeyboardButton(text=texts.BACK, callback_data='back_to_menu')])
+
     await callback.message.edit_text(
-        f'{texts.t("RULES_HEADER", "📋 <b>Правила сервиса</b>")}\n\n{rules_text}',
-        reply_markup=types.InlineKeyboardMarkup(
-            inline_keyboard=[[types.InlineKeyboardButton(text=texts.BACK, callback_data='back_to_menu')]]
-        ),
+        message_text,
+        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard_rows),
     )
     await callback.answer()
 
@@ -1680,6 +1722,11 @@ def register_handlers(dp: Dispatcher):
     )
 
     dp.callback_query.register(show_service_rules, F.data == 'menu_rules')
+
+    dp.callback_query.register(
+        show_service_rules,
+        F.data.startswith('menu_rules:'),
+    )
 
     dp.callback_query.register(
         show_info_menu,

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -65,6 +65,7 @@ from app.services.subscription_service import SubscriptionService
 from app.services.support_settings_service import SupportSettingsService
 from app.services.web_auth_service import WEB_AUTH_TOKEN_MIN_LENGTH, link_web_auth_token
 from app.states import RegistrationStates
+from app.utils.long_messages import answer_long_text, edit_long_text, send_long_text
 from app.utils.user_utils import generate_unique_referral_code
 
 
@@ -659,7 +660,7 @@ async def handle_potential_referral_code(message: types.Message, state: FSMConte
             texts = get_texts(language)
 
             rules_text = await get_rules(language)
-            await message.answer(rules_text, reply_markup=get_rules_keyboard(language))
+            await answer_long_text(message, rules_text, reply_markup=get_rules_keyboard(language))
             await state.set_state(RegistrationStates.waiting_for_rules_accept)
             logger.info('📋 Правила отправлены после ввода реферального кода')
         else:
@@ -694,7 +695,7 @@ async def handle_potential_referral_code(message: types.Message, state: FSMConte
             texts = get_texts(language)
 
             rules_text = await get_rules(language)
-            await message.answer(rules_text, reply_markup=get_rules_keyboard(language))
+            await answer_long_text(message, rules_text, reply_markup=get_rules_keyboard(language))
             await state.set_state(RegistrationStates.waiting_for_rules_accept)
             logger.info('📋 Правила отправлены после принятия промокода')
         else:
@@ -783,7 +784,7 @@ async def _continue_registration_after_language(
 
     rules_text = await get_rules(language)
     try:
-        await target_message.answer(rules_text, reply_markup=get_rules_keyboard(language))
+        await answer_long_text(target_message, rules_text, reply_markup=get_rules_keyboard(language))
     except TelegramForbiddenError:
         logger.warning(
             '⚠️ Пользователь заблокировал бота, пропускаем отправку правил',
@@ -1460,8 +1461,11 @@ async def _show_privacy_policy_after_rules(
         logger.info('🔒 Используется политика конфиденциальности из БД для языка', language=language)
 
     try:
-        await callback.message.edit_text(
-            privacy_policy_text, reply_markup=get_privacy_policy_keyboard(language), parse_mode='HTML'
+        await edit_long_text(
+            callback.message,
+            privacy_policy_text,
+            reply_markup=get_privacy_policy_keyboard(language),
+            parse_mode='HTML',
         )
         await state.set_state(RegistrationStates.waiting_for_privacy_policy_accept)
         logger.info('🔒 Политика конфиденциальности отправлена пользователю', from_user_id=callback.from_user.id)
@@ -1469,8 +1473,11 @@ async def _show_privacy_policy_after_rules(
     except Exception as e:
         logger.error('Ошибка при показе политики конфиденциальности', error=e, exc_info=True)
         try:
-            await callback.message.answer(
-                privacy_policy_text, reply_markup=get_privacy_policy_keyboard(language), parse_mode='HTML'
+            await answer_long_text(
+                callback.message,
+                privacy_policy_text,
+                reply_markup=get_privacy_policy_keyboard(language),
+                parse_mode='HTML',
             )
             await state.set_state(RegistrationStates.waiting_for_privacy_policy_accept)
             logger.info(
@@ -2967,9 +2974,10 @@ async def required_sub_channel_check(
                     )
                     _cache_logo_file_id(_result)
                 else:
-                    await bot.send_message(
-                        chat_id=query.from_user.id,
-                        text=rules_text,
+                    await send_long_text(
+                        bot,
+                        query.from_user.id,
+                        rules_text,
                         reply_markup=get_rules_keyboard(language),
                     )
                 await state.set_state(RegistrationStates.waiting_for_rules_accept)

--- a/app/utils/long_messages.py
+++ b/app/utils/long_messages.py
@@ -1,0 +1,66 @@
+"""Отправка текстов длиннее лимита Telegram (4096) несколькими сообщениями.
+
+Разбивка — через split_telegram_text: по границам абзацев, с переносом
+незакрытых HTML-тегов между кусками. Клавиатура прикрепляется к последнему
+сообщению, чтобы кнопки действия оказались под концом документа.
+"""
+
+from aiogram import types
+
+from app.utils.telegram_html import split_telegram_text
+
+
+def _split(text: str) -> list[str]:
+    chunks = split_telegram_text(text)
+    return chunks if chunks else [text]
+
+
+async def answer_long_text(
+    message: types.Message,
+    text: str,
+    *,
+    reply_markup: types.InlineKeyboardMarkup | None = None,
+    **kwargs,
+) -> types.Message:
+    """message.answer с разбивкой; клавиатура — на последнем куске."""
+    chunks = _split(text)
+    for chunk in chunks[:-1]:
+        await message.answer(chunk, **kwargs)
+    return await message.answer(chunks[-1], reply_markup=reply_markup, **kwargs)
+
+
+async def edit_long_text(
+    message: types.Message,
+    text: str,
+    *,
+    reply_markup: types.InlineKeyboardMarkup | None = None,
+    **kwargs,
+) -> types.Message:
+    """message.edit_text с разбивкой.
+
+    Первый кусок редактирует исходное сообщение (без клавиатуры, если кусков
+    несколько — старые кнопки при этом убираются), остальные отправляются
+    новыми сообщениями, клавиатура — на последнем.
+    """
+    chunks = _split(text)
+    if len(chunks) == 1:
+        return await message.edit_text(chunks[0], reply_markup=reply_markup, **kwargs)
+    await message.edit_text(chunks[0], **kwargs)
+    for chunk in chunks[1:-1]:
+        await message.answer(chunk, **kwargs)
+    return await message.answer(chunks[-1], reply_markup=reply_markup, **kwargs)
+
+
+async def send_long_text(
+    bot,
+    chat_id: int,
+    text: str,
+    *,
+    reply_markup: types.InlineKeyboardMarkup | None = None,
+    **kwargs,
+) -> types.Message:
+    """bot.send_message с разбивкой; клавиатура — на последнем куске."""
+    chunks = _split(text)
+    for chunk in chunks[:-1]:
+        await bot.send_message(chat_id=chat_id, text=chunk, **kwargs)
+    return await bot.send_message(chat_id=chat_id, text=chunks[-1], reply_markup=reply_markup, **kwargs)


### PR DESCRIPTION
## Симптом

Если правила сервиса или политика конфиденциальности длиннее ~4096 символов (например, заполнены через кабинет, где нет ограничения в 4000 символов, в отличие от админки бота), их показ падает:

```
aiogram.exceptions.TelegramBadRequest: Telegram server says - Bad Request: MESSAGE_TOO_LONG
  File "/app/app/handlers/start.py", line 1375, in _show_privacy_policy_after_rules
    await callback.message.edit_text(privacy_policy_text, ...)
```

В регистрационном флоу это блокер: новый пользователь после `/start` принимает правила, политика не показывается — регистрацию завершить нельзя. «Правила сервиса» из меню (Инфо → Правила) падали на длинном тексте так же.

## Что сделано

**1. Новый модуль `app/utils/long_messages.py`** — `answer_long_text` / `edit_long_text` / `send_long_text`: отправка текста несколькими сообщениями через уже существующий `split_telegram_text` (разбивка по границам абзацев, перенос незакрытых HTML-тегов между кусками, куски ≤ 4096). Клавиатура прикрепляется к последнему сообщению — кнопки действия оказываются под концом документа. У `edit_long_text` первый кусок редактирует исходное сообщение (убирая его старые кнопки), остальные идут новыми сообщениями.

**2. Регистрационный флоу (`start.py`)** переведён на эти хелперы во всех точках показа:
- правила: после ввода реферального кода, после промокода, после выбора языка, после проверки подписки на обязательный канал (там же — ветка без logo mode через `send_long_text`);
- политика конфиденциальности: основной показ (`edit_long_text`) и fallback (`answer_long_text`).

**3. «Правила сервиса» из меню (`menu.py`)** получили постраничную навигацию `menu_rules:{page}` (⬅️ 1/3 ➡️) — ровно по тому же паттерну, что уже используют политика (`menu_privacy_policy:{page}`), оферта (`menu_public_offer:{page}`) и info-страницы. До этого правила отправлялись одним `edit_text`.

Показ политики и оферты из меню не менялся — они уже были защищены пагинацией через `split_content_into_pages`.

## Почему разбивка, а не обрезка

Лимит в 4000 символов в админке бота — техническое ограничение Telegram, а не продуктовое: юридические тексты легитимно бывают длиннее. Обрезать документ, который пользователь юридически принимает, нельзя. Парная правка в кабинете (предупреждение в редакторе системных страниц, что длинный текст будет показан по частям) идёт отдельным PR в bedolaga-cabinet.

## Проверка

- `split_telegram_text` на тексте 15k символов: 5 кусков ≤ 4096, HTML-теги в каждом куске сбалансированы;
- короткие тексты идут прежним путём (один кусок — одно сообщение/страница, UX не меняется).

Сценарий ручной проверки: заполнить политику текстом >4096 символов → `/start` новым аккаунтом → принять правила → политика приходит несколькими сообщениями, кнопки «Принять/Отклонить» под последним; меню → Инфо → Правила — листается стрелками.
