### PR TITLE
feat(promo-offers): охват сегментов и прогресс доставки промопредложений

### DIFF
--- a/app/cabinet/routes/admin_promo_offers.py
+++ b/app/cabinet/routes/admin_promo_offers.py
@@ -7,14 +7,12 @@ from datetime import datetime
 from typing import Any, ClassVar
 
 import structlog
-from aiogram import Bot
-from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, validator
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.bot_factory import create_bot
 from app.database.crud.discount_offer import (
     count_discount_offers,
     list_discount_offers,
@@ -28,8 +26,15 @@ from app.database.crud.promo_offer_template import (
     update_promo_offer_template,
 )
 from app.database.crud.user import get_user_by_email, get_user_by_telegram_id
-from app.database.models import DiscountOffer, PromoOfferLog, PromoOfferTemplate, User
-from app.handlers.admin.messages import get_custom_users, get_target_users
+from app.database.models import (
+    BroadcastHistory,
+    DiscountOffer,
+    PromoOfferLog,
+    PromoOfferTemplate,
+    User,
+)
+from app.handlers.admin.messages import get_custom_users, get_target_users, get_target_users_count
+from app.services.broadcast_service import BroadcastConfig, broadcast_service
 from app.utils.miniapp_buttons import build_miniapp_or_callback_button
 
 from ..dependencies import get_cabinet_db, require_permission
@@ -162,8 +167,24 @@ class PromoOfferBroadcastResponse(BaseModel):
     created_offers: int
     user_ids: list[int]
     target: str | None = None
+    # Счётчики email-уведомлений, отправленных синхронно. Доставка в Telegram идёт через
+    # запись рассылки — её прогресс читается по broadcast_id.
     notifications_sent: int = 0
     notifications_failed: int = 0
+    broadcast_id: int | None = Field(
+        None,
+        description='ID записи рассылки для отслеживания прогресса доставки в Telegram',
+    )
+    telegram_recipients: int = Field(0, description='Сколько получателей ушло в Telegram-рассылку')
+
+
+class PromoOfferSegment(BaseModel):
+    key: str
+    count: int
+
+
+class PromoOfferSegmentListResponse(BaseModel):
+    segments: list[PromoOfferSegment]
 
 
 class PromoOfferLogOfferInfo(BaseModel):
@@ -294,6 +315,49 @@ async def _resolve_target_users(db: AsyncSession, target: str) -> list[User]:
     return await get_target_users(db, normalized)
 
 
+# Сегменты, доступные для рассылки промопредложений. Порядок задаёт порядок в кабинете.
+TARGET_SEGMENTS: tuple[str, ...] = (
+    'all',
+    'active',
+    'trial',
+    'trial_ending',
+    'expiring',
+    'expired',
+    'zero',
+    'autopay_failed',
+    'low_balance',
+    'inactive_30d',
+    'inactive_60d',
+    'inactive_90d',
+    'custom_today',
+    'custom_week',
+    'custom_month',
+    'custom_active_today',
+)
+
+
+# ============== Segment Endpoints ==============
+
+
+@router.get('/segments', response_model=PromoOfferSegmentListResponse)
+async def list_segments(
+    admin: User = Depends(require_permission('promo_offers:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+) -> PromoOfferSegmentListResponse:
+    """Число пользователей в каждом сегменте — чтобы админ видел охват до отправки."""
+    segments: list[PromoOfferSegment] = []
+
+    for key in TARGET_SEGMENTS:
+        try:
+            count = await get_target_users_count(db, key)
+        except SQLAlchemyError as exc:
+            logger.warning('Failed to count promo offer segment', segment=key, exc=exc)
+            count = 0
+        segments.append(PromoOfferSegment(key=key, count=count))
+
+    return PromoOfferSegmentListResponse(segments=segments)
+
+
 # ============== Template Endpoints ==============
 
 
@@ -394,9 +458,76 @@ async def list_offers(
     )
 
 
-def _get_bot() -> Bot:
-    """Create bot instance for sending notifications."""
-    return create_bot()
+def _build_promo_keyboard(offer_id: int, button_text: str) -> InlineKeyboardMarkup:
+    """Клавиатура промопредложения: кнопка активации своего оффера + закрыть."""
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                build_miniapp_or_callback_button(
+                    text=button_text,
+                    callback_data=f'claim_discount_{offer_id}',
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text='❌ Закрыть',
+                    callback_data='promo_offer_close',
+                )
+            ],
+        ]
+    )
+
+
+async def _start_promo_broadcast(
+    db: AsyncSession,
+    admin: User,
+    *,
+    target: str | None,
+    message_text: str,
+    button_text: str,
+    notify_targets: list[tuple[int, int]],
+) -> int:
+    """Завести запись рассылки и запустить доставку промопредложений в фоне.
+
+    Возвращает id записи: по нему кабинет читает прогресс, счётчики доставленных,
+    заблокировавших бота и ошибок — теми же ручками, что и обычные рассылки.
+    """
+    broadcast = BroadcastHistory(
+        target_type=target or 'promo_offer_direct',
+        message_text=message_text,
+        total_count=len(notify_targets),
+        sent_count=0,
+        failed_count=0,
+        blocked_count=0,
+        status='queued',
+        admin_id=admin.id,
+        admin_name=admin.username or f'Admin #{admin.id}',
+        category='promo',
+    )
+    db.add(broadcast)
+    await db.commit()
+    await db.refresh(broadcast)
+
+    offer_by_telegram_id = dict(notify_targets)
+
+    def keyboard_factory(telegram_id: int) -> InlineKeyboardMarkup | None:
+        offer_id = offer_by_telegram_id.get(telegram_id)
+        return _build_promo_keyboard(offer_id, button_text) if offer_id else None
+
+    config = BroadcastConfig(
+        target=broadcast.target_type,
+        message_text=message_text,
+        selected_buttons=[],
+        initiator_name=broadcast.admin_name,
+        category='promo',
+        recipient_ids=[telegram_id for telegram_id, _offer_id in notify_targets],
+        keyboard_factory=keyboard_factory,
+    )
+
+    await broadcast_service.start_broadcast(broadcast.id, config)
+    await db.refresh(broadcast)
+
+    return broadcast.id
 
 
 def _build_default_promo_message(
@@ -417,101 +548,6 @@ def _build_default_promo_message(
     lines.append('\nНажмите кнопку ниже, чтобы активировать!')
 
     return '\n'.join(lines)
-
-
-async def _send_promo_notifications(
-    targets: list[tuple[int, int]],
-    message_text: str | None,
-    button_text: str | None,
-    discount_percent: int,
-    bonus_amount_kopeks: int,
-    valid_hours: int,
-) -> tuple[int, int]:
-    """Send Telegram promo notifications.
-
-    Args:
-        targets: list of (telegram_id, offer_id). Plain ids (not ORM objects) so this
-            can run as a detached background task after the request's DB session closed.
-
-    Returns:
-        Tuple of (sent_count, failed_count)
-    """
-    if not targets:
-        return 0, 0
-
-    bot = _get_bot()
-    sent = 0
-    failed = 0
-
-    # Build message text
-    text = message_text or _build_default_promo_message(
-        discount_percent=discount_percent,
-        bonus_amount_kopeks=bonus_amount_kopeks,
-        valid_hours=valid_hours,
-    )
-
-    # Default button text
-    btn_text = button_text or '🎁 Получить'
-
-    semaphore = asyncio.Semaphore(20)
-
-    async def send_single(telegram_id: int, offer_id: int) -> bool:
-        if not telegram_id:
-            return False
-
-        async with semaphore:
-            try:
-                keyboard = InlineKeyboardMarkup(
-                    inline_keyboard=[
-                        [
-                            build_miniapp_or_callback_button(
-                                text=btn_text,
-                                callback_data=f'claim_discount_{offer_id}',
-                            )
-                        ],
-                        [
-                            InlineKeyboardButton(
-                                text='❌ Закрыть',
-                                callback_data='promo_offer_close',
-                            )
-                        ],
-                    ]
-                )
-
-                await bot.send_message(
-                    chat_id=telegram_id,
-                    text=text,
-                    reply_markup=keyboard,
-                )
-                return True
-            except (TelegramForbiddenError, TelegramBadRequest) as exc:
-                logger.warning('Failed to send promo notification to user', telegram_id=telegram_id, exc=exc)
-                return False
-            except Exception as exc:
-                logger.error('Error sending promo notification to user', telegram_id=telegram_id, exc=exc)
-                return False
-
-    # Send in batches
-    batch_size = 50
-    for i in range(0, len(targets), batch_size):
-        batch = targets[i : i + batch_size]
-        tasks = [send_single(tg_id, offer_id) for tg_id, offer_id in batch]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        for result in results:
-            if isinstance(result, bool) and result:
-                sent += 1
-            else:
-                failed += 1
-
-        # Small delay between batches
-        if i + batch_size < len(targets):
-            await asyncio.sleep(0.1)
-
-    # Close bot session
-    await bot.session.close()
-
-    return sent, failed
 
 
 async def _send_promo_email_notifications(
@@ -654,6 +690,7 @@ async def broadcast_offer(
     # Send Telegram/email notifications if requested
     notifications_sent = 0
     notifications_failed = 0
+    broadcast_id: int | None = None
 
     if payload.send_notification and (notify_targets or email_targets):
         # Render placeholders in custom message text
@@ -671,30 +708,29 @@ async def broadcast_offer(
             except (KeyError, ValueError, IndexError):
                 logger.warning('Failed to render promo message placeholders')
 
-        notify_kwargs = {
-            'message_text': rendered_message_text,
-            'button_text': payload.button_text,
-            'discount_percent': payload.discount_percent,
-            'bonus_amount_kopeks': payload.bonus_amount_kopeks,
-            'valid_hours': payload.valid_hours,
-        }
-
         if notify_targets:
-            if len(notify_targets) <= _SYNC_NOTIFY_LIMIT:
-                # Small batch: send inline so exact sent/failed counts come back immediately.
-                notifications_sent, notifications_failed = await _send_promo_notifications(
-                    notify_targets, **notify_kwargs
-                )
-            else:
-                # Mass broadcast: a synchronous fan-out to thousands of users overruns the
-                # proxy timeout — the cabinet showed an error while the offers were already
-                # committed and notifications kept sending (Telegram bug #652234). Detach it:
-                # the request returns now with created_offers; delivery is observable via /logs.
-                _schedule_promo_notifications(_send_promo_notifications(notify_targets, **notify_kwargs))
-                logger.info(
-                    'Promo broadcast: notifications dispatched in background',
-                    recipients=len(notify_targets),
-                )
+            # Доставка в Telegram идёт через сервис рассылок: фан-аут на тысячи получателей
+            # не укладывался в таймаут прокси, а детач в фон не оставлял следов — кабинет
+            # не видел ни прогресса, ни числа заблокировавших бота. Теперь на отправку
+            # заводится запись рассылки, и кабинет опрашивает её по broadcast_id.
+            broadcast_id = await _start_promo_broadcast(
+                db,
+                admin,
+                target=payload.target,
+                message_text=rendered_message_text
+                or _build_default_promo_message(
+                    discount_percent=payload.discount_percent,
+                    bonus_amount_kopeks=payload.bonus_amount_kopeks,
+                    valid_hours=payload.valid_hours,
+                ),
+                button_text=payload.button_text or '🎁 Получить',
+                notify_targets=notify_targets,
+            )
+            logger.info(
+                'Promo broadcast: telegram delivery started',
+                broadcast_id=broadcast_id,
+                recipients=len(notify_targets),
+            )
 
         if email_targets:
             # Email-путь получает тот же текст, что и Telegram (кнопке «Получить»
@@ -728,6 +764,8 @@ async def broadcast_offer(
         target=payload.target,
         notifications_sent=notifications_sent,
         notifications_failed=notifications_failed,
+        broadcast_id=broadcast_id,
+        telegram_recipients=len(notify_targets),
     )
 
 

--- a/app/handlers/admin/messages.py
+++ b/app/handlers/admin/messages.py
@@ -1523,6 +1523,19 @@ async def confirm_broadcast(callback: types.CallbackQuery, db_user: User, state:
     )
 
 
+# Пороги сегментов. Вынесены в константы, потому что get_target_users_count (SQL COUNT)
+# и get_target_users (фильтрация в Python) обязаны совпадать: разъехавшиеся пороги дают
+# счётчик в интерфейсе, который не сходится с реальным числом получателей.
+LOW_BALANCE_THRESHOLD_KOPEKS = 10000
+TRIAL_ENDING_DAYS = 3
+AUTOPAY_FAILED_WINDOW_DAYS = 7
+INACTIVE_TARGET_DAYS = {
+    'inactive_30d': 30,
+    'inactive_60d': 60,
+    'inactive_90d': 90,
+}
+
+
 async def get_target_users_count(db: AsyncSession, target: str) -> int:
     """Быстрый подсчёт пользователей через SQL COUNT вместо загрузки всех в память."""
     from sqlalchemy import distinct, func as sql_func
@@ -1683,6 +1696,88 @@ async def get_target_users_count(db: AsyncSession, target: str) -> int:
                 Subscription.status == SubscriptionStatus.ACTIVE.value,
                 or_(Subscription.traffic_used_gb == None, Subscription.traffic_used_gb <= 0),
             )
+        )
+        result = await db.execute(query)
+        return result.scalar() or 0
+
+    if target == 'expired':
+        # Есть истёкшая подписка и нет ни одной активной — зеркало ветки в get_target_users
+        now = datetime.now(UTC)
+        has_active_sub = (
+            select(Subscription.id)
+            .where(
+                Subscription.user_id == User.id,
+                Subscription.status == SubscriptionStatus.ACTIVE.value,
+                Subscription.end_date > now,
+            )
+            .correlate(User)
+            .exists()
+        )
+        has_expired_sub = (
+            select(Subscription.id)
+            .where(
+                Subscription.user_id == User.id,
+                or_(
+                    Subscription.status.in_([SubscriptionStatus.EXPIRED.value, SubscriptionStatus.DISABLED.value]),
+                    Subscription.end_date <= now,
+                ),
+            )
+            .correlate(User)
+            .exists()
+        )
+        query = select(sql_func.count(User.id)).where(base_filter, ~has_active_sub, has_expired_sub)
+        result = await db.execute(query)
+        return result.scalar() or 0
+
+    if target == 'trial_ending':
+        now = datetime.now(UTC)
+        query = (
+            select(sql_func.count(distinct(User.id)))
+            .join(Subscription, User.id == Subscription.user_id)
+            .where(
+                base_filter,
+                Subscription.is_trial == True,
+                Subscription.status == SubscriptionStatus.ACTIVE.value,
+                Subscription.end_date > now,
+                Subscription.end_date <= now + timedelta(days=TRIAL_ENDING_DAYS),
+            )
+        )
+        result = await db.execute(query)
+        return result.scalar() or 0
+
+    if target == 'autopay_failed':
+        from app.database.models import SubscriptionEvent
+
+        window_start = datetime.now(UTC) - timedelta(days=AUTOPAY_FAILED_WINDOW_DAYS)
+        has_recent_failure = (
+            select(SubscriptionEvent.id)
+            .where(
+                SubscriptionEvent.user_id == User.id,
+                SubscriptionEvent.event_type == 'autopay_failed',
+                SubscriptionEvent.occurred_at >= window_start,
+            )
+            .correlate(User)
+            .exists()
+        )
+        query = select(sql_func.count(User.id)).where(base_filter, has_recent_failure)
+        result = await db.execute(query)
+        return result.scalar() or 0
+
+    if target == 'low_balance':
+        query = select(sql_func.count(User.id)).where(
+            base_filter,
+            User.balance_kopeks > 0,
+            User.balance_kopeks < LOW_BALANCE_THRESHOLD_KOPEKS,
+        )
+        result = await db.execute(query)
+        return result.scalar() or 0
+
+    if target in INACTIVE_TARGET_DAYS:
+        threshold = datetime.now(UTC) - timedelta(days=INACTIVE_TARGET_DAYS[target])
+        query = select(sql_func.count(User.id)).where(
+            base_filter,
+            User.last_activity.isnot(None),
+            User.last_activity < threshold,
         )
         result = await db.execute(query)
         return result.scalar() or 0
@@ -1853,7 +1948,7 @@ async def get_target_users(db: AsyncSession, target: str) -> list:
 
     if target == 'trial_ending':
         now = datetime.now(UTC)
-        in_3_days = now + timedelta(days=3)
+        in_3_days = now + timedelta(days=TRIAL_ENDING_DAYS)
         return [
             user
             for user in users
@@ -1874,7 +1969,7 @@ async def get_target_users(db: AsyncSession, target: str) -> list:
     if target == 'autopay_failed':
         from app.database.models import SubscriptionEvent
 
-        week_ago = datetime.now(UTC) - timedelta(days=7)
+        week_ago = datetime.now(UTC) - timedelta(days=AUTOPAY_FAILED_WINDOW_DAYS)
         stmt = (
             select(SubscriptionEvent.user_id)
             .where(
@@ -1890,21 +1985,13 @@ async def get_target_users(db: AsyncSession, target: str) -> list:
         return [user for user in users if user.id in failed_user_ids]
 
     if target == 'low_balance':
-        threshold_kopeks = 10000  # 100 рублей
+        threshold_kopeks = LOW_BALANCE_THRESHOLD_KOPEKS
         return [
             user for user in users if (user.balance_kopeks or 0) < threshold_kopeks and (user.balance_kopeks or 0) > 0
         ]
 
-    if target == 'inactive_30d':
-        threshold = datetime.now(UTC) - timedelta(days=30)
-        return [user for user in users if user.last_activity and user.last_activity < threshold]
-
-    if target == 'inactive_60d':
-        threshold = datetime.now(UTC) - timedelta(days=60)
-        return [user for user in users if user.last_activity and user.last_activity < threshold]
-
-    if target == 'inactive_90d':
-        threshold = datetime.now(UTC) - timedelta(days=90)
+    if target in INACTIVE_TARGET_DAYS:
+        threshold = datetime.now(UTC) - timedelta(days=INACTIVE_TARGET_DAYS[target])
         return [user for user in users if user.last_activity and user.last_activity < threshold]
 
     # Фильтр по тарифу

--- a/app/services/broadcast_service.py
+++ b/app/services/broadcast_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -69,6 +70,12 @@ class BroadcastConfig:
     initiator_name: str | None = None
     custom_buttons: list[dict] | None = None
     category: str = 'system'  # system|news|promo
+    # Явный список telegram_id вместо резолва target'а. Нужен отправкам, где получатели
+    # уже посчитаны вызывающим кодом (промопредложения создают оффер на каждого).
+    recipient_ids: list[int] | None = None
+    # Персональная клавиатура на получателя (у промопредложений в callback_data зашит
+    # id его оффера). Если задана — вытесняет selected_buttons/custom_buttons.
+    keyboard_factory: Callable[[int], InlineKeyboardMarkup | None] | None = None
 
 
 @dataclass
@@ -167,7 +174,10 @@ class BroadcastService:
                 await session.commit()
 
             # _fetch_recipients теперь возвращает list[int] (telegram_id), а не ORM-объекты
-            recipient_ids: list[int] = await self._fetch_recipients(config.target, config.category)
+            if config.recipient_ids is not None:
+                recipient_ids: list[int] = list(config.recipient_ids)
+            else:
+                recipient_ids = await self._fetch_recipients(config.target, config.category)
 
             async with AsyncSessionLocal() as session:
                 broadcast = await session.get(BroadcastHistory, broadcast_id)
@@ -187,7 +197,11 @@ class BroadcastService:
                 await self._mark_finished(broadcast_id, sent_count, failed_count, blocked_count, cancelled=False)
                 return
 
-            keyboard = self._build_keyboard(config.selected_buttons, config.custom_buttons)
+            keyboard = (
+                None
+                if config.keyboard_factory
+                else self._build_keyboard(config.selected_buttons, config.custom_buttons)
+            )
 
             logger.info(
                 'Рассылка: начинаем отправку получателям',
@@ -303,7 +317,11 @@ class BroadcastService:
                     return 'failed'
 
                 try:
-                    await self._deliver_message(telegram_id, config, keyboard)
+                    await self._deliver_message(
+                        telegram_id,
+                        config,
+                        config.keyboard_factory(telegram_id) if config.keyboard_factory else keyboard,
+                    )
                     return 'sent'
 
                 except TelegramRetryAfter as e:

--- a/tests/cabinet/test_promo_offer_broadcast_notify.py
+++ b/tests/cabinet/test_promo_offer_broadcast_notify.py
@@ -3,54 +3,135 @@
 The broadcast committed an offer per recipient and then sent Telegram notifications to
 everyone synchronously inside the HTTP request; a large fan-out overran the proxy timeout,
 so the cabinet showed an error while offers were already created and notifications kept
-going. The fan-out now takes plain (telegram_id, offer_id) tuples — not ORM objects bound
-to the request session — so it can run detached as a background task.
+going. Delivery now goes through the broadcast service: it takes plain telegram_id values
+and a keyboard factory closing over plain offer ids — not ORM objects bound to the request
+session — so it keeps running after the request (and its session) is gone.
 
-This pins the refactored signature/behaviour: it works off plain ids and counts
-sent/failed correctly (including skipping recipients without a telegram_id).
+This pins that contract: only recipients with a telegram_id are handed over, the payload
+carries no ORM objects, and nothing is queued when there is nobody to notify.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime, timedelta
 
-import pytest
-from aiogram.types import InlineKeyboardButton
+from app.cabinet.routes.admin_promo_offers import PromoOfferBroadcastRequest, broadcast_offer
+from app.database.models import (
+    BroadcastHistory,
+    DiscountOffer,
+    PromoGroup,
+    Subscription,
+    SubscriptionEvent,
+    SubscriptionStatus,
+    Tariff,
+    User,
+    UserStatus,
+)
+from tests.fixtures.sqlite_memory import memory_session
 
-from app.cabinet.routes import admin_promo_offers as m
+
+NOTIFY_TABLES = (
+    User.__table__,
+    Subscription.__table__,
+    SubscriptionEvent.__table__,
+    Tariff.__table__,
+    PromoGroup.__table__,
+    DiscountOffer.__table__,
+    BroadcastHistory.__table__,
+)
 
 
-@pytest.mark.asyncio
-async def test_send_promo_notifications_works_off_plain_ids(monkeypatch):
-    chat_ids: list[int] = []
+def _admin() -> User:
+    return User(id=99, telegram_id=99, username='admin', status=UserStatus.ACTIVE.value)
 
-    bot = MagicMock()
-    bot.send_message = AsyncMock(side_effect=lambda chat_id, text, reply_markup: chat_ids.append(chat_id))
-    bot.session = MagicMock()
-    bot.session.close = AsyncMock()
-    monkeypatch.setattr(m, '_get_bot', lambda: bot)
-    # Isolate the fan-out from the keyboard helper (which needs miniapp config).
+
+def _payload(**kwargs) -> PromoOfferBroadcastRequest:
+    defaults = {
+        'notification_type': 'extend_discount',
+        'valid_hours': 24,
+        'discount_percent': 10,
+        'target': 'active',
+        'send_notification': True,
+        'message_text': 'hi',
+    }
+    defaults.update(kwargs)
+    return PromoOfferBroadcastRequest(**defaults)
+
+
+async def _seed_subscriber(db, *, telegram_id: int | None, email: str | None = None) -> User:
+    now = datetime.now(UTC)
+    user = User(
+        telegram_id=telegram_id,
+        email=email,
+        email_verified=bool(email),
+        username=f'user{telegram_id or email}',
+        first_name='User',
+        status=UserStatus.ACTIVE.value,
+        balance_kopeks=0,
+        last_activity=now,
+    )
+    db.add(user)
+    await db.commit()
+
+    db.add(
+        Subscription(
+            user_id=user.id,
+            status=SubscriptionStatus.ACTIVE.value,
+            is_trial=False,
+            start_date=now - timedelta(days=5),
+            end_date=now + timedelta(days=25),
+            remnawave_short_id=f'short{user.id}',
+        )
+    )
+    await db.commit()
+    return user
+
+
+async def test_delivery_runs_off_plain_ids(monkeypatch):
+    """В сервис рассылок уходят голые telegram_id, без ORM-объектов сессии запроса."""
+    started: list[object] = []
+
+    async def fake_start_broadcast(broadcast_id, config):
+        started.append(config)
+
     monkeypatch.setattr(
-        m,
-        'build_miniapp_or_callback_button',
-        lambda text, callback_data: InlineKeyboardButton(text=text, callback_data=callback_data),
+        'app.cabinet.routes.admin_promo_offers.broadcast_service.start_broadcast',
+        fake_start_broadcast,
     )
 
-    sent, failed = await m._send_promo_notifications(
-        [(111, 1), (222, 2), (0, 3)],  # (telegram_id, offer_id); 0 => email-only, skipped
-        message_text='hi',
-        button_text=None,
-        discount_percent=10,
-        bonus_amount_kopeks=0,
-        valid_hours=24,
+    async with memory_session(monkeypatch, NOTIFY_TABLES) as db:
+        await _seed_subscriber(db, telegram_id=111)
+        await _seed_subscriber(db, telegram_id=222)
+        # Email-only получатель: оффер ему создаётся, но в Telegram-доставку он не идёт
+        await _seed_subscriber(db, telegram_id=None, email='mail@example.com')
+
+        response = await broadcast_offer(_payload(), admin=_admin(), db=db)
+
+        assert response.created_offers == 3
+        assert response.telegram_recipients == 2
+
+        assert len(started) == 1
+        config = started[0]
+        assert sorted(config.recipient_ids) == [111, 222]
+        assert all(isinstance(telegram_id, int) for telegram_id in config.recipient_ids)
+
+
+async def test_nothing_queued_without_telegram_recipients(monkeypatch):
+    """Некому слать в Telegram — запись рассылки не заводится."""
+
+    async def fail_start_broadcast(broadcast_id, config):
+        raise AssertionError('рассылку не должны были запускать')
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.admin_promo_offers.broadcast_service.start_broadcast',
+        fail_start_broadcast,
     )
 
-    assert (sent, failed) == (2, 1)
-    assert chat_ids == [111, 222]
-    bot.session.close.assert_awaited()
+    async with memory_session(monkeypatch, NOTIFY_TABLES) as db:
+        await _seed_subscriber(db, telegram_id=None, email='mail@example.com')
 
+        response = await broadcast_offer(_payload(), admin=_admin(), db=db)
 
-@pytest.mark.asyncio
-async def test_empty_targets_is_noop(monkeypatch):
-    monkeypatch.setattr(m, '_get_bot', lambda: (_ for _ in ()).throw(AssertionError('bot must not be created')))
-    assert await m._send_promo_notifications([], None, None, 0, 0, 24) == (0, 0)
+        assert response.created_offers == 1
+        assert response.telegram_recipients == 0
+        assert response.broadcast_id is None

--- a/tests/cabinet/test_promo_offer_broadcast_progress.py
+++ b/tests/cabinet/test_promo_offer_broadcast_progress.py
@@ -1,0 +1,170 @@
+"""Рассылка промопредложений заводит запись рассылки, по которой кабинет видит доставку.
+
+Раньше отправка на большую аудиторию детачилась в фон и о её судьбе нельзя было
+узнать ничего: ни сколько дошло, ни сколько человек заблокировало бота.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.cabinet.routes.admin_promo_offers import (
+    TARGET_SEGMENTS,
+    PromoOfferBroadcastRequest,
+    broadcast_offer,
+    list_segments,
+)
+from app.database.models import (
+    BroadcastHistory,
+    DiscountOffer,
+    PromoGroup,
+    Subscription,
+    SubscriptionEvent,
+    SubscriptionStatus,
+    Tariff,
+    User,
+    UserStatus,
+)
+from tests.fixtures.sqlite_memory import memory_session
+
+
+PROMO_TABLES = (
+    User.__table__,
+    Subscription.__table__,
+    SubscriptionEvent.__table__,
+    Tariff.__table__,
+    PromoGroup.__table__,
+    DiscountOffer.__table__,
+    BroadcastHistory.__table__,
+)
+
+
+async def _seed_active_subscribers(db, count: int) -> list[User]:
+    now = datetime.now(UTC)
+    users = [
+        User(
+            telegram_id=1000 + index,
+            username=f'user{index}',
+            first_name=f'User {index}',
+            status=UserStatus.ACTIVE.value,
+            balance_kopeks=0,
+            last_activity=now,
+        )
+        for index in range(count)
+    ]
+    db.add_all(users)
+    await db.commit()
+
+    db.add_all(
+        [
+            Subscription(
+                user_id=user.id,
+                status=SubscriptionStatus.ACTIVE.value,
+                is_trial=False,
+                start_date=now - timedelta(days=5),
+                end_date=now + timedelta(days=25),
+                remnawave_short_id=f'short{user.id}',
+            )
+            for user in users
+        ]
+    )
+    await db.commit()
+    return users
+
+
+def _admin() -> User:
+    return User(id=99, telegram_id=99, username='admin', status=UserStatus.ACTIVE.value)
+
+
+def _payload(**kwargs) -> PromoOfferBroadcastRequest:
+    defaults = {
+        'notification_type': 'extend_discount',
+        'valid_hours': 24,
+        'discount_percent': 20,
+        'target': 'active',
+        'send_notification': True,
+        'message_text': 'Скидка {discount_percent}% на продление',
+        'button_text': '🎁 Забрать',
+    }
+    defaults.update(kwargs)
+    return PromoOfferBroadcastRequest(**defaults)
+
+
+async def test_broadcast_creates_tracked_delivery(monkeypatch):
+    """Отправка сегменту заводит запись рассылки с числом получателей и возвращает её id."""
+    started: list[tuple[int, object]] = []
+
+    async def fake_start_broadcast(broadcast_id, config):
+        started.append((broadcast_id, config))
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.admin_promo_offers.broadcast_service.start_broadcast',
+        fake_start_broadcast,
+    )
+
+    async with memory_session(monkeypatch, PROMO_TABLES) as db:
+        users = await _seed_active_subscribers(db, 3)
+
+        response = await broadcast_offer(_payload(), admin=_admin(), db=db)
+
+        assert response.created_offers == 3
+        assert response.telegram_recipients == 3
+        assert response.broadcast_id is not None
+
+        broadcast = await db.get(BroadcastHistory, response.broadcast_id)
+        assert broadcast is not None
+        assert broadcast.total_count == 3
+        assert broadcast.status == 'queued'
+        assert broadcast.category == 'promo'
+        assert broadcast.target_type == 'active'
+        # Плейсхолдеры раскрыты до постановки в очередь — в Telegram уходит готовый текст
+        assert broadcast.message_text == 'Скидка 20% на продление'
+
+        assert len(started) == 1
+        broadcast_id, config = started[0]
+        assert broadcast_id == response.broadcast_id
+        assert sorted(config.recipient_ids) == sorted(user.telegram_id for user in users)
+
+        # Клавиатура персональная: в callback_data зашит оффер конкретного получателя
+        offers = (await db.execute(select(DiscountOffer))).scalars().all()
+        offer_by_user = {offer.user_id: offer.id for offer in offers}
+        for user in users:
+            keyboard = config.keyboard_factory(user.telegram_id)
+            assert keyboard.inline_keyboard[0][0].callback_data == f'claim_discount_{offer_by_user[user.id]}'
+
+
+async def test_broadcast_without_notification_skips_delivery_record(monkeypatch):
+    """Без send_notification офферы создаются, но рассылку заводить не за чем."""
+    started: list[int] = []
+
+    async def fake_start_broadcast(broadcast_id, config):
+        started.append(broadcast_id)
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.admin_promo_offers.broadcast_service.start_broadcast',
+        fake_start_broadcast,
+    )
+
+    async with memory_session(monkeypatch, PROMO_TABLES) as db:
+        await _seed_active_subscribers(db, 2)
+
+        response = await broadcast_offer(_payload(send_notification=False), admin=_admin(), db=db)
+
+        assert response.created_offers == 2
+        assert response.broadcast_id is None
+        assert started == []
+        assert (await db.execute(select(BroadcastHistory))).scalars().first() is None
+
+
+async def test_segments_endpoint_returns_counts_for_every_segment(monkeypatch):
+    """Кабинет получает охват по каждому сегменту, а не только по выбранному."""
+    async with memory_session(monkeypatch, PROMO_TABLES) as db:
+        await _seed_active_subscribers(db, 4)
+
+        response = await list_segments(admin=_admin(), db=db)
+
+        assert [segment.key for segment in response.segments] == list(TARGET_SEGMENTS)
+        counts = {segment.key: segment.count for segment in response.segments}
+        assert counts['all'] == 4
+        assert counts['active'] == 4
+        assert counts['trial'] == 0

--- a/tests/fixtures/sqlite_memory.py
+++ b/tests/fixtures/sqlite_memory.py
@@ -1,0 +1,50 @@
+"""In-memory SQLite сессия для тестов, которым нужны реальные запросы к БД.
+
+Полный ``create_all`` не годится: часть таблиц использует JSONB, поэтому здесь
+регистрируется рендер JSONB как JSON и таблицы создаются точечным списком.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from collections.abc import AsyncIterator, Sequence
+
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+from app.database.models import Base
+
+
+@compiles(JSONB, 'sqlite')
+def _compile_jsonb_on_sqlite(type_, compiler, **kw) -> str:
+    """SQLite не компилирует JSONB (например, User.notification_settings)."""
+    return 'JSON'
+
+
+def ensure_real_aiosqlite(monkeypatch) -> None:
+    """Снять заглушку sys.modules['aiosqlite'] из conftest перед созданием engine.
+
+    conftest подставляет пустой модуль для окружений без aiosqlite, и эта заглушка
+    перекрывает физически установленный пакет — create_async_engine падает.
+    """
+    stub = sys.modules.get('aiosqlite')
+    if stub is not None and not hasattr(stub, 'connect'):
+        monkeypatch.delitem(sys.modules, 'aiosqlite', raising=False)
+
+
+@contextlib.asynccontextmanager
+async def memory_session(monkeypatch, tables: Sequence[Table]) -> AsyncIterator[AsyncSession]:
+    """Сессия к :memory: БД, где созданы только переданные таблицы."""
+    ensure_real_aiosqlite(monkeypatch)
+    engine = create_async_engine('sqlite+aiosqlite:///:memory:')
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=list(tables)))
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            yield session
+    finally:
+        await engine.dispose()

--- a/tests/handlers/test_promo_segment_counts.py
+++ b/tests/handlers/test_promo_segment_counts.py
@@ -1,0 +1,155 @@
+"""Счётчики сегментов промопредложений: SQL COUNT обязан совпадать с Python-фильтрами.
+
+get_target_users_count считает получателей запросом, get_target_users отбирает их
+в Python и именно по нему уходит рассылка. Кабинет показывает первое, а получает
+второе — если ветки разъедутся, админ увидит охват, которого не будет.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from app.database.models import (
+    PromoGroup,
+    Subscription,
+    SubscriptionEvent,
+    SubscriptionStatus,
+    Tariff,
+    User,
+    UserStatus,
+)
+from app.handlers.admin.messages import get_target_users, get_target_users_count
+from tests.fixtures.sqlite_memory import memory_session
+
+
+PROMO_SEGMENTS = (
+    'expired',
+    'trial_ending',
+    'autopay_failed',
+    'low_balance',
+    'inactive_30d',
+    'inactive_60d',
+    'inactive_90d',
+)
+
+SEGMENT_TABLES = (
+    User.__table__,
+    Subscription.__table__,
+    SubscriptionEvent.__table__,
+    Tariff.__table__,
+    PromoGroup.__table__,
+)
+
+
+def _user(telegram_id: int, **kwargs) -> User:
+    defaults = {
+        'telegram_id': telegram_id,
+        'username': f'user{telegram_id}',
+        'first_name': f'User {telegram_id}',
+        'status': UserStatus.ACTIVE.value,
+        'balance_kopeks': 0,
+        'last_activity': datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    return User(**defaults)
+
+
+def _subscription(user_id: int, *, status: str, end_date: datetime, is_trial: bool = False) -> Subscription:
+    return Subscription(
+        user_id=user_id,
+        status=status,
+        is_trial=is_trial,
+        start_date=datetime.now(UTC) - timedelta(days=30),
+        end_date=end_date,
+        # Колонка unique + server_default='' — в тестовой БД проставляем сами
+        remnawave_short_id=f'short{user_id}',
+    )
+
+
+async def _seed(db) -> None:
+    now = datetime.now(UTC)
+
+    paid = _user(1, balance_kopeks=50000)
+    expired_low_balance = _user(2, balance_kopeks=5000, last_activity=now - timedelta(days=40))
+    trial_ending = _user(3, balance_kopeks=20000)
+    long_gone = _user(4, balance_kopeks=0, last_activity=now - timedelta(days=100))
+    autopay_broken = _user(5, balance_kopeks=100)
+    # Заблокированный пользователь не должен попадать ни в один сегмент
+    blocked = _user(6, status=UserStatus.BLOCKED.value, balance_kopeks=5000, last_activity=now - timedelta(days=200))
+
+    db.add_all([paid, expired_low_balance, trial_ending, long_gone, autopay_broken, blocked])
+    await db.commit()
+
+    db.add_all(
+        [
+            _subscription(paid.id, status=SubscriptionStatus.ACTIVE.value, end_date=now + timedelta(days=10)),
+            _subscription(
+                expired_low_balance.id,
+                status=SubscriptionStatus.EXPIRED.value,
+                end_date=now - timedelta(days=5),
+            ),
+            _subscription(
+                trial_ending.id,
+                status=SubscriptionStatus.ACTIVE.value,
+                end_date=now + timedelta(days=2),
+                is_trial=True,
+            ),
+            _subscription(
+                autopay_broken.id,
+                status=SubscriptionStatus.ACTIVE.value,
+                end_date=now + timedelta(days=20),
+            ),
+            _subscription(
+                blocked.id,
+                status=SubscriptionStatus.EXPIRED.value,
+                end_date=now - timedelta(days=15),
+            ),
+        ]
+    )
+    db.add_all(
+        [
+            SubscriptionEvent(
+                user_id=autopay_broken.id,
+                event_type='autopay_failed',
+                occurred_at=now - timedelta(days=3),
+            ),
+            # Старая поломка автоплатежа вне недельного окна — в сегмент не берём
+            SubscriptionEvent(
+                user_id=paid.id,
+                event_type='autopay_failed',
+                occurred_at=now - timedelta(days=30),
+            ),
+        ]
+    )
+    await db.commit()
+
+
+async def test_promo_segment_counts_match_recipient_lists(monkeypatch):
+    """Для каждого промо-сегмента SQL-счётчик равен длине списка получателей."""
+    async with memory_session(monkeypatch, SEGMENT_TABLES) as db:
+        await _seed(db)
+
+        for segment in PROMO_SEGMENTS:
+            counted = await get_target_users_count(db, segment)
+            recipients = await get_target_users(db, segment)
+            assert counted == len(recipients), f'сегмент {segment}: счётчик {counted} != получателей {len(recipients)}'
+
+
+async def test_promo_segment_counts_are_not_all_zero(monkeypatch):
+    """Явные ожидания — паритет сам по себе прошёл бы и на двух одинаково пустых ветках."""
+    async with memory_session(monkeypatch, SEGMENT_TABLES) as db:
+        await _seed(db)
+
+        assert await get_target_users_count(db, 'expired') == 1
+        assert await get_target_users_count(db, 'trial_ending') == 1
+        assert await get_target_users_count(db, 'autopay_failed') == 1
+        assert await get_target_users_count(db, 'low_balance') == 2
+        assert await get_target_users_count(db, 'inactive_30d') == 2
+        assert await get_target_users_count(db, 'inactive_60d') == 1
+        assert await get_target_users_count(db, 'inactive_90d') == 1
+
+
+async def test_unknown_segment_counts_zero(monkeypatch):
+    """Неизвестный ключ не роняет запрос и не показывает мусорный охват."""
+    async with memory_session(monkeypatch, SEGMENT_TABLES) as db:
+        await _seed(db)
+
+        assert await get_target_users_count(db, 'definitely_not_a_segment') == 0

--- a/tests/services/test_broadcast_per_recipient_keyboard.py
+++ b/tests/services/test_broadcast_per_recipient_keyboard.py
@@ -1,0 +1,120 @@
+"""BroadcastConfig.recipient_ids и keyboard_factory: рассылка с персональной кнопкой.
+
+Промопредложения шлют каждому свою кнопку (в callback_data зашит id его оффера),
+поэтому сервису рассылок нужен готовый список получателей и фабрика клавиатур.
+"""
+
+import asyncio
+
+from aiogram.exceptions import TelegramForbiddenError
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from app.services.broadcast_service import BroadcastConfig, BroadcastService
+
+
+def _promo_keyboard(offer_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text='🎁', callback_data=f'claim_discount_{offer_id}')]]
+    )
+
+
+def _config(**kwargs) -> BroadcastConfig:
+    defaults = {
+        'target': 'promo_offer_direct',
+        'message_text': 'Промо',
+        'selected_buttons': [],
+        'category': 'promo',
+    }
+    defaults.update(kwargs)
+    return BroadcastConfig(**defaults)
+
+
+async def test_keyboard_factory_builds_personal_keyboard_per_recipient(monkeypatch):
+    """Каждому получателю уходит своя клавиатура, а не одна общая."""
+    service = BroadcastService()
+    delivered: list[tuple[int, InlineKeyboardMarkup | None]] = []
+
+    async def fake_deliver(telegram_id, config, keyboard):
+        delivered.append((telegram_id, keyboard))
+
+    async def noop_progress(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(service, '_deliver_message', fake_deliver)
+    monkeypatch.setattr(service, '_update_progress', noop_progress)
+    monkeypatch.setattr('app.services.broadcast_service._TG_BATCH_DELAY', 0)
+
+    offers = {101: 5001, 102: 5002}
+    config = _config(
+        recipient_ids=list(offers),
+        keyboard_factory=lambda telegram_id: _promo_keyboard(offers[telegram_id]),
+    )
+
+    sent, failed, blocked, cancelled = await service._send_batched(
+        1,
+        list(offers),
+        config,
+        None,
+        asyncio.Event(),
+    )
+
+    assert (sent, failed, blocked, cancelled) == (2, 0, 0, False)
+    assert [telegram_id for telegram_id, _ in delivered] == [101, 102]
+    callbacks = [keyboard.inline_keyboard[0][0].callback_data for _, keyboard in delivered]
+    assert callbacks == ['claim_discount_5001', 'claim_discount_5002']
+
+
+async def test_blocked_recipients_counted_separately(monkeypatch):
+    """Заблокировавшие бота идут в blocked, а не в общую кучу ошибок."""
+    service = BroadcastService()
+
+    async def fake_deliver(telegram_id, config, keyboard):
+        if telegram_id == 102:
+            raise TelegramForbiddenError(method=None, message='bot was blocked by the user')
+
+    async def noop_progress(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(service, '_deliver_message', fake_deliver)
+    monkeypatch.setattr(service, '_update_progress', noop_progress)
+    monkeypatch.setattr('app.services.broadcast_service._TG_BATCH_DELAY', 0)
+
+    config = _config(recipient_ids=[101, 102], keyboard_factory=lambda telegram_id: _promo_keyboard(1))
+
+    sent, failed, blocked, cancelled = await service._send_batched(
+        1,
+        [101, 102],
+        config,
+        None,
+        asyncio.Event(),
+    )
+
+    assert (sent, failed, blocked, cancelled) == (1, 0, 1, False)
+
+
+async def test_without_factory_shared_keyboard_is_used(monkeypatch):
+    """Обычные рассылки не затронуты: без фабрики уходит общая клавиатура."""
+    service = BroadcastService()
+    delivered: list[InlineKeyboardMarkup | None] = []
+
+    async def fake_deliver(telegram_id, config, keyboard):
+        delivered.append(keyboard)
+
+    async def noop_progress(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(service, '_deliver_message', fake_deliver)
+    monkeypatch.setattr(service, '_update_progress', noop_progress)
+    monkeypatch.setattr('app.services.broadcast_service._TG_BATCH_DELAY', 0)
+
+    shared = _promo_keyboard(1)
+    sent, _failed, _blocked, _cancelled = await service._send_batched(
+        1,
+        [101, 102],
+        _config(),
+        shared,
+        asyncio.Event(),
+    )
+
+    assert sent == 2
+    assert delivered == [shared, shared]


### PR DESCRIPTION
## 📝 Описание
Отправка промопредложения не давала админу ничего, кроме числа созданных офферов:
сегмент выбирался вслепую, а доставка на большую аудиторию уходила детачем в фон —
ни прогресса, ни числа дошедших, ни числа заблокировавших бота (`TelegramForbiddenError`
и обычные ошибки складывались в один счётчик).

**Доставка.** Telegram-отправка переведена на сервис рассылок: заводится запись
`broadcast_history` (`category='promo'`, `total_count` = число получателей), и её
`sent_count` / `blocked_count` / `failed_count` / `progress_percent` кабинет читает по
`broadcast_id` из ответа. Собственный сендер `_send_promo_notifications` удалён — путь
доставки теперь один, вместе с батчингом, FloodWait-ретраями и отменой.

Чтобы это стало возможно, `BroadcastConfig` получил два опциональных поля:

```python
recipient_ids: list[int] | None = None          # готовый список вместо резолва target'а
keyboard_factory: Callable[[int], InlineKeyboardMarkup | None] | None = None
```

Персональная клавиатура нужна потому, что у промопредложения в `callback_data` зашит
`claim_discount_{offer_id}` конкретного получателя. Обычные рассылки не затронуты: без
фабрики строится общая клавиатура, как и раньше (закреплено тестом).

**Охват сегментов.** Добавлен `GET /cabinet/admin/promo-offers/segments` — число
пользователей в каждом из 16 сегментов. Для этого в `get_target_users_count` дописаны
ветки `expired`, `trial_ending`, `autopay_failed`, `low_balance`, `inactive_30d/60d/90d`:
их там не было, и для этих сегментов счётчик молча возвращал 0. Пороги (100 ₽, 3 дня,
7 дней, 30/60/90 дней) вынесены в константы, общие с `get_target_users`.

## 🎯 Мотивация
Админ не видел ни охвата сегмента до отправки, ни того, сколько человек реально
получило предложение и сколько заблокировало бота.

Парная правка в кабинете: BEDOLAGA-DEV/bedolaga-cabinet#526

## 🔧 Тип изменений
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [ ] Документация обновлена (не требуется)

## 🧪 Тестирование
- `uv run ruff check` — All checks passed
- `uv run ruff format --check .` — 863 files already formatted
- `uv run pytest tests/ -q` — 2334 passed
- Новые тесты:
  - `tests/handlers/test_promo_segment_counts.py` — SQL-счётчик каждого промо-сегмента
    сверяется с длиной реального списка получателей на засеянной БД плюс явные ожидаемые
    числа (паритет сам по себе прошёл бы и на двух одинаково пустых ветках);
  - `tests/services/test_broadcast_per_recipient_keyboard.py` — персональная клавиатура
    на получателя, отдельный счёт заблокировавших, неизменность обычных рассылок;
  - `tests/cabinet/test_promo_offer_broadcast_progress.py` — отправка заводит запись
    рассылки с нужным `total_count`/`category`/раскрытым текстом и отдаёт `broadcast_id`;
    эндпоинт сегментов отдаёт охват по всем ключам;
  - `tests/cabinet/test_promo_offer_broadcast_notify.py` — переписан под новую доставку
    (regression Telegram bug #652234: в фан-аут уходят голые telegram_id, без ORM-объектов).
- Общий in-memory SQLite-харнесс вынесен в `tests/fixtures/sqlite_memory.py`.

## ⚠️ На что обратить внимание
1. Промо-отправки теперь видны в списке `/admin/broadcasts` с `category='promo'` — прямое
   следствие переиспользования механики рассылок.
2. `notifications_sent` / `notifications_failed` в ответе `/broadcast` теперь считают только
   email-уведомления (Telegram отслеживается через `broadcast_id`). Поля оставлены ради
   обратной совместимости, семантика описана в схеме.
3. Фильтрация по настройкам уведомлений намеренно не менялась: промопредложение, как и
   раньше, уходит всем в сегменте. Обычные рассылки с `category='promo'` таких
   отфильтровывают — если нужно выровнять, сделаю отдельным PR.
