### PR TITLE
fix(remnawave): пересоздавать удалённого из панели юзера при живой подписке

### DIFF
--- a/app/external/remnawave_api.py
+++ b/app/external/remnawave_api.py
@@ -243,6 +243,17 @@ class RemnaWaveTransientError(RemnaWaveAPIError):
     surfaced by the monitoring service, not by per-request error logs."""
 
 
+def is_user_not_found_error(error: RemnaWaveAPIError) -> bool:
+    """Панель не нашла пользователя (удалён/протух UUID).
+
+    Разные версии RemnaWave сообщают это по-разному: A018 или A063, и не всегда
+    со статусом 404 — проверяем оба признака. Вызывающий код по этому признаку
+    пересоздаёт пользователя вместо падения в ошибку.
+    """
+    error_code = ((error.response_data or {}).get('errorCode') or '').strip()
+    return error.status_code == 404 or error_code in ('A018', 'A063')
+
+
 # Публичный RSA-ключ Happ для crypt4-ссылок — тот же, которым официальная страница
 # подписки Remnawave шифрует ссылку в браузере (@kastov/cryptohapp: JSEncrypt =
 # RSA PKCS#1 v1.5 + base64). Ключ публичный, расшифровать ссылку может только
@@ -715,7 +726,11 @@ class RemnaWaveAPI:
                 )
                 response = await self._make_request('PATCH', '/api/users', data)
             else:
-                logger.error('PATCH /api/users FAILED — full payload', payload=data)
+                # «User not found» — не error: как и 404 в _make_request, его
+                # обрабатывает вызывающий код (пересоздание пользователя), а
+                # error-логи буферизуются и сыплют отчётом в админ-чат.
+                log = logger.warning if is_user_not_found_error(e) else logger.error
+                log('PATCH /api/users FAILED — full payload', payload=data)
                 raise
         user = self._parse_user(response['response'])
         logger.info(

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -51,6 +51,7 @@ from app.external.remnawave_api import (
     RemnaWaveAPIError,
     RemnaWaveUser,
     UserStatus as RemnaWaveUserStatus,
+    is_user_not_found_error,
 )
 from app.localization.texts import get_texts
 from app.services.notification_delivery_service import (
@@ -648,7 +649,10 @@ class MonitoringService:
                     expire_at=subscription.end_date
                     if is_active
                     else max(subscription.end_date, current_time + timedelta(minutes=1)),
-                    traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
+                    # _gb_to_bytes живёт в SubscriptionService — у MonitoringService своего
+                    # никогда не было, и self._gb_to_bytes ронял весь метод AttributeError-ом
+                    # ещё до запроса в панель (молча гасился общим except → return None).
+                    traffic_limit_bytes=self.subscription_service._gb_to_bytes(subscription.traffic_limit_gb),
                     traffic_limit_strategy=get_traffic_reset_strategy(subscription.tariff),
                     description=settings.format_remnawave_user_description(
                         full_name=user.full_name, username=user.username, telegram_id=user.telegram_id
@@ -679,6 +683,10 @@ class MonitoringService:
                 return updated_user
 
         except RemnaWaveAPIError as e:
+            if is_user_not_found_error(e):
+                # Пользователя удалили из панели при живой подписке в боте —
+                # пересоздаём (create-флоу сохранит новый UUID и ссылки в подписку).
+                return await self.subscription_service.recreate_deleted_panel_user(db, subscription)
             logger.error('Ошибка обновления RemnaWave пользователя', error=e)
             return None
         except Exception as e:

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -32,6 +32,7 @@ from app.external.remnawave_api import (
     RemnaWaveAPI,
     RemnaWaveAPIError,
     UserStatus,
+    is_user_not_found_error,
 )
 from app.services.subscription_service import get_traffic_reset_strategy
 from app.utils.subscription_utils import (
@@ -2570,12 +2571,10 @@ class RemnaWaveService:
                                             user.remnawave_uuid = panel_uuid
                                         return ('updated', sub, None)
                                     except RemnaWaveAPIError as api_error:
-                                        # UUID в БД протух — панель-юзера уже нет. Разные версии
-                                        # RemnaWave сообщают это по-разному: A018 или A063, и не всегда
-                                        # со статусом 404. Пересоздаём по любому из этих признаков, чтобы
-                                        # синхронизация в панель чинила рассинхрон, а не падала в ошибку.
-                                        error_code = (api_error.response_data or {}).get('errorCode', '')
-                                        if api_error.status_code == 404 or error_code in ('A018', 'A063'):
+                                        # UUID в БД протух — панель-юзера уже нет. Пересоздаём,
+                                        # чтобы синхронизация в панель чинила рассинхрон,
+                                        # а не падала в ошибку.
+                                        if is_user_not_found_error(api_error):
                                             new_user = await api.create_user(**create_kwargs)
                                             return ('created', sub, new_user)
                                         raise

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -11,7 +11,14 @@ from app.config import settings
 from app.database.crud.server_squad import get_all_server_squads
 from app.database.crud.user import get_user_by_id
 from app.database.models import Subscription, SubscriptionStatus, User
-from app.external.remnawave_api import RemnaWaveAPI, RemnaWaveAPIError, RemnaWaveUser, TrafficLimitStrategy, UserStatus
+from app.external.remnawave_api import (
+    RemnaWaveAPI,
+    RemnaWaveAPIError,
+    RemnaWaveUser,
+    TrafficLimitStrategy,
+    UserStatus,
+    is_user_not_found_error,
+)
 from app.utils.subscription_utils import (
     resolve_hwid_device_limit_for_payload,
 )
@@ -543,11 +550,50 @@ class SubscriptionService:
                 return updated_user
 
         except RemnaWaveAPIError as e:
+            if is_user_not_found_error(e):
+                # Пользователя удалили из панели, пока подписка жива в боте, —
+                # пересоздаём вместо ошибки (create-флоу сам найдёт/создаст
+                # панель-юзера и сохранит новый UUID и ссылки в подписку).
+                return await self.recreate_deleted_panel_user(
+                    db, subscription, reset_traffic=reset_traffic, reset_reason=reset_reason
+                )
             logger.error('Ошибка RemnaWave API', error=e)
             return None
         except Exception as e:
             logger.error('Ошибка обновления RemnaWave пользователя', error=e)
             return None
+
+    async def recreate_deleted_panel_user(
+        self,
+        db: AsyncSession,
+        subscription: Subscription,
+        *,
+        reset_traffic: bool = False,
+        reset_reason: str | None = None,
+    ) -> RemnaWaveUser | None:
+        """Пересоздаёт панель-юзера, удалённого из RemnaWave при живой подписке.
+
+        Только для действующих подписок: пересоздавать DISABLED-юзера ради
+        истёкшей подписки не нужно — админ удалил его намеренно.
+        """
+        is_actually_active = (
+            subscription.status in (SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIAL.value)
+            and subscription.end_date > datetime.now(UTC)
+        )
+        if not is_actually_active:
+            logger.info(
+                'Панель-юзер удалён из RemnaWave, подписка неактивна — пересоздание не требуется',
+                subscription_id=subscription.id,
+                user_id=subscription.user_id,
+            )
+            return None
+
+        logger.warning(
+            '⚠️ Панель-юзер удалён из RemnaWave при активной подписке — пересоздаём',
+            subscription_id=subscription.id,
+            user_id=subscription.user_id,
+        )
+        return await self.create_remnawave_user(db, subscription, reset_traffic=reset_traffic, reset_reason=reset_reason)
 
     @staticmethod
     def _format_user_log(user) -> str:

--- a/tests/services/test_recreate_deleted_panel_user.py
+++ b/tests/services/test_recreate_deleted_panel_user.py
@@ -1,0 +1,249 @@
+"""Самолечение при удалённом из панели юзере: PATCH /api/users отвечает
+«User not found» (404 / A018 / A063), когда подписка в боте живая, — сервисы
+должны пересоздать панель-юзера, а не падать в ошибку (кейс: админ удалил
+пользователя из RemnaWave вручную, бот об этом не знает)."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import app.services.monitoring_service as monitoring_service_mod
+import app.services.subscription_service as subscription_service_mod
+from app.config import Settings
+from app.database.models import SubscriptionStatus
+from app.external.remnawave_api import RemnaWaveAPIError, is_user_not_found_error
+from app.services.monitoring_service import MonitoringService
+from app.services.subscription_service import SubscriptionService
+
+
+# ---- is_user_not_found_error: маркеры «панель-юзера больше нет» ----
+
+
+def test_not_found_by_status_404():
+    assert is_user_not_found_error(RemnaWaveAPIError('User not found', 404, {}))
+
+
+def test_not_found_by_error_code_without_404():
+    # Разные версии RemnaWave отвечают A018/A063 и не всегда со статусом 404
+    assert is_user_not_found_error(RemnaWaveAPIError('x', 400, {'errorCode': 'A018'}))
+    assert is_user_not_found_error(RemnaWaveAPIError('x', 500, {'errorCode': 'A063'}))
+
+
+def test_other_errors_are_not_not_found():
+    assert not is_user_not_found_error(RemnaWaveAPIError('fk violation', 400, {'errorCode': 'A039'}))
+    assert not is_user_not_found_error(RemnaWaveAPIError('internal', 500, {}))
+    assert not is_user_not_found_error(RemnaWaveAPIError('не настроен'))  # без статуса и response_data
+
+
+# ---- общие фикстуры-строители ----
+
+
+def _make_user():
+    return SimpleNamespace(
+        id=1,
+        telegram_id=100,
+        username='u',
+        full_name='User',
+        email=None,
+        remnawave_uuid='dead-uuid',
+    )
+
+
+def _make_subscription(*, status=SubscriptionStatus.ACTIVE.value, days_left=10):
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id=11,
+        user_id=1,
+        status=status,
+        end_date=now + timedelta(days=days_left),
+        traffic_limit_gb=100,
+        connected_squads=[],
+        tariff=None,
+        remnawave_uuid=None,
+        is_trial=False,
+        last_webhook_update_at=None,
+    )
+
+
+def _patch_api_client(monkeypatch, service, api):
+    @asynccontextmanager
+    async def fake_client():
+        yield api
+
+    monkeypatch.setattr(service, 'get_api_client', fake_client)
+
+
+# ---- recreate_deleted_panel_user: гейт «только живые подписки» ----
+
+
+async def test_recreate_active_delegates_to_create_flow():
+    service = SubscriptionService()
+    recreated = object()
+    service.create_remnawave_user = AsyncMock(return_value=recreated)
+
+    result = await service.recreate_deleted_panel_user(
+        AsyncMock(), _make_subscription(), reset_traffic=True, reset_reason='renewal'
+    )
+
+    assert result is recreated
+    service.create_remnawave_user.assert_awaited_once()
+    assert service.create_remnawave_user.await_args.kwargs == {'reset_traffic': True, 'reset_reason': 'renewal'}
+
+
+async def test_recreate_trial_is_also_alive():
+    service = SubscriptionService()
+    service.create_remnawave_user = AsyncMock(return_value=object())
+
+    result = await service.recreate_deleted_panel_user(
+        AsyncMock(), _make_subscription(status=SubscriptionStatus.TRIAL.value)
+    )
+
+    assert result is not None
+    service.create_remnawave_user.assert_awaited_once()
+
+
+async def test_recreate_skips_expired_status():
+    """Истёкшую подписку не пересоздаём: админ удалил панель-юзера намеренно."""
+    service = SubscriptionService()
+    service.create_remnawave_user = AsyncMock()
+
+    result = await service.recreate_deleted_panel_user(
+        AsyncMock(), _make_subscription(status=SubscriptionStatus.EXPIRED.value, days_left=-3)
+    )
+
+    assert result is None
+    service.create_remnawave_user.assert_not_awaited()
+
+
+async def test_recreate_skips_active_status_with_past_end_date():
+    """Статус ACTIVE, но end_date уже прошёл (scheduled job ещё не отработал) — не пересоздаём."""
+    service = SubscriptionService()
+    service.create_remnawave_user = AsyncMock()
+
+    result = await service.recreate_deleted_panel_user(AsyncMock(), _make_subscription(days_left=-1))
+
+    assert result is None
+    service.create_remnawave_user.assert_not_awaited()
+
+
+# ---- SubscriptionService.update_remnawave_user: рекавери вместо ошибки ----
+
+
+def _setup_subscription_service(monkeypatch, api):
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    service = SubscriptionService()
+    monkeypatch.setattr(subscription_service_mod, 'get_user_by_id', AsyncMock(return_value=_make_user()))
+    monkeypatch.setattr(subscription_service_mod, 'resolve_hwid_device_limit_for_payload', lambda s: None)
+    _patch_api_client(monkeypatch, service, api)
+    return service
+
+
+async def test_update_recreates_deleted_panel_user(monkeypatch):
+    api = AsyncMock()
+    api.update_user.side_effect = RemnaWaveAPIError('User not found', 404, {'errorCode': 'A018'})
+    service = _setup_subscription_service(monkeypatch, api)
+
+    recreated = object()
+    service.create_remnawave_user = AsyncMock(return_value=recreated)
+
+    result = await service.update_remnawave_user(AsyncMock(), _make_subscription())
+
+    assert result is recreated
+    api.update_user.assert_awaited_once()
+    service.create_remnawave_user.assert_awaited_once()
+
+
+async def test_update_does_not_recreate_on_other_api_errors(monkeypatch):
+    api = AsyncMock()
+    api.update_user.side_effect = RemnaWaveAPIError('internal error', 500, {})
+    service = _setup_subscription_service(monkeypatch, api)
+    service.create_remnawave_user = AsyncMock()
+
+    result = await service.update_remnawave_user(AsyncMock(), _make_subscription())
+
+    assert result is None
+    service.create_remnawave_user.assert_not_awaited()
+
+
+async def test_update_does_not_recreate_for_expired_subscription(monkeypatch):
+    """Пуш DISABLED в удалённого панель-юзера: молча пропускаем, панель не засоряем."""
+    api = AsyncMock()
+    api.update_user.side_effect = RemnaWaveAPIError('User not found', 404, {})
+    service = _setup_subscription_service(monkeypatch, api)
+    service.create_remnawave_user = AsyncMock()
+
+    result = await service.update_remnawave_user(
+        AsyncMock(), _make_subscription(status=SubscriptionStatus.EXPIRED.value, days_left=-3)
+    )
+
+    assert result is None
+    service.create_remnawave_user.assert_not_awaited()
+
+
+# ---- MonitoringService.update_remnawave_user: тот же рекавери в рутинном синке ----
+
+
+async def test_monitoring_update_happy_path_reaches_panel(monkeypatch):
+    """Регрессия: self._gb_to_bytes не существовал у MonitoringService — метод падал
+    AttributeError-ом до запроса в панель и молча возвращал None из общего except."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    service = MonitoringService()
+    service.subscription_service._config_error = None  # is_configured → True
+
+    monkeypatch.setattr(monitoring_service_mod, 'get_user_by_id', AsyncMock(return_value=_make_user()))
+    monkeypatch.setattr(monitoring_service_mod, 'resolve_hwid_device_limit_for_payload', lambda s: None)
+
+    updated_user = SimpleNamespace(subscription_url='https://sub.example/u', happ_crypto_link=None)
+    api = AsyncMock()
+    api.update_user.return_value = updated_user
+    _patch_api_client(monkeypatch, service.subscription_service, api)
+
+    db = AsyncMock()
+    result = await service.update_remnawave_user(db, _make_subscription())
+
+    assert result is updated_user
+    assert api.update_user.await_args.kwargs['traffic_limit_bytes'] == 100 * 1024**3
+    db.commit.assert_awaited()
+
+
+async def test_monitoring_update_recreates_deleted_panel_user(monkeypatch):
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    service = MonitoringService()
+    service.subscription_service._config_error = None  # is_configured → True
+
+    monkeypatch.setattr(monitoring_service_mod, 'get_user_by_id', AsyncMock(return_value=_make_user()))
+    monkeypatch.setattr(monitoring_service_mod, 'resolve_hwid_device_limit_for_payload', lambda s: None)
+
+    api = AsyncMock()
+    api.update_user.side_effect = RemnaWaveAPIError('User not found', 404, {'errorCode': 'A063'})
+    _patch_api_client(monkeypatch, service.subscription_service, api)
+
+    recreated = object()
+    service.subscription_service.recreate_deleted_panel_user = AsyncMock(return_value=recreated)
+
+    result = await service.update_remnawave_user(AsyncMock(), _make_subscription())
+
+    assert result is recreated
+    api.update_user.assert_awaited_once()
+    service.subscription_service.recreate_deleted_panel_user.assert_awaited_once()
+
+
+async def test_monitoring_update_does_not_recreate_on_other_api_errors(monkeypatch):
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    service = MonitoringService()
+    service.subscription_service._config_error = None
+
+    monkeypatch.setattr(monitoring_service_mod, 'get_user_by_id', AsyncMock(return_value=_make_user()))
+    monkeypatch.setattr(monitoring_service_mod, 'resolve_hwid_device_limit_for_payload', lambda s: None)
+
+    api = AsyncMock()
+    api.update_user.side_effect = RemnaWaveAPIError('internal error', 500, {})
+    _patch_api_client(monkeypatch, service.subscription_service, api)
+
+    service.subscription_service.recreate_deleted_panel_user = AsyncMock()
+
+    result = await service.update_remnawave_user(AsyncMock(), _make_subscription())
+
+    assert result is None
+    service.subscription_service.recreate_deleted_panel_user.assert_not_awaited()


### PR DESCRIPTION
## 📝 Описание

Если пользователя удалили из панели RemnaWave, пока в боте у него живая подписка, любой `PATCH /api/users` по сохранённому UUID падал с `RemnaWaveAPIError: User not found`, сервис логировал ERROR и возвращал `None` — панель для пользователя оставалась сломанной навсегда, а админ-чат получал отчёты об ошибках на каждый цикл.

Теперь update-флоу самолечится:

- `app/external/remnawave_api.py`: общий хелпер `is_user_not_found_error()` — маркеры «панель-юзера больше нет» (404 / errorCode A018 / A063, разные версии RemnaWave отвечают по-разному). Эта же проверка уже жила в `sync_users_to_panel` — дубль заменён на хелпер. Лог `PATCH /api/users FAILED — full payload` для этого случая понижен до warning (как 404 в `_make_request`): случай обрабатывается вызывающим кодом, а error-логи буферизуются в отчёт админ-чата.
- `app/services/subscription_service.py`: `update_remnawave_user` при «user not found» вызывает новый `recreate_deleted_panel_user()` — для подписки в статусе active/trial с непрошедшим `end_date` пересоздаёт панель-юзера через существующий `create_remnawave_user` (тот сам найдёт юзера по telegram_id/email или создаст нового и сохранит новый UUID и ссылки в подписку). Для истёкших подписок пересоздания нет — пользователь удалён из панели намеренно.
- `app/services/monitoring_service.py`: тот же рекавери в рутинном синке мониторинга.

Заодно исправлен давний баг мониторинга: `MonitoringService.update_remnawave_user` вызывал `self._gb_to_bytes()`, которого у этого класса никогда не было (метод живёт в `SubscriptionService`). Каждый вызов падал `AttributeError` ещё до запроса в панель и молча гасился общим `except` — рутинное обновление панель-юзеров из мониторинга фактически не работало. Исправлено вызовом через `self.subscription_service`, добавлен happy-path регресс-тест.

## 🎯 Мотивация

Реальный кейс из прода: админ удалил пользователя из панели, когда в боте у него была активная подписка. Бот сыпал `PATCH /api/users FAILED — User not found` в админ-чат и не восстанавливал пользователя — приходилось чинить руками.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист

- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [ ] Документация обновлена

## 🧪 Тестирование

- `uv run ruff check` — по изменённым файлам чисто (базовый `ruff check` по репо сейчас красный из-за SIM222 в `tests/utils/test_rich_admin.py` на `dev` — не трогал);
- `uv run pytest tests/services/test_recreate_deleted_panel_user.py -q` — 13 passed:
  - маркеры `is_user_not_found_error` (404, A018/A063 без 404, не-маркеры A039/500/без статуса);
  - гейт «только живые подписки»: active/trial → пересоздание, expired и active-с-прошедшим-`end_date` → нет;
  - полнофлоу `SubscriptionService.update_remnawave_user`: 404 → пересоздание и возврат нового юзера, 500 → `None` без пересоздания, истёкшая подписка → `None`;
  - полнофлоу `MonitoringService.update_remnawave_user`: happy-path (регрессия на `AttributeError`, проверка `traffic_limit_bytes`), 404 → пересоздание, 500 → нет;
- полный прогон `pytest tests/ -q` — 1931 passed (4 падения `test_referral_diagnostics` — преждесуществующая Windows-специфика кодировки, к изменению отношения не имеют).
