### PR TITLE
ci(security): CodeQL + pip-audit + Trivy

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Еженедельный полный проход, чтобы ловить новые правила даже без коммитов.
+    - cron: "31 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -16,12 +16,16 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -88,6 +92,7 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -102,6 +107,26 @@ jobs:
             VCS_REF=${{ steps.version.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Trivy сканирует запушенный образ по digest и выгружает SARIF в
+      # Security → Code scanning (персистентные находки, в т.ч. на push в main,
+      # где Docker Scout не запускается). Пока non-blocking (exit-code: 0).
+      - name: Scan image with Trivy
+        if: steps.version.outputs.should_push == 'true'
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload Trivy results to Security tab
+        if: steps.version.outputs.should_push == 'true'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
 
       - name: Generate security report
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -113,7 +113,7 @@ jobs:
       # где Docker Scout не запускается). Пока non-blocking (exit-code: 0).
       - name: Scan image with Trivy
         if: steps.version.outputs.should_push == 'true'
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -28,16 +28,16 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Trivy results to Security tab
         if: steps.version.outputs.should_push == 'true'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,38 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: "31 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit (зависимости)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Sync dependencies (locked)
+        run: uv sync --frozen
+
+      # Аудит установленного окружения по базе OSV/PyPI Advisory.
+      # Пока non-blocking: сообщаем, но не валим пайплайн. Убрать
+      # continue-on-error, когда разгребём долги по зависимостям.
+      - name: Run pip-audit
+        continue-on-error: true
+        run: uv run --with pip-audit pip-audit --progress-spinner off

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
## Что добавляет

Дополняет уже настроенные `dependabot` (pip/actions/docker) и Docker Scout недостающими security-проверками. Все сканеры **non-blocking** — репортят, но сборку не роняют.

- **`codeql.yml`** — SAST для Python (набор `security-and-quality`) на push/PR в `main`/`dev` + еженедельный проход. Находки → Security → Code scanning.
- **`security-audit.yml`** — `pip-audit` по locked-окружению `uv` (`uv sync --frozen` → `uv run --with pip-audit pip-audit`), пока `continue-on-error`. Закрывает то, что dependabot не делает: проверку по базе известных CVE (OSV/PyPI Advisory), а не просто бамп версий.
- **`docker-registry.yml`** — добавлен Trivy: сканирует запушенный GHCR-образ по digest, SARIF выгружается в Security tab. Дополняет существующий Docker Scout — тот работает только на PR (комментарий), а Trivy даёт персистентные находки в т.ч. на push в `main`. `exit-code: 0` — сборку не валит. Плюс least-privilege `permissions`.

## Как ужесточить потом

- pip-audit: убрать `continue-on-error`.
- Trivy: `exit-code: 1` на HIGH/CRITICAL.

## Не входит (follow-up)

Bandit пропущен намеренно — его правила во многом покрывает CodeQL `security-and-quality`; можно добавить отдельно при желании.