### PR TITLE
feat(cabinet): отправка прямого сообщения юзеру из карточки в кабинете

### DIFF
--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -90,6 +90,8 @@ from ..schemas.users import (
     ResetSubscriptionResponse,
     ResetTrialRequest,
     ResetTrialResponse,
+    SendUserMessageRequest,
+    SendUserMessageResponse,
     SortByEnum,
     SubscriptionListItem,
     SyncFromPanelRequest,
@@ -1886,6 +1888,101 @@ async def unblock_user(
         new_status='active',
         message='User unblocked',
     )
+
+
+# === Direct Message ===
+
+
+@router.post('/{user_id}/send-message', response_model=SendUserMessageResponse)
+async def send_user_message(
+    user_id: int,
+    request: SendUserMessageRequest,
+    admin: User = Depends(require_permission('users:send_message')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Send a direct Telegram message to the user via the bot.
+
+    Parity with the bot's «✉️ Отправить сообщение» action in the admin user
+    card. Email-only users (no telegram_id) cannot receive Telegram messages —
+    the endpoint returns 400 with a distinct code so the frontend can explain.
+    """
+    from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+
+    from app.bot_factory import create_bot
+
+    target_user = await get_user_by_id(db, user_id)
+    if not target_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
+
+    if not target_user.telegram_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                'code': 'no_telegram_id',
+                'message': 'User is registered by email only and cannot receive Telegram messages',
+            },
+        )
+
+    if not settings.BOT_TOKEN:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={'code': 'bot_not_configured', 'message': 'Bot token is not configured'},
+        )
+
+    text = request.text.strip()
+    if not text:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={'code': 'empty_message', 'message': 'Message text is empty'},
+        )
+
+    bot = create_bot()
+    try:
+        await bot.send_message(target_user.telegram_id, text, parse_mode='HTML')
+    except TelegramForbiddenError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                'code': 'forbidden',
+                'message': 'User has blocked the bot or cannot receive messages',
+            },
+        )
+    except TelegramBadRequest as err:
+        logger.error(
+            'Cabinet: Telegram rejected direct message to user',
+            user_id=user_id,
+            telegram_id=target_user.telegram_id,
+            error=str(err),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                'code': 'bad_request',
+                'message': 'Telegram rejected the message — check the text (HTML markup) and try again',
+            },
+        )
+    except Exception as err:
+        logger.error(
+            'Cabinet: unexpected error sending direct message to user',
+            user_id=user_id,
+            telegram_id=target_user.telegram_id,
+            error=str(err),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={'code': 'send_failed', 'message': 'Failed to send the message, try again later'},
+        )
+    finally:
+        await bot.session.close()
+
+    logger.info(
+        'Cabinet: direct message sent to user',
+        admin_id=admin.id,
+        user_id=user_id,
+        telegram_id=target_user.telegram_id,
+        text_length=len(text),
+    )
+    return SendUserMessageResponse(success=True, message='Message sent')
 
 
 # === Restrictions Management ===

--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -399,6 +399,21 @@ class UpdateUserStatusResponse(BaseModel):
     message: str
 
 
+class SendUserMessageRequest(BaseModel):
+    """Request to send a direct Telegram message to a user (parity with the
+    bot's «Отправить сообщение» action in the admin user card)."""
+
+    # 4096 — лимит Telegram на текст сообщения
+    text: str = Field(..., min_length=1, max_length=4096, description='Message text (HTML)')
+
+
+class SendUserMessageResponse(BaseModel):
+    """Response after sending a direct message."""
+
+    success: bool
+    message: str
+
+
 class UpdateRestrictionsRequest(BaseModel):
     """Request to update user restrictions."""
 

--- a/app/services/permission_service.py
+++ b/app/services/permission_service.py
@@ -52,6 +52,7 @@ PERMISSION_REGISTRY: dict[str, list[str]] = {
         'balance',
         'subscription',
         'send_offer',
+        'send_message',
         'referral',
     ],
     'tickets': ['read', 'reply', 'close', 'settings'],

--- a/tests/cabinet/test_admin_send_user_message.py
+++ b/tests/cabinet/test_admin_send_user_message.py
@@ -1,0 +1,105 @@
+"""Кабинетный аналог бот-кнопки «✉️ Отправить сообщение» в карточке юзера.
+
+POST /admin/users/{user_id}/send-message: шлёт юзеру прямое Telegram-сообщение
+через бота. Email-only юзеры (без telegram_id) получают отдельный код ошибки
+no_telegram_id — фронт объясняет, а не показывает generic-ошибку. Сессия бота
+закрывается в любом исходе.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_users as m
+from app.cabinet.schemas.users import SendUserMessageRequest
+
+
+def _bot() -> MagicMock:
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+    bot.session = MagicMock()
+    bot.session.close = AsyncMock()
+    return bot
+
+
+async def test_send_message_success(monkeypatch):
+    target = MagicMock(telegram_id=111)
+    monkeypatch.setattr(m, 'get_user_by_id', AsyncMock(return_value=target))
+    monkeypatch.setattr(type(m.settings), 'BOT_TOKEN', 'token', raising=False)
+    bot = _bot()
+    monkeypatch.setattr('app.bot_factory.create_bot', lambda: bot)
+
+    result = await m.send_user_message(
+        user_id=1,
+        request=SendUserMessageRequest(text='  привет  '),
+        admin=MagicMock(id=7),
+        db=AsyncMock(),
+    )
+
+    assert result.success is True
+    bot.send_message.assert_awaited_once_with(111, 'привет', parse_mode='HTML')
+    bot.session.close.assert_awaited_once()  # сессия закрыта
+
+
+async def test_send_message_email_only_user_rejected(monkeypatch):
+    """Email-only юзер → 400 с кодом no_telegram_id, бот не создаётся."""
+    target = MagicMock(telegram_id=None)
+    monkeypatch.setattr(m, 'get_user_by_id', AsyncMock(return_value=target))
+
+    with pytest.raises(HTTPException) as exc:
+        await m.send_user_message(
+            user_id=1,
+            request=SendUserMessageRequest(text='hi'),
+            admin=MagicMock(id=7),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail['code'] == 'no_telegram_id'
+
+
+async def test_send_message_forbidden_maps_to_400_and_closes_session(monkeypatch):
+    """Юзер заблокировал бота → 400 с кодом forbidden, сессия бота закрыта."""
+    from aiogram.exceptions import TelegramForbiddenError
+
+    target = MagicMock(telegram_id=111)
+    monkeypatch.setattr(m, 'get_user_by_id', AsyncMock(return_value=target))
+    monkeypatch.setattr(type(m.settings), 'BOT_TOKEN', 'token', raising=False)
+    bot = _bot()
+    bot.send_message = AsyncMock(side_effect=TelegramForbiddenError(method=MagicMock(), message='blocked'))
+    monkeypatch.setattr('app.bot_factory.create_bot', lambda: bot)
+
+    with pytest.raises(HTTPException) as exc:
+        await m.send_user_message(
+            user_id=1,
+            request=SendUserMessageRequest(text='hi'),
+            admin=MagicMock(id=7),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail['code'] == 'forbidden'
+    bot.session.close.assert_awaited_once()
+
+
+async def test_send_message_user_not_found(monkeypatch):
+    monkeypatch.setattr(m, 'get_user_by_id', AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as exc:
+        await m.send_user_message(
+            user_id=404,
+            request=SendUserMessageRequest(text='hi'),
+            admin=MagicMock(id=7),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 404
+
+
+def test_send_message_permission_registered():
+    """users:send_message должен существовать в реестре RBAC — иначе
+    require_permission молча зарежет всех не-legacy админов."""
+    from app.services.permission_service import get_all_permissions
+
+    assert 'users:send_message' in get_all_permissions()


### PR DESCRIPTION
## 📝 Описание

Паритет с бот-кнопкой «✉️ Отправить сообщение» в карточке пользователя: новый эндпоинт `POST /admin/users/{user_id}/send-message` шлёт юзеру прямое Telegram-сообщение через бота (HTML, лимит 4096).

- Новый RBAC-пермишен **`users:send_message`** (реестр-driven — в UI ролей подхватится автоматически; legacy-админы по ADMIN_IDS имеют доступ сразу).
- Email-only юзеры без telegram_id → 400 с кодом `no_telegram_id` (фронт показывает честное объяснение); блокировка бота юзером → `forbidden`; отказ Telegram по разметке → `bad_request`.
- Сессия бота закрывается в любом исходе (`create_bot()` + `finally`, как в `admin_partners`).

Фронтовая часть: BEDOLAGA-DEV/bedolaga-cabinet — парный PR (кнопка в блоке действий карточки + модалка + локали ru/en/fa/zh).

## 🎯 Мотивация

В боте кнопка «Отправить сообщение» в карточке юзера есть, в кабинете — нет: админам, работающим из кабинета, приходится идти в бота, чтобы написать пользователю.

## 🔧 Тип изменений
- [x] New feature (новая функция)

## ✅ Чеклист
- [x] Код соответствует стандартам проекта (ruff чисто)
- [x] Добавлены тесты: `tests/cabinet/test_admin_send_user_message.py` (5 шт.: успех, email-only, forbidden, not found, регистрация пермишена)
- [x] Полная сюита зелёная (1939 passed на dev после ребейза)