### PR TITLE
feat(tariff): прямая оплата тарифа без отдельного шага пополнения баланса

### DIFF
--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -350,13 +350,35 @@ def get_tariff_insufficient_balance_keyboard(
     tariff_id: int,
     period: int,
     language: str,
+    missing_kopeks: int = 0,
 ) -> InlineKeyboardMarkup:
-    """Создает клавиатуру при недостаточном балансе."""
+    """Создает клавиатуру при недостаточном балансе.
+
+    Если включена автопокупка после пополнения (AUTO_PURCHASE_AFTER_TOPUP_ENABLED),
+    показываем способы оплаты сразу, предзаполненные ровно недостающей суммой: после
+    оплаты подписка оформится автоматически, без отдельного шага «Пополнить баланс».
+    Иначе оставляем классический переход в пополнение баланса.
+    """
     texts = get_texts(language)
+    back_button = InlineKeyboardButton(text=texts.BACK, callback_data=f'tariff_select:{tariff_id}')
+
+    if settings.is_auto_purchase_after_topup_enabled() and missing_kopeks > 0:
+        from app.keyboards.inline import get_payment_methods_keyboard
+
+        # Оставляем только кнопки прямой оплаты (topup_amount|метод|сумма), отбрасывая
+        # навигацию клавиатуры пополнения — возврат ведём к выбору тарифа.
+        payment_rows = [
+            row
+            for row in get_payment_methods_keyboard(missing_kopeks, language).inline_keyboard
+            if row and all((button.callback_data or '').startswith('topup_amount|') for button in row)
+        ]
+        if payment_rows:
+            return InlineKeyboardMarkup(inline_keyboard=[*payment_rows, [back_button]])
+
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text=texts.t('BALANCE_TOPUP', '💳 Пополнить баланс'), callback_data='balance_topup')],
-            [InlineKeyboardButton(text=texts.BACK, callback_data=f'tariff_select:{tariff_id}')],
+            [back_button],
         ]
     )
 
@@ -1522,7 +1544,9 @@ async def select_tariff_period(
                 'TARIFF_PURCHASE_CART_SAVED_HINT',
                 '\n\n🛒 <i>Корзина сохранена! После пополнения баланса подписка будет оформлена автоматически.</i>',
             ),
-            reply_markup=get_tariff_insufficient_balance_keyboard(tariff_id, period, db_user.language),
+            reply_markup=get_tariff_insufficient_balance_keyboard(
+                tariff_id, period, db_user.language, missing_kopeks=missing
+            ),
             parse_mode='HTML',
         )
 
@@ -5094,7 +5118,9 @@ async def return_to_saved_tariff_cart(
                     balance=format_price_kopeks(user_balance),
                     missing=format_price_kopeks(missing),
                 ),
-                reply_markup=get_tariff_insufficient_balance_keyboard(tariff_id, period, db_user.language),
+                reply_markup=get_tariff_insufficient_balance_keyboard(
+                    tariff_id, period, db_user.language, missing_kopeks=missing
+                ),
                 parse_mode='HTML',
             )
         else:  # tariff_purchase
@@ -5115,7 +5141,9 @@ async def return_to_saved_tariff_cart(
                     balance=format_price_kopeks(user_balance),
                     missing=format_price_kopeks(missing),
                 ),
-                reply_markup=get_tariff_insufficient_balance_keyboard(tariff_id, period, db_user.language),
+                reply_markup=get_tariff_insufficient_balance_keyboard(
+                    tariff_id, period, db_user.language, missing_kopeks=missing
+                ),
                 parse_mode='HTML',
             )
         await callback.answer()

