### PR TITLE
feat(nalogo): доставка чека файлом — lknpd недоступен клиентам через VPN

### DIFF
--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -589,6 +589,34 @@ class NaloGoService:
             return None  # None = ошибка, [] = нет чеков
 
 
+async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
+    """Скачивает печатную форму чека для отправки файлом в Telegram.
+
+    lknpd.nalog.ru недоступен с зарубежных IP (и не отдаёт DNS зарубежным
+    резолверам), поэтому у клиентов с включённым VPN ссылка на чек не
+    открывается вовсе. Скачиваем чек на стороне сервера и отправляем сам файл —
+    тогда доступность nalog.ru со стороны клиента не имеет значения.
+
+    Возвращает (bytes, content_type) либо None при любой ошибке (вызывающая
+    сторона откатывается к отправке ссылки). Использует NALOGO_PROXY_URL /
+    PROXY_URL, если настроены. Файл нигде не сохраняется — только память.
+    """
+    import aiohttp
+
+    timeout = aiohttp.ClientTimeout(total=20)
+    proxy_url = settings.get_nalogo_proxy_url()
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(receipt_url, proxy=proxy_url) as resp:
+            if resp.status != 200:
+                logger.warning('Не удалось скачать чек NaloGO для отправки файлом', status=resp.status)
+                return None
+            data = await resp.read()
+            if not data:
+                return None
+            content_type = (resp.headers.get('Content-Type') or '').lower()
+            return data, content_type
+
+
 async def send_nalogo_receipt_notifications(
     bot: Any,
     nalogo_service: 'NaloGoService | None',
@@ -630,19 +658,68 @@ async def send_nalogo_receipt_notifications(
     )
     amount_text = settings.format_price(amount_kopeks)
 
-    # --- Отправка пользователю ---
-    if telegram_user_id:
-        try:
+    # Пытаемся отправить чек файлом (см. _download_receipt_file); при неудаче
+    # откатываемся к прежнему поведению — текст со ссылкой-кнопкой.
+    receipt_file: types.BufferedInputFile | None = None
+    receipt_is_image = False
+    try:
+        downloaded = await _download_receipt_file(receipt_url)
+        if downloaded is not None:
+            data, content_type = downloaded
+            if 'pdf' in content_type:
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.pdf', False
+            elif 'png' in content_type:
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.png', True
+            else:  # печатная форма lknpd отдаётся как jpeg
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.jpg', True
+            receipt_file = types.BufferedInputFile(data, filename=filename)
+    except Exception as download_error:
+        logger.warning(
+            'Ошибка скачивания чека NaloGO, отправим только ссылку',
+            receipt_uuid=receipt_uuid,
+            error=sanitize_proxy_error(download_error),
+        )
+
+    async def _deliver(chat_id: int, caption: str, thread_id: int | None = None) -> None:
+        """Отправляет чек файлом (если скачался) или текстом со ссылкой."""
+        if receipt_file is not None and receipt_is_image:
+            await bot.send_photo(
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                photo=receipt_file,
+                caption=caption,
+                parse_mode='HTML',
+                reply_markup=keyboard,
+            )
+        elif receipt_file is not None:
+            await bot.send_document(
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                document=receipt_file,
+                caption=caption,
+                parse_mode='HTML',
+                reply_markup=keyboard,
+            )
+        else:
             await bot.send_message(
-                chat_id=telegram_user_id,
-                text=(
-                    '🧾 <b>Чек по вашему платежу сформирован</b>\n\n'
-                    f'💰 Сумма: {amount_text}\n\n'
-                    'Чек зарегистрирован в ФНС через сервис «Мой налог» и доступен по кнопке ниже.'
-                ),
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                text=caption,
                 parse_mode='HTML',
                 reply_markup=keyboard,
                 disable_web_page_preview=True,
+            )
+
+    # --- Отправка пользователю ---
+    if telegram_user_id:
+        try:
+            await _deliver(
+                telegram_user_id,
+                (
+                    '🧾 <b>Чек по вашему платежу сформирован</b>\n\n'
+                    f'💰 Сумма: {amount_text}\n\n'
+                    'Чек зарегистрирован в ФНС через сервис «Мой налог».'
+                ),
             )
             logger.info(
                 'Чек NaloGO отправлен пользователю', telegram_user_id=telegram_user_id, receipt_uuid=receipt_uuid
@@ -706,13 +783,10 @@ async def send_nalogo_receipt_notifications(
         recipient_block = '\n'.join(recipient_lines)
         context_line = f'\nℹ️ {context_label}' if context_label else ''
         try:
-            await bot.send_message(
-                chat_id=chat_id,
-                message_thread_id=topic_id,
-                text=(f'🧾 <b>Новый чек NaloGO создан</b>\n\n💰 Сумма: {amount_text}\n{recipient_block}{context_line}'),
-                parse_mode='HTML',
-                reply_markup=keyboard,
-                disable_web_page_preview=True,
+            await _deliver(
+                chat_id,
+                f'🧾 <b>Новый чек NaloGO создан</b>\n\n💰 Сумма: {amount_text}\n{recipient_block}{context_line}',
+                thread_id=topic_id,
             )
         except Exception as error:
             logger.warning(

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -8,15 +8,29 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from aiogram.exceptions import TelegramForbiddenError
 
 from app.config import settings
 from app.services.nalogo_service import send_nalogo_receipt_notifications
 
 
+@pytest.fixture(autouse=True)
+def _no_receipt_download(monkeypatch):
+    """По умолчанию скачивание чека недоступно — тесты проверяют фолбэк-путь
+    (текст со ссылкой), не выходя в сеть. Тесты файловой доставки переопределяют
+    мок точечно."""
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=None),
+    )
+
+
 def _bot() -> MagicMock:
     bot = MagicMock()
     bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock()
+    bot.send_document = AsyncMock()
     return bot
 
 
@@ -155,3 +169,80 @@ def test_get_receipt_print_url_builds_v1_link():
 
     service.configured = False
     assert service.get_receipt_print_url('uuid-42') is None
+
+
+async def test_receipt_delivered_as_photo_when_download_succeeds(monkeypatch):
+    """lknpd недоступен клиентам за VPN — при успешном серверном скачивании чек
+    уходит фотографией (юзеру и в админ-топик), ссылка остаётся кнопкой."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', '-100500', raising=False)
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID', 77, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'jpeg-bytes', 'image/jpeg')),
+    )
+    _patch_user_lookup(monkeypatch, SimpleNamespace(first_name='Вася', last_name=None, username=None, email=None))
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_message.assert_not_awaited()
+    assert bot.send_photo.await_count == 2
+    user_call, admin_call = bot.send_photo.await_args_list
+    assert user_call.kwargs['chat_id'] == 111
+    assert 'Чек по вашему платежу' in user_call.kwargs['caption']
+    assert user_call.kwargs['photo'].filename == 'receipt_uuid-1.jpg'
+    assert user_call.kwargs['reply_markup'].inline_keyboard[0][0].url.endswith('/print')
+    assert admin_call.kwargs['chat_id'] == -100500
+    assert admin_call.kwargs['message_thread_id'] == 77
+
+
+async def test_receipt_delivered_as_document_for_pdf(monkeypatch):
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'%PDF-1.4', 'application/pdf')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_message.assert_not_awaited()
+    bot.send_photo.assert_not_awaited()
+    assert bot.send_document.await_count == 1
+    assert bot.send_document.await_args_list[0].kwargs['document'].filename == 'receipt_uuid-1.pdf'
+
+
+async def test_download_failure_falls_back_to_link(monkeypatch):
+    """Сбой скачивания (сеть/503 ФНС) не ломает доставку — уходит текст со ссылкой."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(side_effect=RuntimeError('boom')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_photo.assert_not_awaited()
+    assert bot.send_message.await_count == 1
+    assert bot.send_message.await_args_list[0].kwargs['chat_id'] == 111


### PR DESCRIPTION
## Проблема

lknpd.nalog.ru блокирует зарубежные IP и не отдаёт DNS зарубежным резолверам. Аудитория ботов на Bedolaga — пользователи VPN: с включённым туннелем кнопка «Открыть чек» из #3082 не открывается вовсе («сервер не найден» ещё на этапе DNS). Клиент получает чек, которым не может воспользоваться, пока не выключит VPN.

## Что сделано

Бот скачивает печатную форму чека **на стороне сервера** (`_download_receipt_file`: aiohttp, таймаут 20с, уважает `NALOGO_PROXY_URL`/`PROXY_URL`) и отправляет её файлом: jpeg/png → `send_photo`, pdf → `send_document`. Доступность nalog.ru со стороны клиента больше не имеет значения; бонус — чек навсегда сохраняется в истории чата.

- Кнопка со ссылкой на официальную печатную форму сохраняется в любом случае;
- Любой сбой скачивания (сеть, 503 ФНС, не-200) → прозрачный фолбэк на прежнее поведение (текст + кнопка), best-effort изоляция от платёжного флоу как в #3082;
- Файл нигде не сохраняется на диске — только память процесса → Telegram (в чеке ИНН, лишние копии ни к чему);
- Работает для всех трёх точек доставки (юзер, админ-топик, guest-флоу) — изменение внутри общей `_deliver`.

## Тесты

+3 к сюите из #3082: фото юзеру и в админ-топик (filename, caption, keyboard), pdf → документ, сбой скачивания → фолбэк на ссылку. Autouse-фикстура мокает `_download_receipt_file` — существующие 6 тестов не выходят в сеть и продолжают проверять фолбэк-путь. Локально: 9 passed, `ruff format` чисто.

## Продовая проверка

Работает в проде с 19.07: чек приходит фотографией и открывается на устройстве с активным VPN-туннелем без каких-либо переходов на nalog.ru.