### PR TITLE
fix(tickets): проверять блокировку поддержки и лимит открытых тикетов в кабинете

### DIFF
--- a/app/cabinet/routes/tickets.py
+++ b/app/cabinet/routes/tickets.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 from app.cabinet.routes.media import make_media_token
 from app.cabinet.routes.websocket import notify_admins_new_ticket, notify_admins_ticket_reply
 from app.config import settings
+from app.database.crud.ticket import TicketCRUD
 from app.database.crud.ticket_notification import TicketNotificationCRUD
 from app.database.models import Ticket, TicketMessage, User
 from app.handlers.tickets import notify_admins_about_new_ticket, notify_admins_about_ticket_reply
@@ -31,6 +32,34 @@ from ..schemas.tickets import (
 logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix='/tickets', tags=['Cabinet Tickets'])
+
+# Сентинел «вечной» блокировки из TicketCRUD.is_user_globally_blocked (datetime.max).
+_PERMANENT_BLOCK_YEAR = 9999
+
+
+def _ensure_tickets_enabled() -> None:
+    """Отказать, если тикеты выключены (режим поддержки ``contact``)."""
+    if not settings.is_support_tickets_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='Support tickets are disabled',
+        )
+
+
+async def _ensure_not_blocked(db: AsyncSession, user: User) -> None:
+    """Отказать, если пользователь заблокирован в поддержке.
+
+    Бот-путь (``app/handlers/tickets.py``) проверяет глобальную блокировку и при
+    создании тикета, и при ответе; кабинет её не проверял вовсе.
+    """
+    blocked_until = await TicketCRUD.is_user_globally_blocked(db, user.id)
+    if not blocked_until:
+        return
+    if blocked_until.year >= _PERMANENT_BLOCK_YEAR:
+        detail = 'You are blocked from contacting support'
+    else:
+        detail = f'You are blocked from contacting support until {blocked_until.strftime("%d.%m.%Y %H:%M")} UTC'
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
 
 def _message_to_response(message: TicketMessage) -> TicketMessageResponse:
@@ -90,12 +119,7 @@ async def get_tickets(
     db: AsyncSession = Depends(get_cabinet_db),
 ):
     """Get user's support tickets."""
-    # Check if tickets are enabled
-    if not settings.is_support_tickets_enabled():
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail='Support tickets are disabled',
-        )
+    _ensure_tickets_enabled()
 
     # Base query
     query = select(Ticket).where(Ticket.user_id == user.id).options(selectinload(Ticket.messages))
@@ -138,11 +162,14 @@ async def create_ticket(
     db: AsyncSession = Depends(get_cabinet_db),
 ):
     """Create a new support ticket."""
-    # Check if tickets are enabled
-    if not settings.is_support_tickets_enabled():
+    _ensure_tickets_enabled()
+    await _ensure_not_blocked(db, user)
+
+    # Один незакрытый тикет на пользователя — паритет с бот-путём
+    if await TicketCRUD.user_has_active_ticket(db, user.id):
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail='Support tickets are disabled',
+            status_code=status.HTTP_409_CONFLICT,
+            detail='You already have an open ticket',
         )
 
     # Create ticket
@@ -226,6 +253,8 @@ async def get_ticket(
     db: AsyncSession = Depends(get_cabinet_db),
 ):
     """Get ticket with all messages."""
+    _ensure_tickets_enabled()
+
     query = (
         select(Ticket).where(Ticket.id == ticket_id, Ticket.user_id == user.id).options(selectinload(Ticket.messages))
     )
@@ -263,6 +292,9 @@ async def add_ticket_message(
     db: AsyncSession = Depends(get_cabinet_db),
 ):
     """Add message to existing ticket."""
+    _ensure_tickets_enabled()
+    await _ensure_not_blocked(db, user)
+
     # Get ticket
     query = select(Ticket).where(Ticket.id == ticket_id, Ticket.user_id == user.id)
     result = await db.execute(query)