--- a/tests/test_tariff_insufficient_balance_keyboard.py
+++ b/tests/test_tariff_insufficient_balance_keyboard.py
@@ -1,0 +1,57 @@
+from app.config import settings
+from app.handlers.subscription.tariff_purchase import get_tariff_insufficient_balance_keyboard
+
+
+def _callbacks(keyboard):
+    return [button.callback_data for row in keyboard.inline_keyboard for button in row]
+
+
+def test_classic_topup_when_autopurchase_disabled(monkeypatch):
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', False)
+
+    keyboard = get_tariff_insufficient_balance_keyboard(7, 30, 'ru', missing_kopeks=50000)
+    callbacks = _callbacks(keyboard)
+
+    assert 'balance_topup' in callbacks
+    assert not any((c or '').startswith('topup_amount|') for c in callbacks)
+    assert 'tariff_select:7' in callbacks
+
+
+def test_inlines_prefilled_payment_when_autopurchase_enabled(monkeypatch):
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', True)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', True)
+
+    keyboard = get_tariff_insufficient_balance_keyboard(7, 30, 'ru', missing_kopeks=50000)
+    callbacks = _callbacks(keyboard)
+
+    # прямая оплата ровно недостающей суммой, без промежуточного «Пополнить баланс»
+    assert 'topup_amount|stars|50000' in callbacks
+    assert 'balance_topup' not in callbacks
+    # возврат ведёт к выбору тарифа
+    assert 'tariff_select:7' in callbacks
+
+
+def test_classic_topup_when_missing_zero(monkeypatch):
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', True)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', True)
+
+    keyboard = get_tariff_insufficient_balance_keyboard(7, 30, 'ru', missing_kopeks=0)
+
+    assert 'balance_topup' in _callbacks(keyboard)
+
+
+def test_falls_back_to_topup_without_direct_payment_methods(monkeypatch):
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', True)
+    # Клавиатура пополнения без кнопок прямой оплаты (только навигация) → классический фолбэк
+    monkeypatch.setattr(
+        'app.keyboards.inline.get_payment_methods_keyboard',
+        lambda amount, language=None: InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text='x', callback_data='menu_balance')]]
+        ),
+    )
+
+    keyboard = get_tariff_insufficient_balance_keyboard(7, 30, 'ru', missing_kopeks=50000)
+
+    assert 'balance_topup' in _callbacks(keyboard)


### PR DESCRIPTION
## 📝 Описание
При нехватке баланса на экране покупки тарифа теперь можно **оплатить сразу**:
кнопки способов оплаты показываются прямо на этом экране, предзаполненные ровно
недостающей суммой (`topup_amount|метод|сумма`). После оплаты подписка
оформляется автоматически уже существующим механизмом автопокупки после
пополнения — без отдельного шага «💳 Пополнить баланс».

## 🎯 Мотивация
Запрос: сделать покупку тарифа быстрее, «без того чтобы сначала пополнять
баланс». Вся механика для этого уже есть (автопокупка после пополнения +
предзаполнение точной суммы) — не хватало только UX-шага: пользователю
приходилось отдельно заходить в «Пополнить баланс». Теперь способы оплаты — прямо
на экране тарифа.

## 🔧 Тип изменений
- [ ] Bug fix (исправление)
- [x] New feature (новая функция)
- [ ] Breaking change (ломающие изменения)
- [ ] Documentation update (обновление документации)

## 🛠 Что сделано
- `get_tariff_insufficient_balance_keyboard(...)` принимает `missing_kopeks` и при
  включённой автопокупке встраивает предзаполненные кнопки прямой оплаты
  (`get_payment_methods_keyboard`), отбрасывая навигацию клавиатуры пополнения;
  возврат ведёт к выбору тарифа.
- Платёжные колбэки (`topup_amount|...` → `handle_topup_amount_callback`) и
  автопокупка после пополнения **не меняются** — переиспользуются как есть.
- Три места вызова передают недостающую сумму.

## 🛡 Безопасность/совместимость
- Под флагом `AUTO_PURCHASE_AFTER_TOPUP_ENABLED`. Если автопокупка выключена или
  прямых методов оплаты нет — остаётся классический переход в пополнение баланса
  (регрессии нет). Списание/создание подписки не затрагиваются.

## 🧪 Тестирование
- [x] Юнит-тесты `tests/test_tariff_insufficient_balance_keyboard.py`
      (классический фолбэк при выкл. автопокупке / missing=0 / без методов;
      предзаполненная прямая оплата при вкл.) — 4 passed.
- [ ] Проверка сквозной оплаты на реальном боте с включённой автопокупкой.
