### PR TITLE
Dev

### DIFF
--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -2724,6 +2724,8 @@ async def confirm_tariff_extend(
     state: FSMContext,
 ):
     """Подтверждает продление по тарифу."""
+    texts = get_texts(db_user.language)
+
     # tariff_ext_confirm:{sub_id}:{tariff_id}:{period}
     parts = callback.data.split(':')
     try:

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -589,6 +589,11 @@ class NaloGoService:
             return None  # None = ошибка, [] = нет чеков
 
 
+# Telegram принимает фото до 10 МБ; печатная форма чека — десятки килобайт,
+# так что лимит здесь исключительно как предохранитель от чтения мусора в память.
+_RECEIPT_MAX_BYTES = 10 * 1024 * 1024
+
+
 async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
     """Скачивает печатную форму чека для отправки файлом в Telegram.
 
@@ -610,10 +615,26 @@ async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
             if resp.status != 200:
                 logger.warning('Не удалось скачать чек NaloGO для отправки файлом', status=resp.status)
                 return None
-            data = await resp.read()
+
+            content_type = (resp.headers.get('Content-Type') or '').lower()
+            # ФНС может отдать HTML (страница ошибки, техработы) с кодом 200 —
+            # отправлять её как «чек» нельзя, лучше откатиться на ссылку.
+            if not content_type.startswith('image/') and 'pdf' not in content_type:
+                logger.warning('Неожиданный формат печатной формы чека NaloGO', content_type=content_type)
+                return None
+
+            if resp.content_length and resp.content_length > _RECEIPT_MAX_BYTES:
+                logger.warning('Печатная форма чека NaloGO слишком велика', content_length=resp.content_length)
+                return None
+
+            # Читаем с запасом в 1 байт, чтобы отличить «ровно лимит» от «больше лимита»
+            data = await resp.content.read(_RECEIPT_MAX_BYTES + 1)
             if not data:
                 return None
-            content_type = (resp.headers.get('Content-Type') or '').lower()
+            if len(data) > _RECEIPT_MAX_BYTES:
+                logger.warning('Печатная форма чека NaloGO превысила лимит при чтении')
+                return None
+
             return data, content_type
 
 
@@ -682,33 +703,47 @@ async def send_nalogo_receipt_notifications(
 
     async def _deliver(chat_id: int, caption: str, thread_id: int | None = None) -> None:
         """Отправляет чек файлом (если скачался) или текстом со ссылкой."""
-        if receipt_file is not None and receipt_is_image:
-            await bot.send_photo(
-                chat_id=chat_id,
-                message_thread_id=thread_id,
-                photo=receipt_file,
-                caption=caption,
-                parse_mode='HTML',
-                reply_markup=keyboard,
-            )
-        elif receipt_file is not None:
-            await bot.send_document(
-                chat_id=chat_id,
-                message_thread_id=thread_id,
-                document=receipt_file,
-                caption=caption,
-                parse_mode='HTML',
-                reply_markup=keyboard,
-            )
-        else:
-            await bot.send_message(
-                chat_id=chat_id,
-                message_thread_id=thread_id,
-                text=caption,
-                parse_mode='HTML',
-                reply_markup=keyboard,
-                disable_web_page_preview=True,
-            )
+        if receipt_file is not None:
+            from aiogram.exceptions import TelegramBadRequest, TelegramEntityTooLarge
+
+            try:
+                if receipt_is_image:
+                    await bot.send_photo(
+                        chat_id=chat_id,
+                        message_thread_id=thread_id,
+                        photo=receipt_file,
+                        caption=caption,
+                        parse_mode='HTML',
+                        reply_markup=keyboard,
+                    )
+                else:
+                    await bot.send_document(
+                        chat_id=chat_id,
+                        message_thread_id=thread_id,
+                        document=receipt_file,
+                        caption=caption,
+                        parse_mode='HTML',
+                        reply_markup=keyboard,
+                    )
+                return
+            except (TelegramBadRequest, TelegramEntityTooLarge) as file_error:
+                # Telegram отверг сам файл (битая картинка, превышен размер,
+                # caption > 1024 символов). По 422-ФЗ чек обязан дойти до
+                # покупателя, поэтому не теряем его, а шлём ссылкой.
+                logger.warning(
+                    'Telegram отклонил файл чека NaloGO, отправляем ссылкой',
+                    chat_id=chat_id,
+                    error=str(file_error)[:200],
+                )
+
+        await bot.send_message(
+            chat_id=chat_id,
+            message_thread_id=thread_id,
+            text=caption,
+            parse_mode='HTML',
+            reply_markup=keyboard,
+            disable_web_page_preview=True,
+        )
 
     # --- Отправка пользователю ---
     if telegram_user_id:

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -589,6 +589,34 @@ class NaloGoService:
             return None  # None = ошибка, [] = нет чеков
 
 
+async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
+    """Скачивает печатную форму чека для отправки файлом в Telegram.
+
+    lknpd.nalog.ru недоступен с зарубежных IP (и не отдаёт DNS зарубежным
+    резолверам), поэтому у клиентов с включённым VPN ссылка на чек не
+    открывается вовсе. Скачиваем чек на стороне сервера и отправляем сам файл —
+    тогда доступность nalog.ru со стороны клиента не имеет значения.
+
+    Возвращает (bytes, content_type) либо None при любой ошибке (вызывающая
+    сторона откатывается к отправке ссылки). Использует NALOGO_PROXY_URL /
+    PROXY_URL, если настроены. Файл нигде не сохраняется — только память.
+    """
+    import aiohttp
+
+    timeout = aiohttp.ClientTimeout(total=20)
+    proxy_url = settings.get_nalogo_proxy_url()
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(receipt_url, proxy=proxy_url) as resp:
+            if resp.status != 200:
+                logger.warning('Не удалось скачать чек NaloGO для отправки файлом', status=resp.status)
+                return None
+            data = await resp.read()
+            if not data:
+                return None
+            content_type = (resp.headers.get('Content-Type') or '').lower()
+            return data, content_type
+
+
 async def send_nalogo_receipt_notifications(
     bot: Any,
     nalogo_service: 'NaloGoService | None',
@@ -630,19 +658,68 @@ async def send_nalogo_receipt_notifications(
     )
     amount_text = settings.format_price(amount_kopeks)
 
-    # --- Отправка пользователю ---
-    if telegram_user_id:
-        try:
+    # Пытаемся отправить чек файлом (см. _download_receipt_file); при неудаче
+    # откатываемся к прежнему поведению — текст со ссылкой-кнопкой.
+    receipt_file: types.BufferedInputFile | None = None
+    receipt_is_image = False
+    try:
+        downloaded = await _download_receipt_file(receipt_url)
+        if downloaded is not None:
+            data, content_type = downloaded
+            if 'pdf' in content_type:
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.pdf', False
+            elif 'png' in content_type:
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.png', True
+            else:  # печатная форма lknpd отдаётся как jpeg
+                filename, receipt_is_image = f'receipt_{receipt_uuid}.jpg', True
+            receipt_file = types.BufferedInputFile(data, filename=filename)
+    except Exception as download_error:
+        logger.warning(
+            'Ошибка скачивания чека NaloGO, отправим только ссылку',
+            receipt_uuid=receipt_uuid,
+            error=sanitize_proxy_error(download_error),
+        )
+
+    async def _deliver(chat_id: int, caption: str, thread_id: int | None = None) -> None:
+        """Отправляет чек файлом (если скачался) или текстом со ссылкой."""
+        if receipt_file is not None and receipt_is_image:
+            await bot.send_photo(
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                photo=receipt_file,
+                caption=caption,
+                parse_mode='HTML',
+                reply_markup=keyboard,
+            )
+        elif receipt_file is not None:
+            await bot.send_document(
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                document=receipt_file,
+                caption=caption,
+                parse_mode='HTML',
+                reply_markup=keyboard,
+            )
+        else:
             await bot.send_message(
-                chat_id=telegram_user_id,
-                text=(
-                    '🧾 <b>Чек по вашему платежу сформирован</b>\n\n'
-                    f'💰 Сумма: {amount_text}\n\n'
-                    'Чек зарегистрирован в ФНС через сервис «Мой налог» и доступен по кнопке ниже.'
-                ),
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                text=caption,
                 parse_mode='HTML',
                 reply_markup=keyboard,
                 disable_web_page_preview=True,
+            )
+
+    # --- Отправка пользователю ---
+    if telegram_user_id:
+        try:
+            await _deliver(
+                telegram_user_id,
+                (
+                    '🧾 <b>Чек по вашему платежу сформирован</b>\n\n'
+                    f'💰 Сумма: {amount_text}\n\n'
+                    'Чек зарегистрирован в ФНС через сервис «Мой налог».'
+                ),
             )
             logger.info(
                 'Чек NaloGO отправлен пользователю', telegram_user_id=telegram_user_id, receipt_uuid=receipt_uuid
@@ -706,13 +783,10 @@ async def send_nalogo_receipt_notifications(
         recipient_block = '\n'.join(recipient_lines)
         context_line = f'\nℹ️ {context_label}' if context_label else ''
         try:
-            await bot.send_message(
-                chat_id=chat_id,
-                message_thread_id=topic_id,
-                text=(f'🧾 <b>Новый чек NaloGO создан</b>\n\n💰 Сумма: {amount_text}\n{recipient_block}{context_line}'),
-                parse_mode='HTML',
-                reply_markup=keyboard,
-                disable_web_page_preview=True,
+            await _deliver(
+                chat_id,
+                f'🧾 <b>Новый чек NaloGO создан</b>\n\n💰 Сумма: {amount_text}\n{recipient_block}{context_line}',
+                thread_id=topic_id,
             )
         except Exception as error:
             logger.warning(

--- a/tests/handlers/test_no_undefined_texts_in_handlers.py
+++ b/tests/handlers/test_no_undefined_texts_in_handlers.py
@@ -1,0 +1,111 @@
+"""Статическая защита от NameError на `texts` в хендлерах.
+
+Локализация переводит хендлеры на `texts.t(...)`, но `texts` — локальная
+переменная, которую каждая функция обязана получить сама через `get_texts(...)`.
+Пропущенное присваивание не ловится ни линтером, ни импортом: падает только
+в рантайме, у живого пользователя, и часто уже ПОСЛЕ списания денег.
+
+Так уже случилось в confirm_tariff_extend (продление тарифа): деньги списаны,
+подписка продлена, а сообщение об успехе падало с NameError; except-ветка
+обращалась к тому же `texts` и падала повторно, поэтому пользователь не видел
+вообще ничего и мог оплатить второй раз.
+
+Проверка учитывает замыкания: вложенная функция законно читает `texts`
+из объемлющей области, если та его определила.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+HANDLERS_ROOT = Path(__file__).resolve().parents[2] / 'app' / 'handlers'
+
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def _walk_own_scope(node: ast.AST):
+    """Обходит тело узла, не заходя во вложенные области видимости."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _SCOPE_NODES):
+            continue
+        yield child
+        yield from _walk_own_scope(child)
+
+
+def _module_level_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split('.')[0])
+    return names
+
+
+def _own_bound_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Имена, связанные непосредственно в этой функции (без вложенных)."""
+    bound: set[str] = set()
+
+    args = func.args
+    for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+        bound.add(arg.arg)
+    if args.vararg:
+        bound.add(args.vararg.arg)
+    if args.kwarg:
+        bound.add(args.kwarg.arg)
+
+    for node in _walk_own_scope(func):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound.add(node.id)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, (ast.Global, ast.Nonlocal)):
+            bound.update(node.names)
+
+    # Вложенные функции видны по имени в этой области
+    for child in ast.iter_child_nodes(func):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(child.name)
+
+    return bound
+
+
+def _check_scope(node: ast.AST, inherited: set[str], found: list[tuple[str, int]]) -> None:
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            available = inherited | _own_bound_names(child)
+            loads = [
+                sub.lineno
+                for sub in _walk_own_scope(child)
+                if isinstance(sub, ast.Name) and sub.id == 'texts' and isinstance(sub.ctx, ast.Load)
+            ]
+            if loads and 'texts' not in available:
+                found.append((child.name, min(loads)))
+            _check_scope(child, available, found)
+        else:
+            _check_scope(child, inherited, found)
+
+
+def _find_undefined_texts(path: Path) -> list[tuple[str, int]]:
+    tree = ast.parse(path.read_text(encoding='utf-8'))
+    found: list[tuple[str, int]] = []
+    _check_scope(tree, _module_level_names(tree), found)
+    return found
+
+
+def test_handlers_never_use_undefined_texts() -> None:
+    problems: list[str] = []
+
+    for path in sorted(HANDLERS_ROOT.rglob('*.py')):
+        for func_name, lineno in _find_undefined_texts(path):
+            rel = path.relative_to(HANDLERS_ROOT.parents[1])
+            problems.append(f'{rel}:{lineno} — {func_name}() использует texts, но не получает его через get_texts()')
+
+    assert not problems, 'Найдены хендлеры с необъявленным `texts`:\n' + '\n'.join(problems)

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -9,10 +9,16 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aiogram.exceptions import TelegramForbiddenError
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
 
