### PR TITLE
feat(nalogo): отправка чека клиенту и дублирование в админ-топик

### DIFF
--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -277,6 +277,28 @@ async def _create_nalogo_receipt_for_purchase(
                     purchase_id=purchase.id,
                     receipt_uuid=receipt_uuid,
                 )
+
+            # Отправляем чек покупателю (если есть telegram_id) и дублируем в админ-топик
+            try:
+                from app.bot_factory import create_bot
+                from app.services.nalogo_service import send_nalogo_receipt_notifications
+
+                async with create_bot() as bot:
+                    await send_nalogo_receipt_notifications(
+                        bot=bot,
+                        nalogo_service=nalogo_service,
+                        receipt_uuid=receipt_uuid,
+                        amount_kopeks=purchase.amount_kopeks,
+                        telegram_user_id=user.telegram_id,
+                        context_label=f'Источник: гостевая покупка с лендинга (purchase_id={purchase.id})',
+                    )
+            except Exception as notify_error:
+                logger.warning(
+                    'Failed to send NaloGO receipt notifications for guest purchase',
+                    purchase_id=purchase.id,
+                    receipt_uuid=receipt_uuid,
+                    error=notify_error,
+                )
     except Exception as exc:
         from app.utils.proxy import sanitize_proxy_error
 

--- a/app/services/nalogo_queue_service.py
+++ b/app/services/nalogo_queue_service.py
@@ -119,6 +119,27 @@ class NalogoQueueService:
         except Exception as error:
             logger.error('Ошибка отправки уведомления о чеках', error=error)
 
+    async def _send_receipt_to_user(
+        self,
+        telegram_user_id: int | None,
+        receipt_uuid: str,
+        amount: float,
+    ) -> None:
+        """Отправляет пользователю ссылку на чек из отложенной очереди и дублирует в админ-топик."""
+        if not self._bot or not self._nalogo_service:
+            return
+
+        from app.services.nalogo_service import send_nalogo_receipt_notifications
+
+        await send_nalogo_receipt_notifications(
+            bot=self._bot,
+            nalogo_service=self._nalogo_service,
+            receipt_uuid=receipt_uuid,
+            amount_kopeks=int(round(amount * 100)),
+            telegram_user_id=telegram_user_id,
+            context_label='Источник: отложенная очередь NaloGO',
+        )
+
     async def _process_queue_loop(self) -> None:
         """Основной цикл обработки очереди."""
         while self._running:
@@ -229,6 +250,14 @@ class NalogoQueueService:
                         payment_id=payment_id,
                         attempts=attempts + 1,
                     )
