### PR TITLE
fix(nalogo): print_url строил ссылку на чек без /v1

### DIFF
--- a/app/lib/nalogo/client.py
+++ b/app/lib/nalogo/client.py
@@ -197,7 +197,7 @@ class Client:
 
         return ReceiptAPI(
             http_client=self.http_client,
-            base_endpoint=self.base_url,
+            base_endpoint=f'{self.base_url}/v1',
             user_inn=self._user_profile['inn'],
         )
 


### PR DESCRIPTION
## Баг

`client.receipt().print_url(uuid)` возвращает нерабочую ссылку:

- возвращается: `https://lknpd.nalog.ru/api/receipt/{ИНН}/{uuid}/print` → 404
- рабочий адрес: `https://lknpd.nalog.ru/api/v1/receipt/{ИНН}/{uuid}/print`

## Причина

В `client.py` HTTP-клиент инициализируется с `base_url + '/v1'` (строка 64), поэтому все API-запросы (`/income` и т.д.) работают. А `ReceiptAPI` получает `base_endpoint=self.base_url` **без** `/v1` (строка 200) — и `print_url()`, который собирает ссылку от `base_endpoint`, выдаёт битый URL.

Баг не проявлялся, потому что `print_url()` нигде в проекте не вызывается — всплыл при разработке #3082 (отправка чека клиенту).

## Фикс

Одна строка: `base_endpoint=f'{self.base_url}/v1'` — приводит ReceiptAPI в соответствие с HTTP-клиентом.

Проверено на реальных чеках: ссылка с `/v1` открывает печатную форму, без — 404.