+import app.services.nalogo_service as _nalogo_module
 from app.config import settings
 from app.services.nalogo_service import send_nalogo_receipt_notifications
+
+
+# Autouse-фикстура ниже подменяет _download_receipt_file, поэтому настоящую
+# функцию забираем сейчас — иначе тесты самого скачивания проверяли бы мок.
+_REAL_DOWNLOAD = _nalogo_module._download_receipt_file
 
 
 @pytest.fixture(autouse=True)
@@ -246,3 +252,119 @@ async def test_download_failure_falls_back_to_link(monkeypatch):
     bot.send_photo.assert_not_awaited()
     assert bot.send_message.await_count == 1
     assert bot.send_message.await_args_list[0].kwargs['chat_id'] == 111
+
+
+async def test_telegram_rejects_file_falls_back_to_link(monkeypatch):
+    """Telegram отверг сам файл — чек обязан дойти, поэтому уходит ссылкой.
+
+    Без фолбэка покупатель не получал бы чек вообще: ошибка гасилась
+    внешним except и доставка молча терялась (нарушение 422-ФЗ).
+    """
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'jpeg-bytes', 'image/jpeg')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+    bot.send_photo = AsyncMock(side_effect=TelegramBadRequest(method=MagicMock(), message='PHOTO_INVALID_DIMENSIONS'))
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_photo.assert_awaited_once()
+    assert bot.send_message.await_count == 1
+    user_call = bot.send_message.await_args_list[0]
+    assert user_call.kwargs['chat_id'] == 111
+    assert user_call.kwargs['reply_markup'].inline_keyboard[0][0].url.endswith('/print')
+
+
+async def test_blocked_user_is_not_retried_as_message(monkeypatch):
+    """Юзер заблокировал бота — это не проблема файла, повторять текстом бессмысленно."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'jpeg-bytes', 'image/jpeg')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+    bot.send_photo = AsyncMock(side_effect=TelegramForbiddenError(method=MagicMock(), message='blocked'))
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_photo.assert_awaited_once()
+    bot.send_message.assert_not_awaited()
+
+
+class _FakeResponse:
+    def __init__(self, *, status=200, content_type='image/jpeg', body=b'jpeg-bytes', content_length=None):
+        self.status = status
+        self.headers = {'Content-Type': content_type}
+        self.content_length = content_length if content_length is not None else len(body)
+        self.content = SimpleNamespace(read=AsyncMock(return_value=body))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+
+    def get(self, *args, **kwargs):
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _patch_aiohttp(monkeypatch, response):
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, 'ClientSession', lambda *a, **kw: _FakeSession(response))
+    monkeypatch.setattr(settings, 'NALOGO_PROXY_URL', None, raising=False)
+
+
+async def test_download_rejects_html_error_page(monkeypatch):
+    """ФНС отдаёт HTML-заглушку с кодом 200 — её нельзя слать как «чек»."""
+    _patch_aiohttp(monkeypatch, _FakeResponse(content_type='text/html; charset=utf-8', body=b'<html>error</html>'))
+
+    assert await _REAL_DOWNLOAD('https://lknpd.nalog.ru/api/v1/receipt/1/u/print') is None
+
+
+async def test_download_accepts_image_and_pdf(monkeypatch):
+    _patch_aiohttp(monkeypatch, _FakeResponse(content_type='image/jpeg', body=b'jpeg'))
+    assert await _REAL_DOWNLOAD('https://x/print') == (b'jpeg', 'image/jpeg')
+
+    _patch_aiohttp(monkeypatch, _FakeResponse(content_type='application/pdf', body=b'%PDF'))
+    assert await _REAL_DOWNLOAD('https://x/print') == (b'%PDF', 'application/pdf')
+
+
+async def test_download_rejects_oversized_receipt(monkeypatch):
+    """Предохранитель от вычитывания мусора в память."""
+    from app.services.nalogo_service import _RECEIPT_MAX_BYTES
+
+    # Заявленный Content-Length больше лимита — не читаем вовсе
+    _patch_aiohttp(monkeypatch, _FakeResponse(content_length=_RECEIPT_MAX_BYTES + 1))
+    assert await _REAL_DOWNLOAD('https://x/print') is None
+
+    # Content-Length занижен/отсутствует, но тело превышает лимит при чтении
+    _patch_aiohttp(monkeypatch, _FakeResponse(body=b'x' * (_RECEIPT_MAX_BYTES + 1), content_length=0))
+    assert await _REAL_DOWNLOAD('https://x/print') is None

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -8,15 +8,29 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from aiogram.exceptions import TelegramForbiddenError
 
 from app.config import settings
 from app.services.nalogo_service import send_nalogo_receipt_notifications
 
 
+@pytest.fixture(autouse=True)
+def _no_receipt_download(monkeypatch):
+    """По умолчанию скачивание чека недоступно — тесты проверяют фолбэк-путь
+    (текст со ссылкой), не выходя в сеть. Тесты файловой доставки переопределяют
+    мок точечно."""
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=None),
+    )
+
+
 def _bot() -> MagicMock:
     bot = MagicMock()
     bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock()
+    bot.send_document = AsyncMock()
     return bot
 
 
@@ -155,3 +169,80 @@ def test_get_receipt_print_url_builds_v1_link():
 
     service.configured = False
     assert service.get_receipt_print_url('uuid-42') is None
+
+
+async def test_receipt_delivered_as_photo_when_download_succeeds(monkeypatch):
+    """lknpd недоступен клиентам за VPN — при успешном серверном скачивании чек
+    уходит фотографией (юзеру и в админ-топик), ссылка остаётся кнопкой."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', '-100500', raising=False)
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID', 77, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'jpeg-bytes', 'image/jpeg')),
+    )
+    _patch_user_lookup(monkeypatch, SimpleNamespace(first_name='Вася', last_name=None, username=None, email=None))
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_message.assert_not_awaited()
+    assert bot.send_photo.await_count == 2
+    user_call, admin_call = bot.send_photo.await_args_list
+    assert user_call.kwargs['chat_id'] == 111
+    assert 'Чек по вашему платежу' in user_call.kwargs['caption']
+    assert user_call.kwargs['photo'].filename == 'receipt_uuid-1.jpg'
+    assert user_call.kwargs['reply_markup'].inline_keyboard[0][0].url.endswith('/print')
+    assert admin_call.kwargs['chat_id'] == -100500
+    assert admin_call.kwargs['message_thread_id'] == 77
+
+
+async def test_receipt_delivered_as_document_for_pdf(monkeypatch):
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'%PDF-1.4', 'application/pdf')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_message.assert_not_awaited()
+    bot.send_photo.assert_not_awaited()
+    assert bot.send_document.await_count == 1
+    assert bot.send_document.await_args_list[0].kwargs['document'].filename == 'receipt_uuid-1.pdf'
+
+
+async def test_download_failure_falls_back_to_link(monkeypatch):
+    """Сбой скачивания (сеть/503 ФНС) не ломает доставку — уходит текст со ссылкой."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(side_effect=RuntimeError('boom')),
+    )
+    _patch_user_lookup(monkeypatch, None)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    bot.send_photo.assert_not_awaited()
+    assert bot.send_message.await_count == 1
+    assert bot.send_message.await_args_list[0].kwargs['chat_id'] == 111


### PR DESCRIPTION
Промоушен dev → main для выпуска релиза. После v3.65.0 накопилось три коммита.

## Что выходит

**fix(subscription): NameError при продлении тарифа после списания денег**

Критично. `confirm_tariff_extend` использует `texts` 11 раз, но ни разу не получает его через `get_texts` — регрессия локализации флоу продления из v3.65.0. Падало на сообщении об успехе, то есть уже ПОСЛЕ списания баланса и продления подписки: деньги сняты, подписка продлена, а пользователь не видел ничего, потому что except-ветка обращается к тому же неопределённому `texts` и падает повторно. Человек считал, что оплата не прошла, и мог заплатить второй раз. Подтверждено в проде 19.07.

Добавлен статический тест, проверяющий все хендлеры на использование `texts` без объявления (с учётом замыканий).

**feat(nalogo): доставка чека файлом — lknpd недоступен клиентам через VPN** (PR #3087)

lknpd.nalog.ru блокирует зарубежные IP, поэтому у пользователей с включённым туннелем кнопка «Открыть чек» не открывалась вовсе. Теперь бот скачивает печатную форму на своей стороне и отправляет файлом (jpeg/png — фото, pdf — документ); ссылка-кнопка сохраняется.

**fix(nalogo): не терять чек, если Telegram отверг файл, и не слать HTML как чек**

Доработка к предыдущему: при отказе Telegram принять файл чек не доходил вообще (до этого уходила ссылка сообщением) — добавлен фолбэк; HTML-заглушка ФНС с кодом 200 уходила пользователю как «чек» — теперь принимаются только `image/*` и pdf, плюс ограничен размер скачивания.

## Проверки

2046 тестов, ruff check и format чисто, CI на dev зелёный (Lint, BedolagaBot, Docker Build).