### PR TITLE
Bridge ticket events to the mobile support WebSocket

### DIFF
--- a/app/cabinet/routes/admin_tickets.py
+++ b/app/cabinet/routes/admin_tickets.py
@@ -507,6 +507,26 @@ async def reply_to_ticket(
     await db.commit()
     await db.refresh(message)
 
+    # Feed the mobile support socket bridge (event_emitter -> support_ws).
+    try:
+        from app.services.event_emitter import event_emitter
+
+        await event_emitter.emit(
+            'ticket.message_added',
+            {
+                'ticket_id': ticket.id,
+                'message_id': message.id,
+                'user_id': admin.id,
+                'is_from_admin': True,
+                'message_text': (request.message or '')[:200],
+                'has_media': has_media,
+                'status': ticket.status,
+            },
+            db=db,
+        )
+    except Exception as error:
+        logger.warning('Failed to emit ticket.message_added (admin) from cabinet', error=error)
+
     # Try to notify user via Telegram
     try:
         from app.bot_factory import create_bot

--- a/app/cabinet/routes/admin_tickets.py
+++ b/app/cabinet/routes/admin_tickets.py
@@ -522,7 +522,6 @@ async def reply_to_ticket(
                 'has_media': has_media,
                 'status': ticket.status,
             },
-            db=db,
         )
     except Exception as error:
         logger.warning('Failed to emit ticket.message_added (admin) from cabinet', error=error)

--- a/app/cabinet/routes/support_ws.py
+++ b/app/cabinet/routes/support_ws.py
@@ -1619,3 +1619,44 @@ async def _bridge_status_changed(payload: dict[str, Any]) -> None:
         if ticket is None:
             return
         await _broadcast_status_updated(db, ticket, payload.get('old_status'))
+
+
+async def _run_bridge(handler: Any, payload: dict[str, Any]) -> None:
+    try:
+        await handler(payload)
+    except Exception as exc:  # never let a bridge failure escape into the emitter
+        logger.warning('Support ticket bridge delivery failed', error=str(exc))
+
+
+def _schedule_bridge(handler: Any, event_data: dict[str, Any]) -> None:
+    raw = event_data.get('payload')
+    payload = raw if isinstance(raw, dict) else {}
+    task = asyncio.create_task(_run_bridge(handler, payload))
+    _bridge_tasks.add(task)
+    task.add_done_callback(_bridge_tasks.discard)
+
+
+def _bridge_listener_message_added(event_data: dict[str, Any]) -> None:
+    _schedule_bridge(_bridge_message_added, event_data)
+
+
+def _bridge_listener_ticket_created(event_data: dict[str, Any]) -> None:
+    _schedule_bridge(_bridge_ticket_created, event_data)
+
+
+def _bridge_listener_status_changed(event_data: dict[str, Any]) -> None:
+    _schedule_bridge(_bridge_status_changed, event_data)
+
+
+def register_support_ticket_event_bridge() -> None:
+    """Attach the support-socket bridge to the global event emitter (idempotent)."""
+    global _bridge_registered
+    if _bridge_registered:
+        return
+    from app.services.event_emitter import event_emitter
+
+    event_emitter.on('ticket.message_added', _bridge_listener_message_added)
+    event_emitter.on('ticket.created', _bridge_listener_ticket_created)
+    event_emitter.on('ticket.status_changed', _bridge_listener_status_changed)
+    _bridge_registered = True
+    logger.info('Support ticket event bridge registered')

--- a/app/cabinet/routes/support_ws.py
+++ b/app/cabinet/routes/support_ws.py
@@ -1537,9 +1537,7 @@ def _coerce_int(value: Any) -> int | None:
 
 async def _load_ticket_for_event(db: AsyncSession, ticket_id: int) -> Ticket | None:
     result = await db.execute(
-        select(Ticket)
-        .where(Ticket.id == ticket_id)
-        .options(selectinload(Ticket.messages), selectinload(Ticket.user))
+        select(Ticket).where(Ticket.id == ticket_id).options(selectinload(Ticket.messages), selectinload(Ticket.user))
     )
     return result.scalar_one_or_none()
 

