### PR TITLE
feat(cabinet): add semantic bot presentation editor

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -278,6 +278,15 @@ async def setup_bot() -> tuple[Bot, Dispatcher]:
     elif settings.is_cabinet_mode():
         logger.info('🏠 Режим Cabinet активен, базовый URL', MINIAPP_CUSTOM_URL=settings.MINIAPP_CUSTOM_URL)
 
+    # Load the presentation overlay independently of menu mode. It decorates all
+    # outgoing bot messages while failing closed to upstream text/emoji.
+    try:
+        from app.services.bot_presentation_service import load_bot_presentation_cache
+
+        await load_bot_presentation_cache()
+    except Exception as e:
+        logger.warning('Failed to load bot presentation cache', error=e)
+
     # Load per-section button styles cache and menu layout cache
     if settings.is_cabinet_mode():
         try:

--- a/app/bot_factory.py
+++ b/app/bot_factory.py
@@ -25,4 +25,11 @@ def create_bot(token: str | None = None, **kwargs) -> Bot:
         session = AiohttpSession(**session_kwargs)
 
     kwargs.setdefault('default', DefaultBotProperties(parse_mode=ParseMode.HTML))
-    return Bot(token=token or settings.BOT_TOKEN, session=session, **kwargs)
+    bot = Bot(token=token or settings.BOT_TOKEN, session=session, **kwargs)
+
+    # Presentation is applied at the Bot API boundary so handler/callback logic and
+    # upstream keyboards remain untouched.
+    from app.middlewares.bot_presentation_request import BotPresentationRequestMiddleware
+
+    bot.session.middleware(BotPresentationRequestMiddleware())
+    return bot

--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -8,6 +8,7 @@ from .account_linking import merge_router as merge_router, router as account_lin
 from .admin_apps import router as admin_apps_router
 from .admin_audit_log import router as admin_audit_log_router
 from .admin_ban_system import router as admin_ban_system_router
+from .admin_bot_presentation import router as admin_bot_presentation_router
 from .admin_broadcasts import router as admin_broadcasts_router
 from .admin_bulk_actions import router as admin_bulk_actions_router
 from .admin_button_styles import router as admin_button_styles_router
@@ -152,6 +153,7 @@ router.include_router(admin_updates_router)
 router.include_router(admin_traffic_router)
 router.include_router(admin_pinned_messages_router)
 router.include_router(admin_button_styles_router)
+router.include_router(admin_bot_presentation_router)
 router.include_router(admin_menu_layout_router)
 router.include_router(admin_channels_router)
 router.include_router(admin_apps_router)

