### PR TITLE
feat(email): deliver Telegram-only lifecycle + autopay notifications to email-only users

### DIFF
--- a/app/cabinet/services/email_templates.py
+++ b/app/cabinet/services/email_templates.py
@@ -44,6 +44,9 @@ class EmailNotificationTemplates:
             NotificationType.SUBSCRIPTION_EXPIRED: self._subscription_expired_template,
             NotificationType.SUBSCRIPTION_RENEWED: self._subscription_renewed_template,
             NotificationType.SUBSCRIPTION_ACTIVATED: self._subscription_activated_template,
+            NotificationType.WINBACK_EXPIRED_1D: self._winback_expired_1d_template,
+            NotificationType.WINBACK_DISCOUNT: self._winback_discount_template,
+            NotificationType.WINBACK_TRIAL_ENDING: self._winback_trial_ending_template,
             NotificationType.AUTOPAY_SUCCESS: self._autopay_success_template,
             NotificationType.AUTOPAY_FAILED: self._autopay_failed_template,
             NotificationType.AUTOPAY_INSUFFICIENT_FUNDS: self._autopay_insufficient_funds_template,
@@ -515,6 +518,45 @@ class EmailNotificationTemplates:
             """,
         }
 
+        return {
+            'subject': subjects.get(language, subjects['ru']),
+            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+        }
+
+    def _winback_expired_1d_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
+        """Email: subscription lapsed 1 day ago (email-only users)."""
+        end_date = html.escape(str(context.get('end_date', '')))
+        subjects = {'ru': 'Подписка закончилась', 'en': 'Your subscription has ended'}
+        bodies = {
+            'ru': f'<h2>Подписка закончилась</h2><div class="highlight danger"><p>Ваша VPN-подписка истекла{f" ({end_date})" if end_date else ""} — доступ отключён.</p><p>Продлите подписку, чтобы вернуться в сервис.</p></div>{self._get_cabinet_button(language)}',
+            'en': f'<h2>Your subscription has ended</h2><div class="highlight danger"><p>Your VPN subscription has expired — access is off.</p><p>Renew it to get back online.</p></div>{self._get_cabinet_button(language)}',
+        }
+        return {
+            'subject': subjects.get(language, subjects['ru']),
+            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+        }
+
+    def _winback_discount_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
+        """Email: winback discount offer (email-only users). Offer is already on the account."""
+        percent = context.get('percent', '')
+        expires_at = html.escape(str(context.get('expires_at', '')))
+        subjects = {'ru': f'Скидка {percent}% на продление', 'en': f'{percent}% off your renewal'}
+        bodies = {
+            'ru': f'<h2>Скидка {percent}% на продление</h2><div class="highlight"><p>Возвращайтесь со скидкой <strong>{percent}%</strong>{f" — действует до {expires_at}" if expires_at else ""}.</p><p>Скидка уже привязана к вашему аккаунту и суммируется с промогруппой — просто продлите подписку в кабинете.</p></div>{self._get_cabinet_button(language)}',
+            'en': f'<h2>{percent}% off your renewal</h2><div class="highlight"><p>Come back with a <strong>{percent}%</strong> discount{f", valid until {expires_at}" if expires_at else ""}.</p><p>The discount is already applied to your account and stacks with your promo group — just renew in the dashboard.</p></div>{self._get_cabinet_button(language)}',
+        }
+        return {
+            'subject': subjects.get(language, subjects['ru']),
+            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+        }
+
+    def _winback_trial_ending_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
+        """Email: trial ending soon (email-only users)."""
+        subjects = {'ru': 'Пробная подписка скоро закончится', 'en': 'Your trial is ending soon'}
+        bodies = {
+            'ru': f'<h2>Пробная подписка скоро закончится</h2><div class="highlight warning"><p>Ваша тестовая подписка скоро истекает.</p><p>Оформите подписку, чтобы не остаться без VPN — конфиг и устройства сохранятся.</p></div>{self._get_cabinet_button(language)}',
+            'en': f'<h2>Your trial is ending soon</h2><div class="highlight warning"><p>Your trial subscription is about to expire.</p><p>Subscribe to keep your VPN — your config and devices stay.</p></div>{self._get_cabinet_button(language)}',
+        }
         return {
             'subject': subjects.get(language, subjects['ru']),
             'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -54,6 +54,7 @@ from app.external.remnawave_api import (
 )
 from app.localization.texts import get_texts
 from app.services.notification_delivery_service import (
+    NotificationType,
     notification_delivery_service,
 )
 from app.services.notification_settings_service import NotificationSettingsService
@@ -1733,6 +1734,12 @@ class MonitoringService:
         self, user: User, subscription: Subscription, *, tariff_name: str | None = None
     ) -> bool:
         try:
+            if not user.telegram_id:
+                return await notification_delivery_service.send_notification(
+                    user=user,
+                    notification_type=NotificationType.SUBSCRIPTION_EXPIRED,
+                    context={'tariff_name': tariff_name or ''},
+                )
             tariff_label = ''
             if settings.is_multi_tariff_enabled():
                 if tariff_name:
@@ -1901,6 +1908,12 @@ class MonitoringService:
 
     async def _send_trial_ending_notification(self, user: User, subscription: Subscription) -> bool:
         try:
+            if not user.telegram_id:
+                return await notification_delivery_service.send_notification(
+                    user=user,
+                    notification_type=NotificationType.WINBACK_TRIAL_ENDING,
+                    context={},
+                )
             get_texts(user.language)
 
             tariff_label = ''
@@ -2032,6 +2045,12 @@ class MonitoringService:
 
     async def _send_expired_day1_notification(self, db: AsyncSession, user: User, subscription: Subscription) -> bool:
         try:
+            if not user.telegram_id:
+                return await notification_delivery_service.send_notification(
+                    user=user,
+                    notification_type=NotificationType.WINBACK_EXPIRED_1D,
+                    context={'end_date': format_local_datetime(subscription.end_date, '%d.%m.%Y %H:%M')},
+                )
             texts = get_texts(user.language)
             tariff = getattr(subscription, 'tariff', None)
             tariff_label = ''
@@ -2131,6 +2150,16 @@ class MonitoringService:
         trigger_days: int = None,
     ) -> bool:
         try:
+            if not user.telegram_id:
+                return await notification_delivery_service.send_notification(
+                    user=user,
+                    notification_type=NotificationType.WINBACK_DISCOUNT,
+                    context={
+                        'percent': percent,
+                        'expires_at': format_local_datetime(expires_at, '%d.%m.%Y %H:%M'),
+                        'trigger_days': trigger_days or '',
+                    },
+                )
             texts = get_texts(user.language)
 
             tariff_label = ''

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -34,6 +34,9 @@ class NotificationType(Enum):
     SUBSCRIPTION_EXPIRING = 'subscription_expiring'
     SUBSCRIPTION_EXPIRED = 'subscription_expired'
     SUBSCRIPTION_RENEWED = 'subscription_renewed'
+    WINBACK_EXPIRED_1D = 'winback_expired_1d'
+    WINBACK_DISCOUNT = 'winback_discount'
+    WINBACK_TRIAL_ENDING = 'winback_trial_ending'
 
     # Autopay notifications
     AUTOPAY_SUCCESS = 'autopay_success'

--- a/app/services/recurrent_payment_service.py
+++ b/app/services/recurrent_payment_service.py
@@ -410,6 +410,21 @@ async def _process_single_subscription(
             except Exception as notify_error:
                 logger.warning('Ошибка уведомления об автоплатеже', notify_error=notify_error)
 
+        if not user.telegram_id and result.get('paid') and user.email and getattr(user, 'email_verified', False):
+            try:
+                from app.services.notification_delivery_service import (
+                    NotificationType,
+                    notification_delivery_service,
+                )
+
+                await notification_delivery_service.send_notification(
+                    user=user,
+                    notification_type=NotificationType.AUTOPAY_SUCCESS,
+                    context={'formatted_amount': settings.format_price(topup_amount_kopeks)},
+                )
+            except Exception as email_error:
+                logger.warning('Ошибка email-уведомления об автоплатеже', email_error=email_error)
+
         return 'created'
 
     # Все карты не сработали — уведомляем пользователя
@@ -433,5 +448,20 @@ async def _process_single_subscription(
             )
         except Exception as notify_error:
             logger.warning('Ошибка уведомления о неудачном автоплатеже', notify_error=notify_error)
+
+    if not user.telegram_id and user.email and getattr(user, 'email_verified', False):
+        try:
+            from app.services.notification_delivery_service import (
+                NotificationType,
+                notification_delivery_service,
+            )
+
+            await notification_delivery_service.send_notification(
+                user=user,
+                notification_type=NotificationType.AUTOPAY_FAILED,
+                context={'formatted_amount': settings.format_price(topup_amount_kopeks)},
+            )
+        except Exception as email_error:
+            logger.warning('Ошибка email-уведомления о неудачном автоплатеже', email_error=email_error)
 
     return 'all_cards_failed'

--- a/app/services/recurrent_payment_service.py
+++ b/app/services/recurrent_payment_service.py
@@ -413,14 +413,13 @@ async def _process_single_subscription(
         if not user.telegram_id and result.get('paid') and user.email and getattr(user, 'email_verified', False):
             try:
                 from app.services.notification_delivery_service import (
-                    NotificationType,
                     notification_delivery_service,
                 )
 
-                await notification_delivery_service.send_notification(
+                await notification_delivery_service.notify_autopay_success(
                     user=user,
-                    notification_type=NotificationType.AUTOPAY_SUCCESS,
-                    context={'formatted_amount': settings.format_price(topup_amount_kopeks)},
+                    amount_kopeks=topup_amount_kopeks,
+                    new_expires_at=subscription.end_date,
                 )
             except Exception as email_error:
                 logger.warning('Ошибка email-уведомления об автоплатеже', email_error=email_error)
@@ -452,14 +451,12 @@ async def _process_single_subscription(
     if not user.telegram_id and user.email and getattr(user, 'email_verified', False):
         try:
             from app.services.notification_delivery_service import (
-                NotificationType,
                 notification_delivery_service,
             )
 
-            await notification_delivery_service.send_notification(
+            await notification_delivery_service.notify_autopay_failed(
                 user=user,
-                notification_type=NotificationType.AUTOPAY_FAILED,
-                context={'formatted_amount': settings.format_price(topup_amount_kopeks)},
+                reason='',
             )
         except Exception as email_error:
             logger.warning('Ошибка email-уведомления о неудачном автоплатеже', email_error=email_error)


### PR DESCRIPTION
Винбэк-лесенка (expired day-1, скидочные волны 2/3), триал-пинок и at-expiry уведомление слались **только в Telegram** (`_send_message_with_logo` выходит для юзеров без telegram_id) → **email-only юзеры не получали ни одно из них**.

Роутит email-only юзеров через `notification_delivery_service` в 4 send-хелперах, добавляет типы `WINBACK_EXPIRED_1D`/`WINBACK_DISCOUNT`/`WINBACK_TRIAL_ENDING` + email-шаблоны (at-expiry реюзит `SUBSCRIPTION_EXPIRED`). Скидка уже привязана к аккаунту → письмо ведёт в кабинет продлить. Telegram не тронут.

ruff/compile зелёные.