### PR TITLE
feat(broadcasts): поддержать icon_custom_emoji_id у кастомных кнопок рассылки

### DIFF
--- a/app/cabinet/schemas/broadcasts.py
+++ b/app/cabinet/schemas/broadcasts.py
@@ -81,6 +81,9 @@ class CustomBroadcastButton(BaseModel):
     label: str = Field(..., min_length=1, max_length=64)
     action_type: Literal['callback', 'url'] = 'callback'
     action_value: str = Field(..., min_length=1, max_length=256)
+    # Telegram custom emoji, показываемый перед текстом кнопки (#3025).
+    # Идентификаторы custom emoji — числовые строки (Bot API custom_emoji_id).
+    icon_custom_emoji_id: str | None = Field(default=None, pattern=r'^\d{1,64}$')
 
     @field_validator('action_value')
     @classmethod

--- a/app/handlers/admin/messages.py
+++ b/app/handlers/admin/messages.py
@@ -134,11 +134,21 @@ def create_broadcast_keyboard(
             action_value = btn.get('action_value', '')
             if not label or not action_value:
                 continue
+            # Необязательный custom emoji перед текстом кнопки (#3025)
+            icon_emoji = btn.get('icon_custom_emoji_id') or None
             if action_type == 'url':
-                keyboard.append([types.InlineKeyboardButton(text=label, url=action_value)])
+                keyboard.append(
+                    [types.InlineKeyboardButton(text=label, url=action_value, icon_custom_emoji_id=icon_emoji)]
+                )
             else:
                 # callback type
-                keyboard.append([types.InlineKeyboardButton(text=label, callback_data=action_value)])
+                keyboard.append(
+                    [
+                        types.InlineKeyboardButton(
+                            text=label, callback_data=action_value, icon_custom_emoji_id=icon_emoji
+                        )
+                    ]
+                )
 
     if not keyboard:
         return None

--- a/tests/handlers/test_broadcast_custom_buttons.py
+++ b/tests/handlers/test_broadcast_custom_buttons.py
@@ -1,0 +1,60 @@
+"""Кастомные кнопки рассылки поддерживают icon_custom_emoji_id (#3025).
+
+Кабинет присылает кастомные кнопки как {label, action_type, action_value};
+поле icon_custom_emoji_id необязательно и, если задано, должно доходить до
+InlineKeyboardButton (custom emoji перед текстом кнопки, Bot API).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.cabinet.schemas.broadcasts import CustomBroadcastButton
+from app.handlers.admin.messages import create_broadcast_keyboard
+
+
+EMOJI_ID = '5368324170671202286'
+
+
+def test_keyboard_passes_icon_custom_emoji_id():
+    keyboard = create_broadcast_keyboard(
+        [],
+        custom_buttons=[
+            {
+                'label': 'Открыть',
+                'action_type': 'url',
+                'action_value': 'https://example.com',
+                'icon_custom_emoji_id': EMOJI_ID,
+            },
+            {'label': 'Меню', 'action_type': 'callback', 'action_value': 'menu_main'},
+        ],
+    )
+
+    url_button = keyboard.inline_keyboard[0][0]
+    assert url_button.url == 'https://example.com'
+    assert url_button.icon_custom_emoji_id == EMOJI_ID
+
+    # Без поля кнопка остаётся обычной
+    callback_button = keyboard.inline_keyboard[1][0]
+    assert callback_button.callback_data == 'menu_main'
+    assert callback_button.icon_custom_emoji_id is None
+
+
+def test_schema_roundtrips_icon_custom_emoji_id():
+    button = CustomBroadcastButton(
+        label='Открыть',
+        action_type='url',
+        action_value='https://example.com',
+        icon_custom_emoji_id=EMOJI_ID,
+    )
+    # model_dump — именно так кнопки уходят в конфиг рассылки (admin_broadcasts.py)
+    assert button.model_dump()['icon_custom_emoji_id'] == EMOJI_ID
+
+
+def test_schema_defaults_to_none_and_rejects_garbage():
+    button = CustomBroadcastButton(label='Меню', action_value='menu_main')
+    assert button.icon_custom_emoji_id is None
+
+    with pytest.raises(ValidationError):
+        CustomBroadcastButton(label='Меню', action_value='menu_main', icon_custom_emoji_id='not-a-number')


### PR DESCRIPTION
## 📝 Описание

Кастомные кнопки рассылок из кабинета теперь принимают необязательное поле `icon_custom_emoji_id` — Telegram custom emoji, показываемый перед текстом кнопки:

```json
{
  "label": "Открыть",
  "action_type": "url",
  "action_value": "https://example.com",
  "icon_custom_emoji_id": "1234567890123456789"
}
```

- `CustomBroadcastButton` (pydantic-схема кабинетного API): новое поле `icon_custom_emoji_id: str | None` с валидацией (числовая строка — формат Bot API `custom_emoji_id`);
- `create_broadcast_keyboard`: поле прокидывается в `InlineKeyboardButton` для обоих типов кнопок (url/callback); установленный в проекте aiogram 3.29.1 поддерживает параметр;
- поле необязательное — существующие рассылки и кнопки без него работают как раньше.

Поле в UI кабинета можно добавить отдельным PR — бэкенд его уже принимает (кнопки уходят в конфиг через `model_dump()` без изменений в роутах).

Closes #3025

## 🎯 Мотивация

Запрошено в #3025: возможность визуально выделять кнопки рассылок кастомными эмодзи.

## 🔧 Тип изменений

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Чеклист

- [x] Код соответствует стандартам проекта (ruff check / format — чисто)
- [x] Добавлены/обновлены тесты
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- Новые тесты `tests/handlers/test_broadcast_custom_buttons.py`: поле доходит до `InlineKeyboardButton`; без поля кнопка остаётся обычной (`None`); схема принимает числовую строку, отклоняет мусор, значение переживает `model_dump()` (путь в конфиг рассылки).
- `pytest tests/handlers/ tests/cabinet/`: 510 passed.