--- a/app/cabinet/routes/admin_bot_presentation.py
+++ b/app/cabinet/routes/admin_bot_presentation.py
@@ -1,0 +1,171 @@
+"""Cabinet editor API for bot text and custom-emoji presentation overrides."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.crud.system_setting import delete_system_setting, upsert_system_setting
+from app.database.models import User
+from app.services.bot_presentation_catalog import (
+    build_bot_presentation_catalog,
+    validate_config_against_catalog,
+)
+from app.services.bot_presentation_service import (
+    BOT_PRESENTATION_KEY,
+    MAX_EMOJI_OVERRIDES,
+    MAX_TEXT_OVERRIDES,
+    BotPresentationConfig,
+    clear_bot_presentation_cache,
+    get_bot_presentation_config,
+    set_bot_presentation_cache,
+)
+
+from ..dependencies import get_cabinet_db, require_permission
+
+
+logger = structlog.get_logger(__name__)
+router = APIRouter(prefix='/admin/bot-presentation', tags=['Admin Bot Presentation'])
+
+
+class PresentationConfigPayload(BaseModel):
+    emoji_overrides: dict[str, str] = Field(default_factory=dict, max_length=MAX_EMOJI_OVERRIDES)
+    text_overrides: dict[str, str] = Field(default_factory=dict, max_length=MAX_TEXT_OVERRIDES)
+
+
+class PresentationConfigResponse(PresentationConfigPayload):
+    version: int = 2
+    emoji_catalog_count: int
+    text_catalog_count: int
+
+
+class CatalogResponse(BaseModel):
+    kind: Literal['emoji', 'text']
+    total: int
+    offset: int
+    limit: int
+    items: list[dict[str, Any]]
+
+
+async def _config_response() -> PresentationConfigResponse:
+    config = get_bot_presentation_config()
+    catalog = await asyncio.to_thread(build_bot_presentation_catalog)
+    return PresentationConfigResponse(
+        version=config.version,
+        emoji_overrides=config.emoji_overrides,
+        text_overrides=config.text_overrides,
+        emoji_catalog_count=len(catalog.emoji),
+        text_catalog_count=len(catalog.texts),
+    )
+
+
+@router.get('', response_model=PresentationConfigResponse)
+async def get_bot_presentation_config_route(
+    _admin: User = Depends(require_permission('settings:read')),
+):
+    return await _config_response()
+
+
+@router.get('/catalog', response_model=CatalogResponse)
+async def get_bot_presentation_catalog_route(
+    kind: Literal['emoji', 'text'],
+    query: str = Query(default='', max_length=200),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=200),
+    _admin: User = Depends(require_permission('settings:read')),
+):
+    catalog = await asyncio.to_thread(build_bot_presentation_catalog)
+    config = get_bot_presentation_config()
+    needle = query.strip().casefold()
+
+    if kind == 'emoji':
+        items = [
+            {
+                'token': item.token,
+                'localization_key': item.localization_key,
+                'occurrence': item.occurrence,
+                'glyph': item.glyph,
+                'custom_emoji_id': config.emoji_overrides.get(item.token, ''),
+                'usage_count': item.usage_count,
+                'usages': item.usages,
+            }
+            for item in catalog.emoji.values()
+            if not needle
+            or needle in item.token.casefold()
+            or needle in item.glyph.casefold()
+            or needle in config.emoji_overrides.get(item.token, '').casefold()
+            or any(needle in usage.casefold() for usage in item.usages)
+        ]
+    else:
+        items = [
+            {
+                'key': item.key,
+                'default': item.default,
+                'override': config.text_overrides.get(item.key, ''),
+                'usage_count': item.usage_count,
+                'usages': item.usages,
+            }
+            for item in catalog.texts.values()
+            if not needle
+            or needle in item.key.casefold()
+            or needle in item.default.casefold()
+            or needle in config.text_overrides.get(item.key, '').casefold()
+        ]
+
+    return CatalogResponse(
+        kind=kind,
+        total=len(items),
+        offset=offset,
+        limit=limit,
+        items=items[offset : offset + limit],
+    )
+
+
+@router.put('', response_model=PresentationConfigResponse)
+async def update_bot_presentation_config_route(
+    payload: PresentationConfigPayload,
+    admin: User = Depends(require_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    config = BotPresentationConfig(
+        emoji_overrides={key: value.strip() for key, value in payload.emoji_overrides.items() if value.strip()},
+        text_overrides={key: value for key, value in payload.text_overrides.items() if value.strip()},
+    )
+    try:
+        await asyncio.to_thread(validate_config_against_catalog, config)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+
+    await upsert_system_setting(
+        db,
+        BOT_PRESENTATION_KEY,
+        json.dumps(config.to_raw(), ensure_ascii=False),
+        description='Russian bot text and Telegram custom emoji presentation overrides',
+    )
+    await db.commit()
+    set_bot_presentation_cache(config)
+    logger.info(
+        'Admin updated bot presentation overrides',
+        telegram_id=admin.telegram_id,
+        emoji_overrides=len(config.emoji_overrides),
+        text_overrides=len(config.text_overrides),
+    )
+    return await _config_response()
+
+
+@router.post('/reset', response_model=PresentationConfigResponse)
+async def reset_bot_presentation_config_route(
+    admin: User = Depends(require_permission('settings:edit')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    await delete_system_setting(db, BOT_PRESENTATION_KEY)
+    await db.commit()
+    clear_bot_presentation_cache()
+    logger.info('Admin reset bot presentation overrides', telegram_id=admin.telegram_id)
+    return await _config_response()

--- a/app/localization/texts.py
+++ b/app/localization/texts.py
@@ -185,11 +185,23 @@ class Texts:
         if item == 'RULES_TEXT':
             return _get_cached_rules_value(self.language)
 
+        # Presentation overrides are a DB-backed Russian-only overlay. Emoji
+        # markers are scoped to this localization key, so equal glyphs in other
+        # contexts and languages remain untouched.
+        from app.services.bot_presentation_service import (
+            decorate_localized_text,
+            get_text_override,
+        )
+
+        override = get_text_override(self.language, item)
+        if override is not None:
+            return decorate_localized_text(self.language, item, override)
+
         if item in self._values:
-            return self._values[item]
+            return decorate_localized_text(self.language, item, self._values[item])
 
         if item in self._fallback_values:
-            return self._fallback_values[item]
+            return decorate_localized_text(self.language, item, self._fallback_values[item])
 
         # Предупреждаем только когда у вызова НЕТ запасного текста. t(key, default) и
         # get(key, default) передают warn=False: для них отсутствие ключа штатно —

--- a/app/middlewares/bot_presentation_request.py
+++ b/app/middlewares/bot_presentation_request.py
@@ -1,0 +1,156 @@
+"""Outgoing Bot API middleware for semantic presentation markers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from aiogram import Bot
+from aiogram.client.session.middlewares.base import BaseRequestMiddleware
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.methods import TelegramMethod
+from pydantic import BaseModel
+
+from app.services.bot_presentation_service import (
+    apply_button_presentation,
+    apply_html_emoji,
+    maybe_refresh_bot_presentation_cache,
+    strip_presentation_markers,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+_TEXT_SLOTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    'text': (('text_entities', 'entities'), ('text_parse_mode', 'parse_mode')),
+    'message_text': (('entities',), ('parse_mode',)),
+    'caption': (('caption_entities',), ('parse_mode',)),
+    'question': (('question_entities',), ('question_parse_mode',)),
+    'explanation': (('explanation_entities',), ('explanation_parse_mode',)),
+    'quote': (('quote_entities',), ('quote_parse_mode',)),
+}
+
+
+def _uses_html(parse_mode: Any, default_parse_mode: Any) -> bool:
+    value = parse_mode
+    if value.__class__.__name__ == 'Default':
+        value = default_parse_mode
+    normalized = str(getattr(value, 'value', value) or '').lower()
+    return normalized == 'html'
+
+
+def _first_present(model: BaseModel, names: tuple[str, ...]) -> Any:
+    for name in names:
+        if name in type(model).model_fields:
+            return getattr(model, name, None)
+    return None
+
+
+def _render_value(
+    value: str,
+    *,
+    parse_mode: Any,
+    default_parse_mode: Any,
+    entities: Any,
+    custom: bool,
+) -> str:
+    if custom and not entities and _uses_html(parse_mode, default_parse_mode):
+        return apply_html_emoji(value) or value
+    return strip_presentation_markers(value) or value
+
+
+def _render_nested(value: Any, default_parse_mode: Any, *, custom: bool) -> Any:
+    if isinstance(value, BaseModel):
+        return _render_model(value, default_parse_mode, custom=custom)
+    if isinstance(value, list):
+        rendered = [_render_nested(item, default_parse_mode, custom=custom) for item in value]
+        return rendered if any(new is not old for new, old in zip(rendered, value, strict=True)) else value
+    if isinstance(value, tuple):
+        rendered = tuple(_render_nested(item, default_parse_mode, custom=custom) for item in value)
+        return rendered if any(new is not old for new, old in zip(rendered, value, strict=True)) else value
+    return value
+
+
+def _render_model(model: BaseModel, default_parse_mode: Any, *, custom: bool) -> BaseModel:
+    updates: dict[str, Any] = {}
+    handled: set[str] = set()
+
+    for field_name, (entity_names, parse_mode_names) in _TEXT_SLOTS.items():
+        if field_name not in type(model).model_fields:
+            continue
+        handled.add(field_name)
+        value = getattr(model, field_name, None)
+        if not value:
+            continue
+        rendered = _render_value(
+            value,
+            parse_mode=_first_present(model, parse_mode_names),
+            default_parse_mode=default_parse_mode,
+            entities=_first_present(model, entity_names),
+            custom=custom,
+        )
+        if rendered != value:
+            updates[field_name] = rendered
+
+    if 'rich_message' in type(model).model_fields:
+        handled.add('rich_message')
+        rich_message = getattr(model, 'rich_message', None)
+        if rich_message is not None and getattr(rich_message, 'html', None):
+            html = rich_message.html
+            rendered = apply_html_emoji(html) if custom else strip_presentation_markers(html)
+            if rendered != html:
+                updates['rich_message'] = rich_message.model_copy(update={'html': rendered}, deep=True)
+
+    if 'reply_markup' in type(model).model_fields:
+        handled.add('reply_markup')
+        reply_markup = getattr(model, 'reply_markup', None)
+        rendered_markup = apply_button_presentation(reply_markup, custom=custom)
+        if rendered_markup is not reply_markup:
+            updates['reply_markup'] = rendered_markup
+
+    for field_name in type(model).model_fields:
+        if field_name in handled or field_name in updates:
+            continue
+        value = getattr(model, field_name, None)
+        if isinstance(value, str):
+            rendered_text = strip_presentation_markers(value) or value
+            if rendered_text != value:
+                updates[field_name] = rendered_text
+            continue
+        if not isinstance(value, (BaseModel, list, tuple)):
+            continue
+        rendered = _render_nested(value, default_parse_mode, custom=custom)
+        if rendered is not value:
+            updates[field_name] = rendered
+
+    return model.model_copy(update=updates, deep=True) if updates else model
+
+
+def apply_method_presentation(
+    method: TelegramMethod,
+    default_parse_mode: Any = 'HTML',
+    *,
+    custom: bool = True,
+) -> TelegramMethod:
+    """Render every supported nested Bot API text while preserving behavior."""
+    rendered = _render_model(method, default_parse_mode, custom=custom)
+    return rendered  # type: ignore[return-value]
+
+
+class BotPresentationRequestMiddleware(BaseRequestMiddleware):
+    async def __call__(self, make_request, bot: Bot, method: TelegramMethod):
+        await maybe_refresh_bot_presentation_cache()
+        default_parse_mode = getattr(getattr(bot, 'default', None), 'parse_mode', 'HTML')
+        fallback = apply_method_presentation(method, default_parse_mode, custom=False)
+        decorated = apply_method_presentation(method, default_parse_mode, custom=True)
+        if decorated == fallback:
+            return await make_request(bot, fallback)
+        try:
+            return await make_request(bot, decorated)
+        except TelegramBadRequest as error:
+            logger.warning(
+                'Decorated Telegram request was rejected; retrying Unicode fallback',
+                method=type(method).__name__,
+                error=str(error),
+            )
+            return await make_request(bot, fallback)

