### PR TITLE
feat(nalogo): доставка чека на почту, когда Telegram недоступен

### DIFF
--- a/app/cabinet/services/email_service.py
+++ b/app/cabinet/services/email_service.py
@@ -2,6 +2,8 @@
 
 import re
 import smtplib
+from email import encoders
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formataddr, formatdate, make_msgid
@@ -108,6 +110,7 @@ class EmailService:
         subject: str,
         body_html: str,
         body_text: str | None = None,
+        attachments: list[tuple[str, bytes, str]] | None = None,
     ) -> bool:
         """
         Send an email.
@@ -117,6 +120,7 @@ class EmailService:
             subject: Email subject
             body_html: HTML body content
             body_text: Plain text body (optional, generated from HTML if not provided)
+            attachments: Optional list of (filename, content, mimetype) tuples
 
         Returns:
             True if email was sent successfully, False otherwise
@@ -135,7 +139,10 @@ class EmailService:
         subject = subject.replace('\n', '').replace('\r', '')
 
         try:
-            msg = MIMEMultipart('alternative')
+            # С вложениями письмо становится multipart/mixed: внутри него
+            # обычная alternative-пара text/html плюс файлы.
+            alternative = MIMEMultipart('alternative')
+            msg = MIMEMultipart('mixed') if attachments else alternative
             msg['Subject'] = subject
             safe_from_name = self.from_name.replace('\n', '').replace('\r', '') if self.from_name else ''
             safe_from_email = sender_email.replace('\n', '').replace('\r', '')
@@ -151,8 +158,19 @@ class EmailService:
             part1 = MIMEText(body_text, 'plain', 'utf-8')
             part2 = MIMEText(body_html, 'html', 'utf-8')
 
-            msg.attach(part1)
-            msg.attach(part2)
+            alternative.attach(part1)
+            alternative.attach(part2)
+
+            if attachments:
+                msg.attach(alternative)
+                for filename, content, mimetype in attachments:
+                    maintype, _, subtype = (mimetype or 'application/octet-stream').partition('/')
+                    attachment_part = MIMEBase(maintype or 'application', subtype or 'octet-stream')
+                    attachment_part.set_payload(content)
+                    encoders.encode_base64(attachment_part)
+                    safe_filename = filename.replace('\n', '').replace('\r', '')
+                    attachment_part.add_header('Content-Disposition', 'attachment', filename=safe_filename)
+                    msg.attach(attachment_part)
 
             with self._get_smtp_connection() as smtp:
                 smtp.sendmail(safe_from_email, to_email, msg.as_string())

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -253,6 +253,7 @@ async def _create_nalogo_receipt_for_purchase(
             payment_id=purchase.payment_id,
             telegram_user_id=user.telegram_id,
             amount_kopeks=purchase.amount_kopeks,
+            user_email=user.email,
         )
 
         if receipt_uuid:
@@ -278,7 +279,7 @@ async def _create_nalogo_receipt_for_purchase(
                     receipt_uuid=receipt_uuid,
                 )
 
-            # Отправляем чек покупателю (если есть telegram_id) и дублируем в админ-топик
+            # Отправляем чек покупателю (Telegram или почта) и дублируем в админ-топик
             try:
                 from app.bot_factory import create_bot
                 from app.services.nalogo_service import send_nalogo_receipt_notifications
@@ -291,6 +292,7 @@ async def _create_nalogo_receipt_for_purchase(
                         amount_kopeks=purchase.amount_kopeks,
                         telegram_user_id=user.telegram_id,
                         context_label=f'Источник: гостевая покупка с лендинга (purchase_id={purchase.id})',
+                        user_email=user.email,
                     )
             except Exception as notify_error:
                 logger.warning(

--- a/app/services/nalogo_queue_service.py
+++ b/app/services/nalogo_queue_service.py
@@ -124,6 +124,7 @@ class NalogoQueueService:
         telegram_user_id: int | None,
         receipt_uuid: str,
         amount: float,
+        user_email: str | None = None,
     ) -> None:
         """Отправляет пользователю ссылку на чек из отложенной очереди и дублирует в админ-топик."""
         if not self._bot or not self._nalogo_service:
@@ -138,6 +139,7 @@ class NalogoQueueService:
             amount_kopeks=int(round(amount * 100)),
             telegram_user_id=telegram_user_id,
             context_label='Источник: отложенная очередь NaloGO',
+            user_email=user_email,
         )
 
     async def _process_queue_loop(self) -> None:
@@ -197,6 +199,7 @@ class NalogoQueueService:
                 # Восстанавливаем описание из сохранённых данных
                 telegram_user_id = receipt_data.get('telegram_user_id')
                 amount_kopeks = receipt_data.get('amount_kopeks')
+                user_email = receipt_data.get('user_email')
 
                 # Извлекаем время оплаты из очереди (чтобы чек был с правильным временем)
                 operation_time = None
@@ -257,6 +260,7 @@ class NalogoQueueService:
                             telegram_user_id=telegram_user_id,
                             receipt_uuid=receipt_uuid,
                             amount=amount,
+                            user_email=user_email,
                         )
                 else:
                     # Вернуть в очередь с увеличенным счетчиком попыток

--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -95,6 +95,7 @@ class NaloGoService:
         payment_id: str | None = None,
         telegram_user_id: int | None = None,
         amount_kopeks: int | None = None,
+        user_email: str | None = None,
     ) -> bool:
         """Добавить чек в очередь для отложенной отправки."""
         if payment_id:
@@ -125,6 +126,7 @@ class NaloGoService:
             'payment_id': payment_id,
             'telegram_user_id': telegram_user_id,
             'amount_kopeks': amount_kopeks,
+            'user_email': user_email,
             'created_at': datetime.now(UTC).isoformat(),
             'attempts': 0,
         }
@@ -305,6 +307,7 @@ class NaloGoService:
         telegram_user_id: int | None = None,
         amount_kopeks: int | None = None,
         operation_time: datetime | None = None,
+        user_email: str | None = None,
     ) -> str | None:
         """Создание чека о доходе.
 
