### PR TITLE
fix(nalogo): печатная форма чека уходила клиенту обрезанной

### DIFF
--- a/app/services/nalogo_service.py
+++ b/app/services/nalogo_service.py
@@ -627,12 +627,21 @@ async def _download_receipt_file(receipt_url: str) -> tuple[bytes, str] | None:
                 logger.warning('Печатная форма чека NaloGO слишком велика', content_length=resp.content_length)
                 return None
 
-            # Читаем с запасом в 1 байт, чтобы отличить «ровно лимит» от «больше лимита»
-            data = await resp.content.read(_RECEIPT_MAX_BYTES + 1)
+            # resp.content.read(n) отдаёт лишь то, что уже накопилось в буфере
+            # (до n байт), не дожидаясь конца ответа — печатная форма уходила
+            # клиенту обрезанной (пустой/серый низ картинки). Читаем тело
+            # целиком по чанкам, лимит применяем по фактически прочитанному.
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.content.iter_chunked(64 * 1024):
+                total += len(chunk)
+                if total > _RECEIPT_MAX_BYTES:
+                    logger.warning('Печатная форма чека NaloGO превысила лимит при чтении')
+                    return None
+                chunks.append(chunk)
+
+            data = b''.join(chunks)
             if not data:
-                return None
-            if len(data) > _RECEIPT_MAX_BYTES:
-                logger.warning('Печатная форма чека NaloGO превысила лимит при чтении')
                 return None
 
             return data, content_type

--- a/tests/services/test_nalogo_receipt_notifications.py
+++ b/tests/services/test_nalogo_receipt_notifications.py
@@ -307,12 +307,41 @@ async def test_blocked_user_is_not_retried_as_message(monkeypatch):
     bot.send_message.assert_not_awaited()
 
 
+class _FakeStreamContent:
+    """Эмулирует aiohttp StreamReader реалистично: iter_chunked отдаёт тело
+    порциями сетевого размера (может не совпадать с размером, запрошенным
+    у read()), а read(n) — как настоящий aiohttp — возвращает ТОЛЬКО то, что
+    уже накопилось в буфере (первую порцию), а не всё тело. Это и есть
+    механизм регресса: код, вызывающий read(n) в расчёте «прочитает всё до
+    лимита», получает обрезанный файл.
+    """
+
+    def __init__(self, body: bytes, network_chunk_size: int = 8192):
+        self._body = body
+        self._network_chunk_size = network_chunk_size
+
+    async def iter_chunked(self, _requested_size: int):
+        for i in range(0, len(self._body), self._network_chunk_size):
+            yield self._body[i : i + self._network_chunk_size]
+
+    async def read(self, n: int) -> bytes:
+        return self._body[: min(n, self._network_chunk_size)]
+
+
 class _FakeResponse:
-    def __init__(self, *, status=200, content_type='image/jpeg', body=b'jpeg-bytes', content_length=None):
+    def __init__(
+        self,
+        *,
+        status=200,
+        content_type='image/jpeg',
+        body=b'jpeg-bytes',
+        content_length=None,
+        network_chunk_size=8192,
+    ):
         self.status = status
         self.headers = {'Content-Type': content_type}
         self.content_length = content_length if content_length is not None else len(body)
-        self.content = SimpleNamespace(read=AsyncMock(return_value=body))
+        self.content = _FakeStreamContent(body, network_chunk_size=network_chunk_size)
 
     async def __aenter__(self):
         return self
@@ -368,3 +397,23 @@ async def test_download_rejects_oversized_receipt(monkeypatch):
     # Content-Length занижен/отсутствует, но тело превышает лимит при чтении
     _patch_aiohttp(monkeypatch, _FakeResponse(body=b'x' * (_RECEIPT_MAX_BYTES + 1), content_length=0))
     assert await _REAL_DOWNLOAD('https://x/print') is None
+
+
+async def test_download_reads_full_body_not_just_first_network_chunk(monkeypatch):
+    """Регресс: resp.content.read(n) отдаёт только текущий буфер (первую
+    сетевую порцию), а не всё тело до n байт. Печатная форма чека приходила
+    клиенту физически обрезанной (валидный JPEG-заголовок, серый/пустой
+    низ картинки) — воспроизведено и подтверждено байтово в проде 20.07.2026.
+    Тело здесь специально больше одной сетевой порции (network_chunk_size),
+    чтобы старая реализация на read(n) вернула только её начало.
+    """
+    body = b'\xff\xd8' + b'X' * 50_000 + b'\xff\xd9'  # больше одного сетевого чанка
+    _patch_aiohttp(monkeypatch, _FakeResponse(body=body, network_chunk_size=8192))
+
+    result = await _REAL_DOWNLOAD('https://x/print')
+
+    assert result is not None
+    data, content_type = result
+    assert content_type == 'image/jpeg'
+    assert data == body, f'ожидали {len(body)} байт, получили {len(data)} — печатная форма чека обрезана'
+    assert data.endswith(b'\xff\xd9'), 'файл должен заканчиваться JPEG-маркером EOI, а не обрывом на первом чанке'


### PR DESCRIPTION
## Проблема

После #3087 печатная форма чека иногда уходила клиенту физически обрезанной: заголовок чека и часть таблицы видны, ниже — серое/пустое поле (типичная картина недокачанного JPEG).

## Причина

При доработке в abde46c `resp.read()` заменили на `resp.content.read(_RECEIPT_MAX_BYTES + 1)`. У aiohttp `StreamReader.read(n)` — контринтуитивная семантика: он возвращает то, что уже накопилось в буфере на момент вызова (до n байт), а не читает поток до n байт или до конца. На практике это первая пришедшая сетевая порция — оставшаяся часть тела просто отбрасывается.

Подтверждено байтово в проде: `curl` и открытие ссылки в браузере всегда отдавали целый файл (проверено на двух реальных чеках, включая повторное скачивание спустя 10+ минут), а бот отправлял ровно первые ~N КБ.

## Фикс

Читаем тело через `resp.content.iter_chunked()` до конца, лимит размера применяем по фактически накопленному объёму. Обе починки из abde46c (фолбэк на ссылку при отказе Telegram принять файл, отсев HTML-заглушки ФНС) не затронуты и продолжают работать.

## Тесты

Существующий `_FakeResponse.content.read()` в тестовом фейке всегда отдавал тело целиком — поэтому баг не ловился существующей сюитой. Расширил фейк (`_FakeStreamContent`) реалистичной посегментной эмуляцией, добавил `test_download_reads_full_body_not_just_first_network_chunk`. Проверил: новый тест красный на коде до фикса (получает ровно первую сетевую порцию, как в проде), зелёный после. Вся сюита (15 тестов) проходит, `ruff format` не требует изменений.

## Продовая проверка

Воспроизведено и починено в проде 20.07.2026: до фикса — два реальных платежа подряд с обрезанным чеком (скриншоты в переписке с автором #3082/#3087), после фикса — чек приходит целой картинкой.