--- a/app/services/bot_presentation_catalog.py
+++ b/app/services/bot_presentation_catalog.py
@@ -1,0 +1,197 @@
+"""Semantic catalog for editable Russian bot presentation tokens.
+
+Only localization keys actually referenced through ``Texts`` are exposed. Emoji
+entries are scoped to ``RU_LOCALE_KEY#occurrence``; arbitrary Python literals,
+logs, Cabinet strings, docstrings, and non-Russian locales are intentionally not
+part of the operator catalog.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+from app.services.bot_presentation_service import (
+    MAX_EMOJI_OVERRIDES,
+    MAX_TEXT_OVERRIDES,
+    BotPresentationConfig,
+    extract_emoji,
+    validate_text_override,
+)
+
+
+_APP_ROOT = Path(__file__).resolve().parents[1]
+_RU_LOCALE_PATH = _APP_ROOT / 'localization' / 'locales' / 'ru.json'
+_CUSTOM_ID_RE = re.compile(r'^\d{1,100}$')
+_MAX_USAGES_PER_ITEM = 20
+_NON_OVERLAY_KEYS = {
+    'RULES_TEXT',
+    'SUPPORT_INFO',
+    'TRAFFIC_5GB',
+    'TRAFFIC_10GB',
+    'TRAFFIC_25GB',
+    'TRAFFIC_50GB',
+    'TRAFFIC_100GB',
+    'TRAFFIC_250GB',
+    'TRAFFIC_UNLIMITED',
+}
+_EXCLUDED_USAGE_PREFIXES = (
+    'app/cabinet/',
+    'app/database/',
+    'app/webapi/',
+    'app/webserver/',
+)
+_EXCLUDED_USAGE_FILES = {
+    'app/bot.py',
+    'app/config.py',
+    'app/logging_config.py',
+    'app/logging_handler.py',
+}
+
+
+@dataclass(slots=True)
+class EmojiCatalogItem:
+    token: str
+    localization_key: str
+    occurrence: int
+    glyph: str
+    usage_count: int = 0
+    usages: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TextCatalogItem:
+    key: str
+    default: str
+    usage_count: int = 0
+    usages: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BotPresentationCatalog:
+    emoji: dict[str, EmojiCatalogItem]
+    texts: dict[str, TextCatalogItem]
+
+
+def _literal_string(node: ast.AST) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _add_usage(usages: dict[str, set[str]], key: str | None, location: str, locale_keys: set[str]) -> None:
+    if not key or key not in locale_keys or key in _NON_OVERLAY_KEYS:
+        return
+    usages.setdefault(key, set()).add(location)
+
+
+def _looks_like_texts_receiver(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in {'texts', 'text', 'locale_texts'}
+    if isinstance(node, ast.Attribute):
+        return node.attr in {'texts', '_texts'}
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name):
+            return node.func.id in {'Texts', 'get_texts'}
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr == 'get_texts'
+    return False
+
+
+def _discover_text_usages(locale_keys: set[str]) -> dict[str, set[str]]:
+    usages: dict[str, set[str]] = {}
+    for path in _APP_ROOT.rglob('*.py'):
+        relative = path.relative_to(_APP_ROOT.parent)
+        relative_text = relative.as_posix()
+        if relative_text in _EXCLUDED_USAGE_FILES or relative_text.startswith(_EXCLUDED_USAGE_PREFIXES):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding='utf-8'))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            location = f'{relative}:{getattr(node, "lineno", 0)}'
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in {'t', 'get'}
+                and _looks_like_texts_receiver(node.func.value)
+            ):
+                key = _literal_string(node.args[0]) if node.args else None
+                _add_usage(usages, key, location, locale_keys)
+            elif (
+                isinstance(node, ast.Attribute)
+                and node.attr in locale_keys
+                and _looks_like_texts_receiver(node.value)
+            ):
+                _add_usage(usages, node.attr, location, locale_keys)
+            elif isinstance(node, ast.Subscript) and _looks_like_texts_receiver(node.value):
+                key = _literal_string(node.slice)
+                _add_usage(usages, key, location, locale_keys)
+    return usages
+
+
+@lru_cache(maxsize=1)
+def build_bot_presentation_catalog() -> BotPresentationCatalog:
+    locale_data = json.loads(_RU_LOCALE_PATH.read_text(encoding='utf-8'))
+    locale_values = {
+        key: value
+        for key, value in locale_data.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+    usages = _discover_text_usages(set(locale_values))
+
+    texts: dict[str, TextCatalogItem] = {}
+    for key, locations in usages.items():
+        ordered_locations = sorted(locations)
+        texts[key] = TextCatalogItem(
+            key=key,
+            default=locale_values[key],
+            usage_count=len(ordered_locations),
+            usages=ordered_locations[:_MAX_USAGES_PER_ITEM],
+        )
+    emoji: dict[str, EmojiCatalogItem] = {}
+    for key, item in texts.items():
+        glyphs = extract_emoji(item.default)
+        for occurrence, glyph in enumerate(glyphs):
+            token = f'{key}#{occurrence}:{glyph}'
+            emoji[token] = EmojiCatalogItem(
+                token=token,
+                localization_key=key,
+                occurrence=occurrence,
+                glyph=glyph,
+                usage_count=item.usage_count,
+                usages=list(item.usages),
+            )
+
+    return BotPresentationCatalog(
+        emoji=dict(
+            sorted(
+                emoji.items(),
+                key=lambda pair: (-pair[1].usage_count, pair[1].localization_key, pair[1].occurrence),
+            )
+        ),
+        texts=dict(sorted(texts.items())),
+    )
+
+
+def validate_config_against_catalog(config: BotPresentationConfig) -> None:
+    catalog = build_bot_presentation_catalog()
+    if len(config.emoji_overrides) > MAX_EMOJI_OVERRIDES:
+        raise ValueError(f'too many emoji overrides; maximum is {MAX_EMOJI_OVERRIDES}')
+    if len(config.text_overrides) > MAX_TEXT_OVERRIDES:
+        raise ValueError(f'too many text overrides; maximum is {MAX_TEXT_OVERRIDES}')
+
+    for token, custom_id in config.emoji_overrides.items():
+        if token not in catalog.emoji:
+            raise ValueError(f'unknown semantic emoji token: {token!r}')
+        if not _CUSTOM_ID_RE.fullmatch(custom_id.strip()):
+            raise ValueError(f'invalid custom emoji id for {token!r}')
+
+    for key, override in config.text_overrides.items():
+        item = catalog.texts.get(key)
+        if item is None:
+            raise ValueError(f'unknown or non-output text key: {key}')
+        validate_text_override(item.default, override)

--- a/app/services/bot_presentation_service.py
+++ b/app/services/bot_presentation_service.py
@@ -1,0 +1,262 @@
+"""Semantic, Russian-only presentation overrides for Telegram bot output.
+
+Emoji overrides are keyed by a localization token (``LOCALE_KEY#occurrence``),
+not by a Unicode glyph. ``Texts`` embeds private runtime markers only for Russian
+localized values; the outgoing request middleware converts those markers to
+Telegram custom emoji or strips them back to Unicode fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from string import Formatter
+from typing import Any
+
+import structlog
+from aiogram.types import InlineKeyboardMarkup, ReplyKeyboardMarkup
+from sqlalchemy import select
+
+
+logger = structlog.get_logger(__name__)
+
+BOT_PRESENTATION_KEY = 'BOT_PRESENTATION_CONFIG'
+BOT_PRESENTATION_VERSION = 2
+MAX_EMOJI_OVERRIDES = 2500
+MAX_TEXT_OVERRIDES = 2500
+MAX_TEXT_LENGTH = 8192
+CACHE_REFRESH_INTERVAL_SECONDS = 30.0
+_CUSTOM_EMOJI_ID_RE = re.compile(r'^\d{1,100}$')
+_TOKEN_RE = re.compile(r'^[A-Z][A-Z0-9_]*#(?:0|[1-9]\d*):.{1,32}$', re.DOTALL)
+_MARKER_RE = re.compile(r'\ue000(\d{1,100})\ue001(.*?)\ue002', re.DOTALL)
+_HTML_TAG_RE = re.compile(r'</?[A-Za-z][^<>]*?>')
+
+# Unicode emoji sequences: keycaps, flags, optional variation selector/skin
+# modifier, and ZWJ compositions. Longest alternatives must come first.
+_EMOJI_BASE = (
+    r'[\U0001F300-\U0001FAFF\u2190-\u21FF\u2300-\u23FF\u2600-\u27BF\u2B00-\u2BFF\u00A9\u00AE\u2122]'
+)
+_EMOJI_ELEMENT = rf'{_EMOJI_BASE}[\uFE0E\uFE0F]?[\U0001F3FB-\U0001F3FF]?'
+_EMOJI_RE = re.compile(
+    rf'(?:[0-9#*][\uFE0E\uFE0F]?\u20E3|'
+    rf'[\U0001F1E6-\U0001F1FF]{{2}}|'
+    rf'{_EMOJI_ELEMENT}(?:\u200D{_EMOJI_ELEMENT})*)'
+)
+
+
+@dataclass(slots=True)
+class BotPresentationConfig:
+    version: int = BOT_PRESENTATION_VERSION
+    emoji_overrides: dict[str, str] = field(default_factory=dict)
+    text_overrides: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> BotPresentationConfig:
+        if not isinstance(raw, dict):
+            return cls()
+        emoji_raw = raw.get('emoji_overrides', {})
+        text_raw = raw.get('text_overrides', {})
+        emoji = (
+            {
+                str(token): str(custom_id).strip()
+                for token, custom_id in emoji_raw.items()
+                if isinstance(token, str)
+                and _TOKEN_RE.fullmatch(token)
+                and isinstance(custom_id, str)
+                and _CUSTOM_EMOJI_ID_RE.fullmatch(custom_id.strip())
+            }
+            if isinstance(emoji_raw, dict)
+            else {}
+        )
+        texts = (
+            {
+                str(key): str(value)
+                for key, value in text_raw.items()
+                if isinstance(key, str) and key and isinstance(value, str) and value.strip()
+            }
+            if isinstance(text_raw, dict)
+            else {}
+        )
+        return cls(
+            version=BOT_PRESENTATION_VERSION,
+            emoji_overrides=dict(list(emoji.items())[:MAX_EMOJI_OVERRIDES]),
+            text_overrides=dict(list(texts.items())[:MAX_TEXT_OVERRIDES]),
+        )
+
+    def to_raw(self) -> dict[str, Any]:
+        return {
+            'version': BOT_PRESENTATION_VERSION,
+            'emoji_overrides': dict(self.emoji_overrides),
+            'text_overrides': dict(self.text_overrides),
+        }
+
+
+_config = BotPresentationConfig()
+_cache_loaded_at = 0.0
+_refresh_lock = asyncio.Lock()
+
+
+def clear_bot_presentation_cache() -> None:
+    set_bot_presentation_cache(BotPresentationConfig())
+
+
+def set_bot_presentation_cache(config: BotPresentationConfig) -> None:
+    global _config, _cache_loaded_at
+    _config = BotPresentationConfig.from_raw(config.to_raw())
+    _cache_loaded_at = time.monotonic()
+
+
+def get_bot_presentation_config() -> BotPresentationConfig:
+    return BotPresentationConfig.from_raw(_config.to_raw())
+
+
+async def load_bot_presentation_cache() -> BotPresentationConfig:
+    """Load and revalidate persisted overrides against the current upstream."""
+    try:
+        from app.database.database import AsyncSessionLocal
+        from app.database.models import SystemSetting
+        from app.services.bot_presentation_catalog import validate_config_against_catalog
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(SystemSetting.value).where(SystemSetting.key == BOT_PRESENTATION_KEY))
+            raw_value = result.scalar_one_or_none()
+        raw = json.loads(raw_value) if raw_value else {}
+        config = BotPresentationConfig.from_raw(raw)
+        validate_config_against_catalog(config)
+    except Exception as error:  # pragma: no cover - defensive startup path
+        logger.warning('Failed to load valid bot presentation config; using upstream defaults', error=str(error))
+        config = BotPresentationConfig()
+    set_bot_presentation_cache(config)
+    return get_bot_presentation_config()
+
+
+async def maybe_refresh_bot_presentation_cache() -> None:
+    """Refresh from DB periodically so multiple workers converge after edits."""
+    if time.monotonic() - _cache_loaded_at < CACHE_REFRESH_INTERVAL_SECONDS:
+        return
+    async with _refresh_lock:
+        if time.monotonic() - _cache_loaded_at < CACHE_REFRESH_INTERVAL_SECONDS:
+            return
+        await load_bot_presentation_cache()
+
+
+def get_text_override(language: str | None, key: str) -> str | None:
+    normalized = (language or '').split('-', 1)[0].lower()
+    if normalized != 'ru':
+        return None
+    return _config.text_overrides.get(key)
+
+
+def extract_emoji(value: str) -> list[str]:
+    """Return complete Unicode emoji grapheme-like sequences in source order."""
+    return [match.group(0) for match in _EMOJI_RE.finditer(value)]
+
+
+def decorate_localized_text(language: str | None, key: str, value: Any) -> Any:
+    """Embed semantic markers for configured emoji in one Russian locale key."""
+    normalized = (language or '').split('-', 1)[0].lower()
+    if normalized != 'ru' or not isinstance(value, str):
+        return value
+
+    matches = list(_EMOJI_RE.finditer(value))
+    replacements: list[tuple[int, int, str]] = []
+    for index, match in enumerate(matches):
+        custom_id = _config.emoji_overrides.get(f'{key}#{index}:{match.group(0)}')
+        if custom_id:
+            glyph = match.group(0)
+            replacements.append((match.start(), match.end(), f'\ue000{custom_id}\ue001{glyph}\ue002'))
+    if not replacements:
+        return value
+    rendered = value
+    for start, end, replacement in reversed(replacements):
+        rendered = rendered[:start] + replacement + rendered[end:]
+    return rendered
+
+
+def strip_presentation_markers(value: str | None) -> str | None:
+    if not value:
+        return value
+    return _MARKER_RE.sub(lambda match: match.group(2), value)
+
+
+def apply_html_emoji(value: str | None) -> str | None:
+    """Convert semantic markers to Telegram HTML custom-emoji tags."""
+    if not value:
+        return value
+    return _MARKER_RE.sub(
+        lambda match: f'<tg-emoji emoji-id="{match.group(1)}">{match.group(2)}</tg-emoji>',
+        value,
+    )
+
+
+def _html_structure(value: str) -> list[str]:
+    tags = _HTML_TAG_RE.findall(value)
+    remainder = _HTML_TAG_RE.sub('', value)
+    if '<' in remainder:
+        raise ValueError('invalid or unbalanced HTML')
+    return tags
+
+
+def _placeholder_signature(value: str) -> Counter[tuple[str, str | None, str | None]]:
+    signature: Counter[tuple[str, str | None, str | None]] = Counter()
+    for _, field_name, format_spec, conversion in Formatter().parse(value):
+        if field_name:
+            signature[(field_name, format_spec, conversion)] += 1
+    return signature
+
+
+def validate_text_override(default: str, override: str) -> None:
+    if any(marker in override for marker in ('\ue000', '\ue001', '\ue002')):
+        raise ValueError('reserved presentation markers are not allowed')
+    if len(override) > MAX_TEXT_LENGTH:
+        raise ValueError(f'text exceeds {MAX_TEXT_LENGTH} characters')
+    expected = _placeholder_signature(default)
+    actual = _placeholder_signature(override)
+    if expected != actual:
+        fields = ', '.join(sorted({item[0] for item in expected} | {item[0] for item in actual}))
+        raise ValueError(
+            f'placeholders, conversions and format specifiers must match the upstream text: {fields}'
+        )
+    if _html_structure(default) != _html_structure(override):
+        raise ValueError('HTML structure must match the upstream text')
+    if extract_emoji(default) != extract_emoji(override):
+        raise ValueError('Unicode emoji sequence must match the upstream text')
+
+
+def _render_button_text(text: str, *, custom: bool, existing_icon: str | None) -> tuple[str, str | None]:
+    match = _MARKER_RE.search(text)
+    if not match:
+        return strip_presentation_markers(text) or text, existing_icon
+    custom_id, glyph = match.group(1), match.group(2)
+    if existing_icon:
+        return strip_presentation_markers(text) or text, existing_icon
+    if custom:
+        without_selected = (text[: match.start()] + text[match.end() :]).strip()
+        rendered = strip_presentation_markers(without_selected) or glyph
+        return rendered, custom_id
+    return strip_presentation_markers(text) or text, None
+
+
+def apply_button_presentation(markup: Any, *, custom: bool = True) -> Any:
+    """Render semantic markers in inline and reply keyboard labels only."""
+    if not isinstance(markup, (InlineKeyboardMarkup, ReplyKeyboardMarkup)):
+        return markup
+    rows = markup.inline_keyboard if isinstance(markup, InlineKeyboardMarkup) else markup.keyboard
+    if not any(_MARKER_RE.search(button.text) for row in rows for button in row):
+        return markup
+
+    rendered = markup.model_copy(deep=True)
+    rendered_rows = (
+        rendered.inline_keyboard if isinstance(rendered, InlineKeyboardMarkup) else rendered.keyboard
+    )
+    for row in rendered_rows:
+        for button in row:
+            existing = getattr(button, 'icon_custom_emoji_id', None)
+            button.text, icon = _render_button_text(button.text, custom=custom, existing_icon=existing)
+            if hasattr(button, 'icon_custom_emoji_id'):
+                button.icon_custom_emoji_id = icon
+    return rendered

