### PR TITLE
feat(unitpay): UnitPay payment provider (WIP on v3.64)

### DIFF
--- a/app/database/crud/unitpay.py
+++ b/app/database/crud/unitpay.py
@@ -1,4 +1,5 @@
 """CRUD for UnitPay payments."""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -65,9 +66,7 @@ async def get_unitpay_payment_by_id(db: AsyncSession, payment_id: int) -> UnitPa
 
 
 async def get_unitpay_payment_by_id_for_update(db: AsyncSession, payment_id: int) -> UnitPayPayment | None:
-    result = await db.execute(
-        select(UnitPayPayment).where(UnitPayPayment.id == payment_id).with_for_update()
-    )
+    result = await db.execute(select(UnitPayPayment).where(UnitPayPayment.id == payment_id).with_for_update())
     return result.scalar_one_or_none()
 
 

--- a/app/database/crud/unitpay.py
+++ b/app/database/crud/unitpay.py
@@ -1,0 +1,128 @@
+"""CRUD for UnitPay payments."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import UnitPayPayment
+
+logger = structlog.get_logger(__name__)
+
+
+async def create_unitpay_payment(
+    db: AsyncSession,
+    *,
+    user_id: int | None,
+    order_id: str,
+    amount_kopeks: int,
+    currency: str = 'RUB',
+    description: str | None = None,
+    payment_url: str | None = None,
+    payment_type: str | None = None,
+    unitpay_id: str | None = None,
+    subscription_id: str | None = None,
+    expires_at: datetime | None = None,
+    metadata_json: dict | None = None,
+) -> UnitPayPayment:
+    payment = UnitPayPayment(
+        user_id=user_id,
+        order_id=order_id,
+        amount_kopeks=amount_kopeks,
+        currency=currency,
+        description=description,
+        payment_url=payment_url,
+        payment_type=payment_type,
+        unitpay_id=unitpay_id,
+        subscription_id=subscription_id,
+        expires_at=expires_at,
+        metadata_json=metadata_json,
+        status='pending',
+        is_paid=False,
+    )
+    db.add(payment)
+    await db.commit()
+    await db.refresh(payment)
+    logger.info('Создан платеж UnitPay', order_id=order_id, user_id=user_id)
+    return payment
+
+
+async def get_unitpay_payment_by_order_id(db: AsyncSession, order_id: str) -> UnitPayPayment | None:
+    result = await db.execute(select(UnitPayPayment).where(UnitPayPayment.order_id == order_id))
+    return result.scalar_one_or_none()
+
+
+async def get_unitpay_payment_by_unitpay_id(db: AsyncSession, unitpay_id: str) -> UnitPayPayment | None:
+    result = await db.execute(select(UnitPayPayment).where(UnitPayPayment.unitpay_id == unitpay_id))
+    return result.scalar_one_or_none()
+
+
+async def get_unitpay_payment_by_id(db: AsyncSession, payment_id: int) -> UnitPayPayment | None:
+    result = await db.execute(select(UnitPayPayment).where(UnitPayPayment.id == payment_id))
+    return result.scalar_one_or_none()
+
+
+async def get_unitpay_payment_by_id_for_update(db: AsyncSession, payment_id: int) -> UnitPayPayment | None:
+    result = await db.execute(
+        select(UnitPayPayment).where(UnitPayPayment.id == payment_id).with_for_update()
+    )
+    return result.scalar_one_or_none()
+
+
+async def update_unitpay_payment_status(
+    db: AsyncSession,
+    payment_id: int,
+    *,
+    status: str | None = None,
+    is_paid: bool | None = None,
+    unitpay_id: str | None = None,
+    subscription_id: str | None = None,
+    callback_payload: dict | None = None,
+    paid_at: datetime | None = None,
+    transaction_id: int | None = None,
+) -> None:
+    values: dict = {}
+    if status is not None:
+        values['status'] = status
+    if is_paid is not None:
+        values['is_paid'] = is_paid
+    if unitpay_id is not None:
+        values['unitpay_id'] = unitpay_id
+    if subscription_id is not None:
+        values['subscription_id'] = subscription_id
+    if callback_payload is not None:
+        values['callback_payload'] = callback_payload
+    if paid_at is not None:
+        values['paid_at'] = paid_at
+    if transaction_id is not None:
+        values['transaction_id'] = transaction_id
+    if not values:
+        return
+    values['updated_at'] = datetime.now(UTC)
+    await db.execute(update(UnitPayPayment).where(UnitPayPayment.id == payment_id).values(**values))
+    await db.commit()
+
+
+async def get_pending_unitpay_payments(db: AsyncSession, user_id: int) -> list[UnitPayPayment]:
+    result = await db.execute(
+        select(UnitPayPayment).where(
+            UnitPayPayment.user_id == user_id,
+            UnitPayPayment.status == 'pending',
+            UnitPayPayment.is_paid.is_(False),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def get_expired_pending_unitpay_payments(db: AsyncSession) -> list[UnitPayPayment]:
+    result = await db.execute(
+        select(UnitPayPayment).where(
+            UnitPayPayment.status == 'pending',
+            UnitPayPayment.is_paid.is_(False),
+            UnitPayPayment.expires_at.isnot(None),
+            UnitPayPayment.expires_at < datetime.now(UTC),
+        )
+    )
+    return list(result.scalars().all())

--- a/app/services/payment/recurring/__init__.py
+++ b/app/services/payment/recurring/__init__.py
@@ -1,0 +1,62 @@
+"""Registry of recurring payment providers.
+
+Import providers here so they self-register via ``register_provider``. Other
+modules should use :func:`get_provider` / :func:`enabled_providers` instead of
+importing concrete classes.
+"""
+
+from __future__ import annotations
+
+from app.services.payment.recurring.base import (
+    CardRegistration,
+    ChargeResult,
+    RecurringProvider,
+)
+from app.services.payment.recurring.etoplatezhi_provider import EtoPlatezhiRecurringProvider
+from app.services.payment.recurring.yookassa_provider import YooKassaRecurringProvider
+
+
+_PROVIDERS: dict[str, RecurringProvider] = {}
+
+
+def register_provider(provider: RecurringProvider) -> None:
+    """Register a provider in the global registry. Last writer wins."""
+    if not provider.name:
+        raise ValueError('RecurringProvider.name must be a non-empty string')
+    _PROVIDERS[provider.name] = provider
+
+
+def get_provider(name: str) -> RecurringProvider | None:
+    """Return the registered provider or ``None`` when unknown."""
+    return _PROVIDERS.get(name)
+
+
+def enabled_providers() -> list[RecurringProvider]:
+    """Return all providers whose configuration is currently complete."""
+    return [provider for provider in _PROVIDERS.values() if provider.is_enabled()]
+
+
+def is_any_recurring_enabled() -> bool:
+    """True if at least one recurring provider can charge saved cards."""
+    return any(provider.is_enabled() for provider in _PROVIDERS.values())
+
+
+# Built-in providers
+register_provider(YooKassaRecurringProvider())
+register_provider(EtoPlatezhiRecurringProvider())
+
+
+__all__ = [
+    'CardRegistration',
+    'ChargeResult',
+    'RecurringProvider',
+    'enabled_providers',
+    'get_provider',
+    'is_any_recurring_enabled',
+    'register_provider',
+]
+
+# UnitPay recurring provider
+from app.services.payment.recurring.unitpay_provider import UnitPayRecurringProvider  # noqa: E402
+
+register_provider(UnitPayRecurringProvider())

--- a/app/services/payment/recurring/base.py
+++ b/app/services/payment/recurring/base.py
@@ -1,0 +1,82 @@
+"""Abstractions for recurring/saved-card payment providers.
+
+Each provider implements :class:`RecurringProvider` and registers itself in
+``app/services/payment/recurring/__init__.py``. The rest of the codebase only
+talks to the registry, so adding a new provider does not require touching the
+monitoring service, CRUD layer or cabinet routes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class CardRegistration:
+    """Saved-card data extracted from a provider's webhook payload."""
+
+    provider_token: str
+    method_type: str = 'bank_card'
+    card_first6: str | None = None
+    card_last4: str | None = None
+    card_type: str | None = None
+    card_expiry_month: str | None = None
+    card_expiry_year: str | None = None
+    title: str | None = None
+    valid_thru: datetime | None = None
+
+
+@dataclass
+class ChargeResult:
+    """Outcome of charging a saved card."""
+
+    success: bool
+    provider_payment_id: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+class RecurringProvider(ABC):
+    """Provider-side adapter for saved-card recurring charges."""
+
+    #: Stable identifier persisted in ``saved_payment_methods.provider``.
+    name: str = ''
+
+    @abstractmethod
+    def is_enabled(self) -> bool:
+        """Return ``True`` if recurring charges via this provider are configured."""
+
+    @abstractmethod
+    async def charge(
+        self,
+        *,
+        provider_token: str,
+        amount_kopeks: int,
+        description: str,
+        metadata: dict[str, Any],
+        idempotency_key: str,
+        user_id: int | None = None,
+    ) -> ChargeResult:
+        """Initiate a saved-card charge.
+
+        Args:
+            provider_token: ``saved_payment_methods.provider_token`` — payment-method
+                id (YooKassa), recurring_id (EtoPlatezhi), etc.
+            amount_kopeks: charge amount in kopeks.
+            description: human-readable payment description.
+            metadata: provider metadata payload (passed through to the gateway).
+            idempotency_key: idempotency key supplied by the orchestrator.
+            user_id: internal user id (for logging only).
+        """
+
+    async def revoke(self, *, provider_token: str) -> bool:  # pragma: no cover - default impl
+        """Best-effort revoke. Default is a no-op.
+
+        Providers that support revoking saved-card data should override this.
+        Returning ``True`` means "local state may now mark the card inactive".
+        """
+        return True

