### PR TITLE
fix(nalogo): чек уходит покупателю обрезанным — дочитывать печатную форму до конца

### DIFF
--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -627,12 +627,23 @@ async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
                 logger.warning('Печатная форма чека NaloGO слишком велика', content_length=resp.content_length)
                 return None
 
-            # Читаем с запасом в 1 байт, чтобы отличить «ровно лимит» от «больше лимита»
-            data = await resp.content.read(_RECEIPT_MAX_BYTES + 1)
+            # ВАЖНО: читать в цикле до EOF. StreamReader.read(n) возвращает
+            # «до n байт» — первый буферизованный кусок, а не весь ответ;
+            # одиночный read(n) отдавал обрезанный JPEG (файл без хвоста).
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = await resp.content.read(64 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _RECEIPT_MAX_BYTES:
+                    logger.warning('Печатная форма чека NaloGO превысила лимит при чтении')
+                    return None
+                chunks.append(chunk)
+
+            data = b''.join(chunks)
             if not data:
-                return None
-            if len(data) > _RECEIPT_MAX_BYTES:
-                logger.warning('Печатная форма чека NaloGO превысила лимит при чтении')
                 return None
 
             return data, content_type

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -308,11 +308,15 @@ async def test_blocked_user_is_not_retried_as_message(monkeypatch):
 
 
 class _FakeResponse:
-    def __init__(self, *, status=200, content_type='image/jpeg', body=b'jpeg-bytes', content_length=None):
+    def __init__(self, *, status=200, content_type='image/jpeg', body=b'jpeg-bytes', content_length=None, chunks=None):
         self.status = status
         self.headers = {'Content-Type': content_type}
         self.content_length = content_length if content_length is not None else len(body)
-        self.content = SimpleNamespace(read=AsyncMock(return_value=body))
+        # Честная семантика StreamReader.read(n): отдаёт тело кусками («до n
+        # байт» за вызов), в конце — b'' (EOF). Одиночный read(n) в проде
+        # возвращал первый кусок и обрезал JPEG — фейк обязан это ловить.
+        pieces = list(chunks) if chunks is not None else [body]
+        self.content = SimpleNamespace(read=AsyncMock(side_effect=[*pieces, b'', b'']))
 
     async def __aenter__(self):
         return self
@@ -355,6 +359,20 @@ async def test_download_accepts_image_and_pdf(monkeypatch):
 
     _patch_aiohttp(monkeypatch, _FakeResponse(content_type='application/pdf', body=b'%PDF'))
     assert await _REAL_DOWNLOAD('https://x/print') == (b'%PDF', 'application/pdf')
+
+
+async def test_download_reads_multi_chunk_body_to_the_end(monkeypatch):
+    """Тело приходит несколькими кусками — файл обязан склеиться целиком.
+
+    Регрессия: одиночный resp.content.read(n) отдаёт «до n байт» (первый
+    буфер), чек уезжал клиенту обрезанным JPEG без хвоста.
+    """
+    _patch_aiohttp(
+        monkeypatch,
+        _FakeResponse(content_type='image/jpeg', chunks=[b'head-', b'middle-', b'tail'], content_length=0),
+    )
+
+    assert await _REAL_DOWNLOAD('https://x/print') == (b'head-middle-tail', 'image/jpeg')
 
 
 async def test_download_rejects_oversized_receipt(monkeypatch):


### PR DESCRIPTION
## Проблема

Файл чека (печатная форма lknpd) приходит покупателю обрезанным, если он больше одного сетевого буфера: сверху шапка чека, дальше картинка обрывается (у получателя — «шахматка» вместо нижней части, без суммы и QR). Затронуты все каналы доставки, использующие `_download_receipt_file` — фото/документ в Telegram.

## Причина

`resp.content.read(n)` у aiohttp `StreamReader` с положительным `n` возвращает «до n байт» — первый буферизованный кусок, а не весь ответ. Реализация ждёт лишь появления каких-то данных (`while not self._buffer and not self._eof`) и отдаёт то, что уже в буфере. На реальном чеке скачивалось 6690 байт из 27091 — JPEG без хвоста (нет EOI-маркера `FF D9`).

Существующий тест это не ловил: фейковый ответ отдавал всё тело одним `read()`.

## Решение

Читать тело циклом до EOF кусками по 64 КБ. Лимит размера `_RECEIPT_MAX_BYTES` сохранён — при превышении по-прежнему `None` и фолбэк на отправку ссылкой.

## Тесты

- `_FakeResponse` теперь честно эмулирует семантику `StreamReader.read(n)`: тело кусками, в конце `b''` (EOF) — однобуферный фейк маскировал баг
- новый `test_download_reads_multi_chunk_body_to_the_end` — регрессионный
- вся пачка `tests/services/test_nalogo_receipt_notifications.py` зелёная

## Проверка на живом стенде

До фикса: скачано 6690 байт, JPEG обрезан. После: 27091 байт, EOI-маркер на месте, чек доходит целиком.