### PR TITLE
fix(pricing): корректная цена за месяц для коротких и некратных периодов

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -47,7 +47,7 @@ from app.services.subscription_purchase_service import (
 )
 from app.services.subscription_service import SubscriptionService
 from app.services.user_cart_service import user_cart_service
-from app.utils.pricing_utils import format_period_description
+from app.utils.pricing_utils import calculate_price_per_month, format_period_description
 
 from ...dependencies import get_cabinet_db, get_current_cabinet_user
 from ...schemas.subscription import (
@@ -192,8 +192,8 @@ async def _build_tariff_response(
                 discount_percent = 0
                 final_price = original_price
 
-            per_month = final_price // months if months > 0 else final_price
-            original_per_month = original_price // months if months > 0 else original_price
+            per_month = calculate_price_per_month(final_price, period_days)
+            original_per_month = calculate_price_per_month(original_price, period_days)
 
             period_data: dict[str, Any] = {
                 'days': period_days,

--- a/app/services/subscription_purchase_service.py
+++ b/app/services/subscription_purchase_service.py
@@ -29,6 +29,7 @@ from app.services.subscription_service import SubscriptionService
 from app.utils.pricing_utils import (
     apply_percentage_discount,
     calculate_months_from_days,
+    calculate_price_per_month,
     format_period_description,
     validate_pricing_calculation,
 )
@@ -392,7 +393,7 @@ class MiniAppSubscriptionPurchaseService:
                 else None
             )
 
-            per_month_price = base_price // months if months else base_price
+            per_month_price = calculate_price_per_month(base_price, period_days)
             per_month_price_label = texts.format_price(per_month_price)
 
             traffic_config = self._build_traffic_config(
@@ -935,7 +936,7 @@ class MiniAppSubscriptionPurchaseService:
                 'Not enough funds on balance',
             )
 
-        per_month_price = pricing.final_total // pricing.months if pricing.months else pricing.final_total
+        per_month_price = calculate_price_per_month(pricing.final_total, pricing.selection.period.days)
 
         return {
             'total_price_kopeks': pricing.final_total,

--- a/app/services/subscription_renewal_service.py
+++ b/app/services/subscription_renewal_service.py
@@ -26,6 +26,7 @@ from app.services.admin_notification_service import AdminNotificationService
 from app.services.pricing_engine import RenewalPricing
 from app.services.remnawave_service import RemnaWaveConfigurationError
 from app.services.subscription_service import SubscriptionService
+from app.utils.pricing_utils import calculate_price_per_month
 
 
 logger = structlog.get_logger(__name__)
@@ -107,8 +108,8 @@ class SubscriptionRenewalPricing:
 
         # per_month
         per_month = int(payload.get('per_month', 0) or 0)
-        if not per_month and months > 0:
-            per_month = final_total // months
+        if not per_month and period_days > 0:
+            per_month = calculate_price_per_month(final_total, period_days)
 
         # server_ids: legacy at top level, RenewalPricing in breakdown
         server_ids = list(payload.get('server_ids') or breakdown.get('server_ids') or [])

--- a/app/utils/pricing_utils.py
+++ b/app/utils/pricing_utils.py
@@ -20,6 +20,20 @@ def calculate_months_from_days(days: int) -> int:
     return max(1, round(days / 30))
 
 
+def calculate_price_per_month(price_kopeks: int, period_days: int) -> int:
+    """Месячная ставка для периода длиной period_days дней (месяц = 30 дней).
+
+    Считается пропорцией, а не делением на округлённое число месяцев:
+    для коротких (7 дней) и некратных 30 (45 дней) периодов делитель
+    зажимался в 1-2 месяца, и цена периода уходила в отображение как
+    месячная. Значение только для показа, начисления идут по полной
+    цене периода.
+    """
+    if price_kopeks <= 0 or period_days <= 0:
+        return max(0, price_kopeks)
+    return round(price_kopeks * 30 / period_days)
+
+
 def calculate_prorated_price(monthly_price: int, end_date: datetime, min_charge_days: int = 1) -> tuple[int, int]:
     """Calculate prorated price based on remaining days.
 

--- a/app/webapi/routes/miniapp.py
+++ b/app/webapi/routes/miniapp.py
@@ -94,6 +94,7 @@ from app.services.tribute_service import TributeService
 from app.utils.currency_converter import currency_converter
 from app.utils.pricing_utils import (
     apply_percentage_discount,
+    calculate_price_per_month,
     calculate_prorated_price,
     format_period_description,
 )
@@ -4638,7 +4639,7 @@ async def _prepare_subscription_renewal_options(
         )
 
         months = max(1, period_days // 30)
-        per_month = pricing_result.final_total // months if months > 0 else pricing_result.final_total
+        per_month = calculate_price_per_month(pricing_result.final_total, period_days)
 
         label = format_period_description(
             period_days,
@@ -6317,7 +6318,7 @@ async def _build_tariff_model(
                 discount_percent = 0
 
             months = max(1, period_days // 30)
-            per_month = price_kopeks // months if months > 0 else price_kopeks
+            per_month = calculate_price_per_month(price_kopeks, period_days)
 
             periods.append(
                 MiniAppTariffPeriod(

--- a/tests/utils/test_pricing_utils.py
+++ b/tests/utils/test_pricing_utils.py
@@ -8,9 +8,36 @@
 from unittest.mock import MagicMock, patch
 
 from app.localization.texts import _build_dynamic_values
+from app.utils.pricing_utils import calculate_price_per_month
 
 
 # DEPRECATED: format_period_option_label tests removed - function replaced with unified price_display system
+
+
+class TestCalculatePricePerMonth:
+    """Тесты для calculate_price_per_month из pricing_utils.py."""
+
+    def test_whole_months_divide_evenly(self) -> None:
+        """Периоды, кратные 30 дням, делятся на целые месяцы."""
+        assert calculate_price_per_month(16030, 30) == 16030
+        assert calculate_price_per_month(30000, 90) == 10000
+        assert calculate_price_per_month(60000, 180) == 10000
+
+    def test_short_period_is_extrapolated(self) -> None:
+        """Для периода короче месяца ставка экстраполируется, а не равна цене периода."""
+        assert calculate_price_per_month(4830, 7) == 20700
+        assert calculate_price_per_month(9900, 14) == 21214
+
+    def test_period_not_multiple_of_month_is_prorated(self) -> None:
+        """Некратные 30 дням периоды считаются пропорцией, а не делением на округлённые месяцы."""
+        assert calculate_price_per_month(15000, 45) == 10000
+        assert calculate_price_per_month(100000, 365) == 8219
+
+    def test_non_positive_input_falls_back_to_price(self) -> None:
+        """Нулевые и отрицательные значения не роняют расчёт."""
+        assert calculate_price_per_month(0, 90) == 0
+        assert calculate_price_per_month(10000, 0) == 10000
+        assert calculate_price_per_month(-100, 30) == 0
 
 
 class TestBuildDynamicValues:


### PR DESCRIPTION
## 📝 Описание
Цена за месяц (`price_per_month_kopeks` / `per_month_price` / `per_month`)
считалась делением цены периода на округлённое число месяцев —
`max(1, days // 30)` или `round(days / 30)`. Для периодов короче месяца
делитель зажимался в 1, и в поле «за месяц» уходила полная цена периода:
период 7 дней за 48.30 ₽ отдавался как 48.30 ₽/мес. Для некратных 30 дням
периодов ставка занижалась: 45 дней делились на 2 месяца.

Расчёт вынесен в `calculate_price_per_month()` (месяц = 30 дней,
пропорция `price * 30 / days`) и применён во всех местах, где месячная
цена уходит в ответ API или в payload котировки:

- `app/cabinet/routes/subscription_modules/purchase.py` — `price_per_month_kopeks`, `original_per_month_kopeks`
- `app/webapi/routes/miniapp.py` — периоды продления и периоды тарифа
- `app/services/subscription_purchase_service.py` — `per_month_price` в опциях и в превью покупки
- `app/services/subscription_renewal_service.py` — восстановление `per_month` из legacy-payload

`months`, по которому считается стоимость доп. устройств, трафика и
серверов, намеренно не тронут: правка касается только отображаемой
величины, начисления идут по полной цене периода.

## 🎯 Мотивация
В кабинете в карточке периода под ценой выводилось «48.30 ₽/мес» для
семидневного периода — то есть цена периода выдавалась за месячную.
Парная правка на фронте: BEDOLAGA-DEV/bedolaga-cabinet#524 (там та же
формула, а для периодов в месяц и короче строка не показывается).

## 🔧 Тип изменений
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [ ] Документация обновлена (не требуется)

## 🧪 Тестирование
- `uv run ruff check` — All checks passed
- `uv run ruff format --check .` — 859 files already formatted
- `uv run pytest tests/ -q` — 2329 passed
- Новые тесты `TestCalculatePricePerMonth` в `tests/utils/test_pricing_utils.py`:
  кратные 30 дням периоды, короткий период (7/14 дней), некратные (45/365 дней),
  нулевые и отрицательные значения
