### PR TITLE
fix(admin): честное сообщение при сохранении настройки, прибитой переменной окружения

### DIFF
--- a/app/handlers/admin/bot_configuration.py
+++ b/app/handlers/admin/bot_configuration.py
@@ -2504,6 +2504,24 @@ async def start_edit_setting(
     await callback.answer()
 
 
+def _build_save_confirmation(key: str) -> str:
+    """Сообщение после сохранения настройки.
+
+    set_value всегда пишет значение в БД, но для ключей, заданных через
+    окружение, рантайм продолжает использовать значение из .env — «✅ обновлена»
+    в этом случае вводит в заблуждение: админ видит подтверждение, а поведение
+    бота не меняется (#2749, вся секция рефералки из .env.example). Говорим
+    честно, какая переменная блокирует применение и что с ней сделать.
+    """
+    if bot_configuration_service.is_env_overridden(key):
+        return (
+            '💾 Сохранено в БД, но <b>не применено</b>: значение задаётся переменной '
+            f'окружения <code>{html.escape(key)}</code> из .env.\n'
+            'Уберите её из .env и перезапустите бота, чтобы управлять этой настройкой отсюда.'
+        )
+    return '✅ Настройка обновлена'
+
+
 @admin_required
 @error_handler
 async def handle_edit_setting(
@@ -2544,7 +2562,7 @@ async def handle_edit_setting(
 
     text = _render_setting_text(key)
     keyboard = _build_setting_keyboard(key, group_key, category_page, settings_page)
-    await message.answer('✅ Настройка обновлена')
+    await message.answer(_build_save_confirmation(key))
     await message.answer(text, reply_markup=keyboard)
     await state.clear()
     await _store_setting_context(
@@ -2595,7 +2613,7 @@ async def handle_direct_setting_input(
 
     text = _render_setting_text(key)
     keyboard = _build_setting_keyboard(key, group_key, category_page, settings_page)
-    await message.answer('✅ Настройка обновлена')
+    await message.answer(_build_save_confirmation(key))
     await message.answer(text, reply_markup=keyboard)
 
     await state.clear()

--- a/tests/handlers/test_setting_save_confirmation.py
+++ b/tests/handlers/test_setting_save_confirmation.py
@@ -1,0 +1,28 @@
+"""Сообщение после сохранения настройки говорит правду про env-переопределение (#2749).
+
+set_value пишет значение в БД всегда, но ключи, заданные через окружение,
+рантайм продолжает читать из .env. Раньше бот в этом случае всё равно отвечал
+«✅ Настройка обновлена» — админ видел подтверждение, а поведение не менялось
+(классический случай — вся секция рефералки, приехавшая из .env.example).
+"""
+
+from __future__ import annotations
+
+from app.handlers.admin.bot_configuration import _build_save_confirmation
+from app.services.system_settings_service import bot_configuration_service
+
+
+def test_env_pinned_setting_warns_instead_of_ok(monkeypatch):
+    monkeypatch.setattr(bot_configuration_service, '_env_override_keys', {'REFERRAL_COMMISSION_PERCENT'})
+
+    message = _build_save_confirmation('REFERRAL_COMMISSION_PERCENT')
+
+    assert 'не применено' in message
+    assert 'REFERRAL_COMMISSION_PERCENT' in message
+    assert '✅' not in message
+
+
+def test_regular_setting_reports_ok(monkeypatch):
+    monkeypatch.setattr(bot_configuration_service, '_env_override_keys', set())
+
+    assert _build_save_confirmation('SUPPORT_USERNAME') == '✅ Настройка обновлена'


### PR DESCRIPTION
## 📝 Описание

В разделах настроек, чьи ключи заданы через окружение, админ-бот после редактирования отвечал «✅ Настройка обновлена», хотя значение сознательно не применяется: `set_value` пишет в БД, но рантайм продолжает использовать значение из `.env` (env приоритетнее БД — это существующий дизайн, он не меняется). Классический случай из репорта — секция «Реферальная программа»: `.env.example` шипит все `REFERRAL_*` переменные, поэтому у типовой установки вся секция прибита окружением, и «не сохраняются никакие ~20 настроек».

Исправление: если ключ переопределён окружением, вместо «✅ Настройка обновлена» бот отвечает честно:

> 💾 Сохранено в БД, но **не применено**: значение задаётся переменной окружения `REFERRAL_COMMISSION_PERCENT` из .env.
> Уберите её из .env и перезапустите бота, чтобы управлять этой настройкой отсюда.

Сообщение строится в `_build_save_confirmation()` (оба пути текстового ввода настроек), определение — через существующий `is_env_overridden()`.

Fixes #2749

## 🎯 Мотивация

Админ получает подтверждение, а поведение бота не меняется — выглядит как баг сохранения и порождает репорты. Теперь бот объясняет, какая переменная блокирует применение и что с ней сделать.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Чеклист

- [x] Код соответствует стандартам проекта (ruff check / format — чисто)
- [x] Добавлены/обновлены тесты
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- Новые тесты `tests/handlers/test_setting_save_confirmation.py`: env-прибитый ключ → предупреждение с именем переменной и без «✅»; обычный ключ → прежнее «✅ Настройка обновлена»;
- `pytest tests/handlers/` — 51 passed.

## ❓ Открытые вопросы (сознательно не трогал)

1. Убрать ли `REFERRAL_*` из `.env.example` (закомментировать блок), чтобы новые установки управляли рефералкой из админки? Значения в примере могут расходиться с кодовыми дефолтами — нужно ваше решение.
2. Альтернатива подходу — дать явному изменению из админки приоритет над env. Это смена семантики конфигурации, тоже оставляю на ваше усмотрение; текущий PR лишь убирает ложное подтверждение.