--- a/app/services/payment/recurring/etoplatezhi_provider.py
+++ b/app/services/payment/recurring/etoplatezhi_provider.py
@@ -1,0 +1,194 @@
+"""EtoPlatezhi adapter for the recurring-provider abstraction.
+
+Charges saved cards via the EtoPlatezhi Gate API endpoint
+``POST /v2/payment/card-partner/recurring``. The card-on-file is identified
+by ``recurring.id``, obtained when the initial Payment Page transaction was
+registered with ``stored_card_type = 3`` (registration of automatic
+charges).
+
+Spec references:
+* https://developers.etoplatezhi.ru/ru/ru_gate__cof_merchant_side.html
+* https://developers.etoplatezhi.ru/ru/ru_gate_payment_recurring_registration.html
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import httpx
+import structlog
+
+from app.config import settings
+from app.services.etoplatezhi_service import etoplatezhi_service
+from app.services.payment.recurring.base import ChargeResult, RecurringProvider
+
+
+logger = structlog.get_logger(__name__)
+
+
+GATE_BASE_URL = 'https://api.etoplatezhi.ru'
+# Default method code when a saved card has no method_code recorded (old rows
+# created before backfill, or unexpected providers): card-partner is the
+# historical default since it was the only recurring channel originally enabled.
+DEFAULT_METHOD_CODE = 'card-partner'
+# Explicit mapping method_code → endpoint URL. Per EtoPlatezhi support docs
+# (2026-05-25), the paths are NOT uniform — yoomoney uses /wallet/yoomoney/
+# rather than the method-code segment that card-partner/sberpay follow.
+_METHOD_ENDPOINTS: dict[str, str] = {
+    'card-partner': '/v2/payment/card-partner/recurring',
+    'sberpay': '/v2/payment/sberpay/recurring',
+    'sbp-qr': '/v2/payment/sbp-qr/recurring',
+    'yoomoney-wallet': '/v2/payment/wallet/yoomoney/recurring',
+}
+
+
+def _build_recurring_endpoint(method_code: str | None) -> str:
+    code = (method_code or DEFAULT_METHOD_CODE).strip()
+    return _METHOD_ENDPOINTS.get(code, _METHOD_ENDPOINTS[DEFAULT_METHOD_CODE])
+
+
+# Statuses returned by EtoPlatezhi for a successful charge initiation.
+# (The actual settlement happens asynchronously via webhook.)
+_SUCCESS_STATUSES = {'success', 'awaiting clarification', 'in process', 'in progress'}
+
+
+class EtoPlatezhiRecurringProvider(RecurringProvider):
+    name = 'etoplatezhi'
+
+    def __init__(self, *, http_timeout: float = 15.0) -> None:
+        self._http_timeout = http_timeout
+        self._client: httpx.AsyncClient | None = None
+
+    def _http_client(self) -> httpx.AsyncClient:
+        # Reuse a single AsyncClient so the TLS connection pool to
+        # api.etoplatezhi.ru survives between charges (~200ms saved per call).
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=self._http_timeout)
+        return self._client
+
+    def _resolve_webhook_url(self) -> str | None:
+        base = getattr(settings, 'WEBHOOK_URL', None)
+        if not base:
+            return None
+        path = getattr(settings, 'ETOPLATEZHI_WEBHOOK_PATH', '/etoplatezhi-webhook')
+        return f'{base.rstrip("/")}{path}'
+
+    def is_enabled(self) -> bool:
+        if not getattr(settings, 'ETOPLATEZHI_ENABLED', False):
+            return False
+        if not getattr(settings, 'ETOPLATEZHI_RECURRENT_ENABLED', False):
+            return False
+        return bool(settings.ETOPLATEZHI_PROJECT_ID and settings.ETOPLATEZHI_SECRET_KEY)
+
+    async def charge(
+        self,
+        *,
+        provider_token: str,
+        amount_kopeks: int,
+        description: str,
+        metadata: dict[str, Any],
+        idempotency_key: str,
+        user_id: int | None = None,
+    ) -> ChargeResult:
+        try:
+            recurring_id_int = int(provider_token)
+        except (TypeError, ValueError):
+            return ChargeResult(
+                success=False,
+                error_code='invalid_token',
+                error_message=f'EtoPlatezhi recurring_id must be numeric, got: {provider_token!r}',
+            )
+
+        customer_id = str(metadata.get('user_telegram_id') or user_id or '0')
+
+        # Use the supplied idempotency key as the EtoPlatezhi `payment_id` so
+        # retries collapse on the gateway side. EtoPlatezhi requires the field
+        # to be unique per project — if a caller did not pass one, generate a
+        # fresh UUID4.
+        payment_id = idempotency_key or uuid.uuid4().hex
+
+        # EtoPlatezhi silently discards recurring requests when
+        # merchant_callback_url or customer.ip_address are missing — the ack
+        # returns status:success but no transaction is ever created.
+        webhook_url = self._resolve_webhook_url()
+
+        customer_block: dict[str, Any] = {'id': customer_id}
+        customer_block['ip_address'] = str(
+            metadata.get('customer_ip_address')
+            or metadata.get('ip_address')
+            or getattr(settings, 'ETOPLATEZHI_FALLBACK_CUSTOMER_IP', '127.0.0.1')
+        )
+
+        general_block: dict[str, Any] = {
+            'project_id': etoplatezhi_service.project_id,
+            'payment_id': payment_id,
+        }
+        if webhook_url:
+            general_block['merchant_callback_url'] = webhook_url
+
+        payload: dict[str, Any] = {
+            'general': general_block,
+            'customer': customer_block,
+            'payment': {
+                'amount': amount_kopeks,
+                'currency': getattr(settings, 'ETOPLATEZHI_CURRENCY', 'RUB'),
+                'description': description,
+            },
+            'recurring': {'id': recurring_id_int},
+        }
+        payload['general']['signature'] = etoplatezhi_service._sign(payload)
+
+        url = f'{GATE_BASE_URL}{_build_recurring_endpoint(metadata.get("method_code"))}'
+        try:
+            response = await self._http_client().post(
+                url,
+                json=payload,
+                headers={'Content-Type': 'application/json', 'Accept': 'application/json'},
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error(
+                'etoplatezhi_recurring_charge_exception',
+                user_id=user_id,
+                recurring_id=recurring_id_int,
+                error=str(exc),
+            )
+            return ChargeResult(success=False, error_code='http_error', error_message=str(exc))
+
+        try:
+            data = response.json()
+        except Exception:
+            data = {'raw_text': response.text[:500]}
+
+        if response.status_code >= 400:
+            logger.warning(
+                'etoplatezhi_recurring_charge_http_error',
+                user_id=user_id,
+                recurring_id=recurring_id_int,
+                http_status=response.status_code,
+                response=data,
+            )
+            return ChargeResult(
+                success=False,
+                error_code=f'http_{response.status_code}',
+                error_message=str(data),
+                raw=data if isinstance(data, dict) else {},
+            )
+
+        operation = (data or {}).get('operation') if isinstance(data, dict) else None
+        op_status = (operation or {}).get('status') or (data or {}).get('status', '')
+        op_status_normalised = str(op_status).strip().lower()
+
+        if op_status_normalised in _SUCCESS_STATUSES:
+            return ChargeResult(
+                success=True,
+                provider_payment_id=str((operation or {}).get('id') or payment_id),
+                raw=data if isinstance(data, dict) else {},
+            )
+
+        return ChargeResult(
+            success=False,
+            error_code='charge_declined',
+            error_message=f'status={op_status_normalised or "unknown"}',
+            raw=data if isinstance(data, dict) else {},
+        )

--- a/app/services/payment/recurring/unitpay_provider.py
+++ b/app/services/payment/recurring/unitpay_provider.py
@@ -3,6 +3,7 @@
 UnitPay рекуррент работает через тот же initPayment API с параметром
 `subscriptionId` (ID подписки, полученный при первом платеже с subscription=true).
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/app/services/payment/recurring/unitpay_provider.py
+++ b/app/services/payment/recurring/unitpay_provider.py
@@ -1,0 +1,91 @@
+"""UnitPay adapter for the recurring-provider abstraction.
+
+UnitPay рекуррент работает через тот же initPayment API с параметром
+`subscriptionId` (ID подписки, полученный при первом платеже с subscription=true).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from app.config import settings
+from app.services.payment.recurring.base import ChargeResult, RecurringProvider
+from app.services.unitpay_service import unitpay_service
+
+logger = structlog.get_logger(__name__)
+
+
+class UnitPayRecurringProvider(RecurringProvider):
+    name = 'unitpay'
+
+    def is_enabled(self) -> bool:
+        return (
+            getattr(settings, 'UNITPAY_ENABLED', False)
+            and getattr(settings, 'UNITPAY_RECURRENT_ENABLED', False)
+            and settings.is_unitpay_enabled()
+        )
+
+    async def charge(
+        self,
+        *,
+        provider_token: str,
+        amount_kopeks: int,
+        description: str,
+        metadata: dict[str, Any],
+        idempotency_key: str,
+        user_id: int | None = None,
+    ) -> ChargeResult:
+        """
+        Charge via UnitPay recurring subscription.
+        provider_token = subscriptionId from initial payment webhook.
+        """
+        subscription_id = provider_token.strip()
+        if not subscription_id:
+            return ChargeResult(
+                success=False,
+                error_code='invalid_token',
+                error_message='UnitPay subscriptionId is empty',
+            )
+
+        amount_rubles = amount_kopeks / 100
+        order_id = idempotency_key or f'upr_{user_id}_{amount_kopeks}'
+        account = str(user_id)  # stable customer ID for UnitPay anti-fraud; webhook looked up by paymentId not account
+
+        customer_email = metadata.get('customer_email') or None
+
+        try:
+            result = await unitpay_service.init_payment(
+                order_id=order_id,
+                amount_rubles=amount_rubles,
+                desc=description,
+                account=account,
+                currency=getattr(settings, 'UNITPAY_CURRENCY', 'RUB'),
+                subscription_id=subscription_id,
+                result_url=settings.get_unitpay_result_url(),
+                back_url=settings.get_unitpay_back_url(),
+                customer_email=customer_email,
+            )
+
+            response = result.get('response') or {}
+            payment_id = str(response.get('paymentId', ''))
+            status = str(response.get('status', '')).lower()
+
+            if response and payment_id and status not in ('error', 'reject', 'declined'):
+                return ChargeResult(
+                    success=True,
+                    provider_payment_id=payment_id,
+                    raw=result if isinstance(result, dict) else {},
+                )
+
+            error = result.get('error') or {}
+            return ChargeResult(
+                success=False,
+                error_code=str(error.get('code', 'charge_declined')),
+                error_message=str(error.get('message', f'status={status}')),
+                raw=result if isinstance(result, dict) else {},
+            )
+
+        except Exception as exc:
+            logger.error('unitpay_recurring_charge_exception', user_id=user_id, error=str(exc))
+            return ChargeResult(success=False, error_code='http_error', error_message=str(exc))

