### PR TITLE
fix(support): синхронизировать persisted-режим поддержки в settings при старте

### DIFF
--- a/app/cabinet/routes/info.py
+++ b/app/cabinet/routes/info.py
@@ -351,8 +351,12 @@ async def update_user_language(
 @router.get('/support-config', response_model=SupportConfigResponse)
 async def get_support_config():
     """Get support/tickets configuration for cabinet."""
-    # Use SUPPORT_SYSTEM_MODE setting (configurable from admin panel)
-    support_mode = settings.get_support_system_mode()  # returns: tickets, contact, or both
+    # Режим берём через сервис: он владеет persisted-значением (data/support_settings.json)
+    # и синхронизирует его в settings. Чтение settings напрямую отдало бы значение
+    # из .env, если сервис в этом процессе ещё ни разу не загружался.
+    from app.services.support_settings_service import SupportSettingsService
+
+    support_mode = SupportSettingsService.get_system_mode()  # returns: tickets, contact, or both
 
     # Map support mode to support type for frontend
     # - "tickets" mode -> tickets only, no contact

--- a/app/services/support_settings_service.py
+++ b/app/services/support_settings_service.py
@@ -37,6 +37,31 @@ class SupportSettingsService:
             logger.error('Failed to load support settings', error=e)
             cls._data = {}
         cls._loaded = True
+        cls._sync_settings()
+
+    @classmethod
+    def _sync_settings(cls) -> None:
+        """Отзеркалить сохранённые значения в ``settings``.
+
+        Часть кода читает режим поддержки не через сервис, а напрямую из
+        ``settings`` — в первую очередь веб-кабинет
+        (``cabinet/routes/tickets.py``, ``cabinet/routes/info.py``).
+        ``set_system_mode`` обновлял ``settings`` в памяти, а ``_load`` при
+        старте — нет: после рестарта бот брал режим из JSON, а кабинет —
+        значение из ``.env``. Режим ``contact``, выставленный из админки бота,
+        переживал рестарт только для бота, и тикеты в кабинете снова
+        открывались.
+
+        JSON здесь — источник истины: он пишется только явным действием
+        админа, ``.env`` задаёт лишь начальное значение.
+        """
+        mode = cls._data.get('system_mode')
+        if isinstance(mode, str):
+            mode_clean = mode.strip().lower()
+            if mode_clean in {'tickets', 'contact', 'both'}:
+                settings.SUPPORT_SYSTEM_MODE = mode_clean
+        if 'menu_enabled' in cls._data:
+            settings.SUPPORT_MENU_ENABLED = bool(cls._data['menu_enabled'])
 
     @classmethod
     def _save(cls) -> bool:
@@ -62,7 +87,7 @@ class SupportSettingsService:
             return False
         cls._load()
         cls._data['system_mode'] = mode_clean
-        settings.SUPPORT_SYSTEM_MODE = mode_clean
+        cls._sync_settings()
         return cls._save()
 
     # Main menu visibility
@@ -77,6 +102,7 @@ class SupportSettingsService:
     def set_support_menu_enabled(cls, enabled: bool) -> bool:
         cls._load()
         cls._data['menu_enabled'] = bool(enabled)
+        cls._sync_settings()
         return cls._save()
 
     # Contact vs tickets helpers

--- a/tests/services/test_support_settings_sync.py
+++ b/tests/services/test_support_settings_sync.py
@@ -1,0 +1,113 @@
+"""Режим поддержки из JSON не доезжал до ``settings`` после рестарта.
+
+``SupportSettingsService`` хранит режим в ``data/support_settings.json``.
+``set_system_mode`` писал JSON *и* обновлял ``settings.SUPPORT_SYSTEM_MODE`` в
+памяти — поэтому в рамках одного запуска всё выглядело согласованно. Но
+``_load`` при старте поднимал JSON и ``settings`` не трогал.
+
+После рестарта источников истины становилось два:
+
+* бот читает режим через сервис — видит значение из JSON;
+* веб-кабинет (``cabinet/routes/tickets.py``, ``cabinet/routes/info.py``)
+  читает ``settings.is_support_tickets_enabled()`` — видит значение из ``.env``.
+
+Итог: режим ``contact``, выставленный из админки бота, после рестарта в
+кабинете игнорировался и тикеты снова открывались.
+
+Фикс: ``_load`` зеркалит persisted-значения в ``settings`` через
+``_sync_settings``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.config import settings
+from app.services.support_settings_service import SupportSettingsService
+
+
+@pytest.fixture
+def support_storage(tmp_path, monkeypatch):
+    """Изолированное JSON-хранилище + сброс кеша класса на каждый тест."""
+    storage = tmp_path / 'support_settings.json'
+    monkeypatch.setattr(SupportSettingsService, '_storage_path', storage)
+    monkeypatch.setattr(SupportSettingsService, '_data', {})
+    monkeypatch.setattr(SupportSettingsService, '_loaded', False)
+    monkeypatch.setattr(settings, 'SUPPORT_SYSTEM_MODE', 'both')
+    monkeypatch.setattr(settings, 'SUPPORT_MENU_ENABLED', True)
+    return storage
+
+
+def _simulate_restart(monkeypatch) -> None:
+    """Сбросить кеш класса, как при старте нового процесса."""
+    monkeypatch.setattr(SupportSettingsService, '_data', {})
+    monkeypatch.setattr(SupportSettingsService, '_loaded', False)
+
+
+def test_load_syncs_system_mode_into_settings(support_storage, monkeypatch):
+    """REGRESSION: persisted-режим должен доезжать до settings при загрузке —
+    иначе кабинет продолжает отдавать значение из .env."""
+    support_storage.write_text(json.dumps({'system_mode': 'contact'}), encoding='utf-8')
+
+    assert SupportSettingsService.get_system_mode() == 'contact'
+    assert settings.SUPPORT_SYSTEM_MODE == 'contact'
+    # Главное следствие: кабинетный guard тикетов теперь согласован с ботом
+    assert settings.is_support_tickets_enabled() is False
+
+
+def test_mode_survives_restart_for_cabinet(support_storage, monkeypatch):
+    """REGRESSION (сквозной сценарий): админ выключил тикеты в боте, бот
+    перезапустился — кабинет обязан по-прежнему считать тикеты выключенными."""
+    assert SupportSettingsService.set_system_mode('contact') is True
+    assert settings.is_support_tickets_enabled() is False
+
+    # Рестарт: settings поднимается из .env, кеш сервиса пуст
+    _simulate_restart(monkeypatch)
+    monkeypatch.setattr(settings, 'SUPPORT_SYSTEM_MODE', 'both')
+
+    SupportSettingsService._load()
+
+    assert settings.SUPPORT_SYSTEM_MODE == 'contact'
+    assert settings.is_support_tickets_enabled() is False
+
+
+def test_load_syncs_menu_enabled_into_settings(support_storage):
+    """REGRESSION: у menu_enabled была ровно та же проблема."""
+    support_storage.write_text(json.dumps({'menu_enabled': False}), encoding='utf-8')
+
+    assert SupportSettingsService.is_support_menu_enabled() is False
+    assert settings.SUPPORT_MENU_ENABLED is False
+
+
+def test_set_support_menu_enabled_syncs_settings(support_storage):
+    """Сеттер меню тоже обязан обновлять settings (раньше не обновлял вовсе)."""
+    assert SupportSettingsService.set_support_menu_enabled(False) is True
+    assert settings.SUPPORT_MENU_ENABLED is False
+
+
+def test_absent_json_keeps_env_value(support_storage):
+    """Без сохранённого значения settings остаётся как задан в .env."""
+    SupportSettingsService._load()
+
+    assert settings.SUPPORT_SYSTEM_MODE == 'both'
+    assert settings.SUPPORT_MENU_ENABLED is True
+
+
+def test_invalid_persisted_mode_does_not_clobber_settings(support_storage):
+    """Мусор в JSON не должен затирать settings невалидным режимом."""
+    support_storage.write_text(json.dumps({'system_mode': 'nonsense'}), encoding='utf-8')
+
+    assert SupportSettingsService.get_system_mode() == 'both'  # нормализация
+    assert settings.SUPPORT_SYSTEM_MODE == 'both'
+
+
+def test_corrupt_json_does_not_clobber_settings(support_storage, monkeypatch):
+    """Битый JSON: _load глотает ошибку, settings остаётся из .env."""
+    monkeypatch.setattr(settings, 'SUPPORT_SYSTEM_MODE', 'tickets')
+    support_storage.write_text('{not json', encoding='utf-8')
+
+    SupportSettingsService._load()
+
+    assert settings.SUPPORT_SYSTEM_MODE == 'tickets'


### PR DESCRIPTION
## 🐛 Проблема

`SupportSettingsService` хранит режим поддержки в `data/support_settings.json`.
`set_system_mode()` пишет JSON **и** обновляет `settings.SUPPORT_SYSTEM_MODE`
в памяти — поэтому в рамках одного запуска всё выглядит согласованно.
Но `_load()` при старте поднимает JSON и `settings` не трогает.

После рестарта источников истины становится два:

- бот читает режим через сервис — видит значение из JSON;
- веб-кабинет (`cabinet/routes/tickets.py`, `cabinet/routes/info.py`) читает
  `settings.is_support_tickets_enabled()` — видит значение из `.env`.

Итог: режим `contact`, выставленный из админки бота, после рестарта в кабинете
игнорируется и тикеты снова открыты.

У `menu_enabled` та же проблема, даже чуть хуже: `set_support_menu_enabled()`
не синхронизировал `settings` вовсе.

## 🔄 Воспроизведение

1. В админке бота выставить режим поддержки `contact`.
2. `GET /api/cabinet/info/support-config` → `tickets_enabled: false`. Ок.
3. Перезапустить бота.
4. Тот же запрос → `tickets_enabled: true`, `POST /api/cabinet/tickets` создаёт
   тикет, хотя тикеты выключены.

## ✅ Фикс

- `_sync_settings()` зеркалит `system_mode` и `menu_enabled` в `settings`;
  вызывается из `_load()` и из обоих сеттеров;
- невалидный режим и битый JSON не затирают значение из `.env`;
- `cabinet/routes/info.py::get_support_config` берёт режим через сервис.
  Загрузка ленивая, поэтому одной синхронизации в `_load()` мало: до первого
  обращения к сервису в процессе кабинет прочитал бы `.env`.

JSON здесь — источник истины: он пишется только явным действием админа,
`.env` задаёт лишь начальное значение.

## 📌 Смежное, вне scope

SLA-поля (`SUPPORT_TICKET_SLA_*`) намеренно не трогаю: там расхождение другого
рода — кабинет (`cabinet/routes/admin_tickets.py`) пишет их в `settings` и
`.env`, а бот-админка в JSON. Односторонняя синхронизация изменила бы
поведение кабинета, а не починила его.

Отдельно: дефолты SLA расходятся между `.env.example` (строки 27-34:
`SUPPORT_TICKET_SLA_ENABLED=false`, 60 минут) и `app/config.py` (строки 37-48:
`True`, 5 минут, интервал 60 сек). Кто поднимет бота без `.env`, получит спам
SLA-напоминаниями. Готов развести отдельным PR, если интересно.

## 🧪 Тесты

`tests/services/test_support_settings_sync.py` — 7 тестов, включая сквозной
сценарий «админ выключил тикеты → рестарт → кабинет всё ещё считает их
выключенными». 4 падают на коде до фикса, 3 — guard-rails.

Полный прогон: `2053 passed`. `ruff check` / `ruff format` — чисто.