@@ -318,6 +321,8 @@ class NaloGoService:
             telegram_user_id: Telegram ID пользователя для формирования описания
             amount_kopeks: Сумма в копейках для формирования описания
             operation_time: Время операции (по умолчанию текущее)
+            user_email: Почта получателя чека (для email-доставки из очереди,
+                когда у покупателя нет Telegram)
 
         Returns:
             UUID чека или None при ошибке
@@ -347,7 +352,14 @@ class NaloGoService:
                     # Аутентификация не прошла — чек не создавался, безопасно в очередь
                     if queue_on_failure:
                         await self._queue_receipt(
-                            name, amount, quantity, client_info, payment_id, telegram_user_id, amount_kopeks
+                            name,
+                            amount,
+                            quantity,
+                            client_info,
+                            payment_id,
+                            telegram_user_id,
+                            amount_kopeks,
+                            user_email=user_email,
                         )
                     return None
         except Exception as auth_error:
@@ -360,7 +372,14 @@ class NaloGoService:
                 )
                 if queue_on_failure:
                     await self._queue_receipt(
-                        name, amount, quantity, client_info, payment_id, telegram_user_id, amount_kopeks
+                        name,
+                        amount,
+                        quantity,
+                        client_info,
+                        payment_id,
+                        telegram_user_id,
+                        amount_kopeks,
+                        user_email=user_email,
                     )
             else:
                 logger.error('Ошибка аутентификации NaloGO', auth_error=sanitize_proxy_error(auth_error))
@@ -638,6 +657,45 @@ async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
             return data, content_type
 
 