--- a/app/webserver/unified_app.py
+++ b/app/webserver/unified_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -21,6 +22,15 @@ from . import payments, telegram
 
 
 logger = structlog.get_logger(__name__)
+
+
+async def _warm_bot_presentation_catalog() -> None:
+    from app.services.bot_presentation_catalog import build_bot_presentation_catalog
+
+    try:
+        await asyncio.to_thread(build_bot_presentation_catalog)
+    except Exception:
+        logger.exception('Failed to warm bot presentation catalog')
 
 
 def _attach_docs_alias(app: FastAPI, docs_url: str | None) -> None:
@@ -225,6 +235,7 @@ def create_unified_app(
     else:
         telegram_processor = None
 
+    startup_handlers.append(_warm_bot_presentation_catalog)
     startup_handlers.append(disposable_email_service.start)
     shutdown_handlers.append(disposable_email_service.stop)
 

--- a/tests/cabinet/test_admin_bot_presentation.py
+++ b/tests/cabinet/test_admin_bot_presentation.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_bot_presentation as routes
+from app.cabinet.routes.admin_bot_presentation import PresentationConfigPayload
+from app.services.bot_presentation_service import (
+    BotPresentationConfig,
+    clear_bot_presentation_cache,
+    get_bot_presentation_config,
+    set_bot_presentation_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_bot_presentation_cache()
+    yield
+    clear_bot_presentation_cache()
+
+
+@pytest.mark.asyncio
+async def test_invalid_update_does_not_write_or_mutate_cache(monkeypatch) -> None:
+    set_bot_presentation_cache(
+        BotPresentationConfig(text_overrides={'MAIN_MENU_ACTION_PROMPT': 'Старый текст'})
+    )
+    upsert = AsyncMock()
+    monkeypatch.setattr(routes, 'upsert_system_setting', upsert)
+    db = SimpleNamespace(commit=AsyncMock())
+
+    with pytest.raises(HTTPException) as error:
+        await routes.update_bot_presentation_config_route(
+            PresentationConfigPayload(
+                text_overrides={'MAIN_MENU_RICH_DAYS_LEFT': 'Плейсхолдер потерян'}
+            ),
+            admin=cast('Any', SimpleNamespace(telegram_id=1)),
+            db=cast('Any', db),
+        )
+
+    assert error.value.status_code == 400
+    upsert.assert_not_awaited()
+    db.commit.assert_not_awaited()
+    assert get_bot_presentation_config().text_overrides == {
+        'MAIN_MENU_ACTION_PROMPT': 'Старый текст'
+    }
+
+
+@pytest.mark.asyncio
+async def test_blank_text_override_is_treated_as_reset(monkeypatch) -> None:
+    upsert = AsyncMock()
+    monkeypatch.setattr(routes, 'upsert_system_setting', upsert)
+    db = SimpleNamespace(commit=AsyncMock())
+
+    response = await routes.update_bot_presentation_config_route(
+        PresentationConfigPayload(text_overrides={'MAIN_MENU_ACTION_PROMPT': '   '}),
+        admin=cast('Any', SimpleNamespace(telegram_id=1)),
+        db=cast('Any', db),
+    )
+
+    assert response.text_overrides == {}
+    assert get_bot_presentation_config().text_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_valid_update_commits_before_refreshing_cache(monkeypatch) -> None:
+    upsert = AsyncMock()
+    monkeypatch.setattr(routes, 'upsert_system_setting', upsert)
+    db = SimpleNamespace(commit=AsyncMock())
+
+    response = await routes.update_bot_presentation_config_route(
+        PresentationConfigPayload(
+            emoji_overrides={'PROMO_GROUP_DISCOUNT_TRAFFIC#0:📊': '5368324170671202286'}
+        ),
+        admin=cast('Any', SimpleNamespace(telegram_id=1)),
+        db=cast('Any', db),
+    )
+
+    upsert.assert_awaited_once()
+    db.commit.assert_awaited_once()
+    assert response.emoji_overrides == {
+        'PROMO_GROUP_DISCOUNT_TRAFFIC#0:📊': '5368324170671202286'
+    }
+    assert get_bot_presentation_config().emoji_overrides == {
+        'PROMO_GROUP_DISCOUNT_TRAFFIC#0:📊': '5368324170671202286'
+    }

--- a/tests/middlewares/test_bot_presentation_request.py
+++ b/tests/middlewares/test_bot_presentation_request.py
@@ -1,0 +1,159 @@
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.methods import AnswerInlineQuery, SendMediaGroup, SendMessage, SendPhoto, SendPoll, SendRichMessage
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    InlineQueryResultArticle,
+    InputMediaPhoto,
+    InputPollOption,
+    InputRichMessage,
+    InputTextMessageContent,
+    MessageEntity,
+)
+
+from app.middlewares.bot_presentation_request import (
+    BotPresentationRequestMiddleware,
+    apply_method_presentation,
+)
+from app.services.bot_presentation_service import (
+    BotPresentationConfig,
+    clear_bot_presentation_cache,
+    decorate_localized_text,
+    set_bot_presentation_cache,
+)
+
+
+CUSTOM_ID = '5368324170671202286'
+KEY = 'PROMO_GROUP_DISCOUNT_TRAFFIC'
+TOKEN = f'{KEY}#0:📊'
+
+
+def teardown_function() -> None:
+    clear_bot_presentation_cache()
+
+
+def marked(value: str = '📊 Трафик') -> str:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+    return decorate_localized_text('ru', KEY, value)
+
+
+def test_send_message_is_decorated_at_request_boundary() -> None:
+    source = marked('📊 <b>Трафик</b>')
+    method = SendMessage(
+        chat_id=1,
+        text=source,
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text=marked(), callback_data='traffic')]]
+        ),
+    )
+
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+
+    assert rendered.text.startswith(f'<tg-emoji emoji-id="{CUSTOM_ID}">📊</tg-emoji>')
+    assert rendered.reply_markup.inline_keyboard[0][0].text == 'Трафик'
+    assert rendered.reply_markup.inline_keyboard[0][0].icon_custom_emoji_id == CUSTOM_ID
+    assert method.text == source
+
+
+def test_explicit_entities_restore_unicode_and_offsets() -> None:
+    method = SendMessage(
+        chat_id=1,
+        text=marked(),
+        entities=[MessageEntity(type='bold', offset=3, length=6)],
+    )
+
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+
+    assert rendered.text == '📊 Трафик'
+    assert rendered.entities == method.entities
+
+
+def test_explicit_parse_mode_none_restores_unicode_without_html() -> None:
+    method = SendMessage(chat_id=1, text=marked('📊 plain'), parse_mode=None)
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    assert rendered.text == '📊 plain'
+    assert '<tg-emoji' not in rendered.text
+
+
+def test_explicit_caption_parse_mode_none_restores_unicode() -> None:
+    method = SendPhoto(chat_id=1, photo='file-id', caption=marked('📊 plain'), parse_mode=None)
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    assert rendered.caption == '📊 plain'
+
+
+def test_explicit_input_media_parse_mode_none_restores_unicode() -> None:
+    method = SendMediaGroup(
+        chat_id=1,
+        media=[InputMediaPhoto(media='file-id', caption=marked('📊 plain'), parse_mode=None)],
+    )
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    assert rendered.media[0].caption == '📊 plain'
+
+
+def test_poll_question_options_and_explanation_are_rendered_recursively() -> None:
+    method = SendPoll(
+        chat_id=1,
+        question=marked('📊 Вопрос'),
+        options=[InputPollOption(text=marked('📊 Ответ'))],
+        explanation=marked('📊 Пояснение'),
+    )
+
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    fallback = apply_method_presentation(method, default_parse_mode='HTML', custom=False)
+
+    assert '<tg-emoji' in rendered.question
+    assert '<tg-emoji' in rendered.options[0].text
+    assert '<tg-emoji' in rendered.explanation
+    assert fallback.question == '📊 Вопрос'
+    assert fallback.options[0].text == '📊 Ответ'
+    assert fallback.explanation == '📊 Пояснение'
+
+
+def test_inline_query_input_message_content_is_rendered_recursively() -> None:
+    method = AnswerInlineQuery(
+        inline_query_id='query',
+        results=[
+            InlineQueryResultArticle(
+                id='result',
+                title='title',
+                input_message_content=InputTextMessageContent(message_text=marked('📊 Текст')),
+            )
+        ],
+    )
+
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    fallback = apply_method_presentation(method, default_parse_mode='HTML', custom=False)
+    rendered_content = rendered.results[0].input_message_content
+    fallback_content = fallback.results[0].input_message_content
+
+    assert isinstance(rendered_content, InputTextMessageContent)
+    assert isinstance(fallback_content, InputTextMessageContent)
+    assert '<tg-emoji' in rendered_content.message_text
+    assert fallback_content.message_text == '📊 Текст'
+
+
+async def test_middleware_retries_unicode_fallback_when_custom_request_is_rejected() -> None:
+    method = SendMessage(chat_id=1, text=marked('📊 test'))
+    calls = []
+
+    async def make_request(bot, candidate):
+        calls.append(candidate)
+        if len(calls) == 1:
+            raise TelegramBadRequest(method=candidate, message='CUSTOM_EMOJI_INVALID')
+        return 'ok'
+
+    bot = type('BotStub', (), {'default': type('DefaultStub', (), {'parse_mode': 'HTML'})()})()
+    result = await BotPresentationRequestMiddleware()(make_request, bot, method)
+
+    assert result == 'ok'
+    assert '<tg-emoji' in calls[0].text
+    assert calls[1].text == '📊 test'
+    assert '\ue000' not in calls[1].text
+
+
+def test_rich_message_html_is_decorated() -> None:
+    method = SendRichMessage(chat_id=1, rich_message=InputRichMessage(html=f'<p>{marked()} </p>'))
+    rendered = apply_method_presentation(method, default_parse_mode='HTML')
+    assert rendered.rich_message.html == (
+        f'<p><tg-emoji emoji-id="{CUSTOM_ID}">📊</tg-emoji> Трафик </p>'
+    )

