### PR TITLE
fix(support): отдавать внешний URL поддержки в конфиге кабинета

### DIFF
--- a/app/cabinet/routes/info.py
+++ b/app/cabinet/routes/info.py
@@ -103,6 +103,7 @@ class SupportConfigResponse(BaseModel):
     support_type: str  # "tickets", "profile", "url", "both"
     support_url: str | None = None
     support_username: str | None = None
+    contact_is_telegram: bool = False
 
 
 class InfoVisibilityResponse(BaseModel):
@@ -354,16 +355,24 @@ async def get_support_config():
     # Use SUPPORT_SYSTEM_MODE setting (configurable from admin panel)
     support_mode = settings.get_support_system_mode()  # returns: tickets, contact, or both
 
+    # SUPPORT_USERNAME принимает и @username, и произвольный URL (см.
+    # Settings.get_support_contact_url) — бот этим уже пользуется и вешает ссылку
+    # на кнопку «Связаться с поддержкой». Кабинет резолвит контакт тем же методом,
+    # чтобы внешний хелпдеск открывался одинаково в обеих поверхностях.
+    contact_url = settings.get_support_contact_url()
+    contact_is_telegram = settings.is_support_contact_telegram()
+
     # Map support mode to support type for frontend
     # - "tickets" mode -> tickets only, no contact
-    # - "contact" mode -> contact only (profile), no tickets
+    # - "contact" mode -> contact only, no tickets: "profile" для Telegram,
+    #   "url" для внешнего хелпдеска
     # - "both" mode -> tickets enabled, contact available as fallback
     if support_mode == 'tickets':
         tickets_enabled = True
         support_type = 'tickets'
     elif support_mode == 'contact':
         tickets_enabled = False
-        support_type = 'profile'
+        support_type = 'profile' if contact_is_telegram else 'url'
     else:  # both
         tickets_enabled = True
         support_type = 'both'
@@ -371,8 +380,11 @@ async def get_support_config():
     return SupportConfigResponse(
         tickets_enabled=tickets_enabled,
         support_type=support_type,
-        support_url=None,  # Cabinet doesn't use custom URLs
-        support_username=settings.SUPPORT_USERNAME,  # Always return for fallback
+        support_url=contact_url,
+        # Нормализованный вид (@user либо URL) — сырое значение могло бы прийти
+        # без схемы и клиент склеил бы из него битую t.me-ссылку.
+        support_username=settings.get_support_contact_display() or None,
+        contact_is_telegram=contact_is_telegram,
     )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -3402,6 +3402,25 @@ class Settings(BaseSettings):
 
         return None
 
+    def is_support_contact_telegram(self) -> bool:
+        """Резолвнутый контакт поддержки ведёт в Telegram, а не на внешний хелпдеск.
+
+        SUPPORT_USERNAME принимает и @username, и произвольный URL, поэтому клиенту
+        нужен явный признак: телеграм-ссылку открывают через openTelegramLink,
+        внешнюю — обычным переходом.
+        """
+        url = self.get_support_contact_url()
+
+        if not url:
+            return False
+
+        if url.startswith('tg://'):
+            return True
+
+        host = (urlparse(url).hostname or '').lower().removeprefix('www.')
+
+        return host in {'t.me', 'telegram.me', 'telegram.dog'}
+
     def get_support_contact_display(self) -> str:
         contact = self._clean_support_contact()
 

