### PR TITLE
feat(promo-offers): доставка промопредложений на email для юзеров без Telegram

### DIFF
--- a/app/cabinet/routes/admin_promo_offers.py
+++ b/app/cabinet/routes/admin_promo_offers.py
@@ -514,6 +514,53 @@ async def _send_promo_notifications(
     return sent, failed
 
 
+async def _send_promo_email_notifications(
+    targets: list[tuple[str, str, str]],
+    *,
+    message_text: str | None,
+    discount_percent: int,
+    bonus_amount_kopeks: int,
+    valid_hours: int,
+) -> tuple[int, int]:
+    """Send promo offer notifications to email-only users.
+
+    Args:
+        targets: list of (email, language, username). Скалярные значения (не
+            ORM) — как и Telegram-фан-аут, может бежать detached после
+            закрытия сессии запроса.
+
+    Returns:
+        Tuple of (sent_count, failed_count)
+    """
+    if not targets:
+        return 0, 0
+
+    from app.services.promo_offer_email import send_promo_offer_email
+
+    # SMTP медленнее и капризнее Telegram — небольшой параллелизм
+    semaphore = asyncio.Semaphore(4)
+
+    async def send_single(email: str, language: str, username: str) -> bool:
+        async with semaphore:
+            try:
+                return await send_promo_offer_email(
+                    email=email,
+                    language=language,
+                    username=username,
+                    message_text=message_text,
+                    valid_hours=valid_hours,
+                    discount_percent=discount_percent,
+                    bonus_amount_kopeks=bonus_amount_kopeks,
+                )
+            except Exception as exc:
+                logger.warning('Не удалось отправить промо-письмо', email=email, exc=exc)
+                return False
+
+    results = await asyncio.gather(*(send_single(*target) for target in targets), return_exceptions=True)
+    sent = sum(1 for result in results if result is True)
+    return sent, len(targets) - sent
+
+
 @router.post('/broadcast', response_model=PromoOfferBroadcastResponse, status_code=status.HTTP_201_CREATED)
 async def broadcast_offer(
     payload: PromoOfferBroadcastRequest,
@@ -594,11 +641,21 @@ async def broadcast_offer(
         (recipient.telegram_id, offer.id) for recipient, offer in offers_to_notify if recipient.telegram_id
     ]
 
-    # Send Telegram notifications if requested
+    # Email-only юзеры (без telegram_id): оффер у них уже создан выше, но о нём
+    # никто не узнавал — Telegram-уведомление им физически не отправить. Шлём
+    # на подтверждённую почту тот же текст (скалярные поля — фан-аут может
+    # бежать detached после закрытия сессии запроса).
+    email_targets = [
+        (recipient.email, recipient.language or 'ru', recipient.first_name or recipient.username or '')
+        for recipient, _offer in offers_to_notify
+        if not recipient.telegram_id and recipient.email and recipient.email_verified
+    ]
+
+    # Send Telegram/email notifications if requested
     notifications_sent = 0
     notifications_failed = 0
 
-    if payload.send_notification and notify_targets:
+    if payload.send_notification and (notify_targets or email_targets):
         # Render placeholders in custom message text
         rendered_message_text = payload.message_text
         if rendered_message_text:
@@ -622,19 +679,48 @@ async def broadcast_offer(
             'valid_hours': payload.valid_hours,
         }
 
-        if len(notify_targets) <= _SYNC_NOTIFY_LIMIT:
-            # Small batch: send inline so exact sent/failed counts come back immediately.
-            notifications_sent, notifications_failed = await _send_promo_notifications(notify_targets, **notify_kwargs)
-        else:
-            # Mass broadcast: a synchronous fan-out to thousands of users overruns the
-            # proxy timeout — the cabinet showed an error while the offers were already
-            # committed and notifications kept sending (Telegram bug #652234). Detach it:
-            # the request returns now with created_offers; delivery is observable via /logs.
-            _schedule_promo_notifications(_send_promo_notifications(notify_targets, **notify_kwargs))
-            logger.info(
-                'Promo broadcast: notifications dispatched in background',
-                recipients=len(notify_targets),
-            )
+        if notify_targets:
+            if len(notify_targets) <= _SYNC_NOTIFY_LIMIT:
+                # Small batch: send inline so exact sent/failed counts come back immediately.
+                notifications_sent, notifications_failed = await _send_promo_notifications(
+                    notify_targets, **notify_kwargs
+                )
+            else:
+                # Mass broadcast: a synchronous fan-out to thousands of users overruns the
+                # proxy timeout — the cabinet showed an error while the offers were already
+                # committed and notifications kept sending (Telegram bug #652234). Detach it:
+                # the request returns now with created_offers; delivery is observable via /logs.
+                _schedule_promo_notifications(_send_promo_notifications(notify_targets, **notify_kwargs))
+                logger.info(
+                    'Promo broadcast: notifications dispatched in background',
+                    recipients=len(notify_targets),
+                )
+
+        if email_targets:
+            # Email-путь получает тот же текст, что и Telegram (кнопке «Получить»
+            # соответствует ссылка на кабинет внутри шаблона письма).
+            email_kwargs = {
+                'message_text': rendered_message_text
+                or _build_default_promo_message(
+                    discount_percent=payload.discount_percent,
+                    bonus_amount_kopeks=payload.bonus_amount_kopeks,
+                    valid_hours=payload.valid_hours,
+                ),
+                'discount_percent': payload.discount_percent,
+                'bonus_amount_kopeks': payload.bonus_amount_kopeks,
+                'valid_hours': payload.valid_hours,
+            }
+            if len(email_targets) <= _SYNC_NOTIFY_LIMIT:
+                _email_sent, _email_failed = await _send_promo_email_notifications(email_targets, **email_kwargs)
+                notifications_sent += _email_sent
+                notifications_failed += _email_failed
+            else:
+                # SMTP-фан-аут ещё медленнее Telegram — большие пачки только в фоне.
+                _schedule_promo_notifications(_send_promo_email_notifications(email_targets, **email_kwargs))
+                logger.info(
+                    'Promo broadcast: email notifications dispatched in background',
+                    recipients=len(email_targets),
+                )
 
     return PromoOfferBroadcastResponse(
         created_offers=created_offers,

--- a/app/cabinet/services/email_templates.py
+++ b/app/cabinet/services/email_templates.py
@@ -60,6 +60,7 @@ class EmailNotificationTemplates:
             NotificationType.WITHDRAWAL_REJECTED: self._withdrawal_rejected_template,
             NotificationType.TRAFFIC_RESET: self._traffic_reset_template,
             NotificationType.PAYMENT_RECEIVED: self._payment_received_template,
+            NotificationType.PROMO_OFFER: self._promo_offer_template,
             NotificationType.EMAIL_VERIFICATION: self._email_verification_template,
             NotificationType.PASSWORD_RESET: self._password_reset_template,
             NotificationType.EMAIL_CHANGE_CODE: self._email_change_code_template,
@@ -925,6 +926,84 @@ class EmailNotificationTemplates:
                     {f'<p>Thanks to: {referral_name}</p>' if referral_name else ''}
                 </div>
                 <p>Keep inviting friends and earn more!</p>
+                {self._get_cabinet_button(language)}
+            """,
+        }
+
+        return {
+            'subject': subjects.get(language, subjects['ru']),
+            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+        }
+
+    def _promo_offer_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
+        """Template for personal promo offer notification.
+
+        ``message_html`` — уже отрендеренный текст предложения (Telegram-HTML:
+        b/i/code — валидный HTML-фрагмент, переносы строк заменены на <br>).
+        Пишется админом или собирается дефолтным билдером — доверенный контент,
+        не экранируем.
+        """
+        message_html = context.get('message_html', '')
+        valid_hours = int(context.get('valid_hours', 0) or 0)
+        discount_percent = int(context.get('discount_percent', 0) or 0)
+
+        if discount_percent > 0:
+            subjects = {
+                'ru': f'🎁 Персональное предложение: скидка {discount_percent}%',
+                'en': f'🎁 Personal offer: {discount_percent}% off',
+                'zh': f'🎁 专属优惠：{discount_percent}% 折扣',
+                'ua': f'🎁 Персональна пропозиція: знижка {discount_percent}%',
+            }
+        else:
+            subjects = {
+                'ru': '🎁 Персональное предложение',
+                'en': '🎁 Personal offer',
+                'zh': '🎁 专属优惠',
+                'ua': '🎁 Персональна пропозиція',
+            }
+
+        valid_lines = {
+            'ru': f'<p>⏰ Предложение действует <b>{valid_hours} ч.</b></p>' if valid_hours else '',
+            'en': f'<p>⏰ The offer is valid for <b>{valid_hours} h.</b></p>' if valid_hours else '',
+            'zh': f'<p>⏰ 优惠有效期 <b>{valid_hours} 小时</b></p>' if valid_hours else '',
+            'ua': f'<p>⏰ Пропозиція діє <b>{valid_hours} год.</b></p>' if valid_hours else '',
+        }
+
+        bodies = {
+            'ru': f"""
+                <h2>Персональное предложение</h2>
+                <div class="highlight">
+                    <p>{message_html}</p>
+                </div>
+                {valid_lines['ru']}
+                <p>Активировать предложение можно в личном кабинете.</p>
+                {self._get_cabinet_button(language)}
+            """,
+            'en': f"""
+                <h2>Personal Offer</h2>
+                <div class="highlight">
+                    <p>{message_html}</p>
+                </div>
+                {valid_lines['en']}
+                <p>You can activate the offer in your account.</p>
+                {self._get_cabinet_button(language)}
+            """,
+            'zh': f"""
+                <h2>专属优惠</h2>
+                <div class="highlight">
+                    <p>{message_html}</p>
+                </div>
+                {valid_lines['zh']}
+                <p>您可以在个人中心激活该优惠。</p>
+                {self._get_cabinet_button(language)}
+            """,
+            'ua': f"""
+                <h2>Персональна пропозиція</h2>
+                <div class="highlight">
+                    <p>{message_html}</p>
+                </div>
+                {valid_lines['ua']}
+                <p>Активувати пропозицію можна в особистому кабінеті.</p>
                 {self._get_cabinet_button(language)}
             """,
         }

--- a/app/handlers/admin/promo_offers.py
+++ b/app/handlers/admin/promo_offers.py
@@ -1979,9 +1979,11 @@ async def _send_offer_to_users(
 
     async def send_single_offer(user):
         """Отправляет одно предложение с семафором ограничения"""
-        # Skip email-only users (no telegram_id)
-        if not user.telegram_id:
-            logger.debug('Пропуск email-пользователя при рассылке промо', user_id=user.id)
+        # Email-only юзеры (без telegram_id) раньше пропускались целиком —
+        # ни оффера, ни уведомления. Теперь оффер создаётся, а уведомление
+        # уходит на подтверждённую почту (активация — в кабинете).
+        if not user.telegram_id and not (user.email and user.email_verified):
+            logger.debug('У пользователя нет ни Telegram, ни подтверждённого email — промо пропущено', user_id=user.id)
             return False
 
         async with semaphore:
@@ -2021,6 +2023,26 @@ async def _send_offer_to_users(
                         },
                     )
 
+                    message_text = _render_template_text(
+                        template,
+                        user.language or db_user.language,
+                        server_name=squad_name,
+                    )
+
+                    if not user.telegram_id:
+                        # Email-only юзер: тот же текст на почту, кнопке «Получить»
+                        # соответствует ссылка на кабинет внутри шаблона письма.
+                        from app.services.promo_offer_email import send_promo_offer_email
+
+                        return await send_promo_offer_email(
+                            email=user.email,
+                            language=user.language or db_user.language,
+                            username=user.first_name or user.username or '',
+                            message_text=message_text,
+                            valid_hours=template.valid_hours,
+                            discount_percent=template.discount_percent or 0,
+                        )
+
                     user_texts = get_texts(user.language or db_user.language)
                     keyboard_rows: list[list[InlineKeyboardButton]] = [
                         [
@@ -2042,11 +2064,6 @@ async def _send_offer_to_users(
 
                     keyboard = InlineKeyboardMarkup(inline_keyboard=keyboard_rows)
 
-                    message_text = _render_template_text(
-                        template,
-                        user.language or db_user.language,
-                        server_name=squad_name,
-                    )
                     await bot.send_message(
                         chat_id=user.telegram_id,
                         text=message_text,

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -86,6 +86,7 @@ class NotificationType(Enum):
     # Other
     BROADCAST = 'broadcast'
     PAYMENT_RECEIVED = 'payment_received'
+    PROMO_OFFER = 'promo_offer'
 
     # Guest purchase notifications
     GUEST_SUBSCRIPTION_DELIVERED = 'guest_subscription_delivered'

--- a/app/services/promo_offer_email.py
+++ b/app/services/promo_offer_email.py
@@ -1,0 +1,98 @@
+"""Доставка промопредложений на email — для аккаунтов без telegram_id.
+
+Промопредложения (шаблоны и broadcast из кабинета, рассылка из бота) уходили
+только в Telegram: email-only юзеры получали оффер в БД, но не узнавали о нём.
+Этот модуль — общий email-канал для обоих путей: кабинетного
+``/admin/promo-offers/broadcast`` и бот-хендлера ``_send_offer_to_users``.
+
+Текст письма — тот же, что и в Telegram (Telegram-HTML b/i/code — валидный
+HTML-фрагмент; переносы строк конвертируются в <br>). Кнопке «Получить»
+соответствует ссылка на кабинет: оффер уже создан в БД и активируется там.
+Поддерживается DB-override шаблона (email_templates, тип ``promo_offer``).
+"""
+
+import asyncio
+
+import structlog
+
+
+logger = structlog.get_logger(__name__)
+
+
+def _to_email_html(text: str | None) -> str:
+    """Telegram-текст → HTML-фрагмент письма (переносы строк → <br>)."""
+    return (text or '').replace('\n', '<br>')
+
+
+async def send_promo_offer_email(
+    *,
+    email: str,
+    language: str | None,
+    username: str = '',
+    message_text: str | None,
+    valid_hours: int,
+    discount_percent: int = 0,
+    bonus_amount_kopeks: int = 0,
+) -> bool:
+    """Шлёт одно промопредложение на почту. True — письмо реально отправлено.
+
+    Принимает только скалярные значения (не ORM-объекты) — безопасно вызывать
+    из detached background-задачи после закрытия сессии запроса.
+    """
+    from app.cabinet.services.email_service import email_service
+    from app.cabinet.services.email_templates import EmailNotificationTemplates
+    from app.config import settings
+    from app.services.notification_delivery_service import NotificationType
+
+    if not email:
+        return False
+    if not email_service.is_configured():
+        logger.debug('SMTP не настроен — промо-письмо пропущено', email=email)
+        return False
+
+    language = language or 'ru'
+    context = {
+        'cabinet_url': getattr(settings, 'CABINET_URL', '') or '',
+        'username': username or '',
+        'email': email,
+        'message_html': _to_email_html(message_text),
+        'valid_hours': valid_hours,
+        'discount_percent': discount_percent,
+        'bonus_amount_kopeks': bonus_amount_kopeks,
+    }
+    if bonus_amount_kopeks:
+        context['amount'] = settings.format_price(bonus_amount_kopeks)
+
+    # DB-override шаблона (раздел email_templates в кабинете), затем дефолтный
+    template = None
+    try:
+        from app.cabinet.services.email_template_overrides import get_rendered_override
+
+        rendered = await get_rendered_override(NotificationType.PROMO_OFFER.value, language, context)
+        if rendered:
+            template = {'subject': rendered[0], 'body_html': rendered[1]}
+    except Exception as e:
+        logger.debug('Не удалось проверить override промо-шаблона', e=e)
+
+    if not template:
+        template = EmailNotificationTemplates().get_template(NotificationType.PROMO_OFFER, language, context)
+    if not template:
+        logger.warning('Не найден email-шаблон промопредложения', language=language)
+        return False
+
+    try:
+        # send_email — sync smtplib, уводим в thread чтобы не блокировать event loop
+        success = await asyncio.to_thread(
+            email_service.send_email,
+            to_email=email,
+            subject=template['subject'],
+            body_html=template['body_html'],
+            body_text=template.get('body_text'),
+        )
+    except Exception as e:
+        logger.error('Ошибка отправки промо-письма', email=email, e=e)
+        return False
+
+    if success:
+        logger.info('Промопредложение отправлено на email', email=email)
+    return bool(success)

--- a/tests/cabinet/test_promo_offer_email_notify.py
+++ b/tests/cabinet/test_promo_offer_email_notify.py
@@ -1,0 +1,142 @@
+"""Промопредложения для email-only юзеров (прод-репорт 2026-07-13).
+
+Раньше шаблоны промопредложений уходили только юзерам с telegram_id:
+кабинетный /admin/promo-offers/broadcast создавал оффер, но фан-аут
+уведомлений скипал получателей без Telegram; бот-рассылка шаблонов скипала
+их целиком (даже без создания оффера). Теперь оба пути шлют письмо на
+подтверждённую почту через общий app/services/promo_offer_email.
+"""
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock
+
+from app.cabinet.routes import admin_promo_offers as route_module
+from app.services import promo_offer_email as m
+
+
+# `import app.cabinet.services.email_service as X` вернул бы ИНСТАНС EmailService:
+# пакетный __init__ шэдоуит имя сабмодуля одноимённым синглтоном. importlib
+# отдаёт настоящий модуль из sys.modules — патчим его атрибуты.
+email_service_module = importlib.import_module('app.cabinet.services.email_service')
+overrides_module = importlib.import_module('app.cabinet.services.email_template_overrides')
+
+
+async def test_send_promo_offer_email_skips_when_smtp_not_configured(monkeypatch):
+    email_service = MagicMock()
+    email_service.is_configured = MagicMock(return_value=False)
+    monkeypatch.setattr(email_service_module, 'email_service', email_service)
+
+    ok = await m.send_promo_offer_email(
+        email='u@example.com',
+        language='ru',
+        message_text='hi',
+        valid_hours=24,
+    )
+
+    assert ok is False
+    email_service.send_email.assert_not_called()
+
+
+async def test_send_promo_offer_email_renders_template_and_sends(monkeypatch):
+    email_service = MagicMock()
+    email_service.is_configured = MagicMock(return_value=True)
+    email_service.send_email = MagicMock(return_value=True)
+    monkeypatch.setattr(email_service_module, 'email_service', email_service)
+    # Без DB-override — падаем на дефолтный шаблон
+    monkeypatch.setattr(overrides_module, 'get_rendered_override', AsyncMock(return_value=None))
+
+    ok = await m.send_promo_offer_email(
+        email='u@example.com',
+        language='ru',
+        username='Вася',
+        message_text='🔥 Скидка <b>20%</b>\nна подписку',
+        valid_hours=24,
+        discount_percent=20,
+    )
+
+    assert ok is True
+    email_service.send_email.assert_called_once()
+    kwargs = email_service.send_email.call_args.kwargs
+    assert kwargs['to_email'] == 'u@example.com'
+    assert '20%' in kwargs['subject']
+    # Telegram-текст конвертирован в HTML-фрагмент (переносы → <br>)
+    assert 'Скидка <b>20%</b><br>на подписку' in kwargs['body_html']
+
+
+async def test_send_promo_offer_email_prefers_db_override(monkeypatch):
+    email_service = MagicMock()
+    email_service.is_configured = MagicMock(return_value=True)
+    email_service.send_email = MagicMock(return_value=True)
+    monkeypatch.setattr(email_service_module, 'email_service', email_service)
+    monkeypatch.setattr(
+        overrides_module,
+        'get_rendered_override',
+        AsyncMock(return_value=('SUBJ', '<p>OVERRIDE</p>')),
+    )
+
+    ok = await m.send_promo_offer_email(
+        email='u@example.com',
+        language='ru',
+        message_text='hi',
+        valid_hours=1,
+    )
+
+    assert ok is True
+    kwargs = email_service.send_email.call_args.kwargs
+    assert kwargs['subject'] == 'SUBJ'
+    assert kwargs['body_html'] == '<p>OVERRIDE</p>'
+
+
+async def test_promo_offer_email_template_registered():
+    """Дефолтный шаблон promo_offer должен резолвиться из EmailNotificationTemplates."""
+    from app.cabinet.services.email_templates import EmailNotificationTemplates
+    from app.services.notification_delivery_service import NotificationType
+
+    template = EmailNotificationTemplates().get_template(
+        NotificationType.PROMO_OFFER,
+        'ru',
+        {'message_html': 'ТЕКСТ-МАРКЕР', 'valid_hours': 24, 'discount_percent': 15},
+    )
+
+    assert template is not None
+    assert '15%' in template['subject']
+    assert 'ТЕКСТ-МАРКЕР' in template['body_html']
+    assert '24' in template['body_html']  # срок действия попал в тело
+
+
+async def test_email_fanout_counts_sent_and_failed(monkeypatch):
+    """Фан-аут работает на скалярных таргетах (email, language, username) и
+    честно считает sent/failed — как Telegram-собрат."""
+    calls: list[str] = []
+
+    async def fake_send(**kwargs):
+        calls.append(kwargs['email'])
+        return kwargs['email'] != 'bad@example.com'
+
+    monkeypatch.setattr('app.services.promo_offer_email.send_promo_offer_email', fake_send)
+
+    sent, failed = await route_module._send_promo_email_notifications(
+        [
+            ('a@example.com', 'ru', 'A'),
+            ('bad@example.com', 'en', 'B'),
+            ('c@example.com', 'ru', 'C'),
+        ],
+        message_text='hi',
+        discount_percent=10,
+        bonus_amount_kopeks=0,
+        valid_hours=24,
+    )
+
+    assert (sent, failed) == (2, 1)
+    assert sorted(calls) == ['a@example.com', 'bad@example.com', 'c@example.com']
+
+
+async def test_email_fanout_empty_targets_noop():
+    sent, failed = await route_module._send_promo_email_notifications(
+        [],
+        message_text=None,
+        discount_percent=0,
+        bonus_amount_kopeks=0,
+        valid_hours=1,
+    )
+    assert (sent, failed) == (0, 0)


### PR DESCRIPTION
## 📝 Описание

Шаблоны промопредложений работали только для аккаунтов с telegram_id: кабинетный `/admin/promo-offers/broadcast` создавал оффер, но фан-аут уведомлений скипал получателей без Telegram; бот-рассылка шаблонов скипала email-only юзеров целиком (даже без создания оффера). Email-аккаунты не узнавали о предложениях.

Теперь оба пути шлют письмо на подтверждённую почту через общий канал `app/services/promo_offer_email.py`:

- тот же текст, что и в Telegram (Telegram-HTML b/i/code — валидный HTML-фрагмент письма, переносы → `<br>`); кнопке «Получить» соответствует ссылка на кабинет — оффер уже создан в БД и активируется там;
- `NotificationType.PROMO_OFFER` + дефолтный шаблон письма (ru/en/zh/ua) + поддержка DB-override (раздел email_templates, тип `promo_offer`);
- кабинетный broadcast: email-фан-аут на скалярных таргетах по образцу Telegram-собрата (inline ≤30 получателей, дальше — background task), счётчики складываются в `notifications_sent/failed`;
- бот-рассылка шаблонов: юзеру без telegram_id, но с подтверждённой почтой оффер создаётся и уведомление уходит письмом.

Если SMTP не настроен — письмо тихо скипается с debug-логом (как в остальных email-уведомлениях).

## 🎯 Мотивация

Кабинет поддерживает email-регистрацию, но промопредложения до этих юзеров не доходили вовсе — сегмент выпадал из маркетинговых рассылок (репорт с боевой инсталляции).

## 🔧 Тип изменений
- [x] New feature (новая функция)

## ✅ Чеклист
- [x] Код соответствует стандартам проекта (ruff чисто)
- [x] Добавлены тесты: `tests/cabinet/test_promo_offer_email_notify.py` (6 шт.: SMTP off, рендер+отправка, DB-override, регистрация шаблона, счётчики фан-аута, пустые таргеты)
- [x] Полная сюита зелёная (1940 passed на dev после ребейза)