### PR TITLE
feat(bot): подсказка про права на каталоги в креш-репорте (PermissionError)

### DIFF
--- a/app/services/startup_notification_service.py
+++ b/app/services/startup_notification_service.py
@@ -47,6 +47,7 @@ COMMUNITY_URL: Final[str] = 'https://t.me/+wTdMtSWq8YdmZmVi'
 DEVELOPER_CONTACT_URL: Final[str] = 'https://t.me/fringg'
 
 # Ключевые слова для определения типа ошибки
+PERMISSION_ERROR_KEYWORDS: Final[tuple[str, ...]] = ('permission denied', 'errno 13')
 WEBHOOK_ERROR_KEYWORDS: Final[tuple[str, ...]] = ('webhook', 'failed to resolve host')
 DATABASE_ERROR_KEYWORDS: Final[tuple[str, ...]] = ('database', 'postgres', 'connection refused')
 REDIS_ERROR_KEYWORD: Final[str] = 'redis'
@@ -357,6 +358,17 @@ def _get_error_recommendations(error_message: str) -> str | None:
         Рекомендации в формате HTML blockquote или None
     """
     error_lower = error_message.lower()
+
+    # Ошибки прав доступа к примонтированным каталогам (logs/data/locales/uploads)
+    if any(keyword in error_lower for keyword in PERMISSION_ERROR_KEYWORDS):
+        tips = [
+            '• Бот в контейнере работает от пользователя с uid 1000',
+            '• Похоже, примонтированные каталоги принадлежат другому пользователю',
+            '• Проверьте права на каталоги logs, data, locales (и uploads)',
+            '• Обычно лечится на хосте: <code>chown -R 1000:1000 logs data locales</code>',
+            '• После исправления: docker compose restart bot',
+        ]
+        return '<blockquote expandable>💡 <b>Рекомендации:</b>\n' + '\n'.join(tips) + '</blockquote>'
 
     # Ошибки вебхука
     if any(keyword in error_lower for keyword in WEBHOOK_ERROR_KEYWORDS):


### PR DESCRIPTION
## Контекст

Частый кейс поддержки: примонтированные каталоги (`logs`, `data`, `locales`, `uploads`) принадлежат не тому пользователю — контейнер работает от uid 1000 (`USER app` в Dockerfile), и бот падает прямо на старте, ещё до инициализации логирования:

```
PermissionError: [Errno 13] Permission denied: '/app/logs/bot.log'
  File "/app/main.py", line 131, in main
    file_handler = logging.FileHandler(settings.LOG_FILE, encoding='utf-8')
```

Креш-репорт в Telegram при этом приходит (механизм ранних падений уже есть: `__main__` ловит исключение и шлёт `send_crash_notification` ботом на голом токене), но не объясняет причину — админ видит голый traceback.

## Что сделано

В `_get_error_recommendations` добавлена ветка по ключевым словам `permission denied` / `errno 13` — первой в списке, по образцу существующих подсказок (вебхук, БД, Redis, панель, токен). Теперь к креш-репорту прикладывается блок:

> 💡 **Рекомендации:**
> • Бот в контейнере работает от пользователя с uid 1000
> • Похоже, примонтированные каталоги принадлежат другому пользователю
> • Проверьте права на каталоги logs, data, locales (и uploads)
> • Обычно лечится на хосте: `chown -R 1000:1000 logs data locales`
> • После исправления: docker compose restart bot

## Проверка

- `_get_error_recommendations("[Errno 13] Permission denied: '/app/logs/bot.log'")` возвращает блок с подсказкой; соседние ветки (БД и др.) не затронуты — проверено запуском в контейнере;
- ruff (0.14.14, как в CI) — чисто.
