### PR TITLE
feat(tariff): add Telegram admin controls for custom traffic

### DIFF
--- a/app/handlers/admin/tariff_custom_traffic.py
+++ b/app/handlers/admin/tariff_custom_traffic.py
@@ -1,0 +1,454 @@
+"""Telegram administrator UI for custom-traffic tariff fields."""
+
+import html
+
+from aiogram import Dispatcher, F, types
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.crud.tariff import get_tariff_by_id, update_tariff
+from app.database.models import Tariff, User
+from app.localization.texts import get_texts
+from app.services.tariff_custom_traffic import (
+    parse_positive_gb,
+    parse_positive_rubles_to_kopeks,
+    validate_custom_traffic_configuration,
+)
+from app.states import AdminStates
+from app.utils.decorators import admin_required, error_handler
+from app.utils.formatting import format_price_kopeks
+
+
+def _format_custom_traffic_value(value: int | None, suffix: str = '') -> str:
+    """Format an optional positive custom-traffic value for the admin UI."""
+    if value is None or value <= 0:
+        return 'Не задано'
+    return f'{value}{suffix}'
+
+
+def format_custom_traffic_settings(tariff: Tariff) -> str:
+    """Format custom-traffic state for the main tariff card."""
+    enabled = getattr(tariff, 'custom_traffic_enabled', False)
+    price = getattr(tariff, 'traffic_price_per_gb_kopeks', None)
+    minimum = getattr(tariff, 'min_traffic_gb', None)
+    maximum = getattr(tariff, 'max_traffic_gb', None)
+
+    status = '✅ Включено' if enabled else '❌ Выключено'
+    price_display = format_price_kopeks(price) if price is not None and price > 0 else 'Не задано'
+    minimum_display = _format_custom_traffic_value(minimum, ' ГБ')
+    maximum_display = _format_custom_traffic_value(maximum, ' ГБ')
+
+    return (
+        f'{status}\n'
+        f'• Цена за 1 ГБ: {price_display}\n'
+        f'• Минимальный объём: {minimum_display}\n'
+        f'• Максимальный объём: {maximum_display}'
+    )
+
+
+def render_custom_traffic_settings(tariff: Tariff) -> str:
+    """Render the dedicated custom-traffic settings screen."""
+    enabled = getattr(tariff, 'custom_traffic_enabled', False)
+    price = getattr(tariff, 'traffic_price_per_gb_kopeks', None)
+    minimum = getattr(tariff, 'min_traffic_gb', None)
+    maximum = getattr(tariff, 'max_traffic_gb', None)
+
+    status = '✅ Включён' if enabled else '❌ Выключен'
+    price_display = format_price_kopeks(price) if price is not None and price > 0 else 'Не задано'
+    minimum_display = _format_custom_traffic_value(minimum, ' ГБ')
+    maximum_display = _format_custom_traffic_value(maximum, ' ГБ')
+
+    return (
+        f'⚙️ <b>Произвольный трафик</b>\n\n'
+        f'Тариф: <b>{html.escape(tariff.name)}</b>\n\n'
+        f'Статус: {status}\n'
+        f'Цена за 1 ГБ: <b>{price_display}</b>\n'
+        f'Минимальный объём: <b>{minimum_display}</b>\n'
+        f'Максимальный объём: <b>{maximum_display}</b>\n\n'
+        'Пользователь сможет выбрать объём трафика в указанных границах. '
+        'Цена выбранного объёма добавляется к цене периода.'
+    )
+
+
+def get_custom_traffic_keyboard(tariff: Tariff, language: str) -> InlineKeyboardMarkup:
+    """Build the dedicated custom-traffic settings keyboard."""
+    texts = get_texts(language)
+    enabled = getattr(tariff, 'custom_traffic_enabled', False)
+    toggle_text = '❌ Выключить' if enabled else '✅ Включить'
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=toggle_text,
+                    callback_data=f'admin_tariff_toggle_custom_traffic:{tariff.id}',
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text='💰 Цена за 1 ГБ',
+                    callback_data=f'admin_tariff_edit_custom_traffic_price:{tariff.id}',
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text='📉 Минимальный объём',
+                    callback_data=f'admin_tariff_edit_custom_traffic_min:{tariff.id}',
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text='📈 Максимальный объём',
+                    callback_data=f'admin_tariff_edit_custom_traffic_max:{tariff.id}',
+                )
+            ],
+            [InlineKeyboardButton(text=texts.BACK, callback_data=f'admin_tariff_view:{tariff.id}')],
+        ]
+    )
+
+
+@admin_required
+@error_handler
+async def show_custom_traffic_settings(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Show custom-traffic settings for a tariff and leave any field-edit state."""
+    await state.clear()
+    tariff_id = int(callback.data.split(':')[1])
+    tariff = await get_tariff_by_id(db, tariff_id)
+
+    if not tariff:
+        await callback.answer('Тариф не найден', show_alert=True)
+        return
+
+    await callback.message.edit_text(
+        render_custom_traffic_settings(tariff),
+        reply_markup=get_custom_traffic_keyboard(tariff, db_user.language),
+        parse_mode='HTML',
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def toggle_custom_traffic(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+):
+    """Enable or disable custom traffic after validating stored settings."""
+    tariff_id = int(callback.data.split(':')[1])
+    tariff = await get_tariff_by_id(db, tariff_id)
+
+    if not tariff:
+        await callback.answer('Тариф не найден', show_alert=True)
+        return
+
+    if tariff.custom_traffic_enabled:
+        tariff = await update_tariff(db, tariff, custom_traffic_enabled=False)
+        await callback.answer('Произвольный трафик выключен')
+    else:
+        errors = validate_custom_traffic_configuration(
+            price_per_gb_kopeks=getattr(tariff, 'traffic_price_per_gb_kopeks', None),
+            min_traffic_gb=getattr(tariff, 'min_traffic_gb', None),
+            max_traffic_gb=getattr(tariff, 'max_traffic_gb', None),
+        )
+        if errors:
+            details = '\n'.join(f'• {error}' for error in errors)
+            await callback.answer(
+                f'Нельзя включить произвольный трафик:\n{details}',
+                show_alert=True,
+            )
+            return
+
+        tariff = await update_tariff(db, tariff, custom_traffic_enabled=True)
+        await callback.answer('Произвольный трафик включён')
+
+    await callback.message.edit_text(
+        render_custom_traffic_settings(tariff),
+        reply_markup=get_custom_traffic_keyboard(tariff, db_user.language),
+        parse_mode='HTML',
+    )
+
+
+async def _start_custom_traffic_field_edit(
+    callback: types.CallbackQuery,
+    db_user: User,
+    state: FSMContext,
+    tariff: Tariff,
+    *,
+    state_value: State,
+    title: str,
+    current_value: str,
+    prompt: str,
+) -> None:
+    """Start one custom-traffic field editor using the shared FSM contract."""
+    tariff_id = tariff.id
+    await state.set_state(state_value)
+    await state.update_data(tariff_id=tariff_id, language=db_user.language)
+    texts = get_texts(db_user.language)
+
+    await callback.message.edit_text(
+        f'{title}\n\nТариф: <b>{html.escape(tariff.name)}</b>\nТекущее значение: <b>{current_value}</b>\n\n{prompt}',
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text=texts.CANCEL,
+                        callback_data=f'admin_tariff_edit_custom_traffic:{tariff_id}',
+                    )
+                ]
+            ]
+        ),
+        parse_mode='HTML',
+    )
+    await callback.answer()
+
+
+@admin_required
+@error_handler
+async def start_edit_custom_traffic_price(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Start editing the custom-traffic price per gigabyte."""
+    tariff_id = int(callback.data.split(':')[1])
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff:
+        await callback.answer('Тариф не найден', show_alert=True)
+        return
+
+    price = getattr(tariff, 'traffic_price_per_gb_kopeks', None)
+    current = format_price_kopeks(price) if price is not None and price > 0 else 'Не задано'
+    await _start_custom_traffic_field_edit(
+        callback,
+        db_user,
+        state,
+        tariff,
+        state_value=AdminStates.editing_tariff_custom_traffic_price,
+        title='💰 <b>Цена произвольного трафика</b>',
+        current_value=current,
+        prompt='Введите цену за 1 ГБ в рублях.\nПример: <code>2</code> или <code>2.50</code>',
+    )
+
+
+@admin_required
+@error_handler
+async def start_edit_custom_traffic_min(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Start editing the minimum selectable traffic amount."""
+    tariff_id = int(callback.data.split(':')[1])
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff:
+        await callback.answer('Тариф не найден', show_alert=True)
+        return
+
+    current = _format_custom_traffic_value(getattr(tariff, 'min_traffic_gb', None), ' ГБ')
+    await _start_custom_traffic_field_edit(
+        callback,
+        db_user,
+        state,
+        tariff,
+        state_value=AdminStates.editing_tariff_custom_traffic_min,
+        title='📉 <b>Минимальный объём</b>',
+        current_value=current,
+        prompt='Введите минимальный объём целым числом гигабайт.\nПример: <code>5</code>',
+    )
+
+
+@admin_required
+@error_handler
+async def start_edit_custom_traffic_max(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Start editing the maximum selectable traffic amount."""
+    tariff_id = int(callback.data.split(':')[1])
+    tariff = await get_tariff_by_id(db, tariff_id)
+    if not tariff:
+        await callback.answer('Тариф не найден', show_alert=True)
+        return
+
+    current = _format_custom_traffic_value(getattr(tariff, 'max_traffic_gb', None), ' ГБ')
+    await _start_custom_traffic_field_edit(
+        callback,
+        db_user,
+        state,
+        tariff,
+        state_value=AdminStates.editing_tariff_custom_traffic_max,
+        title='📈 <b>Максимальный объём</b>',
+        current_value=current,
+        prompt='Введите максимальный объём целым числом гигабайт.\nПример: <code>100</code>',
+    )
+
+
+async def _load_custom_traffic_tariff_from_state(
+    message: types.Message,
+    db: AsyncSession,
+    state: FSMContext,
+) -> Tariff | None:
+    """Resolve the selected tariff and clear stale FSM state if it disappeared."""
+    state_data = await state.get_data()
+    tariff_id = state_data.get('tariff_id')
+    tariff = await get_tariff_by_id(db, tariff_id) if tariff_id is not None else None
+    if tariff is None:
+        await message.answer('Тариф не найден')
+        await state.clear()
+    return tariff
+
+
+async def _send_custom_traffic_update_result(
+    message: types.Message,
+    db_user: User,
+    state: FSMContext,
+    tariff: Tariff,
+    confirmation: str,
+) -> None:
+    """Finish a successful field edit and show the refreshed settings screen."""
+    await state.clear()
+    await message.answer(
+        f'{confirmation}\n\n{render_custom_traffic_settings(tariff)}',
+        reply_markup=get_custom_traffic_keyboard(tariff, db_user.language),
+        parse_mode='HTML',
+    )
+
+
+@admin_required
+@error_handler
+async def process_custom_traffic_price_input(
+    message: types.Message,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Persist a validated custom-traffic price per gigabyte."""
+    tariff = await _load_custom_traffic_tariff_from_state(message, db, state)
+    if tariff is None:
+        return
+
+    try:
+        price_kopeks = parse_positive_rubles_to_kopeks(message.text or '')
+    except ValueError:
+        await message.answer(
+            '❌ Некорректная цена. Введите положительную сумму в рублях '
+            'с точностью не более двух знаков.\nПример: <code>2</code> или <code>2.50</code>',
+            parse_mode='HTML',
+        )
+        return
+
+    tariff = await update_tariff(db, tariff, traffic_price_per_gb_kopeks=price_kopeks)
+    await _send_custom_traffic_update_result(
+        message,
+        db_user,
+        state,
+        tariff,
+        f'✅ Цена за 1 ГБ установлена: {format_price_kopeks(price_kopeks)}',
+    )
+
+
+@admin_required
+@error_handler
+async def process_custom_traffic_min_input(
+    message: types.Message,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Persist a validated minimum selectable traffic amount."""
+    tariff = await _load_custom_traffic_tariff_from_state(message, db, state)
+    if tariff is None:
+        return
+
+    try:
+        minimum = parse_positive_gb(message.text or '')
+    except ValueError:
+        await message.answer(
+            '❌ Введите положительное целое число гигабайт.\nПример: <code>5</code>', parse_mode='HTML'
+        )
+        return
+
+    maximum = getattr(tariff, 'max_traffic_gb', None)
+    if maximum is not None and maximum > 0 and minimum > maximum:
+        await message.answer(
+            f'❌ Минимальный объём не может быть больше текущего максимума ({maximum} ГБ).',
+        )
+        return
+
+    tariff = await update_tariff(db, tariff, min_traffic_gb=minimum)
+    await _send_custom_traffic_update_result(
+        message,
+        db_user,
+        state,
+        tariff,
+        f'✅ Минимальный объём установлен: {minimum} ГБ',
+    )
+
+
+@admin_required
+@error_handler
+async def process_custom_traffic_max_input(
+    message: types.Message,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Persist a validated maximum selectable traffic amount."""
+    tariff = await _load_custom_traffic_tariff_from_state(message, db, state)
+    if tariff is None:
+        return
+
+    try:
+        maximum = parse_positive_gb(message.text or '')
+    except ValueError:
+        await message.answer(
+            '❌ Введите положительное целое число гигабайт.\nПример: <code>100</code>',
+            parse_mode='HTML',
+        )
+        return
+
+    minimum = getattr(tariff, 'min_traffic_gb', None)
+    if minimum is not None and minimum > 0 and maximum < minimum:
+        await message.answer(
+            f'❌ Максимальный объём не может быть меньше текущего минимума ({minimum} ГБ).',
+        )
+        return
+
+    tariff = await update_tariff(db, tariff, max_traffic_gb=maximum)
+    await _send_custom_traffic_update_result(
+        message,
+        db_user,
+        state,
+        tariff,
+        f'✅ Максимальный объём установлен: {maximum} ГБ',
+    )
+
+
+def register_custom_traffic_handlers(dp: Dispatcher) -> None:
+    """Register callbacks and FSM handlers for custom-traffic administration."""
+    dp.callback_query.register(show_custom_traffic_settings, F.data.startswith('admin_tariff_edit_custom_traffic:'))
+    dp.callback_query.register(toggle_custom_traffic, F.data.startswith('admin_tariff_toggle_custom_traffic:'))
+    dp.callback_query.register(
+        start_edit_custom_traffic_price, F.data.startswith('admin_tariff_edit_custom_traffic_price:')
+    )
+    dp.callback_query.register(
+        start_edit_custom_traffic_min, F.data.startswith('admin_tariff_edit_custom_traffic_min:')
+    )
+    dp.callback_query.register(
+        start_edit_custom_traffic_max, F.data.startswith('admin_tariff_edit_custom_traffic_max:')
+    )
+    dp.message.register(process_custom_traffic_price_input, AdminStates.editing_tariff_custom_traffic_price)
+    dp.message.register(process_custom_traffic_min_input, AdminStates.editing_tariff_custom_traffic_min)
+    dp.message.register(process_custom_traffic_max_input, AdminStates.editing_tariff_custom_traffic_max)

--- a/app/handlers/admin/tariffs.py
+++ b/app/handlers/admin/tariffs.py
@@ -22,6 +22,10 @@ from app.database.crud.tariff import (
     update_tariff,
 )
 from app.database.models import Tariff, User
+from app.handlers.admin.tariff_custom_traffic import (
+    format_custom_traffic_settings,
+    register_custom_traffic_handlers,
+)
 from app.localization.texts import Texts, get_texts
 from app.states import AdminStates
 from app.utils.decorators import admin_required, error_handler
@@ -174,6 +178,14 @@ def get_tariff_view_keyboard(
     buttons.append(
         [
             InlineKeyboardButton(
+                text='⚙️ Произвольный трафик',
+                callback_data=f'admin_tariff_edit_custom_traffic:{tariff.id}',
+            ),
+        ]
+    )
+    buttons.append(
+        [
+            InlineKeyboardButton(
                 text='📈 Докупка трафика', callback_data=f'admin_tariff_edit_traffic_topup:{tariff.id}'
             ),
         ]
@@ -302,7 +314,8 @@ def format_tariff_info(tariff: Tariff, language: str, subs_count: int = 0) -> st
     else:
         max_devices_display = '∞ (без лимита)'
 
-    # Форматируем докупку трафика
+    # Форматируем произвольный трафик и докупку трафика
+    custom_traffic_display = format_custom_traffic_settings(tariff)
     traffic_topup_display = _format_traffic_topup_packages(tariff)
 
     # Форматируем режим сброса трафика
@@ -334,6 +347,9 @@ def format_tariff_info(tariff: Tariff, language: str, subs_count: int = 0) -> st
 • Цена за доп. устройство: {device_price_display}
 • Триал: {trial_status}
 • Дней триала: {trial_days_display}
+
+<b>Произвольный трафик:</b>
+{custom_traffic_display}
 
 <b>Докупка трафика:</b>
 {traffic_topup_display}
@@ -2826,6 +2842,9 @@ async def set_traffic_reset_mode(
 
 def register_handlers(dp: Dispatcher):
     """Регистрирует обработчики для управления тарифами."""
+    # Произвольный трафик регистрируется до общего toggle-фильтра.
+    register_custom_traffic_handlers(dp)
+
     # Список тарифов
     dp.callback_query.register(show_tariffs_list, F.data == 'admin_tariffs')
     dp.callback_query.register(show_tariffs_page, F.data.startswith('admin_tariffs_page:'))
@@ -2839,6 +2858,7 @@ def register_handlers(dp: Dispatcher):
         & ~F.data.startswith('trf_sq:')
         & ~F.data.startswith('admin_tariff_toggle_promo:')
         & ~F.data.startswith('admin_tariff_toggle_traffic_topup:')
+        & ~F.data.startswith('admin_tariff_toggle_custom_traffic:')
         & ~F.data.startswith('admin_tariff_toggle_daily:'),
     )
     dp.callback_query.register(toggle_trial_tariff, F.data.startswith('admin_tariff_toggle_trial:'))

--- a/app/services/tariff_custom_traffic.py
+++ b/app/services/tariff_custom_traffic.py
@@ -1,0 +1,70 @@
+"""Pure parsing and validation helpers for custom-traffic tariffs."""
+
+from decimal import Decimal, InvalidOperation
+
+
+def parse_positive_rubles_to_kopeks(raw: str) -> int:
+    """Parse a positive ruble amount without floating-point rounding."""
+    normalized = raw.strip().replace(',', '.')
+    try:
+        rubles = Decimal(normalized)
+    except InvalidOperation as exc:
+        raise ValueError('invalid price') from exc
+
+    if not rubles.is_finite() or rubles <= 0:
+        raise ValueError('price must be positive and finite')
+
+    kopeks = rubles * Decimal(100)
+    if kopeks != kopeks.to_integral_value():
+        raise ValueError('price must have at most two decimal places')
+
+    return int(kopeks)
+
+
+def parse_positive_gb(raw: str) -> int:
+    """Parse a positive whole-number traffic amount in gigabytes."""
+    try:
+        value = int(raw.strip())
+    except ValueError as exc:
+        raise ValueError('traffic must be a whole number') from exc
+
+    if value <= 0:
+        raise ValueError('traffic must be positive')
+
+    return value
+
+
+def validate_custom_traffic_configuration(
+    *,
+    price_per_gb_kopeks: int | None,
+    min_traffic_gb: int | None,
+    max_traffic_gb: int | None,
+) -> tuple[str, ...]:
+    """Return user-facing validation errors for enabling custom traffic."""
+    errors: list[str] = []
+
+    if price_per_gb_kopeks is None:
+        errors.append('не указана цена за 1 ГБ')
+    elif price_per_gb_kopeks <= 0:
+        errors.append('цена за 1 ГБ должна быть больше нуля')
+
+    if min_traffic_gb is None:
+        errors.append('не указан минимальный объём')
+    elif min_traffic_gb <= 0:
+        errors.append('минимальный объём должен быть больше нуля')
+
+    if max_traffic_gb is None:
+        errors.append('не указан максимальный объём')
+    elif max_traffic_gb <= 0:
+        errors.append('максимальный объём должен быть больше нуля')
+
+    if (
+        min_traffic_gb is not None
+        and max_traffic_gb is not None
+        and min_traffic_gb > 0
+        and max_traffic_gb > 0
+        and max_traffic_gb < min_traffic_gb
+    ):
+        errors.append('максимальный объём не может быть меньше минимального')
+
+    return tuple(errors)

--- a/app/states.py
+++ b/app/states.py
@@ -217,6 +217,9 @@ class AdminStates(StatesGroup):
     editing_tariff_promo_groups = State()
     editing_tariff_traffic_topup_packages = State()
     editing_tariff_max_topup_traffic = State()
+    editing_tariff_custom_traffic_price = State()
+    editing_tariff_custom_traffic_min = State()
+    editing_tariff_custom_traffic_max = State()
     editing_tariff_daily_price = State()
 
 

--- a/tests/handlers/test_admin_tariff_custom_traffic.py
+++ b/tests/handlers/test_admin_tariff_custom_traffic.py
@@ -1,0 +1,383 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import app.handlers.admin.tariff_custom_traffic as custom_mod
+from app.handlers.admin.tariffs import format_tariff_info, get_tariff_view_keyboard
+
+
+def _unwrap(fn):
+    while hasattr(fn, '__wrapped__'):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _tariff(**overrides):
+    values = {
+        'id': 7,
+        'name': 'Whitelist <test>',
+        'description': None,
+        'is_active': True,
+        'is_trial_available': False,
+        'trial_duration_days': None,
+        'traffic_limit_gb': 100,
+        'device_limit': 1,
+        'max_device_limit': None,
+        'device_price_kopeks': None,
+        'tier_level': 1,
+        'display_order': 0,
+        'period_prices': {'30': 0},
+        'allowed_squads': [],
+        'allowed_promo_groups': [],
+        'traffic_topup_enabled': False,
+        'traffic_reset_mode': None,
+        'is_daily': False,
+        'daily_price_kopeks': 0,
+        'custom_traffic_enabled': False,
+        'traffic_price_per_gb_kopeks': 0,
+        'min_traffic_gb': 1,
+        'max_traffic_gb': 1000,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _callback(data: str):
+    callback = MagicMock()
+    callback.data = data
+    callback.message = MagicMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+    return callback
+
+
+def _message(text: str | None):
+    message = MagicMock()
+    message.text = text
+    message.answer = AsyncMock()
+    return message
+
+
+def _state(tariff_id: int = 7):
+    state = MagicMock()
+    state.get_data = AsyncMock(return_value={'tariff_id': tariff_id, 'language': 'ru'})
+    state.set_state = AsyncMock()
+    state.update_data = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+def _callbacks(keyboard) -> list[str]:
+    return [button.callback_data for row in keyboard.inline_keyboard for button in row if button.callback_data]
+
+
+def test_tariff_card_renders_custom_traffic_status_and_navigation() -> None:
+    tariff = _tariff(
+        custom_traffic_enabled=True,
+        traffic_price_per_gb_kopeks=200,
+        min_traffic_gb=5,
+        max_traffic_gb=100,
+    )
+
+    rendered = format_tariff_info(tariff, 'ru')
+    callbacks = _callbacks(get_tariff_view_keyboard(tariff, 'ru'))
+
+    assert '<b>Произвольный трафик:</b>' in rendered
+    assert '✅ Включено' in rendered
+    assert 'Цена за 1 ГБ: 2 ₽' in rendered
+    assert 'Минимальный объём: 5 ГБ' in rendered
+    assert 'Максимальный объём: 100 ГБ' in rendered
+    assert 'admin_tariff_edit_custom_traffic:7' in callbacks
+
+
+def test_custom_traffic_screen_uses_neutral_value_for_unset_price() -> None:
+    tariff = _tariff(traffic_price_per_gb_kopeks=0)
+
+    rendered = custom_mod.render_custom_traffic_settings(tariff)
+
+    assert 'Цена за 1 ГБ: <b>Не задано</b>' in rendered
+    assert 'Минимальный объём: <b>1 ГБ</b>' in rendered
+    assert 'Максимальный объём: <b>1000 ГБ</b>' in rendered
+    assert 'Whitelist &lt;test&gt;' in rendered
+
+
+async def test_enable_persists_only_enabled_flag_for_valid_settings(monkeypatch) -> None:
+    tariff = _tariff(
+        custom_traffic_enabled=False,
+        traffic_price_per_gb_kopeks=200,
+        min_traffic_gb=5,
+        max_traffic_gb=100,
+    )
+    callback = _callback('admin_tariff_toggle_custom_traffic:7')
+    updates = []
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    async def fake_update(db, target, **kwargs):
+        updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(target, key, value)
+        return target
+
+    monkeypatch.setattr(custom_mod, 'update_tariff', fake_update)
+
+    await _unwrap(custom_mod.toggle_custom_traffic)(callback, SimpleNamespace(language='ru'), MagicMock())
+
+    assert updates == [{'custom_traffic_enabled': True}]
+    callback.message.edit_text.assert_awaited_once()
+    assert callback.answer.await_args.args[0] == 'Произвольный трафик включён'
+
+
+async def test_enable_rejects_invalid_settings_without_write(monkeypatch) -> None:
+    tariff = _tariff(
+        custom_traffic_enabled=False,
+        traffic_price_per_gb_kopeks=0,
+        min_traffic_gb=100,
+        max_traffic_gb=5,
+    )
+    callback = _callback('admin_tariff_toggle_custom_traffic:7')
+    update = AsyncMock()
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(custom_mod, 'update_tariff', update)
+
+    await _unwrap(custom_mod.toggle_custom_traffic)(callback, SimpleNamespace(language='ru'), MagicMock())
+
+    update.assert_not_awaited()
+    callback.message.edit_text.assert_not_awaited()
+    assert callback.answer.await_args.kwargs['show_alert'] is True
+    alert = callback.answer.await_args.args[0]
+    assert 'цена за 1 ГБ должна быть больше нуля' in alert
+    assert 'максимальный объём не может быть меньше минимального' in alert
+
+
+async def test_disable_preserves_price_and_bounds(monkeypatch) -> None:
+    tariff = _tariff(
+        custom_traffic_enabled=True,
+        traffic_price_per_gb_kopeks=200,
+        min_traffic_gb=5,
+        max_traffic_gb=100,
+    )
+    callback = _callback('admin_tariff_toggle_custom_traffic:7')
+    updates = []
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    async def fake_update(db, target, **kwargs):
+        updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(target, key, value)
+        return target
+
+    monkeypatch.setattr(custom_mod, 'update_tariff', fake_update)
+
+    await _unwrap(custom_mod.toggle_custom_traffic)(callback, SimpleNamespace(language='ru'), MagicMock())
+
+    assert updates == [{'custom_traffic_enabled': False}]
+    assert tariff.traffic_price_per_gb_kopeks == 200
+    assert tariff.min_traffic_gb == 5
+    assert tariff.max_traffic_gb == 100
+
+
+async def test_price_input_converts_rubles_exactly_and_updates_only_price(monkeypatch) -> None:
+    tariff = _tariff()
+    message = _message('2,50')
+    state = _state()
+    updates = []
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    async def fake_update(db, target, **kwargs):
+        updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(target, key, value)
+        return target
+
+    monkeypatch.setattr(custom_mod, 'update_tariff', fake_update)
+
+    await _unwrap(custom_mod.process_custom_traffic_price_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    assert updates == [{'traffic_price_per_gb_kopeks': 250}]
+    state.clear.assert_awaited_once()
+    assert '2.50 ₽' in message.answer.await_args.args[0]
+
+
+async def test_invalid_price_keeps_fsm_active_and_does_not_write(monkeypatch) -> None:
+    tariff = _tariff()
+    message = _message('1.001')
+    state = _state()
+    update = AsyncMock()
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(custom_mod, 'update_tariff', update)
+
+    await _unwrap(custom_mod.process_custom_traffic_price_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    update.assert_not_awaited()
+    state.clear.assert_not_awaited()
+    assert 'Некорректная цена' in message.answer.await_args.args[0]
+
+
+async def test_minimum_above_current_maximum_is_rejected(monkeypatch) -> None:
+    tariff = _tariff(min_traffic_gb=5, max_traffic_gb=100)
+    message = _message('101')
+    state = _state()
+    update = AsyncMock()
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(custom_mod, 'update_tariff', update)
+
+    await _unwrap(custom_mod.process_custom_traffic_min_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    update.assert_not_awaited()
+    state.clear.assert_not_awaited()
+    assert 'не может быть больше текущего максимума' in message.answer.await_args.args[0]
+
+
+async def test_maximum_below_current_minimum_is_rejected(monkeypatch) -> None:
+    tariff = _tariff(min_traffic_gb=5, max_traffic_gb=100)
+    message = _message('4')
+    state = _state()
+    update = AsyncMock()
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(custom_mod, 'update_tariff', update)
+
+    await _unwrap(custom_mod.process_custom_traffic_max_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    update.assert_not_awaited()
+    state.clear.assert_not_awaited()
+    assert 'не может быть меньше текущего минимума' in message.answer.await_args.args[0]
+
+
+async def test_missing_tariff_is_handled_without_update(monkeypatch) -> None:
+    callback = _callback('admin_tariff_edit_custom_traffic:999')
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=None))
+
+    state = _state(999)
+    await _unwrap(custom_mod.show_custom_traffic_settings)(
+        callback,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    state.clear.assert_awaited_once()
+    callback.message.edit_text.assert_not_awaited()
+    assert callback.answer.await_args.args[0] == 'Тариф не найден'
+    assert callback.answer.await_args.kwargs['show_alert'] is True
+
+
+def test_custom_traffic_screen_renders_all_unset_values_and_back_navigation() -> None:
+    tariff = _tariff(
+        traffic_price_per_gb_kopeks=None,
+        min_traffic_gb=None,
+        max_traffic_gb=None,
+    )
+
+    rendered = custom_mod.render_custom_traffic_settings(tariff)
+    callbacks = _callbacks(custom_mod.get_custom_traffic_keyboard(tariff, 'ru'))
+
+    assert rendered.count('Не задано') == 3
+    assert 'admin_tariff_view:7' in callbacks
+    assert 'admin_tariff_toggle_custom_traffic:7' in callbacks
+
+
+def test_existing_topup_control_remains_independent() -> None:
+    tariff = _tariff()
+    callbacks = _callbacks(get_tariff_view_keyboard(tariff, 'ru'))
+
+    assert 'admin_tariff_edit_custom_traffic:7' in callbacks
+    assert 'admin_tariff_edit_traffic_topup:7' in callbacks
+
+
+async def test_show_settings_clears_field_edit_state(monkeypatch) -> None:
+    tariff = _tariff()
+    callback = _callback('admin_tariff_edit_custom_traffic:7')
+    state = _state()
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    await _unwrap(custom_mod.show_custom_traffic_settings)(
+        callback,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    state.clear.assert_awaited_once()
+    callback.message.edit_text.assert_awaited_once()
+    callback.answer.assert_awaited_once_with()
+
+
+async def test_minimum_success_updates_only_minimum(monkeypatch) -> None:
+    tariff = _tariff(min_traffic_gb=1, max_traffic_gb=100)
+    message = _message('5')
+    state = _state()
+    updates = []
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    async def fake_update(db, target, **kwargs):
+        updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(target, key, value)
+        return target
+
+    monkeypatch.setattr(custom_mod, 'update_tariff', fake_update)
+
+    await _unwrap(custom_mod.process_custom_traffic_min_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    assert updates == [{'min_traffic_gb': 5}]
+    state.clear.assert_awaited_once()
+
+
+async def test_maximum_success_updates_only_maximum(monkeypatch) -> None:
+    tariff = _tariff(min_traffic_gb=5, max_traffic_gb=1000)
+    message = _message('100')
+    state = _state()
+    updates = []
+
+    monkeypatch.setattr(custom_mod, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+
+    async def fake_update(db, target, **kwargs):
+        updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(target, key, value)
+        return target
+
+    monkeypatch.setattr(custom_mod, 'update_tariff', fake_update)
+
+    await _unwrap(custom_mod.process_custom_traffic_max_input)(
+        message,
+        SimpleNamespace(language='ru'),
+        MagicMock(),
+        state,
+    )
+
+    assert updates == [{'max_traffic_gb': 100}]
+    state.clear.assert_awaited_once()

--- a/tests/handlers/test_admin_tariff_custom_traffic_contract.py
+++ b/tests/handlers/test_admin_tariff_custom_traffic_contract.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TARIFFS = ROOT / 'app' / 'handlers' / 'admin' / 'tariffs.py'
+CUSTOM = ROOT / 'app' / 'handlers' / 'admin' / 'tariff_custom_traffic.py'
+STATES = ROOT / 'app' / 'states.py'
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _function_source(path: Path, name: str) -> str:
+    source = _source(path)
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            assert node.end_lineno is not None
+            return '\n'.join(lines[node.lineno - 1 : node.end_lineno])
+    raise AssertionError(f'function {name!r} not found in {path}')
+
+
+def test_tariff_card_exposes_custom_traffic_entry() -> None:
+    body = _function_source(TARIFFS, 'get_tariff_view_keyboard')
+    assert '⚙️ Произвольный трафик' in body
+    assert 'admin_tariff_edit_custom_traffic:' in body
+
+
+def test_tariff_summary_includes_custom_traffic_block() -> None:
+    body = _function_source(TARIFFS, 'format_tariff_info')
+    assert 'format_custom_traffic_settings(tariff)' in body
+    assert '<b>Произвольный трафик:</b>' in body
+
+
+def test_custom_traffic_module_is_registered_from_tariff_router() -> None:
+    body = _function_source(TARIFFS, 'register_handlers')
+    assert 'register_custom_traffic_handlers(dp)' in body
+
+
+def test_custom_traffic_screen_and_handlers_are_registered() -> None:
+    body = _function_source(CUSTOM, 'register_custom_traffic_handlers')
+    for callback_prefix in (
+        'admin_tariff_edit_custom_traffic:',
+        'admin_tariff_toggle_custom_traffic:',
+        'admin_tariff_edit_custom_traffic_price:',
+        'admin_tariff_edit_custom_traffic_min:',
+        'admin_tariff_edit_custom_traffic_max:',
+    ):
+        assert callback_prefix in body
+
+    for state_name in (
+        'editing_tariff_custom_traffic_price',
+        'editing_tariff_custom_traffic_min',
+        'editing_tariff_custom_traffic_max',
+    ):
+        assert state_name in body
+
+
+def test_generic_tariff_toggle_excludes_custom_traffic_callback() -> None:
+    body = _function_source(TARIFFS, 'register_handlers')
+    assert "~F.data.startswith('admin_tariff_toggle_custom_traffic:')" in body
+
+
+def test_custom_traffic_fsm_states_exist() -> None:
+    source = _source(STATES)
+    for state_name in (
+        'editing_tariff_custom_traffic_price = State()',
+        'editing_tariff_custom_traffic_min = State()',
+        'editing_tariff_custom_traffic_max = State()',
+    ):
+        assert state_name in source
+
+
+def test_disable_path_updates_only_enabled_flag() -> None:
+    body = _function_source(CUSTOM, 'toggle_custom_traffic')
+    assert 'custom_traffic_enabled=False' in body
+    disable_branch = body.split('if tariff.custom_traffic_enabled:', 1)[1].split('else:', 1)[0]
+    assert 'traffic_price_per_gb_kopeks=' not in disable_branch
+    assert 'min_traffic_gb=' not in disable_branch
+    assert 'max_traffic_gb=' not in disable_branch
+
+
+def test_field_handlers_use_existing_crud_boundary() -> None:
+    source = _source(CUSTOM)
+    for name in (
+        'process_custom_traffic_price_input',
+        'process_custom_traffic_min_input',
+        'process_custom_traffic_max_input',
+    ):
+        body = _function_source(CUSTOM, name)
+        assert 'update_tariff(' in body
+        assert 'execute(' not in body
+        assert 'UPDATE tariffs' not in body
+
+    assert 'from app.services.tariff_custom_traffic import (' in source

--- a/tests/services/test_tariff_custom_traffic.py
+++ b/tests/services/test_tariff_custom_traffic.py
@@ -1,0 +1,85 @@
+import pytest
+
+from app.services.tariff_custom_traffic import (
+    parse_positive_gb,
+    parse_positive_rubles_to_kopeks,
+    validate_custom_traffic_configuration,
+)
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [('2', 200), ('2.50', 250), ('2,50', 250), ('0.01', 1)],
+)
+def test_parse_positive_rubles_to_kopeks(raw: str, expected: int) -> None:
+    assert parse_positive_rubles_to_kopeks(raw) == expected
+
+
+@pytest.mark.parametrize('raw', ['', 'abc', '0', '-1', 'nan', 'NaN', 'inf', '-inf', '1.001'])
+def test_parse_positive_rubles_to_kopeks_rejects_invalid_values(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_positive_rubles_to_kopeks(raw)
+
+
+@pytest.mark.parametrize(('raw', 'expected'), [('1', 1), ('5', 5), ('100', 100)])
+def test_parse_positive_gb(raw: str, expected: int) -> None:
+    assert parse_positive_gb(raw) == expected
+
+
+@pytest.mark.parametrize('raw', ['', '0', '-1', '1.5', 'abc'])
+def test_parse_positive_gb_rejects_invalid_values(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_positive_gb(raw)
+
+
+def test_valid_custom_traffic_configuration_has_no_errors() -> None:
+    assert (
+        validate_custom_traffic_configuration(
+            price_per_gb_kopeks=200,
+            min_traffic_gb=5,
+            max_traffic_gb=100,
+        )
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    ('price', 'minimum', 'maximum', 'expected_fragment'),
+    [
+        (None, 5, 100, 'не указана цена'),
+        (0, 5, 100, 'цена за 1 ГБ должна быть больше нуля'),
+        (-1, 5, 100, 'цена за 1 ГБ должна быть больше нуля'),
+        (200, None, 100, 'не указан минимальный объём'),
+        (200, 0, 100, 'минимальный объём должен быть больше нуля'),
+        (200, -1, 100, 'минимальный объём должен быть больше нуля'),
+        (200, 5, None, 'не указан максимальный объём'),
+        (200, 5, 0, 'максимальный объём должен быть больше нуля'),
+        (200, 5, -1, 'максимальный объём должен быть больше нуля'),
+        (200, 100, 5, 'максимальный объём не может быть меньше минимального'),
+    ],
+)
+def test_invalid_custom_traffic_configuration_reports_specific_error(
+    price: int | None,
+    minimum: int | None,
+    maximum: int | None,
+    expected_fragment: str,
+) -> None:
+    errors = validate_custom_traffic_configuration(
+        price_per_gb_kopeks=price,
+        min_traffic_gb=minimum,
+        max_traffic_gb=maximum,
+    )
+    assert any(expected_fragment in error for error in errors)
+
+
+def test_invalid_configuration_reports_all_independent_missing_fields() -> None:
+    errors = validate_custom_traffic_configuration(
+        price_per_gb_kopeks=None,
+        min_traffic_gb=None,
+        max_traffic_gb=None,
+    )
+    assert errors == (
+        'не указана цена за 1 ГБ',
+        'не указан минимальный объём',
+        'не указан максимальный объём',
+    )


### PR DESCRIPTION
## Что сделано

Добавлен минимальный Telegram-интерфейс администратора для уже существующего механизма произвольного трафика в тарифах.

До этого в проекте уже присутствовали:

- поля модели `custom_traffic_enabled`, `traffic_price_per_gb_kopeks`, `min_traffic_gb`, `max_traffic_gb`;
- API и CRUD для их сохранения;
- расчёт стоимости выбранного объёма;
- пользовательский выбор трафика при покупке.

PR не добавляет новый механизм тарификации, а только делает существующие поля доступными оператору через Telegram-админку.

### Интерфейс

В карточку тарифа добавлена кнопка **«⚙️ Произвольный трафик»**. Она открывает отдельный экран, где можно независимо:

- включить или выключить режим;
- задать цену за 1 ГБ в рублях;
- задать минимальный объём в целых ГБ;
- задать максимальный объём в целых ГБ.

### Валидация

Включение разрешено только когда одновременно выполнены условия:

- цена за 1 ГБ больше нуля;
- минимальный объём больше нуля;
- максимальный объём не меньше минимального.

Ошибки показываются по конкретным полям. Скрытые значения по умолчанию не подставляются.

При выключении меняется только `custom_traffic_enabled=False`. Цена и границы сохраняются для последующего повторного включения.

## Границы изменения

- без миграций БД;
- без изменений Cabinet;
- без изменений Pricing Engine;
- без изменений пользовательского сценария покупки;
- без изменений учёта трафика Remnawave;
- без ad-hoc SQL — используется существующий `update_tariff()`.

## Проверки

- focused-тесты парсинга, валидации, отображения, FSM-обработчиков и сохранения полей;
- регрессия независимости существующей докупки трафика;
- `ruff format --check .`;
- `ruff check .`;
- полный `pytest -q`;
- проверка точного scope: 7 файлов, без миграций и служебных артефактов.

Ветка основана на актуальном `dev` (`64feac0aa8e5da90da38797a4d834fbcb350c2e2`) и содержит один feature-коммит.