### PR TITLE
feat(menu): кнопка «Меню» Telegram открывает веб-кабинет (WebApp)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1016,6 +1016,15 @@ MINIAPP_SERVICE_NAME_RU=Bedolaga VPN
 MINIAPP_SERVICE_DESCRIPTION_EN=Secure & Fast Connection
 MINIAPP_SERVICE_DESCRIPTION_RU=Безопасное и быстрое подключение
 
+# Нижняя кнопка «Меню» в Telegram открывает веб-кабинет (WebApp).
+# Бот при этом продолжает работать через обычные сообщения и inline-кнопки.
+# При false существующая кнопка меню не трогается.
+MENU_BUTTON_WEBAPP_ENABLED=false
+# Текст кнопки меню
+MENU_BUTTON_WEBAPP_TEXT=Кабинет
+# URL веб-кабинета (только https). Пусто → используется MINIAPP_CUSTOM_URL
+MENU_BUTTON_WEBAPP_URL=
+
 # Параметры режима happ_cryptolink
 CONNECT_BUTTON_HAPP_DOWNLOAD_ENABLED=false
 HAPP_DOWNLOAD_LINK_IOS=

--- a/app/config.py
+++ b/app/config.py
@@ -1065,6 +1065,13 @@ class Settings(BaseSettings):
     # достаточно MINIAPP_CUSTOM_URL. Пусто → в группах кнопка кабинета не строится.
     MINIAPP_APP_SHORT_NAME: str = ''
 
+    # Нижняя кнопка «Меню» в Telegram → открытие веб-кабинета (WebApp).
+    # Бот при этом продолжает работать через обычные сообщения/кнопки. При
+    # выключенной опции существующая кнопка меню не трогается.
+    MENU_BUTTON_WEBAPP_ENABLED: bool = False
+    MENU_BUTTON_WEBAPP_TEXT: str = 'Кабинет'
+    MENU_BUTTON_WEBAPP_URL: str = ''  # пусто → берётся MINIAPP_CUSTOM_URL
+
     # Media upload settings (news article images/videos)
     MEDIA_UPLOAD_DIR: str = './uploads'
     MEDIA_MAX_IMAGE_SIZE_MB: int = 10

--- a/app/utils/chat_menu_button.py
+++ b/app/utils/chat_menu_button.py
@@ -1,0 +1,51 @@
+"""Настройка нижней кнопки «Меню» Telegram на открытие веб-кабинета (WebApp).
+
+Кнопка меню (setChatMenuButton без chat_id) — глобальная для всех личных чатов,
+поэтому выставляется один раз при старте бота. Бот продолжает работать через
+обычные сообщения и inline-кнопки; кнопка меню лишь даёт быстрый вход в кабинет.
+"""
+
+import structlog
+from aiogram import Bot
+from aiogram.types import MenuButtonWebApp, WebAppInfo
+
+from app.config import settings
+
+
+logger = structlog.get_logger(__name__)
+
+
+def _resolve_menu_button_url() -> str | None:
+    """URL веб-кабинета для WebApp-кнопки меню, либо None.
+
+    None означает «не настраивать кнопку»: функция выключена, URL не задан или не
+    https (Telegram принимает только https для WebApp).
+    """
+    if not settings.MENU_BUTTON_WEBAPP_ENABLED:
+        return None
+    url = (settings.MENU_BUTTON_WEBAPP_URL or '').strip() or (settings.MINIAPP_CUSTOM_URL or '').strip()
+    if not url.lower().startswith('https://'):
+        return None
+    return url
+
+
+async def configure_chat_menu_button(bot: Bot) -> bool:
+    """Выставляет кнопку меню на открытие веб-кабинета. Возвращает True, если выставлена.
+
+    Если опция выключена или URL кабинета не задан/не https — ничего не делает и
+    возвращает False (существующую кнопку меню не трогаем). Ошибки Telegram API не
+    роняют старт бота.
+    """
+    url = _resolve_menu_button_url()
+    if not url:
+        return False
+
+    text = (settings.MENU_BUTTON_WEBAPP_TEXT or 'Кабинет').strip() or 'Кабинет'
+    try:
+        await bot.set_chat_menu_button(menu_button=MenuButtonWebApp(text=text, web_app=WebAppInfo(url=url)))
+    except Exception as error:
+        logger.error('Не удалось настроить кнопку меню Telegram (WebApp)', error=error)
+        return False
+
+    logger.info('Кнопка меню Telegram настроена на веб-кабинет', url=url, text=text)
+    return True

--- a/main.py
+++ b/main.py
@@ -309,6 +309,10 @@ async def main():
             settings.BOT_USERNAME = bot_user.username
             logger.info('BOT_USERNAME auto-detected', bot_username=bot_user.username)
 
+        from app.utils.chat_menu_button import configure_chat_menu_button
+
+        await configure_chat_menu_button(bot)
+
         monitoring_service.bot = bot
         maintenance_service.set_bot(bot)
         broadcast_service.set_bot(bot)