+async def _send_receipt_email(
+    to_email: str,
+    amount_text: str,
+    receipt_url: str,
+    attachment: tuple[str, bytes, str] | None,
+) -> bool:
+    """Отправляет чек NaloGO на почту: файл во вложении + ссылка в тексте.
+
+    Ссылка lknpd.nalog.ru у покупателя с включённым VPN не открывается
+    (см. _download_receipt_file), поэтому главный носитель чека — вложение;
+    ссылка — запасной вариант. Возвращает True при успешной отправке.
+    """
+    import asyncio
+
+    from app.cabinet.services.email_service import email_service
+
+    if not email_service.is_configured():
+        logger.warning('SMTP не настроен — чек NaloGO не отправлен на почту')
+        return False
+
+    subject = 'Чек по вашему платежу'
+    body_html = (
+        '<h2>🧾 Чек по вашему платежу сформирован</h2>'
+        f'<p>💰 Сумма: <b>{amount_text}</b></p>'
+        '<p>Чек зарегистрирован в ФНС через сервис «Мой налог».</p>'
+        + ('<p>Файл чека — во вложении к этому письму.</p>' if attachment else '')
+        + f'<p><a href="{receipt_url}">Открыть чек на сайте ФНС</a> '
+        '(ссылка может не открываться при включённом VPN или из-за рубежа).</p>'
+    )
+    return await asyncio.to_thread(
+        email_service.send_email,
+        to_email,
+        subject,
+        body_html,
+        None,
+        [attachment] if attachment else None,
+    )
+
+
 async def send_nalogo_receipt_notifications(
     bot: Any,
     nalogo_service: 'NaloGoService | None',
@@ -645,6 +703,7 @@ async def send_nalogo_receipt_notifications(
     amount_kopeks: int,
     telegram_user_id: int | None = None,
     context_label: str | None = None,
+    user_email: str | None = None,
 ) -> None:
     """Отправляет ссылку на созданный чек NaloGO пользователю и дублирует её в
     админский топик чеков (settings.ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID).
@@ -660,6 +719,9 @@ async def send_nalogo_receipt_notifications(
         telegram_user_id: telegram_id получателя чека (None — пользователю не отправляем,
             но в админский топик чек всё равно продублируется)
         context_label: доп. пояснение для админского уведомления (например, источник платежа)
+        user_email: почта получателя — фоллбек-канал, когда чек не доставлен в
+            Telegram (нет аккаунта / бот заблокирован); если не передана,
+            почта ищется в БД по telegram_user_id
     """
     if not bot or not nalogo_service or not receipt_uuid:
         return
@@ -683,6 +745,7 @@ async def send_nalogo_receipt_notifications(
     # откатываемся к прежнему поведению — текст со ссылкой-кнопкой.
     receipt_file: types.BufferedInputFile | None = None
     receipt_is_image = False
+    email_attachment: tuple[str, bytes, str] | None = None
     try:
         downloaded = await _download_receipt_file(receipt_url)
         if downloaded is not None:
@@ -694,6 +757,7 @@ async def send_nalogo_receipt_notifications(
             else:  # печатная форма lknpd отдаётся как jpeg
                 filename, receipt_is_image = f'receipt_{receipt_uuid}.jpg', True
             receipt_file = types.BufferedInputFile(data, filename=filename)
+            email_attachment = (filename, data, content_type.split(';')[0].strip())
     except Exception as download_error:
         logger.warning(
             'Ошибка скачивания чека NaloGO, отправим только ссылку',
@@ -746,6 +810,7 @@ async def send_nalogo_receipt_notifications(
         )
 
     # --- Отправка пользователю ---
+    tg_delivered = False
     if telegram_user_id:
         try:
             await _deliver(
@@ -756,6 +821,7 @@ async def send_nalogo_receipt_notifications(
                     'Чек зарегистрирован в ФНС через сервис «Мой налог».'
                 ),
             )
+            tg_delivered = True
             logger.info(
                 'Чек NaloGO отправлен пользователю', telegram_user_id=telegram_user_id, receipt_uuid=receipt_uuid
             )
@@ -775,6 +841,37 @@ async def send_nalogo_receipt_notifications(
                     telegram_user_id=telegram_user_id,
                     error=error,
                     exc_info=True,
+                )
+
+    # --- Email-фоллбек: чек не ушёл в Telegram (нет аккаунта или бот
+    # заблокирован) — пытаемся доставить на почту. По 422-ФЗ чек обязан
+    # дойти до покупателя хотя бы одним каналом. ---
+    if not tg_delivered:
+        recipient_email = (user_email or '').strip()
+        if not recipient_email and telegram_user_id:
+            try:
+                from app.database.crud.user import get_user_by_telegram_id
+                from app.database.database import AsyncSessionLocal
+
+                async with AsyncSessionLocal() as session:
+                    email_user = await get_user_by_telegram_id(session, telegram_user_id)
+                if email_user and email_user.email:
+                    recipient_email = email_user.email.strip()
+            except Exception as lookup_error:
+                logger.warning(
+                    'Не удалось найти почту пользователя для отправки чека NaloGO',
+                    telegram_user_id=telegram_user_id,
+                    error=lookup_error,
+                )
+        if recipient_email:
+            try:
+                if await _send_receipt_email(recipient_email, amount_text, receipt_url, email_attachment):
+                    logger.info('Чек NaloGO отправлен на почту', receipt_uuid=receipt_uuid)
+            except Exception as email_error:
+                logger.error(
+                    'Ошибка отправки чека NaloGO на почту',
+                    receipt_uuid=receipt_uuid,
+                    error=email_error,
                 )
 
     # --- Дублирование в админский топик чеков ---

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -1157,6 +1157,7 @@ class YooKassaPaymentMixin:
                     payment=payment,
                     transaction=transaction,
                     telegram_user_id=user.telegram_id if user else None,
+                    user_email=user.email if user else None,
                 )
 
             return True
@@ -1302,6 +1303,7 @@ class YooKassaPaymentMixin:
         payment: YooKassaPayment,
         transaction: Transaction | None = None,
         telegram_user_id: int | None = None,
+        user_email: str | None = None,
     ) -> None:
         """Создание чека через NaloGO для успешного платежа."""
         if not hasattr(self, 'nalogo_service') or not self.nalogo_service:
@@ -1331,6 +1333,7 @@ class YooKassaPaymentMixin:
                 payment_id=payment.yookassa_payment_id,
                 telegram_user_id=telegram_user_id,
                 amount_kopeks=payment.amount_kopeks,
+                user_email=user_email,
             )
 
             if receipt_uuid:
@@ -1352,12 +1355,13 @@ class YooKassaPaymentMixin:
                     except Exception as save_error:
                         logger.warning('Не удалось сохранить receipt_uuid в транзакцию', save_error=save_error)
 
-                # Отправляем чек пользователю в Telegram (если есть) и дублируем в админ-топик
+                # Отправляем чек пользователю (Telegram или почта) и дублируем в админ-топик
                 if getattr(self, 'bot', None):
                     await self._send_nalogo_receipt_to_user(
                         telegram_user_id=telegram_user_id,
                         receipt_uuid=receipt_uuid,
                         amount_kopeks=payment.amount_kopeks,
+                        user_email=user_email,
                     )
             # При временной недоступности чек добавляется в очередь автоматически
 
@@ -1374,6 +1378,7 @@ class YooKassaPaymentMixin:
         telegram_user_id: int | None,
         receipt_uuid: str,
         amount_kopeks: int,
+        user_email: str | None = None,
     ) -> None:
         """Отправляет пользователю ссылку на фискальный чек НПД и дублирует в админ-топик."""
         if not hasattr(self, 'nalogo_service') or not self.nalogo_service:
