### PR TITLE
feat(remnawave): транслитерация кириллицы в username пользователя

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,63 @@ DEFAULT_DISPLAY_NAME_BANNED_KEYWORDS: list[str] = [
 
 USER_TAG_PATTERN = re.compile(r'^[A-Z0-9_]{1,16}$')
 
+# Транслитерация кириллицы для идентификаторов RemnaWave: панель принимает только
+# [A-Za-z0-9_-], поэтому без неё кириллические имена выпадают из username целиком.
+_CYRILLIC_TO_LATIN: dict[str, str] = {
+    'а': 'a',
+    'б': 'b',
+    'в': 'v',
+    'г': 'g',
+    'д': 'd',
+    'е': 'e',
+    'ё': 'e',
+    'ж': 'zh',
+    'з': 'z',
+    'и': 'i',
+    'й': 'y',
+    'к': 'k',
+    'л': 'l',
+    'м': 'm',
+    'н': 'n',
+    'о': 'o',
+    'п': 'p',
+    'р': 'r',
+    'с': 's',
+    'т': 't',
+    'у': 'u',
+    'ф': 'f',
+    'х': 'kh',
+    'ц': 'ts',
+    'ч': 'ch',
+    'ш': 'sh',
+    'щ': 'shch',
+    'ъ': '',
+    'ы': 'y',
+    'ь': '',
+    'э': 'e',
+    'ю': 'yu',
+    'я': 'ya',
+    'є': 'ie',
+    'і': 'i',
+    'ї': 'i',
+    'ґ': 'g',
+    'ў': 'u',
+}
+
+
+def transliterate_cyrillic(value: str) -> str:
+    """Заменяет кириллические буквы латинскими, сохраняя регистр («Шмель» → «Shmel»)."""
+    result: list[str] = []
+    for char in value:
+        mapped = _CYRILLIC_TO_LATIN.get(char.lower())
+        if mapped is None:
+            result.append(char)
+        elif char.isupper():
+            result.append(mapped.capitalize())
+        else:
+            result.append(mapped)
+    return ''.join(result)
+
 
 logger = structlog.get_logger(__name__)
 
@@ -1659,9 +1716,10 @@ class Settings(BaseSettings):
         username_clean = (username or '').lstrip('@')
         full_name_value = full_name or ''
 
-        # Remnawave разрешает только буквы, цифры, подчёркивания и дефисы
+        # Remnawave разрешает только буквы, цифры, подчёркивания и дефисы;
+        # кириллицу переводим в латиницу, чтобы имя не выпадало из username целиком.
         def _sanitize(value: str) -> str:
-            result = re.sub(r'[^0-9A-Za-z_-]+', '_', value)
+            result = re.sub(r'[^0-9A-Za-z_-]+', '_', transliterate_cyrillic(value))
             return re.sub(r'_+', '_', result).strip('_-')
 
         # Для email-пользователей формируем уникальный identifier

--- a/tests/services/test_remnawave_username.py
+++ b/tests/services/test_remnawave_username.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.config import settings
+from app.config import settings, transliterate_cyrillic
 
 
 # Note: эти тесты дёргают `format_remnawave_username` напрямую, поэтому
@@ -271,3 +271,55 @@ def test_skeleton_detector_uses_user_id_when_template_references_it(
     # And the rendered result must NOT be the user_<identifier> fallback shape,
     # which would have wiped the template's own structure.
     assert name.startswith('u_42')
+
+
+def test_cyrillic_full_name_is_transliterated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #1659: кириллица в {full_name} должна транслитерироваться, а не выпадать.
+
+    Раньше «Шмель Тим 1234567890» схлопывался до «1234567890» — все кириллические
+    символы заменялись на подчёркивания и вычищались.
+    """
+    monkeypatch.setattr(settings, 'REMNAWAVE_USER_USERNAME_TEMPLATE', '{full_name} {telegram_id}', raising=False)
+
+    name = settings.format_remnawave_username(
+        full_name='Шмель Тим',
+        username=None,
+        telegram_id=1234567890,
+    )
+
+    assert name == 'Shmel_Tim_1234567890'
+
+
+def test_ascii_full_name_stays_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Латинские имена не должны меняться транслитерацией."""
+    monkeypatch.setattr(settings, 'REMNAWAVE_USER_USERNAME_TEMPLATE', '{full_name} {telegram_id}', raising=False)
+
+    name = settings.format_remnawave_username(
+        full_name='Ivan Nginx',
+        username=None,
+        telegram_id=423839580,
+    )
+
+    assert name == 'Ivan_Nginx_423839580'
+
+
+def test_transliterate_cyrillic_preserves_case_and_non_cyrillic() -> None:
+    assert transliterate_cyrillic('Щука Юля-2 x') == 'Shchuka Yulya-2 x'
+    assert transliterate_cyrillic('подъезд') == 'podezd'
+    assert transliterate_cyrillic('no cyrillic') == 'no cyrillic'
+
+
+def test_transliterated_long_cyrillic_name_respects_max_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Транслитерация удлиняет строку (щ → shch) — итог всё равно должен влезать в лимит."""
+    monkeypatch.setattr(settings, 'REMNAWAVE_USER_USERNAME_TEMPLATE', '{full_name} {telegram_id}', raising=False)
+
+    name = settings.format_remnawave_username(
+        full_name='Щедрощащущевский Вячеслав Александрович',
+        username=None,
+        telegram_id=1234567890,
+    )
+
+    assert settings.REMNAWAVE_USERNAME_MIN_LENGTH <= len(name) <= settings.REMNAWAVE_USERNAME_MAX_LENGTH
+    assert all(ch.isalnum() or ch in {'_', '-'} for ch in name)


### PR DESCRIPTION
## 📝 Описание

Транслитерация кириллицы при формировании username для панели RemnaWave.

Панель принимает в username только `[A-Za-z0-9_-]`, поэтому кириллические значения переменных шаблона `REMNAWAVE_USER_USERNAME_TEMPLATE` (например `{full_name}`) выпадали целиком: «Шмель Тим 1234567890» превращался просто в `1234567890`. Теперь `_sanitize` внутри `format_remnawave_username` перед вычисткой переводит кириллицу в латиницу с сохранением регистра: «Шмель Тим 1234567890» → `Shmel_Tim_1234567890`.

Детали реализации:

- Таблица паспортного транслита в `app/config.py` (плюс украинские/белорусские буквы є, і, ї, ґ, ў), новых зависимостей нет.
- Латинские имена не меняются вообще.
- Транслитерация применяется внутри `_sanitize`, поэтому детектор «вырожденного» рендера (fallback на `user_<identifier>`) продолжает работать согласованно.
- Лимиты длины username (3..36) применяются после транслитерации — удлинение строки (щ → shch) не ломает валидацию панели.

Closes #1659

## 🎯 Мотивация

С шаблоном `{full_name} {telegram_id}` пользователи с кириллическими именами получают в панели безликие username из одного telegram_id, хотя имя можно сохранить транслитом (пример из issue: «Шмель Тим»).

## 🔧 Тип изменений
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- Новые тесты в `tests/services/test_remnawave_username.py`: кейс из issue («Шмель Тим» → `Shmel_Tim_1234567890`), неизменность латинских имён, сохранение регистра и не-кириллических символов, соблюдение лимита длины на длинном кириллическом ФИО.
- Существующие тесты username (граничные длины, email-пользователи, детектор вырожденного шаблона) проходят без изменений.
- `uv run ruff check` — без замечаний; `uv run pytest tests/ -q` — падений, связанных с правкой, нет (единственный фейл локально — POSIX-права в `test_store_certificate`, специфика запуска на Windows/NTFS).

Затронутые username: транслитерация меняет результат только для значений с кириллицей, которые раньше вычищались в `_` — существующие латинские username пользователей не пересчитываются и не меняются.
