### PR TITLE
fix(grace): исключить отправку статуса LIMITED в Remnawave

### DIFF
--- a/app/services/grace_access_runtime.py
+++ b/app/services/grace_access_runtime.py
@@ -41,6 +41,8 @@ from app.services.grace_access_service import (
     GraceCompletionReason,
     GracePanelOverlay,
     GracePanelSnapshot,
+    GracePanelTransitionConflict,
+    GracePanelTransitionPending,
     GraceReason,
     GraceReconcileResult,
     GraceRestoreOutcome,
@@ -332,6 +334,22 @@ class RemnawaveGracePanelGateway:
             current = _panel_user_to_snapshot(current_user)
             if _panel_matches_target(current, target):
                 return GraceRestoreOutcome.ALREADY_RESTORED
+            if target.status is PanelUserStatus.LIMITED:
+                if not _limited_transition_source_is_safe(
+                    current,
+                    target,
+                    expected_overlay,
+                    now=now,
+                ):
+                    return GraceRestoreOutcome.CONFLICT
+                updated = await _apply_limited_target(
+                    api,
+                    remnawave_uuid=remnawave_uuid,
+                    target=target,
+                    expected_overlay=expected_overlay,
+                    current_user=current_user,
+                )
+                return GraceRestoreOutcome.RESTORED if updated is not None else GraceRestoreOutcome.CONFLICT
             if not panel_matches_overlay(
                 current,
                 expected_overlay,
@@ -343,14 +361,7 @@ class RemnawaveGracePanelGateway:
             ):
                 return GraceRestoreOutcome.CONFLICT
 
-            updated = await api.update_user(
-                uuid=remnawave_uuid,
-                status=target.status,
-                expire_at=target.expire_at,
-                traffic_limit_bytes=target.traffic_limit_bytes,
-                active_internal_squads=list(target.squad_uuids),
-                external_squad_uuid=target.external_squad_uuid,
-            )
+            updated = await api.update_user(**_serialize_panel_target(remnawave_uuid, target))
             if updated is not None and _panel_matches_target(_panel_user_to_snapshot(updated), target):
                 return GraceRestoreOutcome.RESTORED
 
@@ -367,26 +378,58 @@ class RemnawaveGracePanelGateway:
                 return GraceRestoreOutcome.CONFLICT
         raise GracePanelError('Remnawave restore PATCH could not be verified')
 
-    async def apply_billing_state(self, billing: GraceBillingState) -> None:
+    async def apply_billing_state(
+        self,
+        billing: GraceBillingState,
+        *,
+        expected_overlay: GracePanelOverlay,
+    ) -> None:
         from app.services.remnawave_service import remnawave_service
 
         if not billing.remnawave_uuid:
             raise GracePanelError('Canonical subscription has no Remnawave UUID')
-        target = _build_billing_target(billing, now=datetime.now(UTC))
-        kwargs: dict[str, Any] = {
-            'uuid': billing.remnawave_uuid,
-            'status': target.status,
-            'expire_at': target.expire_at,
-            'traffic_limit_bytes': target.traffic_limit_bytes,
-            'active_internal_squads': list(target.squad_uuids),
-            'external_squad_uuid': target.external_squad_uuid,
-        }
-        if target.device_limit is not None:
-            kwargs['hwid_device_limit'] = target.device_limit
+        now = datetime.now(UTC)
+        target = _build_billing_target(billing, now=now)
 
         async with remnawave_service.get_api_client() as api:
-            updated = await api.update_user(**kwargs)
-        if updated is None or not _panel_matches_target(_panel_user_to_snapshot(updated), target):
+            if target.status is PanelUserStatus.LIMITED:
+                current_user = await api.get_user_by_uuid(billing.remnawave_uuid)
+                if current_user is None:
+                    raise GracePanelTransitionConflict('Canonical Remnawave user disappeared during LIMITED restore')
+                current = _panel_user_to_snapshot(current_user)
+                if _panel_matches_target(current, target):
+                    if _panel_user_matches_device_limit(current_user, target):
+                        return
+                    updated_device = await api.update_user(
+                        uuid=billing.remnawave_uuid,
+                        hwid_device_limit=target.device_limit,
+                    )
+                    if updated_device is None:
+                        updated_device = await api.get_user_by_uuid(billing.remnawave_uuid)
+                    if updated_device is not None and _panel_user_matches_target(updated_device, target):
+                        return
+                    raise GracePanelTransitionConflict('Remnawave did not confirm canonical LIMITED device limit')
+                if not _limited_transition_source_is_safe(
+                    current,
+                    target,
+                    expected_overlay,
+                    now=now,
+                ):
+                    raise GracePanelTransitionConflict(
+                        'Remnawave changed outside grace; canonical LIMITED state was not applied'
+                    )
+                updated = await _apply_limited_target(
+                    api,
+                    remnawave_uuid=billing.remnawave_uuid,
+                    target=target,
+                    expected_overlay=expected_overlay,
+                    current_user=current_user,
+                )
+            else:
+                updated = await api.update_user(**_serialize_panel_target(billing.remnawave_uuid, target))
+        if updated is None or not _panel_user_matches_target(updated, target):
+            if target.status is PanelUserStatus.LIMITED:
+                raise GracePanelTransitionConflict('Remnawave changed while canonical LIMITED state was being applied')
             raise GracePanelError('Remnawave did not confirm canonical billing state')
 
 
@@ -913,20 +956,16 @@ async def apply_recovered_grace_update_locked(
         raise GracePanelError('Recovered canonical subscription has no Remnawave UUID')
 
     target = _build_billing_target(billing, now=datetime.now(UTC))
-    canonical_kwargs = dict(update_kwargs)
-    canonical_kwargs.update(
-        uuid=billing.remnawave_uuid,
-        status=target.status,
-        expire_at=target.expire_at,
-        traffic_limit_bytes=target.traffic_limit_bytes,
-        active_internal_squads=list(target.squad_uuids),
-        external_squad_uuid=target.external_squad_uuid,
+    if target.status not in {PanelUserStatus.ACTIVE, PanelUserStatus.DISABLED}:
+        raise GracePanelError(f'Canonical renewal unexpectedly resolved to derived panel status {target.status.value}')
+    canonical_kwargs = _serialize_panel_target(
+        billing.remnawave_uuid,
+        target,
+        base_kwargs=update_kwargs,
     )
-    if target.device_limit is not None:
-        canonical_kwargs['hwid_device_limit'] = target.device_limit
 
     updated = await api.update_user(**canonical_kwargs)
-    if updated is None or not _panel_matches_target(_panel_user_to_snapshot(updated), target):
+    if updated is None or not _panel_user_matches_target(updated, target):
         raise GracePanelError('Remnawave did not confirm canonical billing state after renewal')
 
     completed = await core.complete_after_payment(
@@ -1461,6 +1500,148 @@ def _build_billing_target(billing: GraceBillingState, *, now: datetime) -> _Pane
         external_squad_uuid=billing.external_squad_uuid,
         device_limit=billing.device_limit,
     )
+
+
+def _serialize_panel_target(
+    remnawave_uuid: str,
+    target: _PanelTarget,
+    *,
+    base_kwargs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a writable Remnawave payload without sending derived statuses."""
+    kwargs = dict(base_kwargs or {})
+    kwargs.pop('status', None)
+    kwargs.update(
+        uuid=remnawave_uuid,
+        expire_at=target.expire_at,
+        traffic_limit_bytes=target.traffic_limit_bytes,
+        active_internal_squads=list(target.squad_uuids),
+        external_squad_uuid=target.external_squad_uuid,
+    )
+    if target.status in {PanelUserStatus.ACTIVE, PanelUserStatus.DISABLED}:
+        kwargs['status'] = target.status
+    elif target.status not in {PanelUserStatus.LIMITED, PanelUserStatus.EXPIRED}:
+        raise GracePanelError(f'Unsupported canonical panel status {target.status!r}')
+    if target.device_limit is not None:
+        kwargs['hwid_device_limit'] = target.device_limit
+    return kwargs
+
+
+def _panel_matches_limited_intermediate(
+    snapshot: GracePanelSnapshot,
+    target: _PanelTarget,
+    expected_overlay: GracePanelOverlay,
+    *,
+    statuses: frozenset[str] = frozenset({'active', 'limited'}),
+) -> bool:
+    return (
+        _normalize(snapshot.status) in statuses
+        and snapshot.expire_at is not None
+        and abs((_as_utc(snapshot.expire_at) - _as_utc(target.expire_at)).total_seconds()) <= 2
+        and snapshot.traffic_limit_bytes == target.traffic_limit_bytes
+        and set(snapshot.squad_uuids) == set(expected_overlay.squad_uuids)
+        and snapshot.external_squad_uuid == expected_overlay.external_squad_uuid
+    )
+
+
+def _limited_transition_source_is_safe(
+    current: GracePanelSnapshot,
+    target: _PanelTarget,
+    expected_overlay: GracePanelOverlay,
+    *,
+    now: datetime,
+) -> bool:
+    if _panel_matches_limited_intermediate(current, target, expected_overlay):
+        return True
+
+    current_status = _normalize(current.status)
+    overlay_status_is_safe = current_status in {'active', 'limited'} or (
+        current_status == 'expired' and _as_utc(now) >= _as_utc(expected_overlay.expire_at)
+    )
+    return overlay_status_is_safe and panel_matches_overlay(
+        current,
+        expected_overlay,
+        now=now,
+    )
+
+
+async def _apply_limited_target(
+    api: Any,
+    *,
+    remnawave_uuid: str,
+    target: _PanelTarget,
+    expected_overlay: GracePanelOverlay,
+    current_user: Any,
+) -> Any | None:
+    """Restore a derived LIMITED target without exposing canonical routing early."""
+    intermediate = _panel_user_to_snapshot(current_user)
+    if not _panel_matches_limited_intermediate(
+        intermediate,
+        target,
+        expected_overlay,
+    ) or not _panel_user_matches_device_limit(current_user, target):
+        phase_a_kwargs: dict[str, Any] = {
+            'uuid': remnawave_uuid,
+            'expire_at': target.expire_at,
+            'traffic_limit_bytes': target.traffic_limit_bytes,
+            'active_internal_squads': list(expected_overlay.squad_uuids),
+            'external_squad_uuid': expected_overlay.external_squad_uuid,
+        }
+        if target.device_limit is not None:
+            phase_a_kwargs['hwid_device_limit'] = target.device_limit
+        phase_a_user = await api.update_user(**phase_a_kwargs)
+        if phase_a_user is None:
+            phase_a_user = await api.get_user_by_uuid(remnawave_uuid)
+        if phase_a_user is None:
+            return None
+        intermediate = _panel_user_to_snapshot(phase_a_user)
+        if not _panel_user_matches_device_limit(phase_a_user, target):
+            return None
+
+    if _panel_matches_limited_intermediate(
+        intermediate,
+        target,
+        expected_overlay,
+        statuses=frozenset({'active'}),
+    ):
+        raise GracePanelTransitionPending('Remnawave has not derived LIMITED after applying canonical quota fields')
+    if not _panel_matches_limited_intermediate(
+        intermediate,
+        target,
+        expected_overlay,
+        statuses=frozenset({'limited'}),
+    ):
+        return None
+
+    phase_b_user = await api.update_user(
+        uuid=remnawave_uuid,
+        active_internal_squads=list(target.squad_uuids),
+        external_squad_uuid=target.external_squad_uuid,
+    )
+    if phase_b_user is not None and _panel_user_matches_target(phase_b_user, target):
+        return phase_b_user
+
+    verified_user = await api.get_user_by_uuid(remnawave_uuid)
+    if verified_user is not None and _panel_user_matches_target(verified_user, target):
+        return verified_user
+    return None
+
+
+def _panel_user_matches_device_limit(panel_user: Any, target: _PanelTarget) -> bool:
+    if target.device_limit is None:
+        return True
+    raw_limit = getattr(panel_user, 'hwid_device_limit', None)
+    try:
+        return raw_limit is not None and int(raw_limit) == target.device_limit
+    except (TypeError, ValueError):
+        return False
+
+
+def _panel_user_matches_target(panel_user: Any, target: _PanelTarget) -> bool:
+    return _panel_matches_target(
+        _panel_user_to_snapshot(panel_user),
+        target,
+    ) and _panel_user_matches_device_limit(panel_user, target)
 
 
 def _panel_matches_target(snapshot: GracePanelSnapshot, target: _PanelTarget) -> bool:

--- a/app/services/grace_access_service.py
+++ b/app/services/grace_access_service.py
@@ -81,6 +81,14 @@ class GraceRestoreOutcome(StrEnum):
     CONFLICT = 'conflict'
 
 
+class GracePanelTransitionPending(Exception):
+    """Signal that Remnawave is still deriving a server-owned panel status."""
+
+
+class GracePanelTransitionConflict(Exception):
+    """Signal that a derived-status transition hit an unrelated panel state."""
+
+
 class GraceStartDecision(StrEnum):
     STARTED = 'started'
     RETRIED = 'retried'
@@ -240,7 +248,12 @@ class GracePanelGateway(Protocol):
         expected_overlay: GracePanelOverlay,
     ) -> GraceRestoreOutcome: ...
 
-    async def apply_billing_state(self, billing: GraceBillingState) -> None: ...
+    async def apply_billing_state(
+        self,
+        billing: GraceBillingState,
+        *,
+        expected_overlay: GracePanelOverlay,
+    ) -> None: ...
 
 
 class GraceBillingGateway(Protocol):
@@ -381,7 +394,10 @@ class GraceAccessService:
             return False
 
         if apply_billing_state:
-            await self._panel.apply_billing_state(billing)
+            await self._panel.apply_billing_state(
+                billing,
+                expected_overlay=session.overlay,
+            )
         await self._complete(session, GraceCompletionReason.PAID)
         return True
 
@@ -424,6 +440,22 @@ class GraceAccessService:
                     activate_pending=activate_pending,
                     force_restore=force_restore,
                 )
+            except GracePanelTransitionConflict as error:
+                latest_session = await self._store.get_open(session.subscription_id)
+                if latest_session is None:
+                    result = replace(result, unchanged=result.unchanged + 1)
+                    continue
+                await self._complete(
+                    latest_session,
+                    GraceCompletionReason.CONFLICT,
+                    last_error=_error_text(error),
+                )
+                result = replace(result, conflicts=result.conflicts + 1)
+                continue
+            except GracePanelTransitionPending:
+                await self._clear_error(session.subscription_id)
+                result = replace(result, unchanged=result.unchanged + 1)
+                continue
             except Exception as error:
                 await self._remember_error(session.subscription_id, error)
                 logger.exception(
@@ -490,7 +522,10 @@ class GraceAccessService:
         latest_billing = await self._billing.get_subscription(session.subscription_id)
 
         if latest_billing and billing_has_recovered(session, latest_billing):
-            await self._panel.apply_billing_state(latest_billing)
+            await self._panel.apply_billing_state(
+                latest_billing,
+                expected_overlay=session.overlay,
+            )
             return await self._complete(session, GraceCompletionReason.PAID)
 
         if latest_billing is None or billing_is_revoked(latest_billing):
@@ -529,7 +564,12 @@ class GraceAccessService:
             # squad preflight.  Any other state may be a manual/emergency
             # revocation. Canonical billing is fail-closed and must win.
             try:
-                await self._panel.apply_billing_state(latest_billing)
+                await self._panel.apply_billing_state(
+                    latest_billing,
+                    expected_overlay=session.overlay,
+                )
+            except (GracePanelTransitionConflict, GracePanelTransitionPending):
+                raise
             except Exception as error:
                 failed_session = replace(
                     session,
@@ -558,11 +598,17 @@ class GraceAccessService:
 
         latest_billing = await self._billing.get_subscription(session.subscription_id)
         if latest_billing and billing_has_recovered(session, latest_billing):
-            await self._panel.apply_billing_state(latest_billing)
+            await self._panel.apply_billing_state(
+                latest_billing,
+                expected_overlay=session.overlay,
+            )
             return await self._complete(session, GraceCompletionReason.PAID)
         if latest_billing is None or billing_is_revoked(latest_billing):
             if latest_billing is not None:
-                await self._panel.apply_billing_state(latest_billing)
+                await self._panel.apply_billing_state(
+                    latest_billing,
+                    expected_overlay=session.overlay,
+                )
                 return await self._complete(session, GraceCompletionReason.REVOKED)
             _, completed = await self._restore_and_complete(session, GraceCompletionReason.REVOKED)
             return completed
@@ -589,16 +635,25 @@ class GraceAccessService:
     ) -> str:
         billing = await self._billing.get_subscription(session.subscription_id)
         if billing and billing_has_recovered(session, billing):
-            await self._panel.apply_billing_state(billing)
+            await self._panel.apply_billing_state(
+                billing,
+                expected_overlay=session.overlay,
+            )
             await self._complete(session, GraceCompletionReason.PAID)
             return GraceCompletionReason.PAID.value
 
         if billing is None or billing_is_revoked(billing):
             if billing is not None:
-                await self._panel.apply_billing_state(billing)
+                await self._panel.apply_billing_state(
+                    billing,
+                    expected_overlay=session.overlay,
+                )
                 latest_billing = await self._billing.get_subscription(session.subscription_id)
                 if latest_billing and billing_has_recovered(session, latest_billing):
-                    await self._panel.apply_billing_state(latest_billing)
+                    await self._panel.apply_billing_state(
+                        latest_billing,
+                        expected_overlay=session.overlay,
+                    )
                     await self._complete(session, GraceCompletionReason.PAID)
                     return GraceCompletionReason.PAID.value
                 await self._complete(session, GraceCompletionReason.REVOKED)
@@ -616,7 +671,10 @@ class GraceAccessService:
             session, billing
         ):
             if billing.remnawave_uuid == session.remnawave_uuid:
-                await self._panel.apply_billing_state(billing)
+                await self._panel.apply_billing_state(
+                    billing,
+                    expected_overlay=session.overlay,
+                )
                 await self._complete(session, GraceCompletionReason.CONFLICT)
                 return GraceCompletionReason.CONFLICT.value
             action, _ = await self._restore_and_complete(session, GraceCompletionReason.CONFLICT)
@@ -652,7 +710,10 @@ class GraceAccessService:
             # grant unrestricted access after a crashed/stale renewal PATCH, so
             # fail closed to the current canonical billing state.
             if _normalize_status(current_panel.status) == 'active':
-                await self._panel.apply_billing_state(billing)
+                await self._panel.apply_billing_state(
+                    billing,
+                    expected_overlay=session.overlay,
+                )
                 await self._complete(
                     session,
                     GraceCompletionReason.CONFLICT,
@@ -692,7 +753,10 @@ class GraceAccessService:
 
         latest_billing = await self._billing.get_subscription(session.subscription_id)
         if latest_billing and billing_has_recovered(restoring_session, latest_billing):
-            await self._panel.apply_billing_state(latest_billing)
+            await self._panel.apply_billing_state(
+                latest_billing,
+                expected_overlay=restoring_session.overlay,
+            )
             completed = await self._complete(restoring_session, GraceCompletionReason.PAID)
             return GraceCompletionReason.PAID.value, completed
 
@@ -706,7 +770,10 @@ class GraceAccessService:
         # over an old snapshot, even if the restore PATCH has already succeeded.
         latest_billing = await self._billing.get_subscription(session.subscription_id)
         if latest_billing and billing_has_recovered(restoring_session, latest_billing):
-            await self._panel.apply_billing_state(latest_billing)
+            await self._panel.apply_billing_state(
+                latest_billing,
+                expected_overlay=restoring_session.overlay,
+            )
             completed = await self._complete(restoring_session, GraceCompletionReason.PAID)
             return GraceCompletionReason.PAID.value, completed
 
@@ -748,6 +815,18 @@ class GraceAccessService:
                 session,
                 updated_at=_as_utc(self._clock()),
                 last_error=_error_text(error),
+            )
+        )
+
+    async def _clear_error(self, subscription_id: int) -> None:
+        session = await self._store.get_open(subscription_id)
+        if not session or session.last_error is None:
+            return
+        await self._store.save(
+            replace(
+                session,
+                updated_at=_as_utc(self._clock()),
+                last_error=None,
             )
         )
 

--- a/tests/services/test_grace_access_runtime.py
+++ b/tests/services/test_grace_access_runtime.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.external.remnawave_api import UserStatus
+from app.services.grace_access_runtime import (
+    RemnawaveGracePanelGateway,
+    _PanelTarget,
+    _serialize_panel_target,
+)
+from app.services.grace_access_service import (
+    GraceBillingState,
+    GracePanelOverlay,
+    GracePanelSnapshot,
+    GracePanelTransitionConflict,
+    GracePanelTransitionPending,
+    GraceRestoreOutcome,
+)
+
+
+GIB = 1024**3
+PANEL_UUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+GRACE_SQUAD = '11111111-1111-1111-1111-111111111111'
+REGULAR_SQUAD = '22222222-2222-2222-2222-222222222222'
+OTHER_SQUAD = '33333333-3333-3333-3333-333333333333'
+EXTERNAL_SQUAD = '44444444-4444-4444-4444-444444444444'
+NOW = datetime.now(UTC).replace(microsecond=0)
+
+
+class FakeRemnawaveApi:
+    def __init__(self, user: SimpleNamespace) -> None:
+        self.user = user
+        self.updates: list[dict[str, Any]] = []
+
+    async def get_user_by_uuid(self, remnawave_uuid: str) -> SimpleNamespace | None:
+        return self.user if remnawave_uuid == self.user.uuid else None
+
+    async def update_user(self, **kwargs: Any) -> SimpleNamespace:
+        self.updates.append(dict(kwargs))
+        if status := kwargs.get('status'):
+            self.user.status = status
+        if 'expire_at' in kwargs:
+            self.user.expire_at = kwargs['expire_at']
+        if 'traffic_limit_bytes' in kwargs:
+            self.user.traffic_limit_bytes = kwargs['traffic_limit_bytes']
+        if 'active_internal_squads' in kwargs:
+            self.user.active_internal_squads = [{'uuid': squad_uuid} for squad_uuid in kwargs['active_internal_squads']]
+        if 'external_squad_uuid' in kwargs:
+            self.user.external_squad_uuid = kwargs['external_squad_uuid']
+        if 'hwid_device_limit' in kwargs:
+            self.user.hwid_device_limit = kwargs['hwid_device_limit']
+        return self.user
+
+
+def make_panel_user(
+    *,
+    status: UserStatus,
+    expire_at: datetime,
+    traffic_limit_bytes: int,
+    squad_uuids: tuple[str, ...],
+    external_squad_uuid: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        uuid=PANEL_UUID,
+        status=status,
+        expire_at=expire_at,
+        traffic_limit_bytes=traffic_limit_bytes,
+        used_traffic_bytes=10 * GIB,
+        active_internal_squads=[{'uuid': value} for value in squad_uuids],
+        external_squad_uuid=external_squad_uuid,
+        user_traffic=SimpleNamespace(used_traffic_bytes=10 * GIB),
+        last_traffic_reset_at=None,
+        hwid_device_limit=2,
+    )
+
+
+def make_overlay() -> GracePanelOverlay:
+    return GracePanelOverlay(
+        status='ACTIVE',
+        expire_at=NOW + timedelta(days=3),
+        traffic_limit_bytes=11 * GIB,
+        squad_uuids=(GRACE_SQUAD,),
+        external_squad_uuid=None,
+    )
+
+
+def make_limited_billing() -> GraceBillingState:
+    return GraceBillingState(
+        subscription_id=42,
+        remnawave_uuid=PANEL_UUID,
+        status='limited',
+        end_at=NOW + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=10 * GIB,
+        device_limit=4,
+        squad_uuids=(REGULAR_SQUAD,),
+        external_squad_uuid=EXTERNAL_SQUAD,
+    )
+
+
+def make_limited_snapshot() -> GracePanelSnapshot:
+    return GracePanelSnapshot(
+        remnawave_uuid=PANEL_UUID,
+        status='LIMITED',
+        expire_at=NOW + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=10 * GIB,
+        squad_uuids=(REGULAR_SQUAD,),
+        external_squad_uuid=EXTERNAL_SQUAD,
+    )
+
+
+def install_fake_api(monkeypatch: pytest.MonkeyPatch, api: FakeRemnawaveApi) -> None:
+    from app.services.remnawave_service import remnawave_service
+
+    @asynccontextmanager
+    async def get_api_client():
+        yield api
+
+    monkeypatch.setattr(remnawave_service, 'get_api_client', get_api_client)
+
+
+def assert_no_derived_status_writes(api: FakeRemnawaveApi) -> None:
+    assert all(update.get('status') not in {UserStatus.LIMITED, UserStatus.EXPIRED} for update in api.updates)
+
+
+@pytest.mark.parametrize('derived_status', [UserStatus.LIMITED, UserStatus.EXPIRED])
+def test_panel_target_serializer_removes_derived_statuses(
+    derived_status: UserStatus,
+) -> None:
+    target = _PanelTarget(
+        status=derived_status,
+        expire_at=NOW + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        squad_uuids=(REGULAR_SQUAD,),
+        external_squad_uuid=EXTERNAL_SQUAD,
+        device_limit=4,
+    )
+
+    payload = _serialize_panel_target(
+        PANEL_UUID,
+        target,
+        base_kwargs={'status': derived_status, 'description': 'preserved'},
+    )
+
+    assert 'status' not in payload
+    assert payload['description'] == 'preserved'
+
+
+@pytest.mark.asyncio
+async def test_apply_limited_billing_restores_canonical_fields_without_writing_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    billing = make_limited_billing()
+    overlay = make_overlay()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=UserStatus.LIMITED,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=overlay.squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+
+    await RemnawaveGracePanelGateway().apply_billing_state(
+        billing,
+        expected_overlay=overlay,
+    )
+
+    assert_no_derived_status_writes(api)
+    assert api.user.status is UserStatus.LIMITED
+    assert api.user.expire_at == billing.end_at
+    assert api.user.traffic_limit_bytes == billing.traffic_limit_bytes
+    assert api.user.hwid_device_limit == billing.device_limit
+    assert api.user.active_internal_squads == [{'uuid': REGULAR_SQUAD}]
+    assert api.user.external_squad_uuid == EXTERNAL_SQUAD
+
+
+@pytest.mark.asyncio
+async def test_apply_limited_billing_keeps_grace_routing_until_panel_derives_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    billing = make_limited_billing()
+    overlay = make_overlay()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=UserStatus.ACTIVE,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=overlay.squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+    gateway = RemnawaveGracePanelGateway()
+
+    with pytest.raises(GracePanelTransitionPending):
+        await gateway.apply_billing_state(billing, expected_overlay=overlay)
+
+    assert_no_derived_status_writes(api)
+    assert api.user.status is UserStatus.ACTIVE
+    assert api.user.expire_at == billing.end_at
+    assert api.user.traffic_limit_bytes == billing.traffic_limit_bytes
+    assert api.user.hwid_device_limit == billing.device_limit
+    assert api.user.active_internal_squads == [{'uuid': GRACE_SQUAD}]
+    assert api.user.external_squad_uuid is None
+
+    api.user.status = UserStatus.LIMITED
+    await gateway.apply_billing_state(billing, expected_overlay=overlay)
+
+    assert_no_derived_status_writes(api)
+    assert api.user.active_internal_squads == [{'uuid': REGULAR_SQUAD}]
+    assert api.user.external_squad_uuid == EXTERNAL_SQUAD
+
+
+@pytest.mark.asyncio
+async def test_restore_limited_snapshot_recognizes_safe_active_intermediate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = make_limited_snapshot()
+    overlay = make_overlay()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=UserStatus.ACTIVE,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=overlay.squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+    gateway = RemnawaveGracePanelGateway()
+
+    with pytest.raises(GracePanelTransitionPending):
+        await gateway.restore_snapshot(PANEL_UUID, snapshot, overlay)
+
+    assert_no_derived_status_writes(api)
+    assert api.user.status is UserStatus.ACTIVE
+    assert api.user.expire_at == snapshot.expire_at
+    assert api.user.traffic_limit_bytes == snapshot.traffic_limit_bytes
+    assert api.user.active_internal_squads == [{'uuid': GRACE_SQUAD}]
+    assert api.user.external_squad_uuid is None
+
+    api.user.status = UserStatus.LIMITED
+    outcome = await gateway.restore_snapshot(PANEL_UUID, snapshot, overlay)
+
+    assert outcome is GraceRestoreOutcome.RESTORED
+    assert_no_derived_status_writes(api)
+    assert api.user.active_internal_squads == [{'uuid': REGULAR_SQUAD}]
+    assert api.user.external_squad_uuid == EXTERNAL_SQUAD
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status', 'squad_uuids'),
+    [
+        (UserStatus.DISABLED, (GRACE_SQUAD,)),
+        (UserStatus.ACTIVE, (OTHER_SQUAD,)),
+    ],
+)
+async def test_restore_does_not_overwrite_manual_or_unrelated_panel_state(
+    monkeypatch: pytest.MonkeyPatch,
+    status: UserStatus,
+    squad_uuids: tuple[str, ...],
+) -> None:
+    snapshot = make_limited_snapshot()
+    overlay = make_overlay()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=status,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+
+    outcome = await RemnawaveGracePanelGateway().restore_snapshot(
+        PANEL_UUID,
+        snapshot,
+        overlay,
+    )
+
+    assert outcome is GraceRestoreOutcome.CONFLICT
+    assert api.updates == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status', 'squad_uuids'),
+    [
+        (UserStatus.DISABLED, (GRACE_SQUAD,)),
+        (UserStatus.ACTIVE, (OTHER_SQUAD,)),
+    ],
+)
+async def test_apply_limited_billing_does_not_overwrite_manual_or_unrelated_panel_state(
+    monkeypatch: pytest.MonkeyPatch,
+    status: UserStatus,
+    squad_uuids: tuple[str, ...],
+) -> None:
+    overlay = make_overlay()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=status,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+
+    with pytest.raises(GracePanelTransitionConflict, match='changed outside grace'):
+        await RemnawaveGracePanelGateway().apply_billing_state(
+            make_limited_billing(),
+            expected_overlay=overlay,
+        )
+
+    assert api.updates == []
+
+
+@pytest.mark.asyncio
+async def test_apply_limited_billing_updates_device_limit_even_when_other_fields_already_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    billing = make_limited_billing()
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=UserStatus.LIMITED,
+            expire_at=billing.end_at,
+            traffic_limit_bytes=billing.traffic_limit_bytes,
+            squad_uuids=billing.squad_uuids,
+            external_squad_uuid=billing.external_squad_uuid,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+
+    await RemnawaveGracePanelGateway().apply_billing_state(
+        billing,
+        expected_overlay=make_overlay(),
+    )
+
+    assert api.user.hwid_device_limit == billing.device_limit
+    assert api.updates == [
+        {
+            'uuid': PANEL_UUID,
+            'hwid_device_limit': billing.device_limit,
+        }
+    ]
+    assert_no_derived_status_writes(api)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('billing_status', 'billing_end_at', 'expected_status'),
+    [
+        ('active', NOW + timedelta(days=20), UserStatus.ACTIVE),
+        ('disabled', NOW + timedelta(days=20), UserStatus.DISABLED),
+    ],
+)
+async def test_apply_non_derived_billing_status_remains_one_phase(
+    monkeypatch: pytest.MonkeyPatch,
+    billing_status: str,
+    billing_end_at: datetime,
+    expected_status: UserStatus,
+) -> None:
+    overlay = make_overlay()
+    billing = GraceBillingState(
+        subscription_id=42,
+        remnawave_uuid=PANEL_UUID,
+        status=billing_status,
+        end_at=billing_end_at,
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=3 * GIB,
+        device_limit=4,
+        squad_uuids=(REGULAR_SQUAD,),
+        external_squad_uuid=EXTERNAL_SQUAD,
+    )
+    api = FakeRemnawaveApi(
+        make_panel_user(
+            status=UserStatus.ACTIVE,
+            expire_at=overlay.expire_at,
+            traffic_limit_bytes=overlay.traffic_limit_bytes,
+            squad_uuids=overlay.squad_uuids,
+        )
+    )
+    install_fake_api(monkeypatch, api)
+
+    await RemnawaveGracePanelGateway().apply_billing_state(
+        billing,
+        expected_overlay=overlay,
+    )
+
+    assert len(api.updates) == 1
+    assert api.updates[0]['status'] is expected_status
+    assert_no_derived_status_writes(api)
+    assert api.user.active_internal_squads == [{'uuid': REGULAR_SQUAD}]
+    assert api.user.external_squad_uuid == EXTERNAL_SQUAD

--- a/tests/services/test_grace_access_service.py
+++ b/tests/services/test_grace_access_service.py
@@ -14,6 +14,8 @@ from app.services.grace_access_service import (
     GraceCompletionReason,
     GracePanelOverlay,
     GracePanelSnapshot,
+    GracePanelTransitionConflict,
+    GracePanelTransitionPending,
     GraceReason,
     GraceRestoreOutcome,
     GraceSessionState,
@@ -101,7 +103,11 @@ class FakePanelGateway:
         self.applied_overlays: list[tuple[str, GracePanelOverlay]] = []
         self.restored_snapshots: list[tuple[str, GracePanelSnapshot]] = []
         self.applied_billing: list[GraceBillingState] = []
+        self.applied_billing_overlays: list[GracePanelOverlay] = []
         self.fail_overlay_attempts = 0
+        self.conflict_billing_attempts = 0
+        self.pending_billing_attempts = 0
+        self.pending_restore_attempts = 0
         self.restore_outcome = GraceRestoreOutcome.RESTORED
 
     async def read_snapshot(self, remnawave_uuid: str) -> GracePanelSnapshot | None:
@@ -133,6 +139,9 @@ class FakePanelGateway:
         expected_overlay: GracePanelOverlay,
     ) -> GraceRestoreOutcome:
         self.restored_snapshots.append((remnawave_uuid, snapshot))
+        if self.pending_restore_attempts > 0:
+            self.pending_restore_attempts -= 1
+            raise GracePanelTransitionPending
         if self.restore_outcome is GraceRestoreOutcome.RESTORED:
             self.snapshot = replace(
                 snapshot,
@@ -141,8 +150,20 @@ class FakePanelGateway:
             )
         return self.restore_outcome
 
-    async def apply_billing_state(self, billing: GraceBillingState) -> None:
+    async def apply_billing_state(
+        self,
+        billing: GraceBillingState,
+        *,
+        expected_overlay: GracePanelOverlay,
+    ) -> None:
         self.applied_billing.append(billing)
+        self.applied_billing_overlays.append(expected_overlay)
+        if self.conflict_billing_attempts > 0:
+            self.conflict_billing_attempts -= 1
+            raise GracePanelTransitionConflict('panel state changed outside grace')
+        if self.pending_billing_attempts > 0:
+            self.pending_billing_attempts -= 1
+            raise GracePanelTransitionPending
 
 
 class FakeBillingGateway:
@@ -452,6 +473,49 @@ async def test_timeout_restores_original_panel_values_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_limited_snapshot_restore_stays_restoring_while_panel_derives_status() -> None:
+    now = datetime(2026, 7, 15, 12, tzinfo=UTC)
+    clock = MutableClock(now)
+    billing = make_billing(
+        status='limited',
+        end_at=now + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=10 * GIB,
+    )
+    snapshot = replace(
+        make_snapshot(
+            expire_at=billing.end_at,
+            traffic_limit_bytes=billing.traffic_limit_bytes,
+            used_traffic_bytes=billing.used_traffic_bytes,
+        ),
+        status='LIMITED',
+    )
+    service, store, panel, _ = make_service(billing=billing, snapshot=snapshot, clock=clock)
+    await service.start_if_eligible(billing, GraceReason.LIMITED)
+    panel.pending_restore_attempts = 1
+    clock.advance(timedelta(days=3, seconds=1))
+
+    pending = await service.reconcile()
+
+    assert pending.unchanged == 1
+    assert pending.errors == 0
+    assert pending.timed_out == 0
+    assert store.only_session().state is GraceSessionState.RESTORING
+    assert store.only_session().last_error is None
+
+    completed = await service.reconcile()
+
+    assert completed.timed_out == 1
+    assert completed.errors == 0
+    assert store.only_session().state is GraceSessionState.COMPLETED
+    assert store.only_session().completion_reason is GraceCompletionReason.TIMEOUT
+    assert panel.restored_snapshots == [
+        (PANEL_UUID, snapshot),
+        (PANEL_UUID, snapshot),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_payment_wins_over_grace_snapshot() -> None:
     now = datetime(2026, 7, 15, 12, tzinfo=UTC)
     clock = MutableClock(now)
@@ -533,6 +597,108 @@ async def test_canonical_squad_change_ends_grace_and_applies_fresh_billing() -> 
     completed = next(iter(store.sessions.values()))
     assert completed.state is GraceSessionState.COMPLETED
     assert completed.completion_reason is GraceCompletionReason.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_limited_canonical_change_waits_without_error_then_completes() -> None:
+    now = datetime(2026, 7, 15, 12, tzinfo=UTC)
+    clock = MutableClock(now)
+    billing = make_billing(
+        status='limited',
+        end_at=now + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=10 * GIB,
+    )
+    snapshot = replace(
+        make_snapshot(
+            expire_at=billing.end_at,
+            traffic_limit_bytes=billing.traffic_limit_bytes,
+            used_traffic_bytes=billing.used_traffic_bytes,
+        ),
+        status='LIMITED',
+    )
+    service, store, panel, billing_gateway = make_service(
+        billing=billing,
+        snapshot=snapshot,
+        clock=clock,
+    )
+    started = await service.start_if_eligible(billing, GraceReason.LIMITED)
+    assert started.session is not None
+
+    changed_billing = replace(
+        billing,
+        traffic_limit_bytes=20 * GIB,
+        squad_uuids=('55555555-5555-5555-5555-555555555555',),
+    )
+    billing_gateway.state = changed_billing
+    panel.pending_billing_attempts = 1
+    store.sessions[started.session.id] = replace(
+        store.only_session(),
+        last_error='RemnaWaveAPIError: invalid status LIMITED',
+    )
+
+    pending = await service.reconcile()
+
+    assert pending.unchanged == 1
+    assert pending.errors == 0
+    assert pending.conflicts == 0
+    assert store.only_session().state is GraceSessionState.ACTIVE
+    assert store.only_session().last_error is None
+    assert panel.applied_billing_overlays == [started.session.overlay]
+
+    completed = await service.reconcile()
+
+    assert completed.conflicts == 1
+    assert completed.errors == 0
+    assert store.only_session().state is GraceSessionState.COMPLETED
+    assert store.only_session().completion_reason is GraceCompletionReason.CONFLICT
+    assert panel.applied_billing == [changed_billing, changed_billing]
+    assert panel.applied_billing_overlays == [
+        started.session.overlay,
+        started.session.overlay,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_limited_transition_conflict_completes_without_retry_error() -> None:
+    now = datetime(2026, 7, 15, 12, tzinfo=UTC)
+    clock = MutableClock(now)
+    billing = make_billing(
+        status='limited',
+        end_at=now + timedelta(days=20),
+        traffic_limit_bytes=10 * GIB,
+        used_traffic_bytes=10 * GIB,
+    )
+    snapshot = replace(
+        make_snapshot(
+            expire_at=billing.end_at,
+            traffic_limit_bytes=billing.traffic_limit_bytes,
+            used_traffic_bytes=billing.used_traffic_bytes,
+        ),
+        status='LIMITED',
+    )
+    service, store, panel, billing_gateway = make_service(
+        billing=billing,
+        snapshot=snapshot,
+        clock=clock,
+    )
+    started = await service.start_if_eligible(billing, GraceReason.LIMITED)
+    assert started.session is not None
+
+    changed_billing = replace(billing, traffic_limit_bytes=20 * GIB)
+    billing_gateway.state = changed_billing
+    panel.conflict_billing_attempts = 1
+
+    result = await service.reconcile()
+
+    assert result.conflicts == 1
+    assert result.errors == 0
+    completed = store.only_session()
+    assert completed.state is GraceSessionState.COMPLETED
+    assert completed.completion_reason is GraceCompletionReason.CONFLICT
+    assert completed.last_error == 'GracePanelTransitionConflict: panel state changed outside grace'
+    assert panel.applied_billing == [changed_billing]
+    assert panel.applied_billing_overlays == [started.session.overlay]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Изменения

- Исключена отправка вычисляемых статусов `LIMITED` и `EXPIRED`.
- Добавлен безопасный двухфазный переход в `LIMITED`.
- Grace-маршрутизация сохраняется до подтверждения статуса панелью.
- Ожидающий переход больше не увеличивает `errors` и не создаёт повторные уведомления об ошибке.
- Ручные и посторонние изменения состояния завершают сессию как `CONFLICT`.
- Поведение для `ACTIVE` и `DISABLED` осталось без изменений.

Исправление полностью локализовано в Grace и не затрагивает общий API-клиент, схему БД, миграции, webhooks и архитектуру приложения.

## Тестирование

- Добавлены тесты восстановления `LIMITED` и двухфазного перехода.
- Добавлены проверки конфликтов и лимита устройств.
- Проверено отсутствие `LIMITED` и `EXPIRED` во всех исходящих Grace PATCH.
- Все Grace-тесты успешно пройдены: `47 passed`.