@@ -1388,6 +1393,7 @@ class YooKassaPaymentMixin:
             amount_kopeks=amount_kopeks,
             telegram_user_id=telegram_user_id,
             context_label='Источник: YooKassa',
+            user_email=user_email,
         )
 
     async def process_yookassa_webhook(

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -368,3 +368,115 @@ async def test_download_rejects_oversized_receipt(monkeypatch):
     # Content-Length занижен/отсутствует, но тело превышает лимит при чтении
     _patch_aiohttp(monkeypatch, _FakeResponse(body=b'x' * (_RECEIPT_MAX_BYTES + 1), content_length=0))
     assert await _REAL_DOWNLOAD('https://x/print') is None
+
+
+# --- Email-фоллбек: чек уходит на почту, когда Telegram-доставка невозможна ---
+
+
+def _patch_email(monkeypatch, configured=True):
+    # Пакет app.cabinet.services реэкспортирует синглтон email_service, который
+    # шадовит одноимённый сабмодуль при обычном import — берём модуль через
+    # importlib, чтобы патчить именно тот инстанс, что использует продовый код.
+    import importlib
+
+    _email_module = importlib.import_module('app.cabinet.services.email_service')
+
+    send_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(_email_module.email_service, 'send_email', send_mock)
+    monkeypatch.setattr(_email_module.email_service, 'is_configured', lambda: configured)
+    return send_mock
+
+
+async def test_email_only_user_gets_receipt_by_email(monkeypatch):
+    """У покупателя нет Telegram (кабинет/лендинг) — чек уходит на почту файлом."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    monkeypatch.setattr(
+        'app.services.nalogo_service._download_receipt_file',
+        AsyncMock(return_value=(b'jpeg-bytes', 'image/jpeg; charset=binary')),
+    )
+    send_mock = _patch_email(monkeypatch)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=None,
+        user_email='buyer@example.com',
+    )
+
+    bot.send_photo.assert_not_awaited()
+    bot.send_message.assert_not_awaited()
+    send_mock.assert_called_once()
+    to_email, subject, body_html, body_text, attachments = send_mock.call_args.args
+    assert to_email == 'buyer@example.com'
+    assert 'Чек' in subject
+    assert '/print' in body_html
+    # charset-суффикс Content-Type отрезан, вложение — исходные байты чека
+    assert attachments == [('receipt_uuid-1.jpg', b'jpeg-bytes', 'image/jpeg')]
+
+
+async def test_blocked_bot_falls_back_to_email_from_db(monkeypatch):
+    """Юзер заблокировал бота — почту берём из БД, чек уходит письмом."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    _patch_user_lookup(
+        monkeypatch,
+        SimpleNamespace(first_name='Вася', last_name=None, username=None, email='vasya@example.com'),
+    )
+    send_mock = _patch_email(monkeypatch)
+    bot = _bot()
+    bot.send_message = AsyncMock(side_effect=TelegramForbiddenError(method=MagicMock(), message='blocked'))
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+    )
+
+    send_mock.assert_called_once()
+    assert send_mock.call_args.args[0] == 'vasya@example.com'
+    # файл не скачался (autouse-мок) — письмо уходит без вложений, только со ссылкой
+    assert send_mock.call_args.args[4] is None
+
+
+async def test_delivered_to_telegram_skips_email(monkeypatch):
+    """Чек дошёл в Telegram — письмо не дублируем."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None, raising=False)
+    _patch_user_lookup(monkeypatch, None)
+    send_mock = _patch_email(monkeypatch)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=111,
+        user_email='buyer@example.com',
+    )
+
+    assert bot.send_message.await_count == 1
+    send_mock.assert_not_called()
+
+
+async def test_email_not_sent_when_smtp_unconfigured(monkeypatch):
+    """SMTP не настроен — не падаем, чек остаётся хотя бы в админ-топике."""
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', '-100500', raising=False)
+    monkeypatch.setattr(settings, 'ADMIN_NOTIFICATIONS_NALOG_TOPIC_ID', None, raising=False)
+    send_mock = _patch_email(monkeypatch, configured=False)
+    bot = _bot()
+
+    await send_nalogo_receipt_notifications(
+        bot=bot,
+        nalogo_service=_nalogo(),
+        receipt_uuid='uuid-1',
+        amount_kopeks=10000,
+        telegram_user_id=None,
+        user_email='buyer@example.com',
+    )
+
+    send_mock.assert_not_called()
+    assert bot.send_message.await_count == 1  # админ-топик


### PR DESCRIPTION
## Проблема

Если чек NaloGO не удалось доставить пользователю в Telegram (у пользователя нет `telegram_id` — например, регистрация через кабинет по почте, — или бот заблокирован), чек просто не доходит до покупателя. Ссылка ФНС при этом у многих не открывается (клиенты сидят за VPN, `lknpd.nalog.ru` из-за рубежа недоступен).

## Решение

Доставка чека **на почту** как fallback, когда Telegram-доставка невозможна:

- Telegram доставлен → письмо **не** отправляется (без дублей).
- Telegram недоступен (нет `telegram_id` или `TelegramForbiddenError`/ошибка отправки) → письмо: печатная форма чека во вложении + ссылка ФНС (с оговоркой, что из-под VPN может не открыться).
- Адрес берётся из параметра `user_email` (прокинут из yookassa / guest purchase / очереди) или из БД по `telegram_user_id`.
- SMTP не настроен (`email_service.is_configured() == False`) → тихий скип, поведение как раньше.

## Изменения

- `app/services/nalogo_service.py` — хелпер `_send_receipt_email` + email-ветка в `send_nalogo_receipt_notifications`; параметр `user_email` в `create_receipt`/`_queue_receipt` (пишется в `receipt_data` очереди, старые записи очереди совместимы — ключ читается через `.get()`).
- `app/cabinet/services/email_service.py` — поддержка вложений в `send_email` (`attachments=[(filename, bytes, mimetype)]`, multipart/mixed).
- `app/services/payment/yookassa.py`, `guest_purchase_service.py`, `nalogo_queue_service.py` — прокидка `user_email`.
- `tests/services/test_nalogo_receipt_notifications.py` — 4 новых теста: email-only юзер получает письмо; заблокированный бот → fallback на почту из БД; доставлено в TG → письма нет; SMTP не настроен → письма нет.

## Тесты

`tests/services/test_nalogo_receipt_notifications.py` — 18 passed (на базе `dev`).

Проверено в проде на живой инсталляции: реальный чек ушёл письмом с целым вложением.

Независим от #3094 (фикс обрезанной печатной формы) — оба трогают один тестовый файл, при мерже второго перебазирую.