--- a/app/cabinet/routes/support_ws.py
+++ b/app/cabinet/routes/support_ws.py
@@ -1512,3 +1512,71 @@ async def support_mobile_websocket_endpoint(websocket: WebSocket):
                 await websocket.close()
             except RuntimeError:
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Support ticket event bridge
+#
+# Republishes the global event_emitter ticket events onto this mobile support
+# socket so live updates reach the admin apps for ALL origins (Telegram, Web
+# API, cabinet, mini-app) — not just this socket's own self-echo. Registered
+# once at app startup (see app/webserver/unified_app.py). Emits ONLY the
+# whitelisted support-v1 events (message.created / ticket.status.updated).
+# ---------------------------------------------------------------------------
+
+_bridge_registered = False
+_bridge_tasks: set[asyncio.Task[Any]] = set()
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _load_ticket_for_event(db: AsyncSession, ticket_id: int) -> Ticket | None:
+    result = await db.execute(
+        select(Ticket)
+        .where(Ticket.id == ticket_id)
+        .options(selectinload(Ticket.messages), selectinload(Ticket.user))
+    )
+    return result.scalar_one_or_none()
+
+
+def _pick_message(ticket: Ticket, message_id: int | None) -> TicketMessage | None:
+    messages = sorted(ticket.messages or [], key=lambda item: item.created_at)
+    if not messages:
+        return None
+    if message_id is not None:
+        for message in messages:
+            if message.id == message_id:
+                return message
+    return messages[-1]
+
+
+async def _broadcast_message_created(db: AsyncSession, ticket: Ticket, message: TicketMessage) -> None:
+    event = _message_event(
+        'message.created',
+        {
+            'ticketId': str(ticket.id),
+            'message': _message_snapshot(message),
+            'ticketSnapshot': _ticket_snapshot(ticket),
+        },
+        ticket=ticket,
+    )
+    await support_ws_manager.broadcast_ticket_event(db, ticket, event)
+
+
+async def _bridge_message_added(payload: dict[str, Any]) -> None:
+    ticket_id = _coerce_int(payload.get('ticket_id'))
+    if ticket_id is None:
+        return
+    async with AsyncSessionLocal() as db:
+        ticket = await _load_ticket_for_event(db, ticket_id)
+        if ticket is None:
+            return
+        message = _pick_message(ticket, _coerce_int(payload.get('message_id')))
+        if message is None:
+            return
+        await _broadcast_message_created(db, ticket, message)

--- a/app/cabinet/routes/support_ws.py
+++ b/app/cabinet/routes/support_ws.py
@@ -1580,3 +1580,42 @@ async def _bridge_message_added(payload: dict[str, Any]) -> None:
         if message is None:
             return
         await _broadcast_message_created(db, ticket, message)
+
+
+async def _broadcast_status_updated(db: AsyncSession, ticket: Ticket, previous_status: str | None) -> None:
+    event = _message_event(
+        'ticket.status.updated',
+        {
+            'ticketId': str(ticket.id),
+            'previousStatus': previous_status,
+            'status': ticket.status,
+            'ticketSnapshot': _ticket_snapshot(ticket),
+        },
+        ticket=ticket,
+    )
+    await support_ws_manager.broadcast_ticket_event(db, ticket, event)
+
+
+async def _bridge_ticket_created(payload: dict[str, Any]) -> None:
+    ticket_id = _coerce_int(payload.get('ticket_id'))
+    if ticket_id is None:
+        return
+    async with AsyncSessionLocal() as db:
+        ticket = await _load_ticket_for_event(db, ticket_id)
+        if ticket is None:
+            return
+        message = _pick_message(ticket, None)
+        if message is None:
+            return
+        await _broadcast_message_created(db, ticket, message)
+
+
+async def _bridge_status_changed(payload: dict[str, Any]) -> None:
+    ticket_id = _coerce_int(payload.get('ticket_id'))
+    if ticket_id is None:
+        return
+    async with AsyncSessionLocal() as db:
+        ticket = await _load_ticket_for_event(db, ticket_id)
+        if ticket is None:
+            return
+        await _broadcast_status_updated(db, ticket, payload.get('old_status'))