--- a/tests/cabinet/test_support_config_external_url.py
+++ b/tests/cabinet/test_support_config_external_url.py
@@ -1,0 +1,76 @@
+import pytest
+
+from app.config import settings
+
+
+TELEGRAM_CONTACT = '@help'
+EXTERNAL_CONTACT = 'https://help.example.com'
+
+
+async def _get_config(monkeypatch, mode: str, contact: str):
+    from app.cabinet.routes.info import get_support_config
+
+    monkeypatch.setattr(settings, 'SUPPORT_SYSTEM_MODE', mode, raising=False)
+    monkeypatch.setattr(settings, 'SUPPORT_USERNAME', contact, raising=False)
+
+    return await get_support_config()
+
+
+@pytest.mark.asyncio
+async def test_contact_mode_with_telegram_username(monkeypatch):
+    response = await _get_config(monkeypatch, 'contact', TELEGRAM_CONTACT)
+
+    assert response.tickets_enabled is False
+    assert response.support_type == 'profile'
+    assert response.support_url == 'https://t.me/help'
+    assert response.support_username == '@help'
+    assert response.contact_is_telegram is True
+
+
+@pytest.mark.asyncio
+async def test_contact_mode_with_external_url(monkeypatch):
+    response = await _get_config(monkeypatch, 'contact', EXTERNAL_CONTACT)
+
+    assert response.tickets_enabled is False
+    # Раньше здесь всегда был "profile", и клиент склеивал t.me/https://help...
+    assert response.support_type == 'url'
+    assert response.support_url == EXTERNAL_CONTACT
+    assert response.contact_is_telegram is False
+
+
+@pytest.mark.asyncio
+async def test_both_mode_exposes_external_url(monkeypatch):
+    response = await _get_config(monkeypatch, 'both', EXTERNAL_CONTACT)
+
+    assert response.tickets_enabled is True
+    assert response.support_type == 'both'
+    assert response.support_url == EXTERNAL_CONTACT
+    assert response.contact_is_telegram is False
+
+
+@pytest.mark.asyncio
+async def test_both_mode_with_telegram_username(monkeypatch):
+    response = await _get_config(monkeypatch, 'both', TELEGRAM_CONTACT)
+
+    assert response.tickets_enabled is True
+    assert response.support_type == 'both'
+    assert response.support_url == 'https://t.me/help'
+    assert response.contact_is_telegram is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('contact', [TELEGRAM_CONTACT, EXTERNAL_CONTACT])
+async def test_tickets_mode_ignores_contact(monkeypatch, contact):
+    response = await _get_config(monkeypatch, 'tickets', contact)
+
+    assert response.tickets_enabled is True
+    assert response.support_type == 'tickets'
+
+
+@pytest.mark.asyncio
+async def test_empty_contact_yields_no_url(monkeypatch):
+    response = await _get_config(monkeypatch, 'both', '')
+
+    assert response.support_url is None
+    assert response.support_username is None
+    assert response.contact_is_telegram is False

--- a/tests/test_support_contact_telegram.py
+++ b/tests/test_support_contact_telegram.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.config import settings
+
+
+@pytest.mark.parametrize(
+    'contact',
+    [
+        '@help',
+        'help',
+        't.me/help',
+        'https://t.me/help',
+        'https://www.t.me/help',
+        'telegram.me/help',
+        'https://telegram.dog/help',
+        'tg://resolve?domain=help',
+    ],
+)
+def test_telegram_contacts_detected(monkeypatch, contact):
+    monkeypatch.setattr(settings, 'SUPPORT_USERNAME', contact, raising=False)
+    assert settings.is_support_contact_telegram() is True
+
+
+@pytest.mark.parametrize(
+    'contact',
+    [
+        'https://help.example.com',
+        'http://help.example.com/support',
+        'help.example.com',
+        'https://example.com/t.me/help',
+    ],
+)
+def test_external_contacts_not_telegram(monkeypatch, contact):
+    monkeypatch.setattr(settings, 'SUPPORT_USERNAME', contact, raising=False)
+    assert settings.is_support_contact_telegram() is False
+
+
+@pytest.mark.parametrize('contact', ['', '   '])
+def test_empty_contact_is_not_telegram(monkeypatch, contact):
+    monkeypatch.setattr(settings, 'SUPPORT_USERNAME', contact, raising=False)
+    assert settings.is_support_contact_telegram() is False


### PR DESCRIPTION
## 📝 Описание

