### PR TITLE
fix(subscription): конверсия живого триала при покупке тарифа в мульти-режиме

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -983,10 +983,27 @@ async def purchase_tariff(
             # TARIFF_SWITCH_RESET_FREE_DAYS перебивает TRIAL_ADD_REMAINING_DAYS_TO_PAID).
             _bonus_seconds = 0
             _now_trial = datetime.now(UTC)
+            # В мульти-тарифе create-ветка ниже (нет живой подписки покупаемого
+            # тарифа) НЕ должна глушить живой триал здесь: create_paid_subscription
+            # конвертирует его на месте (та же строка, тот же Remnawave-юзер и
+            # ссылка) вместо вставки новой подписки. Убив его заранее, мы бы
+            # спрятали кандидата от конверсии и вернули старое поведение — новый
+            # панельный юзер + мёртвый триал, висящий в кабинете. Его остаток
+            # дней переносит extend_subscription внутри конверсии, поэтому в
+            # _bonus_seconds кандидат не попадает — двойного начисления нет.
+            # resolve_trial_conversion_candidate повторяет приоритеты
+            # create_paid_subscription (в т.ч. вернёт None, когда сработает
+            # revive-ветка #3004) — тогда триал глушится по-старому: с переносом
+            # остатка и отключением панельного юзера в цикле ниже.
+            _conversion_trial = None
+            if subscription is None and settings.is_multi_tariff_enabled():
+                from app.database.crud.subscription import resolve_trial_conversion_candidate
+
+                _conversion_trial = await resolve_trial_conversion_candidate(db, user.id, tariff.id)
             killed_trials = await deactivate_user_trial_subscriptions(
                 db,
                 user.id,
-                exclude_subscription_id=subscription.id if subscription else None,
+                exclude_subscription_id=subscription.id if subscription else getattr(_conversion_trial, 'id', None),
             )
             if should_carry_trial_remaining_days():
                 for _kt in killed_trials:
@@ -1016,7 +1033,7 @@ async def purchase_tariff(
                     connected_squads=squads,
                 )
             else:
-                # Create new subscription
+                # Create new subscription (или конверсия исключённого выше триала)
                 try:
                     subscription = await create_paid_subscription(
                         db=db,
@@ -1026,6 +1043,7 @@ async def purchase_tariff(
                         device_limit=tariff.device_limit,
                         connected_squads=squads,
                         tariff_id=tariff.id,
+                        conversion_trial=_conversion_trial,
                     )
                 except IntegrityError:
                     # Partial unique index violation: user already has active subscription for this tariff
@@ -1238,7 +1256,10 @@ async def purchase_tariff(
                         subscription=subscription,
                         transaction=transaction,
                         period_days=period_days,
-                        was_trial_conversion=False,
+                        # Маркер ставит extend_subscription, когда покупка
+                        # конвертировала живой триал (в т.ч. конверсию внутри
+                        # create_paid_subscription).
+                        was_trial_conversion=bool(getattr(subscription, '_converted_from_trial', False)),
                         amount_kopeks=price_kopeks,
                         purchase_type='renewal' if not was_new_subscription else 'first_purchase',
                     )

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -407,6 +407,152 @@ async def _revive_paid_subscription(
     return subscription
 
 
+async def _resolve_connected_squads(
+    db: AsyncSession,
+    connected_squads: list[str] | None,
+    *,
+    user_id: int,
+) -> list[str]:
+    """Fallback: если connected_squads пустой — берём первый доступный сквад.
+
+    Общий для вставки новой платной подписки и конверсии триала: без него
+    конверсия молча оставила бы юзера на триальных сквадах при пустом списке,
+    тогда как вставка подключала бы fallback-сквад.
+    """
+    final_squads = list(connected_squads or [])
+    if not final_squads:
+        try:
+            from app.database.crud.server_squad import get_available_server_squads
+
+            available = await get_available_server_squads(db)
+            if available:
+                final_squads = [available[0].squad_uuid]
+                logger.warning(
+                    '⚠️ connected_squads пустой при создании подписки, используем fallback сквад',
+                    user_id=user_id,
+                    fallback_squad=final_squads[0],
+                )
+        except Exception as error:
+            logger.error('❌ Не удалось получить fallback сквад', user_id=user_id, error=error)
+    return final_squads
+
+
+async def _convert_trial_subscription_to_paid(
+    db: AsyncSession,
+    trial_subscription: Subscription,
+    *,
+    tariff_id: int,
+    duration_days: int,
+    traffic_limit_gb: int,
+    device_limit: int | None,
+    connected_squads: list[str] | None,
+    commit: bool,
+) -> Subscription | None:
+    """Convert an alive trial subscription into the purchased paid tariff in place.
+
+    Multi-tariff used to INSERT a fresh subscription (→ a brand-new Remnawave
+    user) on the first paid purchase and merely disable the trial row, so the
+    user got a NEW link/panel user while the dead trial kept showing in the
+    cabinet (prod report 2026-07). Reusing the trial row keeps the SAME
+    Remnawave user/link the user already configured during the trial — the
+    callers' "update, don't create" panel sync kicks in automatically because
+    the row carries ``remnawave_uuid``. ``extend_subscription`` does the heavy
+    lifting: tariff change with TRIAL_ADD_REMAINING_DAYS_TO_PAID carry-over,
+    ``is_trial`` reset (+ the ``_converted_from_trial`` marker), traffic/device
+    limits, daily flags and deactivation of any other trials.
+
+    Server counters are deliberately NOT bumped here: the trial row already
+    incremented them at trial creation, and the old insert path's +1 was paired
+    with the killed trial's separate decrement — re-adding on an in-place
+    conversion would double-count the same subscription.
+
+    Returns ``None`` when, under the row lock, the candidate turns out to no
+    longer be an alive trial — a concurrent purchase already converted it.
+    Without this re-check two concurrent purchases of different tariffs would
+    both convert the SAME row and the second would silently overwrite the
+    first's tariff (money lost with no exception). The caller falls back to
+    the plain insert, which is exactly the pre-conversion behaviour.
+    """
+    try:
+        await _lock_subscription_row(db, trial_subscription)
+        await db.refresh(trial_subscription, ['is_trial', 'status', 'tariff_id', 'end_date'])
+    except Exception as lock_error:
+        logger.warning(
+            'Не удалось перечитать кандидата конверсии триала под локом — обычная вставка',
+            subscription_id=trial_subscription.id,
+            error=lock_error,
+        )
+        return None
+    if not trial_subscription.is_trial or trial_subscription.status not in _ALIVE_SUBSCRIPTION_STATUSES_TUPLE:
+        logger.info(
+            'Кандидат конверсии триала уже не живой триал (конкурентная покупка) — обычная вставка',
+            subscription_id=trial_subscription.id,
+            user_id=trial_subscription.user_id,
+        )
+        return None
+
+    final_squads = await _resolve_connected_squads(db, connected_squads, user_id=trial_subscription.user_id)
+    subscription = await extend_subscription(
+        db,
+        trial_subscription,
+        days=duration_days,
+        tariff_id=tariff_id,
+        traffic_limit_gb=traffic_limit_gb,
+        device_limit=device_limit if device_limit is not None else settings.DEFAULT_DEVICE_LIMIT,
+        connected_squads=final_squads or None,
+        commit=commit,
+    )
+
+    logger.info(
+        '🎓 Триал конвертирован в купленный тариф вместо создания новой подписки',
+        user_id=subscription.user_id,
+        subscription_id=subscription.id,
+        tariff_id=tariff_id,
+    )
+    return subscription
+
+
+async def _alive_trial_conversion_candidate(
+    db: AsyncSession,
+    user_id: int,
+    same_tariff_existing: Subscription | None,
+) -> Subscription | None:
+    """Единое правило выбора кандидата конверсии триала при платной покупке.
+
+    Живой триал ПОКУПАЕМОГО тарифа (переданный ``same_tariff_existing``)
+    приоритетнее любого другого: его конверсия гарантированно не столкнётся с
+    ``uq_subscriptions_user_tariff_active``. Иначе — самый живой триал юзера.
+    """
+    if (
+        same_tariff_existing is not None
+        and same_tariff_existing.is_trial
+        and same_tariff_existing.status in _ALIVE_SUBSCRIPTION_STATUSES_TUPLE
+    ):
+        return same_tariff_existing
+    return await get_alive_trial_subscription(db, user_id)
+
+
+async def resolve_trial_conversion_candidate(
+    db: AsyncSession,
+    user_id: int,
+    tariff_id: int,
+) -> Subscription | None:
+    """Кандидат конверсии триала, каким его увидит ``create_paid_subscription``.
+
+    Для вызывающих, которым кандидат нужен ДО ``create_paid_subscription``
+    (кабинет исключает его из раннего убийства триалов). Повторяет приоритеты
+    create_paid_subscription через тот же ``_alive_trial_conversion_candidate``:
+    если у юзера есть EXPIRED подписка ПОКУПАЕМОГО тарифа, создание уйдёт в
+    revive-ветку (#3004) и конверсии не будет — возвращаем None, чтобы
+    вызывающий обращался с триалом по-старому (kill + перенос остатка +
+    отключение панельного юзера).
+    """
+    existing = await get_subscription_by_user_and_tariff(db, user_id, tariff_id, include_inactive=True)
+    if existing is not None and existing.status == SubscriptionStatus.EXPIRED.value:
+        return None
+    return await _alive_trial_conversion_candidate(db, user_id, existing)
+
+
 async def create_paid_subscription(
     db: AsyncSession,
     user_id: int,
@@ -418,6 +564,7 @@ async def create_paid_subscription(
     is_trial: bool = False,
     tariff_id: int | None = None,
     commit: bool = True,
+    conversion_trial: Subscription | None = None,
 ) -> Subscription:
     # Multi-tariff invariant: at most ONE subscription per (user, tariff). If a
     # subscription for this tariff has EXPIRED, revive it in place instead of
@@ -444,27 +591,41 @@ async def create_paid_subscription(
                 commit=commit,
             )
 
+        # Paid purchase while an alive (active/trial/limited) TRIAL exists —
+        # usually of a DIFFERENT tariff: convert that trial row in place instead
+        # of inserting a new subscription. Otherwise the user gets a brand-new
+        # Remnawave user/link while the killed trial keeps hanging in the
+        # cabinet (prod report 2026-07: триал → покупка тарифа → «две подписки»,
+        # см. скрин #disabled + #created). Mirrors the classic-mode purchase,
+        # which has always converted the trial in place. ``conversion_trial``
+        # lets callers that pre-resolved the candidate (cabinet, via
+        # ``resolve_trial_conversion_candidate``) pass it through instead of a
+        # second lookup; the selection rule is shared either way.
+        _alive_trial = conversion_trial
+        if _alive_trial is None:
+            _alive_trial = await _alive_trial_conversion_candidate(db, user_id, _existing)
+        if _alive_trial is not None:
+            _converted = await _convert_trial_subscription_to_paid(
+                db,
+                _alive_trial,
+                tariff_id=tariff_id,
+                duration_days=duration_days,
+                traffic_limit_gb=traffic_limit_gb,
+                device_limit=device_limit,
+                connected_squads=connected_squads,
+                commit=commit,
+            )
+            if _converted is not None:
+                return _converted
+            # Гонка: кандидат уже конвертирован конкурентной покупкой — падаем
+            # в обычную вставку (две платные подписки, как до фикса).
+
     end_date = datetime.now(UTC) + timedelta(days=duration_days)
 
     if device_limit is None:
         device_limit = settings.DEFAULT_DEVICE_LIMIT
 
-    # Fallback: если connected_squads пустой — берём первый доступный сквад
-    final_squads = list(connected_squads or [])
-    if not final_squads:
-        try:
-            from app.database.crud.server_squad import get_available_server_squads
-
-            available = await get_available_server_squads(db)
-            if available:
-                final_squads = [available[0].squad_uuid]
-                logger.warning(
-                    '⚠️ connected_squads пустой при создании подписки, используем fallback сквад',
-                    user_id=user_id,
-                    fallback_squad=final_squads[0],
-                )
-        except Exception as error:
-            logger.error('❌ Не удалось получить fallback сквад', user_id=user_id, error=error)
+    final_squads = await _resolve_connected_squads(db, connected_squads, user_id=user_id)
 
     short_id = await generate_unique_short_id(db)
 
@@ -1029,6 +1190,9 @@ async def extend_subscription(
         # попадёт в авто-продление (баг #629889).
         if subscription.is_trial and convert_trial:
             subscription.is_trial = False
+            # Transient marker (not persisted): lets purchase handlers report the
+            # payment as a trial→paid conversion without a signature change.
+            subscription._converted_from_trial = True
             logger.info('🎓 Подписка конвертирована из триала в платную', subscription_id=subscription.id)
 
     if traffic_limit_gb is not None:
@@ -2789,6 +2953,34 @@ async def get_subscription_by_user_and_tariff(
     return result.scalar_one_or_none()
 
 
+async def get_alive_trial_subscription(db: AsyncSession, user_id: int) -> Subscription | None:
+    """Alive (active/trial/limited) trial subscription of the user, if any.
+
+    LIMITED is included on purpose: an exhausted-traffic trial is exactly the
+    «попробовал → покупаю» case and must convert on purchase, not hang around
+    next to the new paid subscription. But an ACTIVE/TRIAL trial always beats a
+    LIMITED one regardless of end_date — the non-limited trial carries the link
+    the user is actually using, and converting the wrong row would kill their
+    working link right after payment. Ties break by freshest ``end_date``.
+    """
+    result = await db.execute(
+        select(Subscription)
+        .options(selectinload(Subscription.tariff))
+        .where(
+            Subscription.user_id == user_id,
+            Subscription.is_trial.is_(True),
+            Subscription.status.in_(_ALIVE_SUBSCRIPTION_STATUSES_TUPLE),
+        )
+        .order_by(
+            case((Subscription.status == SubscriptionStatus.LIMITED.value, 1), else_=0),
+            Subscription.end_date.desc(),
+            Subscription.created_at.desc(),
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def deactivate_user_trial_subscriptions(
     db: AsyncSession,
     user_id: int,
@@ -2799,7 +2991,10 @@ async def deactivate_user_trial_subscriptions(
 
     Called when user purchases a paid tariff — trial is a probe that must die on purchase.
     Returns remaining trial time in seconds (for TRIAL_ADD_REMAINING_DAYS_TO_PAID).
-    Handles both tariff-based and squad-based trials uniformly.
+    Handles both tariff-based and squad-based trials uniformly. LIMITED
+    (traffic-exhausted) trials are included: they are alive per the partial
+    unique index and used to survive every paid purchase, hanging in the
+    cabinet next to the new subscription.
     """
     result = await db.execute(
         select(Subscription).where(
@@ -2809,6 +3004,7 @@ async def deactivate_user_trial_subscriptions(
                 [
                     SubscriptionStatus.ACTIVE.value,
                     SubscriptionStatus.TRIAL.value,
+                    SubscriptionStatus.LIMITED.value,
                 ]
             ),
         )

--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -1110,13 +1110,12 @@ async def handle_custom_confirm(
     try:
         # Обновляем пользователя в Remnawave
         # При покупке тарифа ВСЕГДА сбрасываем трафик в панели
+        if settings.is_multi_tariff_enabled():
+            _should_create = not subscription.remnawave_uuid
+        else:
+            _should_create = not getattr(db_user, 'remnawave_uuid', None)
         try:
             subscription_service = SubscriptionService()
-            if settings.is_multi_tariff_enabled():
-                _should_create = not subscription.remnawave_uuid
-            else:
-                _should_create = not getattr(db_user, 'remnawave_uuid', None)
-
             if _should_create:
                 await subscription_service.create_remnawave_user(
                     db,
@@ -1135,10 +1134,12 @@ async def handle_custom_confirm(
             logger.error('Ошибка обновления Remnawave', error=e)
             from app.services.remnawave_retry_queue import remnawave_retry_queue
 
+            # То же mode-aware решение, что и синк выше: конвертированный из
+            # триала ретраится как 'update', а не плодит дубль панельного юзера.
             remnawave_retry_queue.enqueue(
                 subscription_id=subscription.id,
                 user_id=db_user.id,
-                action='create',
+                action='create' if _should_create else 'update',
             )
 
         # Создаем транзакцию
@@ -1159,7 +1160,8 @@ async def handle_custom_confirm(
                 subscription,
                 None,
                 custom_days,
-                was_trial_conversion=False,
+                # Маркер ставит extend_subscription при конверсии живого триала
+                was_trial_conversion=bool(getattr(subscription, '_converted_from_trial', False)),
                 amount_kopeks=total_price,
                 purchase_type='renewal' if existing_subscription else 'first_purchase',
             )
@@ -1545,8 +1547,13 @@ async def confirm_tariff_purchase(
                     connected_squads=squads,
                 )
             else:
-                # Guard: enforce MAX_ACTIVE_SUBSCRIPTIONS limit
-                active_count = len(await get_active_subscriptions_by_user_id(db, db_user.id))
+                # Guard: enforce MAX_ACTIVE_SUBSCRIPTIONS limit.
+                # Живой триал не считаем: create_paid_subscription конвертирует
+                # его на месте (строка переиспользуется), количество подписок не
+                # растёт — блокировать такую покупку лимитом нельзя, иначе юзер
+                # на пределе лимита не может превратить триал в платный тариф.
+                _alive_subs = await get_active_subscriptions_by_user_id(db, db_user.id)
+                active_count = len([s for s in _alive_subs if not s.is_trial])
                 if active_count >= settings.get_max_active_subscriptions():
                     from app.database.crud.user import add_user_balance
 
@@ -1709,16 +1716,15 @@ async def confirm_tariff_purchase(
 
     # Обновляем пользователя в Remnawave
     # При покупке тарифа ВСЕГДА сбрасываем трафик в панели
+    # In multi-tariff mode, each subscription has its own panel user.
+    # A new subscription has no remnawave_uuid yet, so always CREATE.
+    # In single-tariff mode, reuse the user-level UUID if available.
+    if settings.is_multi_tariff_enabled():
+        _should_create = not subscription.remnawave_uuid
+    else:
+        _should_create = not getattr(db_user, 'remnawave_uuid', None)
     try:
         subscription_service = SubscriptionService()
-        # In multi-tariff mode, each subscription has its own panel user.
-        # A new subscription has no remnawave_uuid yet, so always CREATE.
-        # In single-tariff mode, reuse the user-level UUID if available.
-        if settings.is_multi_tariff_enabled():
-            _should_create = not subscription.remnawave_uuid
-        else:
-            _should_create = not getattr(db_user, 'remnawave_uuid', None)
-
         if _should_create:
             await subscription_service.create_remnawave_user(
                 db,
@@ -1737,10 +1743,16 @@ async def confirm_tariff_purchase(
         logger.error('Ошибка обновления Remnawave', error=e)
         from app.services.remnawave_retry_queue import remnawave_retry_queue
 
+        # Ретрай повторяет то же mode-aware решение, что и синк выше: у
+        # конвертированного из триала (или реанимированной #3004) подписки уже
+        # есть панельный юзер — его надо ОБНОВИТЬ, а не создать дубль. Хардкод
+        # 'update' по subscription.remnawave_uuid здесь не годится: в
+        # single-tariff вебхук панели чистит user.remnawave_uuid при удалении
+        # юзера, а на подписке остаётся стухший UUID.
         remnawave_retry_queue.enqueue(
             subscription_id=subscription.id,
             user_id=db_user.id,
-            action='create',
+            action='create' if _should_create else 'update',
         )
 
     # Создаем транзакцию
@@ -1764,7 +1776,9 @@ async def confirm_tariff_purchase(
             subscription,
             None,  # Транзакция отсутствует, оплата с баланса
             period,
-            was_trial_conversion=False,
+            # Маркер выставляют extend_subscription/_convert_trial_subscription_to_paid,
+            # когда покупка конвертировала живой триал (та же строка, тот же панельный юзер).
+            was_trial_conversion=bool(getattr(subscription, '_converted_from_trial', False)),
             amount_kopeks=final_price,
             purchase_type='renewal' if existing_subscription else 'first_purchase',
         )

--- a/tests/crud/test_subscription_revive.py
+++ b/tests/crud/test_subscription_revive.py
@@ -187,6 +187,8 @@ async def test_create_paid_subscription_does_not_revive_active(monkeypatch):
     monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
     active = _sub(id=5, user_id=7, tariff_id=3, is_trial=False, status=SubscriptionStatus.ACTIVE.value)
     monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=active))
+    # Живого триала нет — иначе сработала бы конверсия триала на месте
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', AsyncMock(return_value=None))
     revive = AsyncMock(return_value=active)
     monkeypatch.setattr(sub_crud, '_revive_paid_subscription', revive)
     # short-circuit тяжёлый путь создания сразу после guard

--- a/tests/crud/test_trial_conversion_on_paid_purchase.py
+++ b/tests/crud/test_trial_conversion_on_paid_purchase.py
@@ -1,0 +1,324 @@
+"""Регрессия (прод-репорт 2026-07, SALES_MODE=tariffs + MULTI_TARIFF_ENABLED):
+первая платная покупка при ЖИВОМ триале должна КОНВЕРТИРОВАТЬ строку триала на
+месте (тот же Remnawave-юзер и ссылка), а не вставлять новую подписку.
+
+Старое поведение: ``create_paid_subscription`` вставлял новую строку → новый
+панельный юзер (#created), а живой триал глушился в DISABLED (#disabled) и
+продолжал висеть в кабинете рядом с купленным тарифом. Пользователь при этом
+терял ссылку/устройства, настроенные за время триала.
+
+Новое поведение зеркалит classic-режим (там триал всегда конвертировался в
+той же записи): в мульти-тарифе живой (active/trial/limited) триал уходит в
+``_convert_trial_subscription_to_paid`` → ``extend_subscription`` (смена тарифа,
+перенос остатка по TRIAL_ADD_REMAINING_DAYS_TO_PAID, снятие is_trial), запись
+сохраняет ``remnawave_uuid`` → вызывающие пути обновляют панельного юзера
+вместо создания нового. Под локом кандидат перечитывается: конкурентная
+покупка могла уже конвертировать его — тогда откат к обычной вставке, чтобы
+вторая покупка не затёрла тариф первой.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from app.database.crud import subscription as sub_crud
+from app.database.models import SubscriptionStatus
+
+
+def _sub(**kw) -> MagicMock:
+    s = MagicMock()
+    for k, v in kw.items():
+        setattr(s, k, v)
+    return s
+
+
+def _db() -> AsyncMock:
+    db = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.flush = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+# --- create_paid_subscription: ветка конверсии ---
+
+
+async def test_create_paid_subscription_converts_alive_trial_of_other_tariff(monkeypatch):
+    """Живой триал ДРУГОГО тарифа при платной покупке конвертируется на месте."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    trial = _sub(id=11, user_id=7, tariff_id=6, is_trial=True, status=SubscriptionStatus.ACTIVE.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=None))
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', AsyncMock(return_value=trial))
+    convert = AsyncMock(return_value=trial)
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', convert)
+    db = _db()
+
+    result = await sub_crud.create_paid_subscription(db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1)
+
+    assert result is trial
+    convert.assert_awaited_once()
+    assert convert.await_args.kwargs.get('tariff_id') == 1
+    db.add.assert_not_called()  # новую подписку (и нового панельного юзера) НЕ создаём
+
+
+async def test_create_paid_subscription_prefers_same_tariff_alive_trial(monkeypatch):
+    """Живой триал ТОГО ЖЕ тарифа берётся из lookup'а напрямую — без второго
+    запроса, чтобы конверсия не столкнулась с uq_subscriptions_user_tariff_active."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    trial = _sub(id=11, user_id=7, tariff_id=1, is_trial=True, status=SubscriptionStatus.TRIAL.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=trial))
+    helper = AsyncMock(return_value=None)
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+    convert = AsyncMock(return_value=trial)
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', convert)
+    db = _db()
+
+    result = await sub_crud.create_paid_subscription(db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1)
+
+    assert result is trial
+    helper.assert_not_awaited()  # кандидат уже найден lookup'ом
+    convert.assert_awaited_once()
+    db.add.assert_not_called()
+
+
+async def test_create_paid_subscription_uses_passed_conversion_trial(monkeypatch):
+    """Кабинет передаёт пре-резолвленного кандидата — повторный lookup не нужен."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    trial = _sub(id=11, user_id=7, tariff_id=6, is_trial=True, status=SubscriptionStatus.ACTIVE.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=None))
+    helper = AsyncMock(return_value=None)
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+    convert = AsyncMock(return_value=trial)
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', convert)
+    db = _db()
+
+    result = await sub_crud.create_paid_subscription(
+        db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1, conversion_trial=trial
+    )
+
+    assert result is trial
+    helper.assert_not_awaited()
+    convert.assert_awaited_once()
+
+
+async def test_create_paid_subscription_falls_to_insert_when_conversion_raced(monkeypatch):
+    """Конкурентная покупка успела конвертировать кандидата (конверсия вернула
+    None) — падаем в обычную вставку, а не затираем чужой тариф."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    trial = _sub(id=11, user_id=7, tariff_id=6, is_trial=True, status=SubscriptionStatus.ACTIVE.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=None))
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', AsyncMock(return_value=trial))
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', AsyncMock(return_value=None))
+    monkeypatch.setattr(sub_crud, 'generate_unique_short_id', AsyncMock(side_effect=RuntimeError('reached create')))
+    db = _db()
+
+    try:
+        await sub_crud.create_paid_subscription(db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1)
+    except RuntimeError as e:
+        assert str(e) == 'reached create'  # дошли до вставки
+
+
+async def test_create_paid_subscription_without_trial_falls_to_insert(monkeypatch):
+    """Нет живого триала — обычная вставка новой подписки, как раньше."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=None))
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', AsyncMock(return_value=None))
+    convert = AsyncMock()
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', convert)
+    # short-circuit тяжёлый путь создания сразу после guard'а
+    monkeypatch.setattr(sub_crud, 'generate_unique_short_id', AsyncMock(side_effect=RuntimeError('reached create')))
+    db = _db()
+
+    try:
+        await sub_crud.create_paid_subscription(db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1)
+    except RuntimeError as e:
+        assert str(e) == 'reached create'
+
+    convert.assert_not_awaited()
+
+
+async def test_expired_same_tariff_revive_wins_over_conversion(monkeypatch):
+    """Истёкшая запись ПОКУПАЕМОГО тарифа реанимируется (#3004) — конверсия
+    триала не запускается: у той записи уже есть свой панельный юзер/ссылка."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    expired = _sub(id=5, user_id=7, tariff_id=1, is_trial=False, status=SubscriptionStatus.EXPIRED.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=expired))
+    revive = AsyncMock(return_value=expired)
+    monkeypatch.setattr(sub_crud, '_revive_paid_subscription', revive)
+    helper = AsyncMock()
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+    convert = AsyncMock()
+    monkeypatch.setattr(sub_crud, '_convert_trial_subscription_to_paid', convert)
+    db = _db()
+
+    result = await sub_crud.create_paid_subscription(db, user_id=7, duration_days=30, traffic_limit_gb=100, tariff_id=1)
+
+    assert result is expired
+    revive.assert_awaited_once()
+    helper.assert_not_awaited()
+    convert.assert_not_awaited()
+
+
+async def test_trial_creation_never_triggers_conversion(monkeypatch):
+    """Создание САМОГО триала (is_trial=True) не трогает ветку конверсии."""
+    monkeypatch.setattr(type(sub_crud.settings), 'is_multi_tariff_enabled', lambda self: True)
+    lookup = AsyncMock()
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', lookup)
+    helper = AsyncMock()
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+    monkeypatch.setattr(sub_crud, 'generate_unique_short_id', AsyncMock(side_effect=RuntimeError('reached create')))
+    db = _db()
+
+    try:
+        await sub_crud.create_paid_subscription(
+            db, user_id=7, duration_days=3, traffic_limit_gb=10, tariff_id=6, is_trial=True
+        )
+    except RuntimeError as e:
+        assert str(e) == 'reached create'
+
+    lookup.assert_not_awaited()
+    helper.assert_not_awaited()
+
+
+# --- _convert_trial_subscription_to_paid: делегирование и защита от гонки ---
+
+
+async def test_convert_helper_delegates_to_extend(monkeypatch):
+    """Обёртка конверсии ревалидирует кандидата под локом и делегирует
+    extend_subscription (смена тарифа, перенос остатка, снятие is_trial,
+    добивание других триалов — всё там). Счётчики серверов НЕ бампает:
+    строка уже посчитана при создании триала."""
+    trial = _sub(
+        id=11,
+        user_id=7,
+        tariff_id=6,
+        is_trial=True,
+        status=SubscriptionStatus.ACTIVE.value,
+        connected_squads=['paid-squad'],
+        end_date=datetime.now(UTC) + timedelta(days=2),
+    )
+    monkeypatch.setattr(sub_crud, '_lock_subscription_row', AsyncMock())
+    extend = AsyncMock(return_value=trial)
+    monkeypatch.setattr(sub_crud, 'extend_subscription', extend)
+    db = _db()
+
+    result = await sub_crud._convert_trial_subscription_to_paid(
+        db,
+        trial,
+        tariff_id=1,
+        duration_days=30,
+        traffic_limit_gb=100,
+        device_limit=3,
+        connected_squads=['paid-squad'],
+        commit=True,
+    )
+
+    assert result is trial
+    extend.assert_awaited_once()
+    kwargs = extend.await_args.kwargs
+    assert kwargs['days'] == 30
+    assert kwargs['tariff_id'] == 1
+    assert kwargs['traffic_limit_gb'] == 100
+    assert kwargs['device_limit'] == 3
+    assert kwargs['connected_squads'] == ['paid-squad']
+    assert kwargs['commit'] is True
+    db.add.assert_not_called()
+
+
+async def test_convert_helper_bails_out_when_candidate_no_longer_trial(monkeypatch):
+    """Гонка: под локом кандидат уже не живой триал (конкурентная покупка
+    конвертировала его) — возвращаем None, extend НЕ вызывается, тариф
+    первой покупки не затирается."""
+    converted_by_other = _sub(
+        id=11,
+        user_id=7,
+        tariff_id=2,  # уже чужой купленный тариф
+        is_trial=False,
+        status=SubscriptionStatus.ACTIVE.value,
+        connected_squads=['sq'],
+    )
+    monkeypatch.setattr(sub_crud, '_lock_subscription_row', AsyncMock())
+    extend = AsyncMock()
+    monkeypatch.setattr(sub_crud, 'extend_subscription', extend)
+    db = _db()
+
+    result = await sub_crud._convert_trial_subscription_to_paid(
+        db,
+        converted_by_other,
+        tariff_id=1,
+        duration_days=30,
+        traffic_limit_gb=100,
+        device_limit=3,
+        connected_squads=['sq'],
+        commit=True,
+    )
+
+    assert result is None
+    extend.assert_not_awaited()
+
+
+# --- resolve_trial_conversion_candidate: единые приоритеты для кабинета ---
+
+
+async def test_resolver_returns_none_when_revive_will_preempt(monkeypatch):
+    """EXPIRED подписка покупаемого тарифа → create уйдёт в revive (#3004),
+    кандидата нет: кабинет глушит триал по-старому (перенос остатка +
+    отключение панельного юзера)."""
+    expired = _sub(id=5, user_id=7, tariff_id=1, is_trial=False, status=SubscriptionStatus.EXPIRED.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=expired))
+    helper = AsyncMock()
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+
+    result = await sub_crud.resolve_trial_conversion_candidate(_db(), 7, 1)
+
+    assert result is None
+    helper.assert_not_awaited()
+
+
+async def test_resolver_prefers_same_tariff_alive_trial(monkeypatch):
+    trial = _sub(id=11, user_id=7, tariff_id=1, is_trial=True, status=SubscriptionStatus.TRIAL.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=trial))
+    helper = AsyncMock(return_value=None)
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', helper)
+
+    result = await sub_crud.resolve_trial_conversion_candidate(_db(), 7, 1)
+
+    assert result is trial
+    helper.assert_not_awaited()
+
+
+async def test_resolver_falls_back_to_freshest_alive_trial(monkeypatch):
+    other_trial = _sub(id=12, user_id=7, tariff_id=6, is_trial=True, status=SubscriptionStatus.ACTIVE.value)
+    monkeypatch.setattr(sub_crud, 'get_subscription_by_user_and_tariff', AsyncMock(return_value=None))
+    monkeypatch.setattr(sub_crud, 'get_alive_trial_subscription', AsyncMock(return_value=other_trial))
+
+    result = await sub_crud.resolve_trial_conversion_candidate(_db(), 7, 1)
+
+    assert result is other_trial
+
+
+# --- Source-pin кабинетного пути ---
+
+
+def test_cabinet_purchase_excludes_conversion_candidate_from_trial_kill():
+    """Source-pin (в духе test_purchase_tariff_expired_trial_reuse): кабинетный
+    ``purchase_tariff`` обязан резолвить кандидата через
+    resolve_trial_conversion_candidate, исключать его из раннего
+    deactivate_user_trial_subscriptions и передавать в create_paid_subscription
+    — иначе триал будет заглушен ДО create_paid_subscription и конверсия не
+    увидит его (регресс к «новый панельный юзер + мёртвый триал в кабинете»)."""
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[2] / 'app' / 'cabinet' / 'routes' / 'subscription_modules' / 'purchase.py'
+    ).read_text(encoding='utf-8')
+
+    assert 'resolve_trial_conversion_candidate' in source, (
+        'cabinet purchase.py больше не резолвит кандидата конверсии триала — '
+        'ранний deactivate_user_trial_subscriptions заглушит живой триал до '
+        'create_paid_subscription, и конверсия на месте не сработает'
+    )
+    assert 'conversion_trial=_conversion_trial' in source, (
+        'пре-резолвленный кандидат должен передаваться в create_paid_subscription, '
+        'чтобы кабинет и CRUD гарантированно работали с ОДНОЙ и той же строкой триала'
+    )


### PR DESCRIPTION
## 📝 Описание

При `SALES_MODE=tariffs` + `MULTI_TARIFF_ENABLED=true` покупка платного тарифа после триала вставляла **новую** подписку (→ новый Remnawave-юзер, `#created`), а живой триал глушился в DISABLED (`#disabled`) и продолжал висеть в кабинете рядом с купленным тарифом. Юзер терял ссылку и устройства, настроенные за время триала.

Теперь `create_paid_subscription` **конвертирует живой (active/trial/limited) триал на месте** через `extend_subscription`: та же строка, тот же панельный юзер и ссылка, перенос остатка по `TRIAL_ADD_REMAINING_DAYS_TO_PAID`, снятие `is_trial`, сквады/лимиты нового тарифа. Зеркалит classic-режим (там триал всегда конвертировался in-place) и паттерн revive-ветки #3004 — фикс в общем CRUD, выигрывают все пути (бот, кабинет, miniapp, guest, купоны, кампании).

## 🎯 Мотивация

Прод-репорт (v3.62.0, боевая инсталляция): у пользователей после оплаты появлялись «две подписки», в БД скопилось ~19 заглушенных строк триалов (`is_trial=f, status=disabled`), а плативший юзер получал новую ссылку и заново добавлял устройства.

## 🔧 Детали реализации

- **Защита от гонки**: под `SELECT FOR UPDATE` кандидат перечитывается; если конкурентная покупка другого тарифа уже конвертировала его — откат к обычной вставке (иначе вторая покупка молча затёрла бы тариф первой без исключения и рефанда).
- **`resolve_trial_conversion_candidate`** — единое правило выбора кандидата; кабинет исключает его из раннего `deactivate_user_trial_subscriptions` и передаёт строку в `create_paid_subscription` (`conversion_trial=`). Учитывает приоритет revive (#3004): при EXPIRED-подписке покупаемого тарифа триал глушится по-старому (перенос остатка + отключение панельного юзера).
- **Счётчики серверов** при конверсии не бампаются: строка уже посчитана при создании триала (иначе double-count на путях с `update_server_counters=True`).
- **LIMITED-триалы** теперь добиваются `deactivate_user_trial_subscriptions` (раньше переживали любую покупку), а кандидат-выбор предпочитает ACTIVE/TRIAL перед LIMITED — чтобы не убить рабочую ссылку юзера конверсией не той строки.
- **`MAX_ACTIVE_SUBSCRIPTIONS`** не считает живой триал: конверсия не добавляет строку.
- **Retry-очередь панели** в боте использует то же mode-aware решение create/update, что и основной синк (у конвертированной подписки уже есть панельный юзер — обновляем, не плодим дубль).
- **`was_trial_conversion`** в админ-уведомлениях бота и кабинета берётся из маркера конверсии вместо хардкода `False`.
- **Сквад-фоллбек** вынесен в `_resolve_connected_squads` и переиспользован конверсией.

## 🔧 Тип изменений
- [x] Bug fix (исправление)

## ✅ Чеклист
- [x] Код соответствует стандартам проекта (ruff check/format чисто)
- [x] Добавлены тесты: `tests/crud/test_trial_conversion_on_paid_purchase.py` (13 шт.: ветка конверсии, приоритеты кандидата, откат при гонке, revive-преемпция, резолвер, source-pin кабинетного пути)
- [x] Полная сюита зелёная (1947 passed на dev после ребейза)

## 🧪 Тестирование
Юнит-тесты в стиле `test_subscription_revive.py`; сценарий проверен на данных боевой инсталляции (SALES_MODE=tariffs, MULTI_TARIFF_ENABLED=true, TRIAL_ADD_REMAINING_DAYS_TO_PAID=true).

## ⚠️ Сознательно вне скоупа
- Конверсия same-tariff триала наследует поведение основного extend-пути (продление от end_date триала).
- `create_subscription_conversion` (статистика конверсий) на мульти-тарифных путях не записывается — как и до фикса: в CRUD нет данных о платеже.
- Хардкоды `was_trial_conversion=False` в stars/yookassa/auto-purchase — пре-существующие.