--- a/tests/cabinet/test_ticket_cabinet_guards.py
+++ b/tests/cabinet/test_ticket_cabinet_guards.py
@@ -1,0 +1,194 @@
+"""Кабинетные тикет-роуты обходили блокировку поддержки и лимит открытых тикетов.
+
+Бот-путь (``app/handlers/tickets.py``) перед созданием тикета проверяет две
+вещи через ``TicketCRUD``:
+
+* ``is_user_globally_blocked`` — админ мог заблокировать пользователя в
+  поддержке (навсегда или до даты);
+* ``user_has_active_ticket`` — один незакрытый тикет на пользователя.
+
+``app/cabinet/routes/tickets.py`` не проверял ни того, ни другого: единственным
+условием было ``settings.is_support_tickets_enabled()``. Заблокированный
+пользователь открывал кабинет и создавал тикеты пачками, лимит «один открытый
+тикет» тоже обходился.
+
+Дополнительно ``get_ticket`` и ``add_ticket_message`` вообще не смотрели на
+режим поддержки: при ``SUPPORT_SYSTEM_MODE=contact`` (тикеты выключены) список
+тикетов отдавал 403, а чтение конкретного тикета и дозапись в него продолжали
+работать.
+
+Тесты дёргают функции-роуты напрямую: guard'ы обязаны сработать до любых
+обращений к БД, поэтому ``db`` — простой ``AsyncMock``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.cabinet.routes import tickets as tickets_route
+from app.cabinet.schemas.tickets import TicketCreateRequest, TicketMessageCreateRequest
+from app.database.models import User
+
+
+PERMANENT_BLOCK = datetime.max.replace(tzinfo=UTC)
+
+
+@pytest.fixture
+def user() -> User:
+    return User(id=42, telegram_id=123456)
+
+
+@pytest.fixture
+def _tickets_enabled(monkeypatch) -> None:
+    """Режим поддержки с включёнными тикетами (дефолт ``both``)."""
+    monkeypatch.setattr(tickets_route.settings, 'SUPPORT_SYSTEM_MODE', 'both')
+
+
+@pytest.fixture
+def _tickets_disabled(monkeypatch) -> None:
+    """Режим ``contact`` — тикеты выключены."""
+    monkeypatch.setattr(tickets_route.settings, 'SUPPORT_SYSTEM_MODE', 'contact')
+
+
+def _patch_crud(monkeypatch, *, blocked_until=None, has_active: bool = False) -> None:
+    monkeypatch.setattr(
+        tickets_route.TicketCRUD,
+        'is_user_globally_blocked',
+        AsyncMock(return_value=blocked_until),
+    )
+    monkeypatch.setattr(
+        tickets_route.TicketCRUD,
+        'user_has_active_ticket',
+        AsyncMock(return_value=has_active),
+    )
+
+
+def _create_request() -> TicketCreateRequest:
+    return TicketCreateRequest(title='Не работает VPN', message='Помогите, пожалуйста')
+
+
+def _message_request() -> TicketMessageCreateRequest:
+    return TicketMessageCreateRequest(message='Есть новости?')
+
+
+# --- Блокировка в поддержке -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'blocked_until',
+    [
+        pytest.param(PERMANENT_BLOCK, id='permanent'),
+        pytest.param(datetime.now(UTC) + timedelta(days=3), id='temporary'),
+    ],
+)
+@pytest.mark.usefixtures('_tickets_enabled')
+async def test_create_ticket_rejects_blocked_user(monkeypatch, user, blocked_until):
+    """REGRESSION: заблокированный в поддержке пользователь не должен создавать
+    тикеты через кабинет — бот-путь его останавливает, кабинет пропускал."""
+    _patch_crud(monkeypatch, blocked_until=blocked_until)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.create_ticket(request=_create_request(), user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert 'blocked' in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.usefixtures('_tickets_enabled')
+async def test_add_message_rejects_blocked_user(monkeypatch, user):
+    """REGRESSION: дозапись в тикет тоже должна упираться в глобальную блокировку."""
+    _patch_crud(monkeypatch, blocked_until=PERMANENT_BLOCK)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.add_ticket_message(ticket_id=1, request=_message_request(), user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert 'blocked' in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.usefixtures('_tickets_enabled')
+async def test_expired_block_does_not_reject(monkeypatch, user):
+    """Истёкшая блокировка не считается: CRUD возвращает None, guard молчит."""
+    _patch_crud(monkeypatch, blocked_until=None)
+
+    await tickets_route._ensure_not_blocked(AsyncMock(), user)  # не должно бросить
+
+
+# --- Лимит «один открытый тикет» -------------------------------------------
+
+
+@pytest.mark.usefixtures('_tickets_enabled')
+async def test_create_ticket_rejects_second_open_ticket(monkeypatch, user):
+    """REGRESSION: второй незакрытый тикет через кабинет создать нельзя."""
+    _patch_crud(monkeypatch, has_active=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.create_ticket(request=_create_request(), user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
+    assert 'open ticket' in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.usefixtures('_tickets_enabled')
+async def test_add_message_not_limited_by_open_ticket_check(monkeypatch, user):
+    """Лимит открытых тикетов относится только к созданию: отвечать в свой
+    открытый тикет пользователь обязан мочь."""
+    _patch_crud(monkeypatch, has_active=True)
+    db = AsyncMock()
+    # scalar_one_or_none() синхронный — иначе AsyncMock вернёт корутину
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.add_ticket_message(ticket_id=1, request=_message_request(), user=user, db=db)
+
+    # 404 (а не 409) => guard'ы пройдены, дошли до поиска тикета
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+# --- Режим поддержки --------------------------------------------------------
+
+
+@pytest.mark.usefixtures('_tickets_disabled')
+async def test_get_ticket_respects_disabled_mode(user):
+    """REGRESSION: при SUPPORT_SYSTEM_MODE=contact чтение тикета должно давать
+    403, как и список тикетов, а не отдавать содержимое."""
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.get_ticket(ticket_id=1, user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == 'Support tickets are disabled'
+
+
+@pytest.mark.usefixtures('_tickets_disabled')
+async def test_add_message_respects_disabled_mode(user):
+    """REGRESSION: при выключенных тикетах дозапись в существующий тикет
+    должна отклоняться."""
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.add_ticket_message(ticket_id=1, request=_message_request(), user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == 'Support tickets are disabled'
+
+
+@pytest.mark.usefixtures('_tickets_disabled')
+async def test_create_ticket_respects_disabled_mode(user):
+    """Пин существующего поведения create_ticket."""
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.create_ticket(request=_create_request(), user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == 'Support tickets are disabled'
+
+
+@pytest.mark.usefixtures('_tickets_disabled')
+async def test_get_tickets_respects_disabled_mode(user):
+    """Пин существующего поведения списка тикетов."""
+    with pytest.raises(HTTPException) as exc_info:
+        await tickets_route.get_tickets(user=user, db=AsyncMock())
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == 'Support tickets are disabled'


### PR DESCRIPTION
## 🐛 Проблема

Кабинетные роуты тикетов не повторяют guard'ы бот-пути.
`app/handlers/tickets.py` перед созданием тикета спрашивает у `TicketCRUD`
`is_user_globally_blocked()` и `user_has_active_ticket()`, а
`app/cabinet/routes/tickets.py::create_ticket` проверяет только
`settings.is_support_tickets_enabled()`.

Следствия:

1. Пользователь, заблокированный админом в поддержке (`user_reply_block_permanent`
   / `user_reply_block_until`), открывает веб-кабинет и создаёт тикеты пачками.
   Бан в поддержке обходится полностью.
2. Лимит «один незакрытый тикет» тоже обходится через кабинет.
3. `get_ticket` и `add_ticket_message` вообще не смотрят на режим поддержки:
   при `SUPPORT_SYSTEM_MODE=contact` список тикетов отдаёт 403, а чтение
   конкретного тикета и дозапись в него продолжают работать.
4. `add_ticket_message` проверяет только per-ticket `is_reply_blocked`, но не
   глобальную блокировку пользователя.

## 🔄 Воспроизведение

1. Забанить пользователя в поддержке из админки бота (блокировка ответов).
2. В боте кнопка создания тикета отдаёт «Вы заблокированы».
3. `POST /api/cabinet/tickets` тем же пользователем — тикет создаётся.
4. Повторить — создаётся второй, третий и т.д.

## ✅ Фикс

- `_ensure_tickets_enabled()` — общий guard режима, применён во всех четырёх
  роутах (два существующих инлайн-вызова заменены на него);
- `_ensure_not_blocked()` — 403 для глобальной блокировки, с датой окончания
  в `detail` для временной; применён в `create_ticket` и `add_ticket_message`;
- `create_ticket` отдаёт 409, если незакрытый тикет уже есть.

Лимит открытых тикетов намеренно **не** применяется к `add_ticket_message`:
отвечать в собственный открытый тикет пользователь должен мочь.

## 🧪 Тесты

`tests/cabinet/test_ticket_cabinet_guards.py` — 10 тестов, роуты дёргаются
напрямую (guard'ы обязаны срабатывать до обращений к БД). 8 из них падают на
коде до фикса, 2 пинят существующее поведение.

Полный прогон: `2056 passed`. `ruff check` / `ruff format` — чисто.