`SUPPORT_USERNAME` принимает не только `@username`, но и произвольный URL — `Settings.get_support_contact_url()` это уже разбирает, и бот вешает результат на кнопку «Связаться с поддержкой». Кабинет же в `/cabinet/info/support-config` отдавал `support_url=None` и сырой `SUPPORT_USERNAME`, из-за чего фронт склеивал `https://t.me/https://help.example.com` и ссылка на внешний хелпдеск ломалась.

Теперь кабинет резолвит контакт тем же методом, что и бот.

## 🎯 Мотивация

Расхождение паритета между ботом и кабинетом: одна и та же настройка работает в боте и не работает в вебе. Побочно оживает ветка `support_type === 'url'`, которая во фронте кабинета уже реализована, но до которой бэкенд никогда не доводил.

## 🔧 Что изменилось

- `Settings.is_support_contact_telegram()` — признак «резолвнутый контакт ведёт в Telegram». Использует уже импортированный `urlparse`, новых зависимостей нет.
- `get_support_config()`:
  - `support_url` заполняется всегда (было — жёстко `None`);
  - `support_username` отдаётся нормализованным (`get_support_contact_display()`), чтобы клиент не склеивал ссылку из значения без схемы;
  - в режиме `contact` внешний хелпдеск помечается `support_type='url'` вместо `'profile'`;
  - новое поле `contact_is_telegram`.

Про `contact_is_telegram`: в режиме `both` значение `support_type` не позволяет клиенту понять, открывать ссылку через `openTelegramLink` или обычным переходом. Разбирать URL на фронте значило бы продублировать логику бэка и завести ровно то расхождение, которое здесь и чинится. В режиме `contact` поле избыточно с `profile`/`url` — `support_type` оставлен нетронутым ради совместимости с уже задеплоенными кабинетами.

`SUPPORT_SYSTEM_MODE` намеренно не трогается: новые режимы не нужны, `contact` уже означает внешний канал.

## 🔄 Совместимость

| Комбинация | Поведение |
|---|---|
| Новый бэк + новый фронт | Работает полностью |
| Новый бэк + текущий фронт | Ветку `url` фронт уже умеет → режим `contact` чинится сам; в `both` остаётся прежнее поведение, регрессии нет |
| Старый бэк + новый фронт | `support_url` не приходит → фронт остаётся на текущей склейке |

Ломающих изменений нет: поле добавлено с дефолтом, `get_support_contact_url()` не менялся, поэтому бот и платёжные хендлеры с кнопкой «Обжаловать» не затронуты.

Полный фикс режима `both` требует правки `Support.tsx` в `bedolaga-cabinet` (перестать склеивать `t.me/` и ходить в `support_url`) — оформлю отдельным PR туда.

## 🔧 Тип изменений

- [x] Bug fix (исправление)
- [ ] New feature (новая функция)
- [ ] Breaking change (ломающие изменения)
- [ ] Documentation update (обновление документации)

## ✅ Чеклист

- [x] Код соответствует стандартам проекта (`ruff check`, `ruff format --check` — чисто)
- [x] Добавлены тесты
- [ ] Документация обновлена — не требуется, новых настроек нет
- [ ] Проверена работа в Docker — не проверялась, изменения не затрагивают сборку
- [x] Проверена совместимость с существующим API

## 🧪 Тестирование

- `tests/cabinet/test_support_config_external_url.py` — матрица 3 режима × Telegram/внешний URL.
- `tests/test_support_contact_telegram.py` — юнит-тесты хелпера (`@user`, `t.me/x`, `www.t.me/x`, `tg://`, внешний URL, пустое значение).

Локально: `2109 passed`.

## ⚠️ Пересечение

Затрагивает ту же функцию, что и #3098, но соседнюю строку (там — источник режима, здесь — тело ответа). Мержатся в любом порядке; готов отребейзить, если возникнет конфликт.