--- a/tests/services/test_bot_presentation_catalog.py
+++ b/tests/services/test_bot_presentation_catalog.py
@@ -1,0 +1,51 @@
+import pytest
+
+from app.services.bot_presentation_catalog import (
+    build_bot_presentation_catalog,
+    validate_config_against_catalog,
+)
+from app.services.bot_presentation_service import BotPresentationConfig
+
+
+def test_catalog_discovers_real_texts_accessed_by_attribute_and_t_call() -> None:
+    catalog = build_bot_presentation_catalog()
+
+    assert 'MAIN_MENU_ACTION_PROMPT' in catalog.texts
+    assert any('app/handlers/menu.py:' in usage for usage in catalog.texts['MAIN_MENU_ACTION_PROMPT'].usages)
+    assert 'MENU_BALANCE' in catalog.texts
+    assert catalog.texts['MENU_BALANCE'].usages
+    assert 'ADMIN_POLLS_CUSTOM_PROMPT' in catalog.texts
+    assert catalog.texts['BACK'].usage_count > len(catalog.texts['BACK'].usages)
+    assert len(catalog.texts['BACK'].usages) == 20
+
+
+def test_catalog_excludes_non_output_rule_and_diagnostic_literals() -> None:
+    catalog = build_bot_presentation_catalog()
+
+    assert 'RULES_TEXT' not in catalog.texts
+    assert 'TRAFFIC_5GB' not in catalog.texts
+    assert all('app/bot.py:90' not in usage for item in catalog.emoji.values() for usage in item.usages)
+
+
+def test_catalog_emoji_tokens_are_semantic_and_unicode_sequences_are_complete() -> None:
+    catalog = build_bot_presentation_catalog()
+    item = catalog.emoji['PROMO_GROUP_DISCOUNT_TRAFFIC#0:📊']
+
+    assert item.localization_key == 'PROMO_GROUP_DISCOUNT_TRAFFIC'
+    assert item.glyph == '📊'
+    assert item.usages
+    assert all(token.rsplit('#', 1)[0] in catalog.texts for token in catalog.emoji)
+
+
+def test_config_validation_rejects_unknown_semantic_token() -> None:
+    with pytest.raises(ValueError, match='unknown semantic emoji token'):
+        validate_config_against_catalog(
+            BotPresentationConfig(emoji_overrides={'UNKNOWN#0:❓': '5368324170671202286'})
+        )
+
+
+def test_config_validation_rejects_lost_text_placeholder() -> None:
+    with pytest.raises(ValueError, match='days'):
+        validate_config_against_catalog(
+            BotPresentationConfig(text_overrides={'MAIN_MENU_RICH_DAYS_LEFT': 'Осталось немного'})
+        )

