### PR TITLE
fix(monitoring): поддержать плейсхолдер {days} в SUBSCRIPTION_EXPIRING_PAID

### DIFF
--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -1834,6 +1834,9 @@ class MonitoringService:
                 '💳 <b>Автоплатеж:</b> {autopay_status}\n\n'
                 '{action_text}\n',
             ).format(
+                # Кастомные/старые локали используют {days} вместо {days_text} —
+                # передаём оба, иначе .format() падает с KeyError('days') (#2737).
+                days=days,
                 days_text=days_text,
                 end_date=end_date,
                 autopay_status=autopay_status,

--- a/tests/services/test_expiring_notification_days_placeholder.py
+++ b/tests/services/test_expiring_notification_days_placeholder.py
@@ -1,0 +1,59 @@
+"""SUBSCRIPTION_EXPIRING_PAID must format templates that use {days} (#2737).
+
+Custom/older locale files (e.g. fa.json) use a {days} placeholder while the code
+historically passed only days_text= to .format(). The KeyError('days') was
+swallowed by the broad except in _send_subscription_expiring_notification, so the
+user silently got no notification. The format call now passes both days and
+days_text.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.config import settings
+from app.services.monitoring_service import MonitoringService
+
+
+class _LegacyTexts:
+    """Texts stub emulating a custom locale with the legacy {days} placeholder."""
+
+    def t(self, key: str, default: str | None = None) -> str:
+        if key == 'SUBSCRIPTION_EXPIRING_PAID':
+            return 'Подписка{tariff_label} истекает через {days} дн. ({days_text}) — {end_date}\n{autopay_status}\n{action_text}'
+        return default if default is not None else key
+
+
+def _user() -> SimpleNamespace:
+    return SimpleNamespace(telegram_id=12345, language='fa', balance_kopeks=0)
+
+
+def _subscription() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        autopay_enabled=False,
+        end_date=datetime.now(UTC) + timedelta(days=3),
+        tariff=None,
+    )
+
+
+async def test_expiring_paid_supports_days_placeholder(monkeypatch):
+    monkeypatch.setattr(settings, 'ENABLE_LOGO_MODE', False)
+    monkeypatch.setattr(settings, 'ENABLE_AUTOPAY', False)
+    # Метод патчится на классе: pydantic не даёт setattr для методов на инстансе.
+    monkeypatch.setattr(type(settings), 'is_multi_tariff_enabled', lambda self: False)
+    monkeypatch.setattr('app.services.monitoring_service.get_texts', lambda _lang: _LegacyTexts())
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    svc = MonitoringService(bot=bot)
+    result = await svc._send_subscription_expiring_notification(_user(), _subscription(), days=3)
+
+    # Без days= в .format() KeyError гасился общим except и метод возвращал False.
+    assert result is True
+    bot.send_message.assert_awaited_once()
+    sent_text = bot.send_message.await_args.kwargs['text']
+    assert 'через 3 дн.' in sent_text


### PR DESCRIPTION
## 📝 Описание

`MonitoringService._send_subscription_expiring_notification` форматирует шаблон `SUBSCRIPTION_EXPIRING_PAID`, передавая только `days_text=`. Если локаль использует плейсхолдер `{days}` (кастомные/старые файлы локалей, например fa.json), `.format()` падает с `KeyError('days')`, ошибка гасится общим `except` — и пользователь молча не получает уведомление об истечении подписки.

Фикс: в `.format()` передаются оба значения — `days` (число) и `days_text` (склонённая строка), так что работают оба варианта шаблона.

Fixes #2737

## 🎯 Мотивация

Кастомные локали с `{days}` — легальный сценарий (совместимость со старыми шаблонами), а падение при этом невидимо для оператора: в логах `KeyError('days')`, уведомления не уходят.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Чеклист

- [x] Код соответствует стандартам проекта (ruff check / format — чисто)
- [x] Добавлены/обновлены тесты
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- Новый тест `tests/services/test_expiring_notification_days_placeholder.py` эмулирует локаль с `{days}`: без фикса метод возвращает `False` (KeyError проглочен), с фиксом — уведомление отправляется, текст содержит подставленное число.
- Проверено в обе стороны: тест красный на коде без фикса, зелёный с фиксом.
- Полный прогон `pytest tests/` (без integration): 1052 passed.