--- a/tests/utils/test_chat_menu_button.py
+++ b/tests/utils/test_chat_menu_button.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from app.utils.chat_menu_button import configure_chat_menu_button
+
+
+def _fake_settings(**overrides):
+    base = {
+        'MENU_BUTTON_WEBAPP_ENABLED': True,
+        'MENU_BUTTON_WEBAPP_URL': 'https://cab.example.com',
+        'MENU_BUTTON_WEBAPP_TEXT': 'Кабинет',
+        'MINIAPP_CUSTOM_URL': '',
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+async def test_disabled_does_not_touch_menu_button(monkeypatch):
+    monkeypatch.setattr('app.utils.chat_menu_button.settings', _fake_settings(MENU_BUTTON_WEBAPP_ENABLED=False))
+    bot = AsyncMock()
+    assert await configure_chat_menu_button(bot) is False
+    bot.set_chat_menu_button.assert_not_awaited()
+
+
+async def test_enabled_sets_webapp_menu_button(monkeypatch):
+    from aiogram.types import MenuButtonWebApp
+
+    monkeypatch.setattr('app.utils.chat_menu_button.settings', _fake_settings())
+    bot = AsyncMock()
+
+    assert await configure_chat_menu_button(bot) is True
+    bot.set_chat_menu_button.assert_awaited_once()
+    button = bot.set_chat_menu_button.await_args.kwargs['menu_button']
+    assert isinstance(button, MenuButtonWebApp)
+    assert button.web_app.url == 'https://cab.example.com'
+    assert button.text == 'Кабинет'
+
+
+async def test_falls_back_to_miniapp_custom_url(monkeypatch):
+    monkeypatch.setattr(
+        'app.utils.chat_menu_button.settings',
+        _fake_settings(MENU_BUTTON_WEBAPP_URL='', MINIAPP_CUSTOM_URL='https://miniapp.example.com'),
+    )
+    bot = AsyncMock()
+
+    assert await configure_chat_menu_button(bot) is True
+    button = bot.set_chat_menu_button.await_args.kwargs['menu_button']
+    assert button.web_app.url == 'https://miniapp.example.com'
+
+
+async def test_non_https_url_is_skipped(monkeypatch):
+    monkeypatch.setattr(
+        'app.utils.chat_menu_button.settings',
+        _fake_settings(MENU_BUTTON_WEBAPP_URL='http://insecure.example', MINIAPP_CUSTOM_URL=''),
+    )
+    bot = AsyncMock()
+
+    assert await configure_chat_menu_button(bot) is False
+    bot.set_chat_menu_button.assert_not_awaited()
+
+
+async def test_empty_text_defaults(monkeypatch):
+    monkeypatch.setattr('app.utils.chat_menu_button.settings', _fake_settings(MENU_BUTTON_WEBAPP_TEXT='  '))
+    bot = AsyncMock()
+
+    assert await configure_chat_menu_button(bot) is True
+    button = bot.set_chat_menu_button.await_args.kwargs['menu_button']
+    assert button.text == 'Кабинет'


### PR DESCRIPTION
## 📝 Описание
Добавлена опциональная настройка нижней кнопки «Меню» в Telegram
(`setChatMenuButton`) на открытие веб-кабинета как **WebApp**. Бот продолжает
работать через обычные сообщения и inline-кнопки — кнопка меню лишь даёт
быстрый вход в кабинет.

Настройка глобальная (для всех личных чатов), поэтому выставляется один раз при
старте бота (после `get_me()`), в новом модуле `app/utils/chat_menu_button.py`.

## 🎯 Мотивация
Частый запрос: чтобы у бота внизу была кнопка, открывающая веб-версию кабинета,
но при этом бот оставался полноценно управляемым через Telegram.

## 🔧 Тип изменений
- [ ] Bug fix (исправление)
- [x] New feature (новая функция)
- [ ] Breaking change (ломающие изменения)
- [ ] Documentation update (обновление документации)

## ⚙️ Настройки (.env)
- `MENU_BUTTON_WEBAPP_ENABLED` — по умолчанию `false`; при выключенной опции
  существующая кнопка меню **не трогается** (не клоббрит ручную настройку из BotFather).
- `MENU_BUTTON_WEBAPP_TEXT` — текст кнопки (по умолчанию «Кабинет»).
- `MENU_BUTTON_WEBAPP_URL` — https-URL кабинета; пусто → берётся `MINIAPP_CUSTOM_URL`.

## 🛡 Поведение
- URL валидируется как `https://` (требование Telegram для WebApp); иначе кнопка
  не выставляется, пишется предупреждение.
- Ошибки Telegram API при установке кнопки не роняют старт бота.
- Кабинет уже умеет авторизоваться как Telegram WebApp (init data), так что
  открытие через кнопку меню работает из коробки.

## 🧪 Тестирование
- [x] Юнит-тесты `tests/utils/test_chat_menu_button.py` (enabled/disabled,
      fallback на `MINIAPP_CUSTOM_URL`, отсев non-https, дефолт текста) — 5 passed.
- [ ] Проверка на реальном боте (установка кнопки/открытие кабинета)