--- a/tests/services/test_bot_presentation_service.py
+++ b/tests/services/test_bot_presentation_service.py
@@ -1,0 +1,162 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, KeyboardButton, ReplyKeyboardMarkup
+
+from app.localization.texts import Texts
+from app.services import bot_presentation_service as presentation_service
+from app.services.bot_presentation_service import (
+    BotPresentationConfig,
+    apply_button_presentation,
+    apply_html_emoji,
+    clear_bot_presentation_cache,
+    decorate_localized_text,
+    extract_emoji,
+    get_text_override,
+    set_bot_presentation_cache,
+    strip_presentation_markers,
+    validate_text_override,
+)
+
+
+CUSTOM_ID = '5368324170671202286'
+TOKEN = 'PROMO_GROUP_DISCOUNT_TRAFFIC#0:📊'
+
+
+def teardown_function() -> None:
+    clear_bot_presentation_cache()
+
+
+async def test_stale_cache_refresh_is_coalesced_for_concurrent_requests(monkeypatch) -> None:
+    monkeypatch.setattr(presentation_service, '_cache_loaded_at', 0.0)
+
+    async def refresh() -> BotPresentationConfig:
+        await asyncio.sleep(0)
+        config = BotPresentationConfig()
+        set_bot_presentation_cache(config)
+        return config
+
+    loader = AsyncMock(side_effect=refresh)
+    monkeypatch.setattr(presentation_service, 'load_bot_presentation_cache', loader)
+
+    await asyncio.gather(
+        presentation_service.maybe_refresh_bot_presentation_cache(),
+        presentation_service.maybe_refresh_bot_presentation_cache(),
+    )
+    loader.assert_awaited_once()
+
+
+def test_russian_text_override_preserves_other_languages() -> None:
+    set_bot_presentation_cache(
+        BotPresentationConfig(text_overrides={'MAIN_MENU_ACTION_PROMPT': 'Что будем делать?'})
+    )
+    assert get_text_override('ru', 'MAIN_MENU_ACTION_PROMPT') == 'Что будем делать?'
+    assert get_text_override('en', 'MAIN_MENU_ACTION_PROMPT') is None
+    assert Texts('ru').t('MAIN_MENU_ACTION_PROMPT') == 'Что будем делать?'
+    assert Texts('en').t('MAIN_MENU_ACTION_PROMPT') != 'Что будем делать?'
+
+
+def test_semantic_emoji_override_only_marks_one_ru_key() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+
+    target = decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик')
+    same_glyph_other_context = decorate_localized_text('ru', 'UNRELATED_STATUS', '📊 Диагностика')
+    non_russian = decorate_localized_text('en', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Traffic')
+
+    assert apply_html_emoji(target) == f'<tg-emoji emoji-id="{CUSTOM_ID}">📊</tg-emoji> Трафик'
+    assert same_glyph_other_context == '📊 Диагностика'
+    assert non_russian == '📊 Traffic'
+
+
+def test_semantic_token_is_bound_to_upstream_fallback_glyph() -> None:
+    stale_token = 'PROMO_GROUP_DISCOUNT_TRAFFIC#0:⚠️'
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={stale_token: CUSTOM_ID}))
+
+    assert decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик') == '📊 Трафик'
+
+
+def test_texts_lookup_embeds_marker_only_for_target_ru_key() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+
+    assert '\ue000' in Texts('ru').t('PROMO_GROUP_DISCOUNT_TRAFFIC')
+    assert '\ue000' not in Texts('ru').t('PROMO_GROUP_DISCOUNT_DEVICES')
+    assert '\ue000' not in Texts('en').t('PROMO_GROUP_DISCOUNT_TRAFFIC')
+
+
+def test_unicode_fallback_is_recoverable_from_marker() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+    marked = decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик')
+    assert strip_presentation_markers(marked) == '📊 Трафик'
+
+
+def test_emoji_extraction_keeps_flag_skin_tone_keycap_and_zwj_sequences() -> None:
+    assert extract_emoji('↩️ 🇷🇺 👍🏻 1️⃣ 👨‍💻') == ['↩️', '🇷🇺', '👍🏻', '1️⃣', '👨‍💻']
+
+
+def test_text_override_rejects_changed_html_structure() -> None:
+    with pytest.raises(ValueError, match='HTML structure'):
+        validate_text_override('<b>Трафик: {value}</b>', '<i>Трафик: {value}</i>')
+
+
+def test_text_override_rejects_malformed_html() -> None:
+    with pytest.raises(ValueError, match='invalid or unbalanced HTML'):
+        validate_text_override('Обычный текст', 'Сломанный <b')
+
+
+def test_text_override_rejects_changed_placeholder_or_emoji_contract() -> None:
+    with pytest.raises(ValueError, match='placeholders'):
+        validate_text_override('Сумма: {amount:.2f}', 'Сумма: {amount}')
+    with pytest.raises(ValueError, match='Unicode emoji'):
+        validate_text_override('📊 Трафик: {amount}', '⚠️ Трафик: {amount}')
+
+
+def test_text_override_accepts_same_contract() -> None:
+    validate_text_override('📊 Истекает через {days} дн.', '📊 Осталось {days} дней')
+
+
+def test_inline_button_uses_icon_without_changing_callback() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+    marked = decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик')
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text=marked, callback_data='menu_traffic')]]
+    )
+
+    button = apply_button_presentation(keyboard).inline_keyboard[0][0]
+    assert button.text == 'Трафик'
+    assert button.icon_custom_emoji_id == CUSTOM_ID
+    assert button.callback_data == 'menu_traffic'
+
+
+def test_reply_keyboard_supports_semantic_icon_without_layout_change() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+    marked = decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик')
+    keyboard = ReplyKeyboardMarkup(keyboard=[[KeyboardButton(text=marked)]])
+
+    result = apply_button_presentation(keyboard)
+    assert len(result.keyboard) == 1
+    assert result.keyboard[0][0].text == 'Трафик'
+    assert result.keyboard[0][0].icon_custom_emoji_id == CUSTOM_ID
+
+
+def test_button_with_explicit_custom_icon_keeps_existing_icon() -> None:
+    set_bot_presentation_cache(BotPresentationConfig(emoji_overrides={TOKEN: CUSTOM_ID}))
+    marked = decorate_localized_text('ru', 'PROMO_GROUP_DISCOUNT_TRAFFIC', '📊 Трафик')
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[[
+            InlineKeyboardButton(
+                text=marked,
+                icon_custom_emoji_id='999',
+                callback_data='menu_traffic',
+            )
+        ]]
+    )
+
+    rendered = apply_button_presentation(keyboard)
+    fallback = apply_button_presentation(keyboard, custom=False)
+    button = rendered.inline_keyboard[0][0]
+    fallback_button = fallback.inline_keyboard[0][0]
+    assert button.text == '📊 Трафик'
+    assert button.icon_custom_emoji_id == '999'
+    assert fallback_button.text == '📊 Трафик'
+    assert fallback_button.icon_custom_emoji_id == '999'

