### PR TITLE
fix(settings): отображать DEVICES_SELECTION_DISABLED_AMOUNT как число, а не цену

### DIFF
--- a/app/services/system_settings_service.py
+++ b/app/services/system_settings_service.py
@@ -1227,7 +1227,9 @@ class BotConfigurationService:
         if isinstance(value, bool):
             return None
         upper_key = key.upper()
-        if any(suffix in upper_key for suffix in ('PRICE', '_KOPEKS', 'AMOUNT')):
+        # Денежные ключи содержат PRICE или оканчиваются на _KOPEKS; голое AMOUNT
+        # не признак цены (DEVICES_SELECTION_DISABLED_AMOUNT — количество устройств).
+        if any(suffix in upper_key for suffix in ('PRICE', '_KOPEKS')):
             try:
                 return settings.format_price(int(value))
             except Exception:

--- a/tests/services/test_settings_numeric_units.py
+++ b/tests/services/test_settings_numeric_units.py
@@ -1,0 +1,39 @@
+"""Regression tests for numeric unit formatting in the settings UI.
+
+``DEVICES_SELECTION_DISABLED_AMOUNT`` — это количество устройств, но эвристика
+``_format_numeric_with_unit`` считала любой ключ с подстрокой ``AMOUNT`` денежным
+и показывала его в рублях («3 ₽» вместо «3»). Все реальные денежные ключи содержат
+``PRICE`` или оканчиваются на ``_KOPEKS``, поэтому голое ``AMOUNT`` из эвристики
+убрано. Тесты пинят обе стороны: счётчик устройств — без валюты, деньги — с ₽.
+
+Regression cover for issue #1658.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.system_settings_service import bot_configuration_service as svc
+
+
+def test_devices_selection_disabled_amount_is_not_a_price() -> None:
+    assert svc.format_value_human('DEVICES_SELECTION_DISABLED_AMOUNT', 3) == '3'
+
+
+def test_devices_selection_disabled_amount_zero_stays_plain() -> None:
+    assert svc.format_value_human('DEVICES_SELECTION_DISABLED_AMOUNT', 0) == '0'
+
+
+@pytest.mark.parametrize(
+    'key',
+    [
+        'YOOKASSA_MIN_AMOUNT_KOPEKS',
+        'CLOUDPAYMENTS_MAX_AMOUNT_KOPEKS',
+        'REFERRAL_WITHDRAWAL_MIN_AMOUNT_KOPEKS',
+        'BASE_SUBSCRIPTION_PRICE',
+        'PRICE_30_DAYS',
+        'MIN_BALANCE_FOR_AUTOPAY_KOPEKS',
+    ],
+)
+def test_money_keys_keep_currency_formatting(key: str) -> None:
+    assert '₽' in svc.format_value_human(key, 5000)


### PR DESCRIPTION
## 📝 Описание

`DEVICES_SELECTION_DISABLED_AMOUNT` (лимит устройств при выключенном выборе количества) отображался в настройках как цена — «3 ₽» вместо «3».

Причина: эвристика `_format_numeric_with_unit` в `app/services/system_settings_service.py` считала денежным любой ключ с подстрокой `AMOUNT`. При этом все реальные денежные ключи либо содержат `PRICE`, либо оканчиваются на `_AMOUNT_KOPEKS` (их ловит проверка `_KOPEKS`) — голое `AMOUNT` встречается только у этого ключа-счётчика. Убрал `AMOUNT` из эвристики.

Fixes #1658

## 🎯 Мотивация

Целочисленный лимит устройств не должен показываться в рублях — это сбивает с толку при настройке (см. скриншоты в issue).

## 🔧 Тип изменений
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- Перед правкой прогрепал все ключи настроек: денежных ключей с голым `AMOUNT` (без `_KOPEKS`/`PRICE`) в конфиге нет — регресс форматирования цен исключён.
- Новые тесты `tests/services/test_settings_numeric_units.py`: `DEVICES_SELECTION_DISABLED_AMOUNT` со значениями 3 и 0 форматируется без валюты; денежные ключи (`*_AMOUNT_KOPEKS`, `BASE_SUBSCRIPTION_PRICE`, `PRICE_30_DAYS`, `MIN_BALANCE_FOR_AUTOPAY_KOPEKS`) по-прежнему показываются с ₽.
- `uv run ruff check` — без замечаний; `uv run pytest tests/ -q` — падений, связанных с правкой, нет (единственный фейл локально — POSIX-права в `test_store_certificate`, специфика запуска на Windows/NTFS).