--- a/app/services/payment/recurring/yookassa_provider.py
+++ b/app/services/payment/recurring/yookassa_provider.py
@@ -1,0 +1,84 @@
+"""YooKassa adapter for the recurring-provider abstraction.
+
+Wraps the existing :class:`~app.services.yookassa_service.YooKassaService`
+``create_autopayment`` call. Pure adapter — no behavioural changes vs. the
+previous direct call site in ``recurrent_payment_service``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from app.config import settings
+from app.services.payment.recurring.base import ChargeResult, RecurringProvider
+
+
+logger = structlog.get_logger(__name__)
+
+
+class YooKassaRecurringProvider(RecurringProvider):
+    name = 'yookassa'
+
+    def __init__(self) -> None:
+        self._service = None
+
+    def _get_service(self):
+        """Lazy-instantiate the YooKassa service so import order does not matter."""
+        if self._service is not None:
+            return self._service
+        if not settings.is_yookassa_enabled():
+            return None
+        from app.services.yookassa_service import YooKassaService
+
+        self._service = YooKassaService()
+        return self._service
+
+    def is_enabled(self) -> bool:
+        if not getattr(settings, 'YOOKASSA_RECURRENT_ENABLED', False):
+            return False
+        service = self._get_service()
+        return bool(service and getattr(service, 'configured', False))
+
+    async def charge(
+        self,
+        *,
+        provider_token: str,
+        amount_kopeks: int,
+        description: str,
+        metadata: dict[str, Any],
+        idempotency_key: str,
+        user_id: int | None = None,
+    ) -> ChargeResult:
+        service = self._get_service()
+        if not service:
+            return ChargeResult(success=False, error_message='YooKassa is not configured')
+
+        amount_rubles = round(amount_kopeks / 100, 2)
+        try:
+            result = await service.create_autopayment(
+                amount=amount_rubles,
+                currency='RUB',
+                description=description,
+                payment_method_id=provider_token,
+                metadata=metadata,
+                idempotence_key=idempotency_key,
+            )
+        except Exception as exc:  # pragma: no cover - network/runtime errors
+            logger.error(
+                'yookassa_recurring_charge_exception',
+                user_id=user_id,
+                provider_token_prefix=provider_token[:8] if provider_token else None,
+                error=str(exc),
+            )
+            return ChargeResult(success=False, error_message=str(exc))
+
+        if not result:
+            return ChargeResult(success=False, error_message='create_autopayment returned None')
+
+        return ChargeResult(
+            success=True,
+            provider_payment_id=str(result.get('id') or ''),
+            raw=result,
+        )

--- a/app/services/payment/unitpay.py
+++ b/app/services/payment/unitpay.py
@@ -1,0 +1,349 @@
+"""Mixin для интеграции с UnitPay (unitpay.ru)."""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.models import PaymentMethod, TransactionType
+from app.services.unitpay_service import unitpay_service
+from app.utils.payment_logger import payment_logger as logger
+from app.utils.user_utils import format_referrer_info
+
+
+class UnitPayPaymentMixin:
+    """Mixin для работы с платежами UnitPay."""
+
+    async def create_unitpay_payment(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int | None,
+        amount_kopeks: int,
+        description: str = 'Пополнение баланса',
+        payment_type: str | None = None,
+        enable_subscription: bool = False,
+        email: str | None = None,
+    ) -> dict[str, Any] | None:
+        if not settings.is_unitpay_enabled():
+            logger.error('UnitPay не настроен')
+            return None
+
+        if amount_kopeks < settings.UNITPAY_MIN_AMOUNT_KOPEKS:
+            logger.warning('UnitPay: сумма меньше минимальной', amount_kopeks=amount_kopeks)
+            return None
+        if amount_kopeks > settings.UNITPAY_MAX_AMOUNT_KOPEKS:
+            logger.warning('UnitPay: сумма больше максимальной', amount_kopeks=amount_kopeks)
+            return None
+
+        payment_module = import_module('app.services.payment_service')
+        user = await payment_module.get_user_by_id(db, user_id) if user_id else None
+        tg_id = user.telegram_id if user else (user_id or 'guest')
+        customer_email = email or (getattr(user, 'email', None) if user else None)
+
+        order_id = f'up{tg_id}_{uuid.uuid4().hex[:6]}'
+        amount_rubles = amount_kopeks / 100
+        effective_type = payment_type or settings.UNITPAY_PAYMENT_TYPE or 'sbp'
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+        metadata = {
+            'user_id': user_id,
+            'amount_kopeks': amount_kopeks,
+            'description': description,
+            'type': 'balance_topup',
+            'enable_subscription': enable_subscription,
+        }
+
+        try:
+            result = await unitpay_service.init_payment(
+                order_id=order_id,
+                amount_rubles=amount_rubles,
+                desc=description,
+                account=str(tg_id),
+                payment_type=effective_type,
+                currency=settings.UNITPAY_CURRENCY,
+                result_url=settings.get_unitpay_result_url(),
+                back_url=settings.get_unitpay_back_url(),
+                hide_other_methods=settings.UNITPAY_HIDE_OTHER_METHODS,
+                subscription=enable_subscription,
+                customer_email=customer_email,
+            )
+
+            payment_url = (result.get('response') or {}).get('redirectUrl')
+            unitpay_id = str((result.get('response') or {}).get('paymentId', '')) or None
+            if not payment_url:
+                logger.error('UnitPay API не вернул redirectUrl', result=result)
+                return None
+
+            unitpay_crud = import_module('app.database.crud.unitpay')
+            local_payment = await unitpay_crud.create_unitpay_payment(
+                db=db,
+                user_id=user_id,
+                order_id=order_id,
+                amount_kopeks=amount_kopeks,
+                currency=settings.UNITPAY_CURRENCY,
+                description=description,
+                payment_url=payment_url,
+                payment_type=effective_type,
+                unitpay_id=unitpay_id,
+                expires_at=expires_at,
+                metadata_json=metadata,
+            )
+
+            logger.info('UnitPay: создан платеж', order_id=order_id, user_id=user_id, amount_rubles=amount_rubles)
+            return {
+                'order_id': order_id,
+                'amount_kopeks': amount_kopeks,
+                'amount_rubles': amount_rubles,
+                'currency': settings.UNITPAY_CURRENCY,
+                'payment_url': payment_url,
+                'expires_at': expires_at.isoformat(),
+                'local_payment_id': local_payment.id,
+            }
+
+        except Exception as e:
+            logger.exception('UnitPay: ошибка создания платежа', e=e)
+            return None
+
+    async def process_unitpay_webhook(
+        self,
+        db: AsyncSession,
+        *,
+        method: str,
+        params: dict[str, Any],
+    ) -> str:
+        """
+        Обрабатывает GET-webhook от UnitPay.
+        Возвращает JSON-строку ответа.
+        """
+        import json
+
+        def _ok() -> str:
+            return json.dumps({'result': {'message': 'ok'}})
+
+        def _err(msg: str) -> str:
+            return json.dumps({'error': {'message': msg}})
+
+        try:
+            sign = params.get('signature', '')
+            if not unitpay_service.verify_webhook_signature(method, params, sign):
+                logger.warning('UnitPay webhook: неверная подпись', method=method)
+                return _err('bad signature')
+
+            if method == 'check':
+                return _ok()
+
+            if method not in ('pay', 'preauth'):
+                return _ok()
+
+            account_field = params.get('account', '')
+            unitpay_id = str(params.get('paymentId', ''))
+            subscription_id = str(params.get('subscriptionId', '')) or None
+            amount_str = params.get('orderSum', params.get('sum', '0'))
+            try:
+                amount = float(amount_str)
+            except (ValueError, TypeError):
+                amount = 0.0
+
+            if not unitpay_id:
+                return _err('missing paymentId')
+
+            unitpay_crud = import_module('app.database.crud.unitpay')
+            payment = await unitpay_crud.get_unitpay_payment_by_unitpay_id(db, unitpay_id)
+            if not payment and account_field:
+                payment = await unitpay_crud.get_unitpay_payment_by_order_id(db, account_field)
+            if not payment:
+                logger.warning('UnitPay webhook: платеж не найден', unitpay_id=unitpay_id, account=account_field)
+                return _err('payment not found')
+
+            locked = await unitpay_crud.get_unitpay_payment_by_id_for_update(db, payment.id)
+            if not locked:
+                return _err('lock failed')
+            payment = locked
+
+            if payment.is_paid:
+                return _ok()
+
+            expected = payment.amount_kopeks / 100
+            if abs(amount - expected) > 0.01:
+                logger.warning(
+                    'UnitPay webhook: несоответствие суммы',
+                    expected=expected,
+                    got=amount,
+                    order_id=order_id,
+                )
+                return _err('amount mismatch')
+
+            payment.status = 'success'
+            payment.is_paid = True
+            payment.paid_at = datetime.now(UTC)
+            payment.unitpay_id = unitpay_id or payment.unitpay_id
+            if subscription_id:
+                payment.subscription_id = subscription_id
+            payment.callback_payload = dict(params)
+            payment.updated_at = datetime.now(UTC)
+            await db.flush()
+
+            await self._finalize_unitpay_payment(db, payment, unitpay_id=unitpay_id, trigger='webhook')
+            return _ok()
+
+        except Exception as e:
+            logger.exception('UnitPay webhook: ошибка обработки', e=e)
+            return '{"error":{"message":"internal error"}}'
+
+    async def _finalize_unitpay_payment(
+        self,
+        db: AsyncSession,
+        payment: Any,
+        *,
+        unitpay_id: str | None,
+        trigger: str,
+    ) -> bool:
+        payment_module = import_module('app.services.payment_service')
+
+        if payment.transaction_id:
+            return True
+
+        metadata = dict(getattr(payment, 'metadata_json', {}) or {})
+        from app.services.payment.common import try_fulfill_guest_purchase
+
+        guest_result = await try_fulfill_guest_purchase(
+            db,
+            metadata=metadata,
+            payment_amount_kopeks=payment.amount_kopeks,
+            provider_payment_id=unitpay_id or payment.order_id,
+            provider_name='unitpay',
+        )
+        if guest_result is not None:
+            return True
+
+        user = await payment_module.get_user_by_id(db, payment.user_id)
+        if not user:
+            logger.error('Пользователь не найден для UnitPay платежа', user_id=payment.user_id, order_id=payment.order_id)
+            return False
+
+        transaction = await payment_module.create_transaction(
+            db,
+            user_id=payment.user_id,
+            type=TransactionType.DEPOSIT,
+            amount_kopeks=payment.amount_kopeks,
+            description=f'Пополнение через UnitPay (#{unitpay_id or payment.order_id})',
+            payment_method=PaymentMethod.UNITPAY,
+            external_id=unitpay_id or payment.order_id,
+            is_completed=True,
+            created_at=getattr(payment, 'created_at', None),
+            commit=False,
+        )
+
+        payment.transaction_id = transaction.id
+        payment.updated_at = datetime.now(UTC)
+        await db.flush()
+
+        from app.database.crud.user import lock_user_for_update
+
+        user = await lock_user_for_update(db, user)
+        old_balance = user.balance_kopeks
+        was_first_topup = not user.has_made_first_topup
+
+        user.balance_kopeks += payment.amount_kopeks
+        user.updated_at = datetime.now(UTC)
+
+        promo_group = user.get_primary_promo_group()
+        subscription = getattr(user, 'subscription', None)
+        referrer_info = format_referrer_info(user)
+        topup_status = 'Первое пополнение' if was_first_topup else 'Пополнение'
+
+        await db.commit()
+
+        from app.database.crud.transaction import emit_transaction_side_effects
+
+        await emit_transaction_side_effects(
+            db,
+            transaction,
+            amount_kopeks=payment.amount_kopeks,
+            user_id=payment.user_id,
+            type=TransactionType.DEPOSIT,
+            payment_method=PaymentMethod.UNITPAY,
+            external_id=unitpay_id or payment.order_id,
+        )
+
+        try:
+            from app.services.referral_service import process_referral_topup
+
+            await process_referral_topup(db, user.id, payment.amount_kopeks, getattr(self, 'bot', None))
+        except Exception as error:
+            logger.error('Ошибка реферального пополнения UnitPay', error=error)
+
+        if was_first_topup and not user.has_made_first_topup and not user.referred_by_id:
+            user.has_made_first_topup = True
+            await db.commit()
+
+        await db.refresh(user)
+        await db.refresh(payment)
+
+        if getattr(self, 'bot', None):
+            try:
+                from app.services.admin_notification_service import AdminNotificationService
+
+                notification_service = AdminNotificationService(self.bot)
+                await notification_service.send_balance_topup_notification(
+                    user,
+                    transaction,
+                    old_balance,
+                    topup_status=topup_status,
+                    referrer_info=referrer_info,
+                    subscription=subscription,
+                    promo_group=promo_group,
+                    db=db,
+                )
+            except Exception as error:
+                logger.error('Ошибка отправки админ уведомления UnitPay', error=error)
+
+        if getattr(self, 'bot', None) and user.telegram_id:
+            try:
+                display_name = settings.get_unitpay_display_name()
+                keyboard = await self.build_topup_success_keyboard(user)
+                message = (
+                    '✅ <b>Пополнение успешно!</b>\n\n'
+                    f'💰 Сумма: {settings.format_price(payment.amount_kopeks)}\n'
+                    f'💳 Способ: {display_name}\n'
+                    f'🆔 Транзакция: {transaction.id}\n\n'
+                    'Баланс пополнен автоматически!'
+                )
+                await self.bot.send_message(user.telegram_id, message, parse_mode='HTML', reply_markup=keyboard)
+            except Exception as error:
+                logger.error('Ошибка уведомления пользователю UnitPay', error=error)
+
+        try:
+            from app.services.payment.common import send_cart_notification_after_topup
+
+            await send_cart_notification_after_topup(user, payment.amount_kopeks, db, getattr(self, 'bot', None))
+        except Exception as error:
+            logger.error('Ошибка корзины после пополнения UnitPay', user_id=user.id, error=error)
+
+        if payment.subscription_id and payment.user_id:
+            try:
+                from app.database.crud.saved_payment_method import create_saved_payment_method
+
+                await create_saved_payment_method(
+                    db,
+                    user_id=payment.user_id,
+                    provider_token=payment.subscription_id,
+                    provider='unitpay',
+                    method_type='bank_card',
+                    commit=True,
+                )
+                logger.info(
+                    'UnitPay: сохранена карта для рекуррента',
+                    user_id=payment.user_id,
+                    subscription_id=payment.subscription_id,
+                )
+            except Exception as error:
+                logger.error('UnitPay: ошибка сохранения карты для рекуррента', user_id=payment.user_id, error=error)
+
+        logger.info('✅ Обработан UnitPay платеж', order_id=payment.order_id, user_id=payment.user_id, trigger=trigger)
+        return True

--- a/app/services/payment/unitpay.py
+++ b/app/services/payment/unitpay.py
@@ -1,4 +1,5 @@
 """Mixin для интеграции с UnitPay (unitpay.ru)."""
+
 from __future__ import annotations
 
 import uuid
@@ -223,7 +224,9 @@ class UnitPayPaymentMixin:
 
         user = await payment_module.get_user_by_id(db, payment.user_id)
         if not user:
-            logger.error('Пользователь не найден для UnitPay платежа', user_id=payment.user_id, order_id=payment.order_id)
+            logger.error(
+                'Пользователь не найден для UnitPay платежа', user_id=payment.user_id, order_id=payment.order_id
+            )
             return False
 
         transaction = await payment_module.create_transaction(

--- a/app/services/unitpay_service.py
+++ b/app/services/unitpay_service.py
@@ -1,0 +1,119 @@
+"""UnitPay API client."""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+API_URL = 'https://unitpay.ru/api'
+# IPs from which UnitPay sends webhook notifications
+UNITPAY_WEBHOOK_IPS: frozenset[str] = frozenset({'31.186.100.49', '51.250.20.9'})
+
+
+class UnitPayService:
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+
+    def _http(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=15.0)
+        return self._client
+
+    @staticmethod
+    def _compute_signature(method: str, params: dict[str, Any], secret_key: str) -> str:
+        """sha256(method + "{up}" + sorted_param_values + "{up}" + secretKey)."""
+        keys = sorted(params.keys())
+        values = [str(params[k]) for k in keys]
+        data = method + '{up}' + '{up}'.join(values) + '{up}' + secret_key
+        return hashlib.sha256(data.encode()).hexdigest()
+
+    def verify_webhook_signature(
+        self, method: str, params: dict[str, Any], received_sign: str
+    ) -> bool:
+        """Verify incoming webhook signature; excludes 'signature' key from params."""
+        from app.config import settings
+
+        clean = {k: v for k, v in params.items() if k != 'signature'}
+        expected = self._compute_signature(method, clean, settings.UNITPAY_SECRET_KEY or '')
+        return expected == received_sign
+
+    async def init_payment(
+        self,
+        *,
+        order_id: str,
+        amount_rubles: float,
+        desc: str,
+        account: str,
+        payment_type: str | None = None,
+        currency: str = 'RUB',
+        result_url: str | None = None,
+        back_url: str | None = None,
+        hide_other_methods: bool = True,
+        subscription: bool = False,
+        subscription_id: str | None = None,
+        customer_email: str | None = None,
+        customer_phone: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Initiate a payment via the UnitPay API.
+        When subscription_id is provided it charges the saved card directly.
+        Otherwise creates a new redirect payment.
+        """
+        from app.config import settings
+
+        params: dict[str, Any] = {
+            'account': account,
+            'currency': currency,
+            'desc': desc,
+            'projectId': settings.UNITPAY_PROJECT_ID,
+            'sum': f'{amount_rubles:.2f}',
+        }
+        if subscription_id:
+            params['subscriptionId'] = subscription_id
+        elif payment_type:
+            params['paymentType'] = payment_type
+
+        if result_url:
+            params['resultUrl'] = result_url
+        if back_url:
+            params['backUrl'] = back_url
+        if hide_other_methods:
+            params['hideOtherMethods'] = 1
+        if subscription and not subscription_id:
+            params['subscription'] = 'true'
+        if customer_email:
+            params['customerEmail'] = customer_email
+        if customer_phone:
+            params['customerPhone'] = customer_phone
+
+        params['signature'] = self._compute_signature(
+            'initPayment', params, settings.UNITPAY_SECRET_KEY or ''
+        )
+
+        flat: dict[str, Any] = {'method': 'initPayment'}
+        for k, v in params.items():
+            flat[f'params[{k}]'] = v
+
+        response = await self._http().get(API_URL, params=flat)
+        response.raise_for_status()
+        return response.json()
+
+    async def get_payment(self, unitpay_id: str) -> dict[str, Any]:
+        """Retrieve payment info by UnitPay payment ID."""
+        from app.config import settings
+
+        flat = {
+            'method': 'getPayment',
+            'params[paymentId]': unitpay_id,
+            'params[secretKey]': settings.UNITPAY_SECRET_KEY or '',
+        }
+        response = await self._http().get(API_URL, params=flat)
+        response.raise_for_status()
+        return response.json()
+
+
+unitpay_service = UnitPayService()