+
+                    # Отправляем чек пользователю (если есть telegram_id) и дублируем в админ-топик
+                    if self._bot:
+                        await self._send_receipt_to_user(
+                            telegram_user_id=telegram_user_id,
+                            receipt_uuid=receipt_uuid,
+                            amount=amount,
+                        )
                 else:
                     # Вернуть в очередь с увеличенным счетчиком попыток
                     await self._nalogo_service.requeue_receipt(receipt_data)

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -666,7 +666,39 @@ async def send_nalogo_receipt_notifications(
     chat_id = settings.get_admin_notifications_chat_id()
     if chat_id:
         topic_id = settings.ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID
-        recipient_line = f'\n👤 Получатель: <code>{telegram_user_id}</code>' if telegram_user_id else '\n👤 Получатель: без Telegram (email/гость)'
+
+        # Подгружаем данные пользователя для подробного блока «Получатель»
+        recipient_lines: list[str] = []
+        if telegram_user_id:
+            try:
+                from app.database.crud.user import get_user_by_telegram_id
+                from app.database.database import AsyncSessionLocal
+
+                async with AsyncSessionLocal() as session:
+                    db_user = await get_user_by_telegram_id(session, telegram_user_id)
+
+                if db_user:
+                    if db_user.username:
+                        recipient_lines.append(f'👤 Username: @{db_user.username}')
+                    full_name = ' '.join(filter(None, [db_user.first_name, db_user.last_name])).strip()
+                    if full_name:
+                        recipient_lines.append(f'📛 Имя: {full_name}')
+                    recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
+                    if db_user.email:
+                        recipient_lines.append(f'📧 Почта: {db_user.email}')
+                else:
+                    recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
+            except Exception as user_error:
+                logger.warning(
+                    'Не удалось загрузить данные пользователя для уведомления о чеке',
+                    telegram_user_id=telegram_user_id,
+                    error=user_error,
+                )
+                recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
+        else:
+            recipient_lines.append('👤 Получатель: без Telegram (email/гость)')
+
+        recipient_block = '\n'.join(recipient_lines)
         context_line = f'\nℹ️ {context_label}' if context_label else ''
         try:
             await bot.send_message(
@@ -674,8 +706,8 @@ async def send_nalogo_receipt_notifications(
                 message_thread_id=topic_id,
                 text=(
                     '🧾 <b>Новый чек NaloGO создан</b>\n\n'
-                    f'💰 Сумма: {amount_text}'
-                    f'{recipient_line}'
+                    f'💰 Сумма: {amount_text}\n'
+                    f'{recipient_block}'
                     f'{context_line}'
                 ),
                 parse_mode='HTML',

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -432,24 +432,21 @@ class NaloGoService:
     def get_receipt_print_url(self, receipt_uuid: str | None) -> str | None:
         """Строит публичную ссылку на чек для отправки клиенту.
 
-        Пытается использовать client.receipt().print_url(), который берёт ИНН
-        из профиля, загруженного при аутентификации. Если профиль ещё не
-        загружен в этом процессе (например, чек был создан ранее другим
-        воркером), собираем ссылку вручную по известному self.inn — формат
-        идентичен: {base_url}/receipt/{inn}/{uuid}/print.
+        ВАЖНО: библиотечный client.receipt().print_url() содержит баг — он
+        собирает URL от base_url БЕЗ '/v1' (client.py передаёт в ReceiptAPI
+        self.base_url, тогда как HTTP-клиент работает с base_url + '/v1').
+        Рабочий формат ссылки: {base_url}/v1/receipt/{inn}/{uuid}/print,
+        поэтому собираем URL вручную.
         """
         if not self.configured or not receipt_uuid:
             return None
 
         try:
-            return self.client.receipt().print_url(receipt_uuid)
-        except Exception:
-            try:
-                base = self.client.base_url.rstrip('/')
-                return f'{base}/receipt/{self.inn}/{receipt_uuid.strip()}/print'
-            except Exception as error:
-                logger.warning('Не удалось построить ссылку на чек NaloGO', error=sanitize_proxy_error(error))
-                return None
+            base = self.client.base_url.rstrip('/')
+            return f'{base}/v1/receipt/{self.inn}/{receipt_uuid.strip()}/print'
+        except Exception as error:
+            logger.warning('Не удалось построить ссылку на чек NaloGO', error=sanitize_proxy_error(error))
+            return None
 
     async def get_queue_length(self) -> int:
         """Получить количество чеков в очереди."""

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -678,12 +678,12 @@ async def send_nalogo_receipt_notifications(
                     db_user = await get_user_by_telegram_id(session, telegram_user_id)
 
                 if db_user:
-                    if db_user.username:
-                        recipient_lines.append(f'👤 Username: @{db_user.username}')
+                    recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
                     full_name = ' '.join(filter(None, [db_user.first_name, db_user.last_name])).strip()
                     if full_name:
                         recipient_lines.append(f'📛 Имя: {full_name}')
-                    recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
+                    if db_user.username:
+                        recipient_lines.append(f'👤 Username: @{db_user.username}')
                     if db_user.email:
                         recipient_lines.append(f'📧 Почта: {db_user.email}')
                 else:

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -429,6 +429,28 @@ class NaloGoService:
                 logger.error('Ошибка создания чека в NaloGO', error=sanitize_proxy_error(error))
             return None
 
+    def get_receipt_print_url(self, receipt_uuid: str | None) -> str | None:
+        """Строит публичную ссылку на чек для отправки клиенту.
+
+        Пытается использовать client.receipt().print_url(), который берёт ИНН
+        из профиля, загруженного при аутентификации. Если профиль ещё не
+        загружен в этом процессе (например, чек был создан ранее другим
+        воркером), собираем ссылку вручную по известному self.inn — формат
+        идентичен: {base_url}/receipt/{inn}/{uuid}/print.
+        """
+        if not self.configured or not receipt_uuid:
+            return None
+
+        try:
+            return self.client.receipt().print_url(receipt_uuid)
+        except Exception:
+            try:
+                base = self.client.base_url.rstrip('/')
+                return f'{base}/receipt/{self.inn}/{receipt_uuid.strip()}/print'
+            except Exception as error:
+                logger.warning('Не удалось построить ссылку на чек NaloGO', error=sanitize_proxy_error(error))
+                return None
+
     async def get_queue_length(self) -> int:
         """Получить количество чеков в очереди."""
         return await cache.llen(NALOGO_QUEUE_KEY)
@@ -567,3 +589,105 @@ class NaloGoService:
             else:
                 logger.error('Ошибка получения списка доходов', error=sanitize_proxy_error(error))
             return None  # None = ошибка, [] = нет чеков
+
+
+async def send_nalogo_receipt_notifications(
+    bot: Any,
+    nalogo_service: 'NaloGoService | None',
+    receipt_uuid: str | None,
+    amount_kopeks: int,
+    telegram_user_id: int | None = None,
+    context_label: str | None = None,
+) -> None:
+    """Отправляет ссылку на созданный чек NaloGO пользователю и дублирует её в
+    админский топик чеков (settings.ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID).
+
+    Используется из всех точек создания чека (YooKassa, отложенная очередь,
+    гостевые покупки с лендинга), чтобы не дублировать логику отправки.
+
+    Args:
+        bot: экземпляр aiogram Bot (может быть None — тогда функция не делает ничего)
+        nalogo_service: сервис NaloGO для построения ссылки на чек
+        receipt_uuid: UUID созданного чека
+        amount_kopeks: сумма чека в копейках (для отображения)
+        telegram_user_id: telegram_id получателя чека (None — пользователю не отправляем,
+            но в админский топик чек всё равно продублируется)
+        context_label: доп. пояснение для админского уведомления (например, источник платежа)
+    """
+    if not bot or not nalogo_service or not receipt_uuid:
+        return
+
+    receipt_url = nalogo_service.get_receipt_print_url(receipt_uuid)
+    if not receipt_url:
+        logger.warning(
+            'Не удалось получить ссылку на чек NaloGO, уведомления не отправлены',
+            receipt_uuid=receipt_uuid,
+        )
+        return
+
+    from aiogram import types
+
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[[types.InlineKeyboardButton(text='🧾 Открыть чек', url=receipt_url)]]
+    )
+    amount_text = settings.format_price(amount_kopeks)
+
+    # --- Отправка пользователю ---
+    if telegram_user_id:
+        try:
+            await bot.send_message(
+                chat_id=telegram_user_id,
+                text=(
+                    '🧾 <b>Чек по вашему платежу сформирован</b>\n\n'
+                    f'💰 Сумма: {amount_text}\n\n'
+                    'Чек зарегистрирован в ФНС через сервис «Мой налог» и доступен по кнопке ниже.'
+                ),
+                parse_mode='HTML',
+                reply_markup=keyboard,
+                disable_web_page_preview=True,
+            )
+            logger.info('Чек NaloGO отправлен пользователю', telegram_user_id=telegram_user_id, receipt_uuid=receipt_uuid)
+        except Exception as error:
+            from aiogram.exceptions import TelegramForbiddenError, TelegramNetworkError, TelegramServerError
+
+            if isinstance(error, (TelegramNetworkError, TelegramServerError, TelegramForbiddenError)):
+                logger.warning(
+                    'Не доставлен чек NaloGO пользователю (транзиент)',
+                    telegram_user_id=telegram_user_id,
+                    error=str(error)[:200],
+                    error_type=type(error).__name__,
+                )
+            else:
+                logger.error(
+                    'Ошибка отправки чека NaloGO пользователю',
+                    telegram_user_id=telegram_user_id,
+                    error=error,
+                    exc_info=True,
+                )
+
+    # --- Дублирование в админский топик чеков ---
+    chat_id = settings.get_admin_notifications_chat_id()
+    if chat_id:
+        topic_id = settings.ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID
+        recipient_line = f'\n👤 Получатель: <code>{telegram_user_id}</code>' if telegram_user_id else '\n👤 Получатель: без Telegram (email/гость)'
+        context_line = f'\nℹ️ {context_label}' if context_label else ''
+        try:
+            await bot.send_message(
+                chat_id=chat_id,
+                message_thread_id=topic_id,
+                text=(
+                    '🧾 <b>Новый чек NaloGO создан</b>\n\n'
+                    f'💰 Сумма: {amount_text}'
+                    f'{recipient_line}'
+                    f'{context_line}'
+                ),
+                parse_mode='HTML',
+                reply_markup=keyboard,
+                disable_web_page_preview=True,
+            )
+        except Exception as error:
+            logger.warning(
+                'Не удалось продублировать чек NaloGO в админский топик',
+                receipt_uuid=receipt_uuid,
+                error=error,
+            )

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -678,14 +678,16 @@ async def send_nalogo_receipt_notifications(
                     db_user = await get_user_by_telegram_id(session, telegram_user_id)
 
                 if db_user:
+                    from html import escape as html_escape
+
                     recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
                     full_name = ' '.join(filter(None, [db_user.first_name, db_user.last_name])).strip()
                     if full_name:
-                        recipient_lines.append(f'📛 Имя: {full_name}')
+                        recipient_lines.append(f'📛 Имя: <code>{html_escape(full_name)}</code>')
                     if db_user.username:
                         recipient_lines.append(f'👤 Username: @{db_user.username}')
                     if db_user.email:
-                        recipient_lines.append(f'📧 Почта: {db_user.email}')
+                        recipient_lines.append(f'📧 Почта: <code>{html_escape(db_user.email)}</code>')
                 else:
                     recipient_lines.append(f'🆔 Telegram ID: <code>{telegram_user_id}</code>')
             except Exception as user_error:

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -1351,6 +1351,14 @@ class YooKassaPaymentMixin:
                         )
                     except Exception as save_error:
                         logger.warning('Не удалось сохранить receipt_uuid в транзакцию', save_error=save_error)
+
+                # Отправляем чек пользователю в Telegram (если есть) и дублируем в админ-топик
+                if getattr(self, 'bot', None):
+                    await self._send_nalogo_receipt_to_user(
+                        telegram_user_id=telegram_user_id,
+                        receipt_uuid=receipt_uuid,
+                        amount_kopeks=payment.amount_kopeks,
+                    )
             # При временной недоступности чек добавляется в очередь автоматически
 
         except Exception as error:
@@ -1360,6 +1368,27 @@ class YooKassaPaymentMixin:
                 error=error,
                 exc_info=True,
             )
+
+    async def _send_nalogo_receipt_to_user(
+        self,
+        telegram_user_id: int | None,
+        receipt_uuid: str,
+        amount_kopeks: int,
+    ) -> None:
+        """Отправляет пользователю ссылку на фискальный чек НПД и дублирует в админ-топик."""
+        if not hasattr(self, 'nalogo_service') or not self.nalogo_service:
+            return
+
+        from app.services.nalogo_service import send_nalogo_receipt_notifications
+
+        await send_nalogo_receipt_notifications(
+            bot=getattr(self, 'bot', None),
+            nalogo_service=self.nalogo_service,
+            receipt_uuid=receipt_uuid,
+            amount_kopeks=amount_kopeks,
+            telegram_user_id=telegram_user_id,
+            context_label='Источник: YooKassa',
+        )
 
     async def process_yookassa_webhook(
         self,


### PR DESCRIPTION
## Проблема

Сейчас бот создаёт чеки NaloGO («Мой налог»), но никуда их не отправляет — `receipt_uuid` сохраняется в транзакцию и на этом всё. Клиент чек не получает, хотя по 422-ФЗ самозанятый обязан передать чек покупателю. Админ тоже не видит созданные чеки без захода в ЛК налоговой.

## Что сделано

После успешного создания чека бот:

1. **Отправляет клиенту** сообщение с inline-кнопкой «🧾 Открыть чек» (ссылка на печатную форму `lknpd.nalog.ru/api/v1/receipt/{ИНН}/{uuid}/print`);
2. **Дублирует чек в админ-топик** `ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID` с информацией о получателе: Telegram ID, имя, username, почта (ID/имя/почта обёрнуты в `<code>` для копирования по тапу, имя и почта экранируются `html.escape` — иначе спецсимволы в имени Telegram ломают HTML-разметку сообщения).

Покрыты **все точки создания чеков**:
- `payment/yookassa.py` — обычные платежи;
- `nalogo_queue_service.py` — чеки из отложенной очереди (при недоступности nalog.ru уведомления доходят после успешного ретрая);
- `guest_purchase_service.py` — гостевые покупки с лендингов (если у покупателя нет telegram_id, клиенту не шлём, но в админ-топик чек попадает с пометкой).

Логика вынесена в одну общую функцию `send_nalogo_receipt_notifications()` в `nalogo_service.py`, чтобы не дублировать код по провайдерам.

## Замечания

- Ошибки отправки уведомлений не влияют на создание чека и обработку платежа (best-effort, try/except с warning в лог).
- Попутно: `client.receipt().print_url()` в `app/lib/nalogo` строит ссылку без `/v1` (в `client.py` ReceiptAPI получает `base_url` без суффикса, в отличие от HTTP-клиента) — ссылка нерабочая. Здесь URL собирается вручную с `/v1`; фикс самой библиотеки вынесу отдельным PR.
- Протестировано в проде на реальных платежах ЮKassa (v3.64.0): прямой путь, отложенная очередь при недоступности nalog.ru, недоступность DNS.

## Возможное развитие (если интересно мейнтейнерам)

- Опциональный флаг