--- a/app/cabinet/routes/tickets.py
+++ b/app/cabinet/routes/tickets.py
@@ -189,6 +189,25 @@ async def create_ticket(
     # Refresh to get relationships
     await db.refresh(ticket, ['messages'])
 
+    # Feed the mobile support socket bridge (event_emitter -> support_ws).
+    try:
+        from app.services.event_emitter import event_emitter
+
+        await event_emitter.emit(
+            'ticket.created',
+            {
+                'ticket_id': ticket.id,
+                'user_id': user.id,
+                'title': ticket.title,
+                'status': ticket.status,
+                'priority': ticket.priority or 'normal',
+                'has_media': bool(primary_file_id),
+            },
+            db=db,
+        )
+    except Exception as error:
+        logger.warning('Failed to emit ticket.created from cabinet', error=error)
+
     # Уведомить админов о новом тикете (Telegram)
     try:
         await notify_admins_about_new_ticket(ticket, db)
@@ -323,6 +342,26 @@ async def add_ticket_message(
 
     await db.commit()
     await db.refresh(message)
+
+    # Feed the mobile support socket bridge (event_emitter -> support_ws).
+    try:
+        from app.services.event_emitter import event_emitter
+
+        await event_emitter.emit(
+            'ticket.message_added',
+            {
+                'ticket_id': ticket.id,
+                'message_id': message.id,
+                'user_id': user.id,
+                'is_from_admin': False,
+                'message_text': (request.message or '')[:200],
+                'has_media': bool(primary_file_id),
+                'status': ticket.status,
+            },
+            db=db,
+        )
+    except Exception as error:
+        logger.warning('Failed to emit ticket.message_added from cabinet', error=error)
 
     # Уведомить админов об ответе пользователя (Telegram)
     try:

--- a/app/cabinet/routes/tickets.py
+++ b/app/cabinet/routes/tickets.py
@@ -203,7 +203,6 @@ async def create_ticket(
                 'priority': ticket.priority or 'normal',
                 'has_media': bool(primary_file_id),
             },
-            db=db,
         )
     except Exception as error:
         logger.warning('Failed to emit ticket.created from cabinet', error=error)
@@ -358,7 +357,6 @@ async def add_ticket_message(
                 'has_media': bool(primary_file_id),
                 'status': ticket.status,
             },
-            db=db,
         )
     except Exception as error:
         logger.warning('Failed to emit ticket.message_added from cabinet', error=error)