--- a/app/services/unitpay_service.py
+++ b/app/services/unitpay_service.py
@@ -1,4 +1,5 @@
 """UnitPay API client."""
+
 from __future__ import annotations
 
 import hashlib
@@ -31,9 +32,7 @@ class UnitPayService:
         data = method + '{up}' + '{up}'.join(values) + '{up}' + secret_key
         return hashlib.sha256(data.encode()).hexdigest()
 
-    def verify_webhook_signature(
-        self, method: str, params: dict[str, Any], received_sign: str
-    ) -> bool:
+    def verify_webhook_signature(self, method: str, params: dict[str, Any], received_sign: str) -> bool:
         """Verify incoming webhook signature; excludes 'signature' key from params."""
         from app.config import settings
 
@@ -90,9 +89,7 @@ class UnitPayService:
         if customer_phone:
             params['customerPhone'] = customer_phone
 
-        params['signature'] = self._compute_signature(
-            'initPayment', params, settings.UNITPAY_SECRET_KEY or ''
-        )
+        params['signature'] = self._compute_signature('initPayment', params, settings.UNITPAY_SECRET_KEY or '')
 
         flat: dict[str, Any] = {'method': 'initPayment'}
         for k, v in params.items():

--- a/migrations/alembic/versions/0097_unitpay_payments.py
+++ b/migrations/alembic/versions/0097_unitpay_payments.py
@@ -1,0 +1,54 @@
+"""unitpay_payments table
+
+Revision ID: 0097
+Revises: 0096
+Create Date: 2026-06-30
+"""
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0097'
+down_revision: Union[str, None] = '0096'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'unitpay_payments',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('order_id', sa.String(length=64), nullable=False),
+        sa.Column('unitpay_id', sa.String(length=128), nullable=True),
+        sa.Column('subscription_id', sa.String(length=128), nullable=True),
+        sa.Column('amount_kopeks', sa.Integer(), nullable=False),
+        sa.Column('currency', sa.String(length=10), nullable=False, server_default='RUB'),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('status', sa.String(length=32), nullable=False, server_default='pending'),
+        sa.Column('is_paid', sa.Boolean(), nullable=True, server_default='false'),
+        sa.Column('payment_url', sa.Text(), nullable=True),
+        sa.Column('payment_type', sa.String(length=32), nullable=True),
+        sa.Column('metadata_json', sa.JSON(), nullable=True),
+        sa.Column('callback_payload', sa.JSON(), nullable=True),
+        sa.Column('paid_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('transaction_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['transaction_id'], ['transactions.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_unitpay_payments_id', 'unitpay_payments', ['id'])
+    op.create_index('ix_unitpay_payments_order_id', 'unitpay_payments', ['order_id'], unique=True)
+    op.create_index('ix_unitpay_payments_unitpay_id', 'unitpay_payments', ['unitpay_id'], unique=True)
+    op.create_index('ix_unitpay_payments_subscription_id', 'unitpay_payments', ['subscription_id'])
+    op.create_index('ix_unitpay_payments_user_id', 'unitpay_payments', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_table('unitpay_payments')


### PR DESCRIPTION
**DRAFT / WIP** — ядро UnitPay перенесено на v3.64, обвязка допиливается.

## Что готово (в этом PR, компилится, миграция сцеплена)
- `app/services/payment/recurring/` — наша recurring-provider абстракция (base + registry + etoplatezhi/yookassa/unitpay провайдеры). **В апстрим v3.64 этой папки нет** — UnitPay на неё завязан, поэтому несётся вместе.
- `app/services/payment/unitpay.py`, `app/services/unitpay_service.py`, `app/database/crud/unitpay.py`
- `migrations/alembic/versions/0097_unitpay_payments.py` — down_revision=0096 (апстримный хвост), коллизии нет.

## ⚠️ Допилить (обвязка в общие файлы — v3.64 их разошёл, автопорт не лёг). Источник = ветка `deploy-snapshot-v3.62.0` (936ba1d4):
- [ ] `app/config.py` — блок `UNITPAY_*` настроек (ENABLED/PROJECT_ID/SECRET_KEY/DISPLAY_NAME/CURRENCY/MIN_AMOUNT_KOPEKS) + `is_unitpay_enabled()`
- [ ] `app/database/models.py` — ORM-класс `UnitPayPayment` + `PaymentMethod.UNITPAY` (без него `crud/unitpay` не импортится)
- [ ] `app/services/recurrent_payment_service.py` — pre-create блок UnitPay (≈58 строк, зеркало etoplatezhi)
- [ ] `app/services/payment_service.py` — регистрация unitpay
- [ ] `app/cabinet/routes/balance.py` + `subscription_modules/purchase.py` — отображение метода
- [ ] `app/webserver/payments.py` — webhook-хендлер UnitPay (GET /notify). В снапшоте смешан с семафором — семафор отдельно в #3071, брать только UnitPay-часть.
- [ ] **Помирить нашу recurring-абстракцию с апстримным etoplatezhi** (у них свой, без абстракции — иначе два etoplatezhi).

Реф: PR #2806 (module) + #2827 (admin UI).