### PR TITLE
fix(campaign): MissingGreenlet при начислении бонуса кампании на регистрации

### DIFF
--- a/app/services/campaign_service.py
+++ b/app/services/campaign_service.py
@@ -56,6 +56,26 @@ class AdvertisingCampaignService:
         user: User,
         campaign: AdvertisingCampaign,
     ) -> CampaignBonusResult:
+        # Пользователь мог прийти с протухшими (expired) атрибутами: любой
+        # rollback выше по флоу регистрации (реферал, промокод, phantom-merge)
+        # экспайрит инстансы даже при expire_on_commit=False, а последующий
+        # sync-доступ к user.id здесь дёргает ленивую подгрузку вне greenlet →
+        # MissingGreenlet и бонус кампании не начисляется (прод-репорт
+        # 2026-07-13, регистрация по рекламной кампании). Перечитываем
+        # атрибуты асинхронно ДО первого sync-доступа.
+        try:
+            await db.refresh(user)
+        except Exception as refresh_error:
+            # user.id здесь читаем через __dict__: атрибут может быть expired,
+            # и обычный доступ сам бы дёрнул ленивую подгрузку → повторный
+            # MissingGreenlet уже внутри обработчика.
+            logger.warning(
+                '⚠️ Не удалось освежить пользователя перед бонусом кампании',
+                user_id=user.__dict__.get('id'),
+                campaign_id=campaign.id,
+                error=refresh_error,
+            )
+
         if not campaign.is_active:
             logger.warning('⚠️ Попытка выдать бонус по неактивной кампании', campaign_id=campaign.id)
             return CampaignBonusResult(success=False)

--- a/tests/services/test_campaign_bonus_expired_user.py
+++ b/tests/services/test_campaign_bonus_expired_user.py
@@ -1,0 +1,56 @@
+"""Регрессия (прод-репорт 2026-07-13): MissingGreenlet при начислении бонуса
+рекламной кампании на регистрации.
+
+Любой rollback выше по флоу регистрации (реферал, промокод, phantom-merge)
+экспайрит ORM-инстанс пользователя даже при expire_on_commit=False. Дальше
+``apply_campaign_bonus`` читал ``user.id`` синхронно → ленивая подгрузка
+протухшего атрибута вне greenlet → ``sqlalchemy.exc.MissingGreenlet``, бонус
+кампании не начислялся (у юзера падала регистрация по рекламной ссылке).
+
+Фикс: сервис асинхронно освежает пользователя ДО первого sync-доступа к
+атрибутам; сбой refresh не роняет начисление.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services.campaign_service import AdvertisingCampaignService
+
+
+def _service(monkeypatch) -> AdvertisingCampaignService:
+    # SubscriptionService в конструкторе не нужен для этих сценариев
+    monkeypatch.setattr('app.services.campaign_service.SubscriptionService', MagicMock())
+    return AdvertisingCampaignService()
+
+
+def _db() -> AsyncMock:
+    db = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+async def test_apply_campaign_bonus_refreshes_user_before_attribute_access(monkeypatch):
+    """Пользователь перечитывается асинхронно на входе — до любых sync-чтений
+    user.id (иначе expired-инстанс валит MissingGreenlet)."""
+    service = _service(monkeypatch)
+    db = _db()
+    campaign = MagicMock(is_active=False, id=1)  # ранний выход, но refresh обязан случиться
+    user = MagicMock()
+
+    result = await service.apply_campaign_bonus(db, user, campaign)
+
+    db.refresh.assert_awaited_once_with(user)
+    assert result.success is False
+
+
+async def test_apply_campaign_bonus_survives_refresh_failure(monkeypatch):
+    """Сбой refresh (например, PendingRollbackError) не роняет начисление —
+    логируем и продолжаем со старыми атрибутами."""
+    service = _service(monkeypatch)
+    db = _db()
+    db.refresh = AsyncMock(side_effect=RuntimeError('session in failed state'))
+    campaign = MagicMock(is_active=False, id=1)
+    user = MagicMock()
+
+    result = await service.apply_campaign_bonus(db, user, campaign)
+
+    assert result.success is False  # дошли до обычной логики, исключение не всплыло


### PR DESCRIPTION
## 📝 Описание

При регистрации по рекламной кампании падало `sqlalchemy.exc.MissingGreenlet` в `campaign_service._apply_balance_bonus` (доступ к `user.id`) — бонус кампании не начислялся.

**Причина:** любой rollback выше по флоу регистрации (реферал, промокод, phantom-merge) **экспайрит** ORM-инстанс пользователя даже при `expire_on_commit=False` (rollback экспайрит всегда). Дальше `apply_campaign_bonus` читает `user.id` синхронно → ленивая подгрузка протухшего атрибута вне greenlet → MissingGreenlet.

**Фикс:** сервис асинхронно освежает пользователя (`await db.refresh(user)`) до первого sync-доступа к атрибутам. Сбой refresh логируется (id в логе читается через `__dict__`, чтобы не словить повторный MissingGreenlet уже в обработчике) и не роняет начисление. Покрывает оба пути — бот (`start.py`) и кабинетную регистрацию (`cabinet/routes/auth.py`).

## 🎯 Мотивация

Прод-репорт с боевой инсталляции v3.62.0 (error report 13.07.2026): traceback `process_referral_code_input → complete_registration → _apply_campaign_bonus_if_needed → apply_campaign_bonus → _apply_balance_bonus:104 user_id=user.id → MissingGreenlet`. Юзеры, пришедшие по рекламной ссылке, не получали бонус.

## 🔧 Тип изменений
- [x] Bug fix (исправление)

## ✅ Чеклист
- [x] Код соответствует стандартам проекта (ruff чисто)
- [x] Добавлены тесты: `tests/services/test_campaign_bonus_expired_user.py` (refresh на входе + устойчивость к сбою refresh)
- [x] Полная сюита зелёная (1936 passed на dev после ребейза)