### PR TITLE
fix(subscription): не показывать неоплаченный черновик платного триала как подписку

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2070,8 +2070,13 @@ class User(Base):
         for sub in self.subscriptions:
             if sub.status in (SubscriptionStatus.ACTIVE.value, SubscriptionStatus.TRIAL.value):
                 return sub
-        # Fallback to most recent (already ordered by created_at desc)
-        return self.subscriptions[0]
+        # Fallback to most recent real subscription (already ordered by created_at desc).
+        # Неоплаченные черновики триала пропускаем — иначе меню покажет незавершённую
+        # покупку триала как существующую подписку.
+        for sub in self.subscriptions:
+            if not sub.is_pending_trial:
+                return sub
+        return None
 
     def is_trial_already_used(self) -> bool:
         """Единый гейт доступности триала для бота И кабинета.
@@ -2084,9 +2089,7 @@ class User(Base):
         """
         if self.has_had_paid_subscription:
             return True
-        return any(
-            not (sub.status == SubscriptionStatus.PENDING.value and sub.is_trial) for sub in (self.subscriptions or [])
-        )
+        return any(not sub.is_pending_trial for sub in (self.subscriptions or []))
 
     transactions = relationship('Transaction', back_populates='user')
     referral_earnings = relationship('ReferralEarning', foreign_keys='ReferralEarning.user_id', back_populates='user')
@@ -2294,6 +2297,17 @@ class Subscription(Base):
         current_time = datetime.now(UTC)
         end = _aware(self.end_date)
         return self.status == SubscriptionStatus.ACTIVE.value and end is not None and end > current_time
+
+    @property
+    def is_pending_trial(self) -> bool:
+        """Неоплаченный черновик триала (PENDING + is_trial).
+
+        Такой драфт создаётся при выборе способа оплаты платного триала и означает
+        «повторную попытку оплаты», а не реальную подписку. Он не считается
+        использованным триалом (см. User.is_trial_already_used) и не должен
+        отображаться в пользовательских меню как существующая подписка.
+        """
+        return self.status == SubscriptionStatus.PENDING.value and bool(self.is_trial)
 
     @property
     def is_expired(self) -> bool:

--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -1386,6 +1386,8 @@ async def _get_multi_tariff_status(user, texts, db: AsyncSession) -> tuple[str, 
     from app.database.crud.subscription import get_all_subscriptions_by_user_id
 
     subscriptions = await get_all_subscriptions_by_user_id(db, user.id)
+    # Неоплаченные черновики триала не показываем как существующую подписку
+    subscriptions = [sub for sub in subscriptions if not getattr(sub, 'is_pending_trial', False)]
 
     if not subscriptions:
         return texts.t('SUB_STATUS_NONE', '❌ Отсутствует'), ''

--- a/app/utils/rich_menu.py
+++ b/app/utils/rich_menu.py
@@ -500,6 +500,8 @@ async def build_main_menu_rich_html(user: User, texts, db: AsyncSession) -> str:
     if settings.is_multi_tariff_enabled():
         heading = texts.t('MAIN_MENU_RICH_SUBSCRIPTIONS_HEADING', '📱 Подписки')
         subscriptions = await get_all_subscriptions_by_user_id(db, user.id)
+        # Неоплаченные черновики триала не показываем как существующую подписку
+        subscriptions = [sub for sub in subscriptions if not getattr(sub, 'is_pending_trial', False)]
         subscription_block = _build_subscriptions_table(subscriptions, texts)
         if len(subscriptions) > 1 and settings.MAIN_MENU_RICH_SUBSCRIPTIONS_COLLAPSIBLE:
             # Несколько подписок раздувают меню — сворачиваем таблицу в details;

--- a/tests/database/crud/test_subscription.py
+++ b/tests/database/crud/test_subscription.py
@@ -233,3 +233,34 @@ def test_is_trial_already_used_gate():
     # не платил, PENDING-триал (повторная попытка оплаты) → можно
     pending_trial = Subscription(status=SubscriptionStatus.PENDING.value, is_trial=True)
     assert _user(False, pending_trial).is_trial_already_used() is False
+
+
+def test_subscription_property_ignores_pending_trial_draft():
+    """Незавершённый платный триал не должен подставляться как основная подписка.
+
+    Регрессия: после «Назад» с экрана оплаты платного триала в меню оставался
+    PENDING-черновик, и подписка выглядела купленной.
+    """
+    from app.database.models import Subscription, SubscriptionStatus, User
+
+    def _user(*subs):
+        u = User(has_had_paid_subscription=False)
+        u.subscriptions = list(subs)
+        return u
+
+    pending_trial = Subscription(status=SubscriptionStatus.PENDING.value, is_trial=True)
+    active = Subscription(status=SubscriptionStatus.ACTIVE.value, is_trial=False)
+    expired = Subscription(status=SubscriptionStatus.EXPIRED.value, is_trial=False)
+
+    # предикат
+    assert pending_trial.is_pending_trial is True
+    assert active.is_pending_trial is False
+    # PENDING-триал (не оплачен) как non-trial не считается
+    assert Subscription(status=SubscriptionStatus.PENDING.value, is_trial=False).is_pending_trial is False
+
+    # только незавершённый триал → «подписки нет»
+    assert _user(pending_trial).subscription is None
+    # активная подписка имеет приоритет
+    assert _user(active, pending_trial).subscription is active
+    # истёкшая подписка (для продления) показывается, черновик триала — нет
+    assert _user(pending_trial, expired).subscription is expired


### PR DESCRIPTION
## 📝 Описание
При выборе способа оплаты платного триала создаётся PENDING-подписка
(`is_trial=True`) — она нужна как payload для платежа. Если пользователь не
оплачивает и жмёт «Назад», этот черновик оставался в списке подписок, и главное
меню показывало его как существующую/купленную подписку:
- мультитариф-статус: `🔴 <тариф> — до <дата> (N дн.)`;
- rich-меню: `⏳ Ожидает`.

При этом гейт доступности триала `is_trial_already_used()` такие черновики уже
игнорирует — поведение было несогласованным.

## 🎯 Мотивация
Пользователь, начавший оформление платного триала и передумавший, видит, будто
триал уже куплен. Баг чисто визуальный, но подрывает доверие и путает.
Воспроизведение: «Активировать триал» → выбрать способ оплаты → не оплачивать →
«Назад» → в меню появляется строка подписки.

## 🔧 Тип изменений
- [x] Bug fix (исправление)
- [ ] New feature (новая функция)
- [ ] Breaking change (ломающие изменения)
- [ ] Documentation update (обновление документации)

## ✅ Что сделано
- Добавлен предикат `Subscription.is_pending_trial` (PENDING + `is_trial`).
- `User.subscription` в фолбэке пропускает неоплаченные черновики триала.
- `is_trial_already_used()` переведён на тот же предикат (поведение идентично).
- Черновики скрыты в мультитариф-статусе (`menu.py`) и rich-меню (`rich_menu.py`).
- Добавлен регресс-тест.

## 🧪 Тестирование
- [x] Локальные тесты: test_subscription, test_rich_menu, test_menu_subscription_status,
      test_trial_activation_paid, test_trial_disabled_menu_gating,
      test_start_menu_text_consistency — 61 passed + новый тест.
- [ ] Проверка с реальным Remnawave API (не требуется — доступ не затрагивается)