--- a/tests/test_bot_presentation_factory.py
+++ b/tests/test_bot_presentation_factory.py
@@ -1,0 +1,8 @@
+from app.bot_factory import create_bot
+from app.middlewares.bot_presentation_request import BotPresentationRequestMiddleware
+
+
+def test_create_bot_registers_presentation_request_middleware() -> None:
+    bot = create_bot(token='123456:TESTTOKEN')
+
+    assert any(isinstance(item, BotPresentationRequestMiddleware) for item in bot.session.middleware)


### PR DESCRIPTION
## Summary

- adds a versioned Cabinet API for Russian bot presentation settings stored in `SystemSetting`
- adds semantic `LOCALIZATION_KEY#occurrence:glyph` Custom Emoji slots so identical Unicode in unrelated contexts/locales is not changed
- applies Custom Emoji at the outbound aiogram request boundary, preserving callbacks, URLs, keyboard geometry and non-Russian locales
- adds strict validation, Unicode fallback/retry, periodic cache refresh and a curated usage catalog

## Safety boundaries

- Russian localization only
- no tariff/payment/subscription/business-logic changes
- explicit Telegram entities and `parse_mode=None` remain untouched
- reply keyboards remain untouched
- invalid/stale configuration fails closed to upstream Unicode/text

## Verification

- targeted backend regression suite: 31 passed
- Ruff: passed
- independent static release review: passed; no security or logic errors
- `git diff --check`: passed

The full repository suite previously passed before the final narrow fixes; CI is expected to provide the immutable commit-wide gate for this PR.