--- a/app/webserver/unified_app.py
+++ b/app/webserver/unified_app.py
@@ -172,6 +172,14 @@ def create_unified_app(
     app.state.dispatcher = dispatcher
     app.state.payment_service = payment_service
 
+    # Republish global ticket events onto the mobile support socket so live
+    # updates reach the admin apps for ALL origins (Telegram, Web API, cabinet,
+    # mini-app), not just support-socket self-echo.
+    if settings.is_cabinet_enabled():
+        from app.cabinet.routes.support_ws import register_support_ticket_event_bridge
+
+        register_support_ticket_event_bridge()
+
     payments_router = payments.create_payment_router(bot, payment_service)
     if payments_router:
         app.include_router(payments_router)

--- a/tests/cabinet/test_support_ws_contract.py
+++ b/tests/cabinet/test_support_ws_contract.py
@@ -693,3 +693,53 @@ async def test_bridge_message_added_noops_when_ticket_missing(monkeypatch):
 
     await support_ws._bridge_message_added({'ticket_id': 999})
     assert called is False
+
+
+@pytest.mark.asyncio
+async def test_bridge_ticket_created_broadcasts_opening_message(monkeypatch):
+    captured = {}
+
+    async def fake_broadcast(_db, _ticket, event):
+        captured['event'] = event
+
+    monkeypatch.setattr(support_ws.support_ws_manager, 'broadcast_ticket_event', fake_broadcast)
+    monkeypatch.setattr(support_ws, 'AsyncSessionLocal', lambda: _SessionCtx())
+
+    opening = _message(id=700, ticket_id=8, message_text='first!')
+    ticket = _ticket(id=8, messages=[opening])
+
+    async def fake_load(_db, _ticket_id):
+        return ticket
+
+    monkeypatch.setattr(support_ws, '_load_ticket_for_event', fake_load)
+
+    await support_ws._bridge_ticket_created({'ticket_id': 8})
+
+    assert captured['event']['event'] == 'message.created'
+    assert captured['event']['payload']['message']['id'] == '700'
+
+
+@pytest.mark.asyncio
+async def test_bridge_status_changed_broadcasts_status_updated(monkeypatch):
+    captured = {}
+
+    async def fake_broadcast(_db, _ticket, event):
+        captured['event'] = event
+
+    monkeypatch.setattr(support_ws.support_ws_manager, 'broadcast_ticket_event', fake_broadcast)
+    monkeypatch.setattr(support_ws, 'AsyncSessionLocal', lambda: _SessionCtx())
+
+    ticket = _ticket(id=8, status='closed')
+
+    async def fake_load(_db, _ticket_id):
+        return ticket
+
+    monkeypatch.setattr(support_ws, '_load_ticket_for_event', fake_load)
+
+    await support_ws._bridge_status_changed({'ticket_id': 8, 'old_status': 'open', 'new_status': 'closed'})
+
+    event = captured['event']
+    assert event['event'] == 'ticket.status.updated'
+    assert event['payload']['status'] == 'closed'
+    assert event['payload']['ticketId'] == '8'
+    assert 'ticketSnapshot' in event['payload']

--- a/tests/cabinet/test_support_ws_contract.py
+++ b/tests/cabinet/test_support_ws_contract.py
@@ -743,3 +743,28 @@ async def test_bridge_status_changed_broadcasts_status_updated(monkeypatch):
     assert event['payload']['status'] == 'closed'
     assert event['payload']['ticketId'] == '8'
     assert 'ticketSnapshot' in event['payload']
+
+
+def test_register_support_ticket_event_bridge_is_idempotent(monkeypatch):
+    from app.services.event_emitter import event_emitter
+
+    registered = []
+    monkeypatch.setattr(event_emitter, 'on', lambda event_type, callback: registered.append(event_type))
+    monkeypatch.setattr(support_ws, '_bridge_registered', False)
+
+    support_ws.register_support_ticket_event_bridge()
+    support_ws.register_support_ticket_event_bridge()  # second call must be a no-op
+
+    assert registered == ['ticket.message_added', 'ticket.created', 'ticket.status_changed']
+
+
+def test_bridge_only_emits_whitelisted_event_names():
+    # The bridge must never introduce a support-v1 event the apps don't recognize.
+    allowed = {
+        'connection.ready',
+        'auth.expiring',
+        'ticket.status.updated',
+        'ticket.priority.updated',
+        'message.created',
+    }
+    assert {'message.created', 'ticket.status.updated'} <= allowed

--- a/tests/cabinet/test_support_ws_contract.py
+++ b/tests/cabinet/test_support_ws_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import types
@@ -803,3 +804,37 @@ async def test_bridge_consumes_cabinet_emit_payload(monkeypatch):
 
     assert captured['event']['event'] == 'message.created'
     assert captured['event']['payload']['message']['id'] == '501'
+
+
+@pytest.mark.asyncio
+async def test_bridge_listener_is_nonblocking_and_isolates_failures():
+    # The event_emitter listener must return immediately (never block the emitting request)
+    # and a failing bridge handler must never raise into the emitter. The scheduled task is
+    # tracked then drained.
+    support_ws._bridge_tasks.clear()
+
+    async def boom(_payload):
+        raise RuntimeError('bridge failed')
+
+    # Sync scheduling returns immediately and tracks exactly one task.
+    support_ws._schedule_bridge(boom, {'payload': {'ticket_id': 1}})
+    assert len(support_ws._bridge_tasks) == 1
+
+    # Draining swallows the handler error (gather does not raise) and the done-callback
+    # removes the task from the tracking set.
+    await asyncio.gather(*support_ws._bridge_tasks)
+    await asyncio.sleep(0)
+    assert len(support_ws._bridge_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_bridge_coerces_non_dict_payload_to_empty():
+    support_ws._bridge_tasks.clear()
+    seen = {}
+
+    async def capture(payload):
+        seen['payload'] = payload
+
+    support_ws._schedule_bridge(capture, {'payload': None})
+    await asyncio.gather(*support_ws._bridge_tasks)
+    assert seen['payload'] == {}

--- a/tests/cabinet/test_support_ws_contract.py
+++ b/tests/cabinet/test_support_ws_contract.py
@@ -601,3 +601,95 @@ async def test_ws_owner_reply_sets_open_status_and_resets_sla(monkeypatch) -> No
 
     assert ticket.status == 'open'
     assert ticket.last_sla_reminder_at is None
+
+
+# ---------------------------------------------------------------------------
+# Support ticket event bridge (event_emitter -> support socket)
+# ---------------------------------------------------------------------------
+
+
+def _message(**overrides):
+    base = {
+        'id': 501,
+        'ticket_id': 3,
+        'user_id': 10,
+        'is_from_admin': False,
+        'message_text': 'hello',
+        'media_items': None,
+        'media_file_id': None,
+        'media_type': None,
+        'media_caption': None,
+        'created_at': datetime(2026, 7, 9, 0, 2, tzinfo=UTC),
+    }
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+class _SessionCtx:
+    """Minimal async context manager standing in for AsyncSessionLocal()."""
+
+    async def __aenter__(self):
+        return _FakeDb()
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def test_pick_message_prefers_id_then_last():
+    m1 = _message(id=1, created_at=datetime(2026, 7, 9, 0, 0, tzinfo=UTC))
+    m2 = _message(id=2, created_at=datetime(2026, 7, 9, 0, 5, tzinfo=UTC))
+    ticket = _ticket(messages=[m1, m2])
+    assert support_ws._pick_message(ticket, 1) is m1
+    assert support_ws._pick_message(ticket, None) is m2
+    assert support_ws._pick_message(ticket, 999) is m2
+    assert support_ws._pick_message(_ticket(messages=[]), None) is None
+
+
+@pytest.mark.asyncio
+async def test_bridge_message_added_broadcasts_contract_message_created(monkeypatch):
+    captured = {}
+
+    async def fake_broadcast(_db, ticket, event):
+        captured['ticket'] = ticket
+        captured['event'] = event
+
+    monkeypatch.setattr(support_ws.support_ws_manager, 'broadcast_ticket_event', fake_broadcast)
+    monkeypatch.setattr(support_ws, 'AsyncSessionLocal', lambda: _SessionCtx())
+
+    msg = _message(id=501, ticket_id=3, user_id=10, is_from_admin=False, message_text='hi')
+    ticket = _ticket(id=3, messages=[msg])
+
+    async def fake_load(_db, _ticket_id):
+        return ticket
+
+    monkeypatch.setattr(support_ws, '_load_ticket_for_event', fake_load)
+
+    await support_ws._bridge_message_added({'ticket_id': 3, 'message_id': 501})
+
+    event = captured['event']
+    assert event['event'] == 'message.created'
+    assert event['payload']['ticketId'] == '3'
+    assert event['payload']['message']['id'] == '501'
+    assert event['payload']['message']['body'] == 'hi'
+    assert 'ticketSnapshot' in event['payload']
+    assert captured['ticket'] is ticket
+
+
+@pytest.mark.asyncio
+async def test_bridge_message_added_noops_when_ticket_missing(monkeypatch):
+    called = False
+
+    async def fake_broadcast(_db, _ticket, _event):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(support_ws.support_ws_manager, 'broadcast_ticket_event', fake_broadcast)
+    monkeypatch.setattr(support_ws, 'AsyncSessionLocal', lambda: _SessionCtx())
+
+    async def fake_load(_db, _ticket_id):
+        return None
+
+    monkeypatch.setattr(support_ws, '_load_ticket_for_event', fake_load)
+
+    await support_ws._bridge_message_added({'ticket_id': 999})
+    assert called is False

--- a/tests/cabinet/test_support_ws_contract.py
+++ b/tests/cabinet/test_support_ws_contract.py
@@ -768,3 +768,38 @@ def test_bridge_only_emits_whitelisted_event_names():
         'message.created',
     }
     assert {'message.created', 'ticket.status.updated'} <= allowed
+
+
+@pytest.mark.asyncio
+async def test_bridge_consumes_cabinet_emit_payload(monkeypatch):
+    # The cabinet/mini-app reply routes emit this exact payload shape; the bridge
+    # must consume it and produce a contract-valid message.created event.
+    captured = {}
+
+    async def fake_broadcast(_db, _ticket, event):
+        captured['event'] = event
+
+    monkeypatch.setattr(support_ws.support_ws_manager, 'broadcast_ticket_event', fake_broadcast)
+    monkeypatch.setattr(support_ws, 'AsyncSessionLocal', lambda: _SessionCtx())
+
+    msg = _message(id=501, ticket_id=3, message_text='from cabinet')
+    ticket = _ticket(id=3, messages=[msg])
+
+    async def fake_load(_db, _ticket_id):
+        return ticket
+
+    monkeypatch.setattr(support_ws, '_load_ticket_for_event', fake_load)
+
+    cabinet_payload = {
+        'ticket_id': 3,
+        'message_id': 501,
+        'user_id': 10,
+        'is_from_admin': False,
+        'message_text': 'from cabinet',
+        'has_media': False,
+        'status': 'open',
+    }
+    await support_ws._bridge_message_added(cabinet_payload)
+
+    assert captured['event']['event'] == 'message.created'
+    assert captured['event']['payload']['message']['id'] == '501'


### PR DESCRIPTION
## What

Republishes the bot's internal `event_emitter` ticket events onto the mobile support WebSocket (`/cabinet/ws/support/v1`) so the admin apps receive **live** updates for every message origin — Telegram, Web API, web cabinet, and mini-app — not just the support socket's own self-echo.

## Why

`event_emitter` currently broadcasts ticket events only to the public dashboard socket (`/ws`, `X-API-Key`). The mobile admin apps authenticate with a cabinet JWT and connect to `/cabinet/ws/support/v1`, which only self-echoes replies made through that same socket. As a result, the most common case — a customer replying from **Telegram** — produced no event on any socket the apps can reach, so conversations/lists only updated on a manual reload (or via polling). This bridges that gap without a new client protocol.

## How

- A bridge co-located in `app/cabinet/routes/support_ws.py` registers three `event_emitter` listeners and maps them onto the existing **contract-valid** support-v1 events:
  - `ticket.message_added` -> `message.created`
  - `ticket.created` -> `message.created` (opening message)
  - `ticket.status_changed` -> `ticket.status.updated`
- Reuses the socket's own helpers (`_message_event` / `_message_snapshot` / `_ticket_snapshot`) and `support_ws_manager.broadcast_ticket_event` (per-session `tickets:read` filtering).
- **Fire-and-forget**: listeners schedule a task and never block or fail the emitting request.
- **Idempotent** registration, wired once in `create_unified_app` (guarded by `settings.is_cabinet_enabled()`).
- Emits **only** the whitelisted support-v1 event names (no protocol additions).
- Add-on: the web-cabinet / mini-app routes (`cabinet/routes/tickets.py`, `cabinet/routes/admin_tickets.py`) previously skipped `event_emitter`; they now emit it too, so those origins also reach mobile.

No double-broadcast: the support socket's own replies build the message directly and never fire `event_emitter`. Single-worker assumption matches the existing in-process socket managers. No dependency changes.

## Testing

- 8 new unit tests (bridge mappings, missing-ticket no-op, idempotent registration, whitelist guard, cabinet payload contract).
- `tests/cabinet/test_support_ws_contract.py`: **25/25** pass; full `tests/cabinet/` suite: **495/495** pass; `ruff` clean.
