### PR TITLE
feat(admin): add Bedolaga-first User Detail contracts

### DIFF
--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -2,6 +2,7 @@
 
 import math
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -115,6 +116,7 @@ from ..schemas.users import (
     UserActivityResponse,
     UserAvailableTariffItem,
     UserAvailableTariffsResponse,
+    UserByRemnawaveResponse,
     UserDetailResponse,
     UserDevicesResponse,
     UserListItem,
@@ -704,6 +706,43 @@ async def get_users_stats(
 
 
 # === User Detail ===
+
+
+@router.get('/by-remnawave/{remnawave_uuid}', response_model=UserByRemnawaveResponse)
+async def get_user_by_remnawave_uuid(
+    remnawave_uuid: str,
+    admin: User = Depends(require_permission('users:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Resolve an exact Remnawave UUID through its owning subscription only."""
+    try:
+        normalized = str(UUID(remnawave_uuid))
+    except (TypeError, ValueError, AttributeError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid Remnawave UUID')
+
+    matches = (
+        (
+            await db.execute(
+                select(Subscription).where(Subscription.remnawave_uuid == normalized).limit(2)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not matches:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Remnawave UUID is not linked to a subscription')
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Remnawave UUID is linked to multiple subscriptions',
+        )
+
+    subscription = matches[0]
+    return UserByRemnawaveResponse(
+        user_id=subscription.user_id,
+        subscription_id=subscription.id,
+        matched_remnawave_uuid=normalized,
+    )
 
 
 @router.get('/{user_id}', response_model=UserDetailResponse)

--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -944,6 +944,10 @@ async def get_user_panel_info(
             detail='User not found',
         )
 
+    panel_uuid = None
+    if subscription_id is not None:
+        panel_uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
+
     try:
         from app.services.remnawave_service import RemnaWaveService
 
@@ -954,23 +958,25 @@ async def get_user_panel_info(
         async with service.get_api_client() as api:
             panel_user = None
 
-            # Multi-tariff: use per-subscription UUID
-            if settings.is_multi_tariff_enabled() and subscription_id is not None:
-                sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
-                if sub.remnawave_uuid:
-                    panel_user = await api.get_user_by_uuid(sub.remnawave_uuid)
-            # Single-tariff: user-level UUID
+            if subscription_id is not None and panel_uuid:
+                panel_user = await api.get_user_by_uuid(panel_uuid)
+            # Legacy fallback is only for callers that did not select a subscription.
             elif user.remnawave_uuid:
                 panel_user = await api.get_user_by_uuid(user.remnawave_uuid)
 
             # Fallback: search by telegram_id (single-tariff only)
-            if not panel_user and not settings.is_multi_tariff_enabled() and user.telegram_id:
+            if (
+                not panel_user
+                and subscription_id is None
+                and not settings.is_multi_tariff_enabled()
+                and user.telegram_id
+            ):
                 panel_users = await api.get_user_by_telegram_id(user.telegram_id)
                 if panel_users:
                     panel_user = panel_users[0]
 
             # Fallback: search by email (single-tariff, OAuth users)
-            if not panel_user and not settings.is_multi_tariff_enabled() and user.email:
+            if not panel_user and subscription_id is None and not settings.is_multi_tariff_enabled() and user.email:
                 panel_users_by_email = await api.get_user_by_email(user.email)
                 if panel_users_by_email:
                     panel_user = panel_users_by_email[0]
@@ -1032,9 +1038,8 @@ async def get_subscription_request_history(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
 
     panel_uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id is not None:
-        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
-        panel_uuid = sub.remnawave_uuid
+    if subscription_id is not None:
+        panel_uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
     else:
         panel_uuid = getattr(user, 'remnawave_uuid', None)
 
@@ -2517,9 +2522,8 @@ async def get_user_devices(
 
     # Resolve panel UUID
     _dev_uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id is not None:
-        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
-        _dev_uuid = sub.remnawave_uuid
+    if subscription_id is not None:
+        _dev_uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
     else:
         _dev_uuid = user.remnawave_uuid
 
@@ -2595,9 +2599,8 @@ async def delete_user_device(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
 
     _uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id is not None:
-        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
-        _uuid = sub.remnawave_uuid
+    if subscription_id is not None:
+        _uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
     else:
         _uuid = user.remnawave_uuid
 

--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -947,6 +947,8 @@ async def get_user_panel_info(
     panel_uuid = None
     if subscription_id is not None:
         panel_uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
+        if panel_uuid is None:
+            return UserPanelInfoResponse(found=False)
 
     try:
         from app.services.remnawave_service import RemnaWaveService
@@ -961,7 +963,7 @@ async def get_user_panel_info(
             if subscription_id is not None and panel_uuid:
                 panel_user = await api.get_user_by_uuid(panel_uuid)
             # Legacy fallback is only for callers that did not select a subscription.
-            elif user.remnawave_uuid:
+            elif subscription_id is None and user.remnawave_uuid:
                 panel_user = await api.get_user_by_uuid(user.remnawave_uuid)
 
             # Fallback: search by telegram_id (single-tariff only)

--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -331,6 +331,7 @@ async def _sync_subscription_to_panel(
     subscription: Subscription,
     reset_traffic: bool = False,
     reset_traffic_reason: str | None = None,
+    pinned_subscription_identity: bool = False,
 ) -> dict:
     """
     Sync user subscription to Remnawave panel.
@@ -338,6 +339,9 @@ async def _sync_subscription_to_panel(
     Optionally resets traffic after sync.
     Returns dict with changes/errors.
     """
+    if pinned_subscription_identity and not subscription.remnawave_uuid:
+        return {'skipped': True, 'reason': 'Selected subscription has no panel UUID'}
+
     try:
         from app.config import settings
         from app.external.remnawave_api import UserStatus as PanelUserStatus
@@ -403,7 +407,7 @@ async def _sync_subscription_to_panel(
         changes = {}
         async with service.get_api_client() as api:
             # Multi-tariff: each subscription has its own panel user
-            if settings.is_multi_tariff_enabled():
+            if pinned_subscription_identity or settings.is_multi_tariff_enabled():
                 panel_uuid = subscription.remnawave_uuid
             else:
                 panel_uuid = user.remnawave_uuid
@@ -414,13 +418,18 @@ async def _sync_subscription_to_panel(
                 if not existing_user:
                     logger.warning('Stale remnawave_uuid, clearing', user_id=user.id, panel_uuid=panel_uuid)
                     panel_uuid = None
-                    if settings.is_multi_tariff_enabled():
+                    if pinned_subscription_identity or settings.is_multi_tariff_enabled():
                         subscription.remnawave_uuid = None
                     else:
                         user.remnawave_uuid = None
 
             # Fallback: search by telegram_id (single-tariff only)
-            if not panel_uuid and not settings.is_multi_tariff_enabled() and user.telegram_id:
+            if (
+                not panel_uuid
+                and not pinned_subscription_identity
+                and not settings.is_multi_tariff_enabled()
+                and user.telegram_id
+            ):
                 existing_users = await api.get_user_by_telegram_id(user.telegram_id)
                 if existing_users:
                     panel_uuid = existing_users[0].uuid
@@ -428,7 +437,12 @@ async def _sync_subscription_to_panel(
                     changes['remnawave_uuid_discovered'] = panel_uuid
 
             # Fallback: search by email (single-tariff, OAuth users)
-            if not panel_uuid and not settings.is_multi_tariff_enabled() and user.email:
+            if (
+                not panel_uuid
+                and not pinned_subscription_identity
+                and not settings.is_multi_tariff_enabled()
+                and user.email
+            ):
                 existing_users = await api.get_user_by_email(user.email)
                 if existing_users:
                     panel_uuid = existing_users[0].uuid
@@ -476,7 +490,7 @@ async def _sync_subscription_to_panel(
                     else:
                         raise
 
-            if not panel_uuid:
+            if not panel_uuid and not pinned_subscription_identity:
                 # Create new user
                 create_kwargs = {
                     'username': username,
@@ -514,7 +528,11 @@ async def _sync_subscription_to_panel(
                 logger.info('Created user in Remnawave panel', user_id=user.id, uuid=new_panel_user.uuid)
 
             # Reset traffic on panel if requested
-            _reset_uuid = subscription.remnawave_uuid if settings.is_multi_tariff_enabled() else user.remnawave_uuid
+            _reset_uuid = (
+                subscription.remnawave_uuid
+                if pinned_subscription_identity or settings.is_multi_tariff_enabled()
+                else user.remnawave_uuid
+            )
             if reset_traffic and _reset_uuid:
                 try:
                     await api.reset_user_traffic(_reset_uuid)
@@ -741,16 +759,14 @@ async def get_user_by_remnawave_uuid(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid Remnawave UUID')
 
     matches = (
-        (
-            await db.execute(
-                select(Subscription).where(Subscription.remnawave_uuid == normalized).limit(2)
-            )
-        )
+        (await db.execute(select(Subscription).where(Subscription.remnawave_uuid == normalized).limit(2)))
         .scalars()
         .all()
     )
     if not matches:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Remnawave UUID is not linked to a subscription')
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='Remnawave UUID is not linked to a subscription'
+        )
     if len(matches) > 1:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -1363,7 +1379,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info(
             'Admin extended subscription for user by days', admin_id=admin.id, user_id=user_id, days=request.days
@@ -1398,7 +1416,9 @@ async def update_user_subscription(
             await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info(
             'Admin shortened subscription for user by days', admin_id=admin.id, user_id=user_id, days=request.days
@@ -1428,7 +1448,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info('Admin set end_date for user subscription', admin_id=admin.id, user_id=user_id)
 
@@ -1553,7 +1575,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info('Admin updated traffic for user', admin_id=admin.id, user_id=user_id)
 
@@ -1608,7 +1632,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info('Admin cancelled subscription for user', admin_id=admin.id, user_id=user_id)
 
@@ -1623,9 +1649,39 @@ async def update_user_subscription(
         # наспамленные дни, обнулить трафик/сквады, пометить DISABLED и ОТКЛЮЧИТЬ в
         # панели RemnaWave (не удаляя). Пользователь и его тикеты сохраняются —
         # дальше юзер сам покупает тариф с нуля и выбирает срок.
-        from app.services.subscription_service import reset_subscription_with_panel
+        if request.subscription_id is not None:
+            # A selected BP-S reset is fail-closed: never substitute the
+            # legacy user UUID, and preserve the selected row for an exact
+            # retry when panel deactivation fails.
+            from app.database.crud.subscription import reset_subscription
+            from app.services.payment.platega import cancel_platega_recurring_for_subscription_safe
+            from app.services.subscription_service import SubscriptionService
 
-        result = await reset_subscription_with_panel(db, user, subscription)
+            await cancel_platega_recurring_for_subscription_safe(db, subscription.id)
+            panel_uuid = subscription.remnawave_uuid
+            panel_disabled = False
+            if panel_uuid:
+                try:
+                    panel_disabled = await SubscriptionService().disable_remnawave_user(panel_uuid)
+                except Exception as error:
+                    logger.warning(
+                        'Failed to disable selected Remnawave subscription during reset',
+                        subscription_id=subscription.id,
+                        error=error,
+                    )
+                if not panel_disabled:
+                    return UpdateSubscriptionResponse(
+                        success=False,
+                        message='Subscription reset failed: panel deactivation was not completed',
+                        subscription=await _build_subscription_info_async(db, subscription),
+                    )
+
+            await reset_subscription(db, subscription)
+            result = {'panel_disabled': panel_disabled}
+        else:
+            from app.services.subscription_service import reset_subscription_with_panel
+
+            result = await reset_subscription_with_panel(db, user, subscription)
 
         logger.info(
             'Admin reset subscription for user',
@@ -1662,7 +1718,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info('Admin activated subscription for user', admin_id=admin.id, user_id=user_id)
 
@@ -1786,7 +1844,9 @@ async def update_user_subscription(
         await db.refresh(subscription)
 
         # Sync to Remnawave panel
-        await _sync_subscription_to_panel(db, user, subscription)
+        await _sync_subscription_to_panel(
+            db, user, subscription, pinned_subscription_identity=request.subscription_id is not None
+        )
 
         logger.info(
             'Admin set device limit to for user', admin_id=admin.id, device_limit=request.device_limit, user_id=user_id
@@ -2523,9 +2583,11 @@ async def get_user_devices(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
 
     # Resolve panel UUID
+    selected_subscription = None
     _dev_uuid = None
     if subscription_id is not None:
-        _dev_uuid = (await _get_owned_subscription_or_404(db, subscription_id, user_id)).remnawave_uuid
+        selected_subscription = await _get_owned_subscription_or_404(db, subscription_id, user_id)
+        _dev_uuid = selected_subscription.remnawave_uuid
     else:
         _dev_uuid = user.remnawave_uuid
 
@@ -2572,7 +2634,7 @@ async def get_user_devices(
 
             device_limit = 0
             subs = getattr(user, 'subscriptions', None) or []
-            subscription = next((s for s in subs if s.is_active), subs[0] if subs else None)
+            subscription = selected_subscription or next((s for s in subs if s.is_active), subs[0] if subs else None)
             if subscription:
                 device_limit = subscription.device_limit or 0
 
@@ -2984,20 +3046,33 @@ async def reset_user_subscription(
 
             subscription_service = SubscriptionService()
             if settings.is_multi_tariff_enabled():
-                for sub in subs:
-                    if sub.remnawave_uuid:
-                        try:
-                            await subscription_service.disable_remnawave_user(sub.remnawave_uuid, db=db)
-                        except Exception:
-                            pass
-                panel_deactivated = True
-            elif user.remnawave_uuid:
-                panel_deactivated = await subscription_service.disable_remnawave_user(user.remnawave_uuid, db=db)
+                panel_targets = [sub.remnawave_uuid for sub in subs if sub.remnawave_uuid]
+            else:
+                panel_targets = [user.remnawave_uuid] if user.remnawave_uuid else []
+
+            panel_results = [
+                await subscription_service.disable_remnawave_user(panel_uuid, db=db) for panel_uuid in panel_targets
+            ]
+            panel_deactivated = bool(panel_targets) and all(panel_results)
+            if panel_targets and not panel_deactivated:
+                return ResetSubscriptionResponse(
+                    success=False,
+                    message='Subscription reset failed: panel deactivation was not completed',
+                    subscription_deleted=False,
+                    panel_deactivated=False,
+                    panel_error='Не удалось отключить всех пользователей в Remnawave',
+                )
             if panel_deactivated:
                 logger.info('Disabled Remnawave users for subscription reset', user_id=user_id)
         except Exception as e:
-            panel_error = 'Ошибка обработки пользователя в Remnawave'
             logger.warning('Failed to disable Remnawave user during subscription reset', error=e)
+            return ResetSubscriptionResponse(
+                success=False,
+                message='Subscription reset failed: panel deactivation was not completed',
+                subscription_deleted=False,
+                panel_deactivated=False,
+                panel_error='Ошибка обработки пользователя в Remnawave',
+            )
 
     # Delete all subscriptions from database
     from sqlalchemy import delete

--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -138,6 +138,26 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix='/admin/users', tags=['Cabinet Admin Users'])
 
 
+async def _get_owned_subscription_or_404(db: AsyncSession, subscription_id: int, user_id: int) -> Subscription:
+    """Load a subscription only when it belongs to the route's user.
+
+    Subscription ids are not authorization credentials: every admin
+    multi-tariff operation that receives one must constrain this lookup by the
+    path user id as well.  A single not-found response deliberately prevents
+    distinguishing an absent row from somebody else's subscription.
+    """
+    result = await db.execute(
+        select(Subscription).where(
+            Subscription.id == subscription_id,
+            Subscription.user_id == user_id,
+        )
+    )
+    subscription = result.scalar_one_or_none()
+    if not subscription:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Subscription not found for this user')
+    return subscription
+
+
 def _build_user_list_item(user: User, spending_stats: dict = None) -> UserListItem:
     """Build UserListItem from User model."""
     stats = spending_stats or {}
@@ -935,11 +955,9 @@ async def get_user_panel_info(
             panel_user = None
 
             # Multi-tariff: use per-subscription UUID
-            if settings.is_multi_tariff_enabled() and subscription_id:
-                from app.database.crud.subscription import get_subscription_by_id_for_user
-
-                sub = await get_subscription_by_id_for_user(db, subscription_id, user_id)
-                if sub and sub.remnawave_uuid:
+            if settings.is_multi_tariff_enabled() and subscription_id is not None:
+                sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
+                if sub.remnawave_uuid:
                     panel_user = await api.get_user_by_uuid(sub.remnawave_uuid)
             # Single-tariff: user-level UUID
             elif user.remnawave_uuid:
@@ -990,6 +1008,8 @@ async def get_user_panel_info(
                 last_connected_node_name=last_node_name,
             )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error('Error getting panel info for user', user_id=user_id, error=e)
         return UserPanelInfoResponse(found=False)
@@ -1012,12 +1032,9 @@ async def get_subscription_request_history(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
 
     panel_uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id:
-        from app.database.crud.subscription import get_subscription_by_id_for_user
-
-        sub = await get_subscription_by_id_for_user(db, subscription_id, user_id)
-        if sub:
-            panel_uuid = sub.remnawave_uuid
+    if settings.is_multi_tariff_enabled() and subscription_id is not None:
+        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
+        panel_uuid = sub.remnawave_uuid
     else:
         panel_uuid = getattr(user, 'remnawave_uuid', None)
 
@@ -1248,13 +1265,8 @@ async def update_user_subscription(
     is_multi_tariff = settings.is_multi_tariff_enabled()
 
     # Select target subscription
-    if request.subscription_id:
-        subscription = next((s for s in subs if s.id == request.subscription_id), None)
-        if not subscription and request.action != 'create':
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Subscription {request.subscription_id} not found for this user',
-            )
+    if request.subscription_id is not None and request.action != 'create':
+        subscription = await _get_owned_subscription_or_404(db, request.subscription_id, user_id)
     else:
         subscription = next((s for s in subs if s.is_active), subs[0] if subs else None)
 
@@ -2505,12 +2517,9 @@ async def get_user_devices(
 
     # Resolve panel UUID
     _dev_uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id:
-        from app.database.crud.subscription import get_subscription_by_id_for_user
-
-        sub = await get_subscription_by_id_for_user(db, subscription_id, user_id)
-        if sub:
-            _dev_uuid = sub.remnawave_uuid
+    if settings.is_multi_tariff_enabled() and subscription_id is not None:
+        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
+        _dev_uuid = sub.remnawave_uuid
     else:
         _dev_uuid = user.remnawave_uuid
 
@@ -2586,12 +2595,9 @@ async def delete_user_device(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
 
     _uuid = None
-    if settings.is_multi_tariff_enabled() and subscription_id:
-        from app.database.crud.subscription import get_subscription_by_id_for_user
-
-        sub = await get_subscription_by_id_for_user(db, subscription_id, user_id)
-        if sub:
-            _uuid = sub.remnawave_uuid
+    if settings.is_multi_tariff_enabled() and subscription_id is not None:
+        sub = await _get_owned_subscription_or_404(db, subscription_id, user_id)
+        _uuid = sub.remnawave_uuid
     else:
         _uuid = user.remnawave_uuid
 

--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -155,6 +155,14 @@ class UsersListResponse(BaseModel):
     limit: int = 50
 
 
+class UserByRemnawaveResponse(BaseModel):
+    """Subscription-level owner resolved from an exact Remnawave UUID."""
+
+    user_id: int
+    subscription_id: int
+    matched_remnawave_uuid: str
+
+
 # === User Detail ===
 
 

--- a/tests/cabinet/test_admin_user_detail_subscription_ownership.py
+++ b/tests/cabinet/test_admin_user_detail_subscription_ownership.py
@@ -63,7 +63,6 @@ def foreign_subscription() -> SimpleNamespace:
 @pytest.fixture
 def ownership_boundary(monkeypatch, owned_subscription, foreign_subscription):
     """Make the authoritative lookup return only the subscription owned by OWNER_ID."""
-    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: True)
     user = _user(owned_subscription, foreign_subscription)
     monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
 
@@ -82,7 +81,11 @@ def ownership_boundary(monkeypatch, owned_subscription, foreign_subscription):
 
 
 class _Api:
+    def __init__(self, calls: dict[str, int]):
+        self.calls = calls
+
     async def get_user_by_uuid(self, uuid):
+        self.calls['get_user_by_uuid'] += 1
         return SimpleNamespace(
             uuid=uuid,
             trojan_password='owned-secret',
@@ -99,29 +102,51 @@ class _Api:
         )
 
     async def get_user_devices_all(self, _uuid):
+        self.calls['get_user_devices_all'] += 1
         return {'devices': [{'hwid': 'owned-hwid', 'platform': 'ios'}], 'total': 1}
 
     async def get_subscription_request_history(self, _uuid, *, offset, limit):
+        self.calls['get_subscription_request_history'] += 1
         return {'total': 1, 'records': [{'ip': '192.0.2.1'}]}
 
     async def remove_device(self, _uuid, _hwid):
+        self.calls['remove_device'] += 1
         return True
-
-
-class _Service:
-    is_configured = True
-
-    def get_api_client(self):
-        context = MagicMock()
-        context.__aenter__ = AsyncMock(return_value=_Api())
-        context.__aexit__ = AsyncMock(return_value=None)
-        return context
 
 
 @pytest.fixture
 def panel_service(monkeypatch):
-    monkeypatch.setattr('app.services.remnawave_service.RemnaWaveService', _Service)
+    calls = {
+        'constructed': 0,
+        'get_api_client': 0,
+        'client_entered': 0,
+        'get_user_by_uuid': 0,
+        'get_user_devices_all': 0,
+        'get_subscription_request_history': 0,
+        'remove_device': 0,
+    }
+
+    class Service:
+        is_configured = True
+
+        def __init__(self):
+            calls['constructed'] += 1
+
+        def get_api_client(self):
+            calls['get_api_client'] += 1
+            context = MagicMock()
+
+            async def enter():
+                calls['client_entered'] += 1
+                return _Api(calls)
+
+            context.__aenter__ = AsyncMock(side_effect=enter)
+            context.__aexit__ = AsyncMock(return_value=None)
+            return context
+
+    monkeypatch.setattr('app.services.remnawave_service.RemnaWaveService', Service)
     monkeypatch.setattr(admin_users, 'get_aliases_for_user', AsyncMock(return_value={}))
+    return calls
 
 
 async def test_authoritative_subscription_lookup_constrains_id_and_user_id(owned_subscription):
@@ -148,10 +173,12 @@ async def test_authoritative_subscription_lookup_constrains_id_and_user_id(owned
     ],
     ids=['panel-info', 'devices', 'request-history', 'delete-device'],
 )
-async def test_subscription_reads_and_device_delete_are_ownership_isolated(
-    ownership_boundary, panel_service, route_name, kwargs, foreign_marker
+@pytest.mark.parametrize('multi_tariff', [True, False], ids=['multi-tariff', 'single-tariff'])
+async def test_subscription_reads_and_device_delete_accept_owned_subscription(
+    monkeypatch, ownership_boundary, panel_service, route_name, kwargs, foreign_marker, multi_tariff
 ):
-    """A foreign id must not disclose panel data or invoke the device mutation."""
+    """Every BP-S route uses the selected owned subscription in either mode."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: multi_tariff)
     route = getattr(admin_users, route_name)
     db = AsyncMock()
     admin = SimpleNamespace(id=1)
@@ -159,13 +186,73 @@ async def test_subscription_reads_and_device_delete_are_ownership_isolated(
     owned_result = await route(OWNER_ID, admin=admin, db=db, subscription_id=OWNED_ID, **kwargs)
     assert foreign_marker in str(owned_result)
 
-    with pytest.raises(HTTPException) as foreign:
-        await route(OWNER_ID, admin=admin, db=db, subscription_id=FOREIGN_ID, **kwargs)
-    assert foreign.value.status_code == 404
 
-    with pytest.raises(HTTPException) as missing:
-        await route(OWNER_ID, admin=admin, db=db, subscription_id=MISSING_ID, **kwargs)
-    assert missing.value.status_code == 404
+@pytest.mark.parametrize(
+    ('route_name', 'kwargs'),
+    [
+        ('get_user_panel_info', {}),
+        ('get_user_devices', {}),
+        ('get_subscription_request_history', {}),
+        ('delete_user_device', {'hwid': 'owned-hwid'}),
+    ],
+    ids=['panel-info', 'devices', 'request-history', 'delete-device'],
+)
+@pytest.mark.parametrize('multi_tariff', [True, False], ids=['multi-tariff', 'single-tariff'])
+async def test_subscription_reads_and_device_delete_reject_foreign_and_absent_without_panel_access(
+    monkeypatch, ownership_boundary, panel_service, route_name, kwargs, multi_tariff
+):
+    """No rejected BP-S request may construct or call the panel client in either mode."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: multi_tariff)
+    route = getattr(admin_users, route_name)
+    db = AsyncMock()
+    admin = SimpleNamespace(id=1)
+
+    for subscription_id in (FOREIGN_ID, MISSING_ID):
+        with pytest.raises(HTTPException) as rejected:
+            await route(OWNER_ID, admin=admin, db=db, subscription_id=subscription_id, **kwargs)
+        assert rejected.value.status_code == 404
+        assert panel_service == {
+            'constructed': 0,
+            'get_api_client': 0,
+            'client_entered': 0,
+            'get_user_by_uuid': 0,
+            'get_user_devices_all': 0,
+            'get_subscription_request_history': 0,
+            'remove_device': 0,
+        }
+
+
+@pytest.mark.parametrize('multi_tariff', [True, False], ids=['multi-tariff', 'single-tariff'])
+@pytest.mark.parametrize('subscription_id', [FOREIGN_ID, MISSING_ID], ids=['foreign', 'absent'])
+async def test_panel_info_validates_supplied_subscription_before_unconfigured_service_access(
+    monkeypatch, ownership_boundary, multi_tariff, subscription_id
+):
+    """Would fail if panel-info checks service configuration before ownership."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: multi_tariff)
+    calls = {'constructed': 0, 'get_api_client': 0}
+
+    class UnconfiguredService:
+        is_configured = False
+
+        def __init__(self):
+            calls['constructed'] += 1
+
+        def get_api_client(self):
+            calls['get_api_client'] += 1
+            raise AssertionError('ownership rejection must not request a panel client')
+
+    monkeypatch.setattr('app.services.remnawave_service.RemnaWaveService', UnconfiguredService)
+
+    with pytest.raises(HTTPException) as rejected:
+        await admin_users.get_user_panel_info(
+            OWNER_ID,
+            admin=SimpleNamespace(id=1),
+            db=AsyncMock(),
+            subscription_id=subscription_id,
+        )
+
+    assert rejected.value.status_code == 404
+    assert calls == {'constructed': 0, 'get_api_client': 0}
 
 
 @pytest.mark.parametrize(
@@ -236,3 +323,6 @@ async def test_subscription_actions_reject_foreign_or_absent_ids_before_mutation
         await admin_users.update_user_subscription(OWNER_ID, missing_request, admin=SimpleNamespace(id=1), db=db)
     assert missing.value.status_code == 404
     assert getattr(foreign_subscription, state_field) == before
+    sync.assert_not_awaited()
+    reset.assert_not_awaited()
+    db.commit.assert_not_awaited()

--- a/tests/cabinet/test_admin_user_detail_subscription_ownership.py
+++ b/tests/cabinet/test_admin_user_detail_subscription_ownership.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -88,9 +88,9 @@ class _Api:
         self.calls['get_user_by_uuid'] += 1
         return SimpleNamespace(
             uuid=uuid,
-            trojan_password='owned-secret',
+            trojan_password='owned-panel-marker',  # pragma: allowlist secret
             vless_uuid='owned-vless',
-            ss_password='owned-ss',
+            ss_password='owned-ss',  # pragma: allowlist secret
             subscription_url='https://owned.example/sub',
             happ_link=None,
             used_traffic_bytes=1,
@@ -166,7 +166,7 @@ async def test_authoritative_subscription_lookup_constrains_id_and_user_id(owned
 @pytest.mark.parametrize(
     ('route_name', 'kwargs', 'foreign_marker'),
     [
-        ('get_user_panel_info', {}, 'owned-secret'),
+        ('get_user_panel_info', {}, 'owned-panel-marker'),
         ('get_user_devices', {}, 'owned-hwid'),
         ('get_subscription_request_history', {}, '192.0.2.1'),
         ('delete_user_device', {'hwid': 'owned-hwid'}, 'Device deleted'),
@@ -303,10 +303,13 @@ async def test_subscription_actions_accept_an_owned_subscription(
 ):
     """An ownership guard must not reject the requested user's own subscription."""
     sync = AsyncMock()
-    reset = AsyncMock(return_value={'panel_disabled': True})
+    panel_disable = AsyncMock(return_value=True)
+    reset_subscription = AsyncMock()
     monkeypatch.setattr(admin_users, '_sync_subscription_to_panel', sync)
     monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
-    monkeypatch.setattr('app.services.subscription_service.reset_subscription_with_panel', reset)
+    monkeypatch.setattr('app.services.subscription_service.SubscriptionService.disable_remnawave_user', panel_disable)
+    monkeypatch.setattr('app.database.crud.subscription.reset_subscription', reset_subscription)
+    monkeypatch.setattr('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', AsyncMock())
     db = AsyncMock()
     request = UpdateSubscriptionRequest(action=action, subscription_id=OWNED_ID, **request_kwargs)
 
@@ -314,10 +317,191 @@ async def test_subscription_actions_accept_an_owned_subscription(
 
     assert result.success is True
     if action == 'reset':
-        reset.assert_awaited_once_with(db, ownership_boundary, owned_subscription)
+        panel_disable.assert_awaited_once_with(owned_subscription.remnawave_uuid)
+        reset_subscription.assert_awaited_once_with(db, owned_subscription)
     else:
-        sync.assert_awaited_once_with(db, ownership_boundary, owned_subscription)
+        sync.assert_awaited_once_with(db, ownership_boundary, owned_subscription, pinned_subscription_identity=True)
         assert db.commit.await_count == 1
+
+
+@pytest.mark.parametrize(
+    ('action', 'request_kwargs'),
+    [
+        ('set_end_date', {'end_date': datetime.now(UTC) + timedelta(days=30)}),
+        ('set_traffic', {'traffic_limit_gb': 999}),
+        ('set_device_limit', {'device_limit': 99}),
+    ],
+    ids=['set-expiry', 'set-traffic', 'set-device-limit'],
+)
+async def test_selected_actions_pin_sync_to_the_selected_identity_when_legacy_mode_is_enabled(
+    monkeypatch, ownership_boundary, owned_subscription, action, request_kwargs
+):
+    """A supplied subscription id must opt out of all single-tariff fallbacks."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    ownership_boundary.remnawave_uuid = 'legacy-other-subscription-uuid'
+    owned_subscription.remnawave_uuid = 'selected-exact-uuid'
+    sync = AsyncMock()
+    monkeypatch.setattr(admin_users, '_sync_subscription_to_panel', sync)
+    monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
+
+    result = await admin_users.update_user_subscription(
+        OWNER_ID,
+        UpdateSubscriptionRequest(action=action, subscription_id=OWNED_ID, **request_kwargs),
+        admin=SimpleNamespace(id=1),
+        db=AsyncMock(),
+    )
+
+    assert result.success is True
+    sync.assert_awaited_once_with(
+        ANY,
+        ownership_boundary,
+        owned_subscription,
+        pinned_subscription_identity=True,
+    )
+
+
+async def test_selected_sync_uses_only_selected_uuid_when_legacy_mode_is_enabled(monkeypatch):
+    """The helper itself must not substitute the user's legacy panel UUID."""
+    looked_up: list[str] = []
+    updated: list[str] = []
+
+    class Api:
+        async def get_user_by_uuid(self, panel_uuid):
+            looked_up.append(panel_uuid)
+            return SimpleNamespace(uuid=panel_uuid)
+
+    class Service:
+        is_configured = True
+
+        def get_api_client(self):
+            context = MagicMock()
+            context.__aenter__ = AsyncMock(return_value=Api())
+            context.__aexit__ = AsyncMock(return_value=None)
+            return context
+
+    async def update_panel_user(_api, _subscription_id, **kwargs):
+        updated.append(kwargs['uuid'])
+        return SimpleNamespace(
+            subscription_url='https://selected.example/sub',
+            happ_crypto_link='crypto',
+            short_uuid='short',
+        )
+
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    monkeypatch.setattr('app.services.remnawave_service.RemnaWaveService', Service)
+    monkeypatch.setattr('app.services.grace_access_runtime.update_panel_user_grace_safe', update_panel_user)
+    monkeypatch.setattr('app.services.subscription_service.get_traffic_reset_strategy', lambda _tariff: 'NO_RESET')
+    monkeypatch.setattr('app.utils.subscription_utils.resolve_hwid_device_limit_for_payload', lambda _sub: None)
+    user = SimpleNamespace(
+        id=OWNER_ID,
+        full_name='Owner',
+        username=None,
+        telegram_id=1000,
+        email=None,
+        remnawave_uuid='legacy-other-subscription-uuid',
+        last_remnawave_sync=None,
+    )
+    subscription = SimpleNamespace(
+        id=OWNED_ID,
+        status='active',
+        end_date=datetime.now(UTC) + timedelta(days=30),
+        remnawave_uuid='selected-exact-uuid',
+        remnawave_short_id=None,
+        traffic_limit_gb=10,
+        tariff=None,
+        connected_squads=[],
+        device_limit=1,
+        subscription_url=None,
+        subscription_crypto_link=None,
+        remnawave_short_uuid=None,
+    )
+    db = AsyncMock()
+
+    await admin_users._sync_subscription_to_panel(db, user, subscription, pinned_subscription_identity=True)
+
+    assert looked_up == ['selected-exact-uuid']
+    assert updated == ['selected-exact-uuid']
+    assert user.remnawave_uuid == 'legacy-other-subscription-uuid'
+
+
+async def test_selected_sync_with_no_panel_link_does_not_substitute_legacy_identity(monkeypatch):
+    """A null selected link must cause no panel access, even in legacy mode."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    user = SimpleNamespace(id=OWNER_ID, remnawave_uuid='legacy-other-subscription-uuid')
+    subscription = SimpleNamespace(remnawave_uuid=None)
+    db = AsyncMock()
+
+    result = await admin_users._sync_subscription_to_panel(db, user, subscription, pinned_subscription_identity=True)
+
+    assert result == {'skipped': True, 'reason': 'Selected subscription has no panel UUID'}
+    db.commit.assert_not_awaited()
+
+
+async def test_selected_devices_return_selected_subscription_device_limit(monkeypatch, panel_service):
+    primary = _subscription(11, OWNER_ID, uuid='primary-uuid')
+    primary.device_limit = 2
+    selected = _subscription(OWNED_ID, OWNER_ID, uuid='selected-uuid')
+    selected.device_limit = 9
+    user = _user(primary, selected, remnawave_uuid='legacy-user-uuid')
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
+    monkeypatch.setattr(admin_users, '_get_owned_subscription_or_404', AsyncMock(return_value=selected))
+
+    response = await admin_users.get_user_devices(
+        OWNER_ID, admin=SimpleNamespace(id=1), db=AsyncMock(), subscription_id=OWNED_ID
+    )
+
+    assert response.device_limit == 9
+
+
+@pytest.mark.parametrize('raises', [False, True], ids=['false-result', 'exception'])
+async def test_selected_reset_returns_unsuccessful_when_panel_deactivation_fails(
+    monkeypatch, ownership_boundary, owned_subscription, raises
+):
+    async def panel_disable(_self, _panel_uuid):
+        if raises:
+            raise RuntimeError('panel down')
+        return False
+
+    reset_subscription = AsyncMock()
+    monkeypatch.setattr('app.services.subscription_service.SubscriptionService.disable_remnawave_user', panel_disable)
+    monkeypatch.setattr('app.database.crud.subscription.reset_subscription', reset_subscription)
+    monkeypatch.setattr('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', AsyncMock())
+    monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
+
+    result = await admin_users.update_user_subscription(
+        OWNER_ID,
+        UpdateSubscriptionRequest(action='reset', subscription_id=OWNED_ID),
+        admin=SimpleNamespace(id=1),
+        db=AsyncMock(),
+    )
+
+    assert result.success is False
+    reset_subscription.assert_not_awaited()
+
+
+async def test_selected_reset_without_link_does_not_substitute_legacy_identity(
+    monkeypatch, ownership_boundary, owned_subscription
+):
+    ownership_boundary.remnawave_uuid = 'legacy-other-subscription-uuid'
+    owned_subscription.remnawave_uuid = None
+    panel_disable = AsyncMock(return_value=True)
+    reset_subscription = AsyncMock()
+    monkeypatch.setattr('app.services.subscription_service.SubscriptionService.disable_remnawave_user', panel_disable)
+    monkeypatch.setattr('app.database.crud.subscription.reset_subscription', reset_subscription)
+    monkeypatch.setattr('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', AsyncMock())
+    monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
+
+    result = await admin_users.update_user_subscription(
+        OWNER_ID,
+        UpdateSubscriptionRequest(action='reset', subscription_id=OWNED_ID),
+        admin=SimpleNamespace(id=1),
+        db=AsyncMock(),
+    )
+
+    assert result.success is True
+    panel_disable.assert_not_awaited()
+    reset_subscription.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/cabinet/test_admin_user_detail_subscription_ownership.py
+++ b/tests/cabinet/test_admin_user_detail_subscription_ownership.py
@@ -26,7 +26,7 @@ FOREIGN_ID = 202
 MISSING_ID = 303
 
 
-def _subscription(subscription_id: int, user_id: int, *, uuid: str) -> SimpleNamespace:
+def _subscription(subscription_id: int, user_id: int, *, uuid: str | None) -> SimpleNamespace:
     return SimpleNamespace(
         id=subscription_id,
         user_id=user_id,
@@ -40,12 +40,12 @@ def _subscription(subscription_id: int, user_id: int, *, uuid: str) -> SimpleNam
     )
 
 
-def _user(*subscriptions: SimpleNamespace) -> SimpleNamespace:
+def _user(*subscriptions: SimpleNamespace, remnawave_uuid: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         id=OWNER_ID,
         telegram_id=1000,
         email=None,
-        remnawave_uuid=None,
+        remnawave_uuid=remnawave_uuid,
         subscriptions=list(subscriptions),
     )
 
@@ -253,6 +253,39 @@ async def test_panel_info_validates_supplied_subscription_before_unconfigured_se
 
     assert rejected.value.status_code == 404
     assert calls == {'constructed': 0, 'get_api_client': 0}
+
+
+async def test_panel_info_does_not_fall_back_to_user_uuid_for_selected_unlinked_subscription(
+    monkeypatch, panel_service
+):
+    """Would fail if a selected null-link subscription leaked legacy panel information."""
+    selected = _subscription(OWNED_ID, OWNER_ID, uuid=None)
+    user = _user(selected, remnawave_uuid='legacy-user-uuid')
+    monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
+
+    async def get_selected(_db, subscription_id, user_id):
+        assert (subscription_id, user_id) == (OWNED_ID, OWNER_ID)
+        return selected
+
+    monkeypatch.setattr(admin_users, '_get_owned_subscription_or_404', get_selected)
+
+    response = await admin_users.get_user_panel_info(
+        OWNER_ID,
+        admin=SimpleNamespace(id=1),
+        db=AsyncMock(),
+        subscription_id=OWNED_ID,
+    )
+
+    assert response.found is False
+    assert panel_service == {
+        'constructed': 0,
+        'get_api_client': 0,
+        'client_entered': 0,
+        'get_user_by_uuid': 0,
+        'get_user_devices_all': 0,
+        'get_subscription_request_history': 0,
+        'remove_device': 0,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/cabinet/test_admin_user_detail_subscription_ownership.py
+++ b/tests/cabinet/test_admin_user_detail_subscription_ownership.py
@@ -1,0 +1,238 @@
+"""Ownership boundaries for subscription-scoped admin user-detail routes.
+
+The regression these tests guard against is treating a subscription id as an
+authorization token.  Every multi-tariff operation must resolve the row with
+both the requested subscription id and the route's user id before doing any
+read or mutation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_users
+from app.cabinet.schemas.users import UpdateSubscriptionRequest
+from app.config import Settings
+
+
+OWNER_ID = 10
+OWNED_ID = 101
+FOREIGN_ID = 202
+MISSING_ID = 303
+
+
+def _subscription(subscription_id: int, user_id: int, *, uuid: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=subscription_id,
+        user_id=user_id,
+        remnawave_uuid=uuid,
+        is_active=True,
+        status='active',
+        end_date=datetime.now(UTC) + timedelta(days=10),
+        traffic_limit_gb=100,
+        traffic_used_gb=1.5,
+        device_limit=2,
+    )
+
+
+def _user(*subscriptions: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=OWNER_ID,
+        telegram_id=1000,
+        email=None,
+        remnawave_uuid=None,
+        subscriptions=list(subscriptions),
+    )
+
+
+@pytest.fixture
+def owned_subscription() -> SimpleNamespace:
+    return _subscription(OWNED_ID, OWNER_ID, uuid='owned-panel-uuid')
+
+
+@pytest.fixture
+def foreign_subscription() -> SimpleNamespace:
+    return _subscription(FOREIGN_ID, 20, uuid='foreign-panel-uuid')
+
+
+@pytest.fixture
+def ownership_boundary(monkeypatch, owned_subscription, foreign_subscription):
+    """Make the authoritative lookup return only the subscription owned by OWNER_ID."""
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: True)
+    user = _user(owned_subscription, foreign_subscription)
+    monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
+
+    async def get_owned_subscription(_db, subscription_id, user_id):
+        if (subscription_id, user_id) == (OWNED_ID, OWNER_ID):
+            return owned_subscription
+        raise HTTPException(status_code=404, detail='Subscription not found for this user')
+
+    monkeypatch.setattr(
+        admin_users,
+        '_get_owned_subscription_or_404',
+        get_owned_subscription,
+    )
+    monkeypatch.setattr('app.database.crud.user.get_user_by_id', AsyncMock(return_value=user))
+    return user
+
+
+class _Api:
+    async def get_user_by_uuid(self, uuid):
+        return SimpleNamespace(
+            uuid=uuid,
+            trojan_password='owned-secret',
+            vless_uuid='owned-vless',
+            ss_password='owned-ss',
+            subscription_url='https://owned.example/sub',
+            happ_link=None,
+            used_traffic_bytes=1,
+            lifetime_used_traffic_bytes=2,
+            traffic_limit_bytes=3,
+            first_connected_at=None,
+            online_at=None,
+            user_traffic=None,
+        )
+
+    async def get_user_devices_all(self, _uuid):
+        return {'devices': [{'hwid': 'owned-hwid', 'platform': 'ios'}], 'total': 1}
+
+    async def get_subscription_request_history(self, _uuid, *, offset, limit):
+        return {'total': 1, 'records': [{'ip': '192.0.2.1'}]}
+
+    async def remove_device(self, _uuid, _hwid):
+        return True
+
+
+class _Service:
+    is_configured = True
+
+    def get_api_client(self):
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=_Api())
+        context.__aexit__ = AsyncMock(return_value=None)
+        return context
+
+
+@pytest.fixture
+def panel_service(monkeypatch):
+    monkeypatch.setattr('app.services.remnawave_service.RemnaWaveService', _Service)
+    monkeypatch.setattr(admin_users, 'get_aliases_for_user', AsyncMock(return_value={}))
+
+
+async def test_authoritative_subscription_lookup_constrains_id_and_user_id(owned_subscription):
+    """Would fail if a route reverted to an id-only subscription lookup."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = owned_subscription
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+
+    assert await admin_users._get_owned_subscription_or_404(db, OWNED_ID, OWNER_ID) is owned_subscription
+
+    query = str(db.execute.await_args.args[0])
+    assert 'subscriptions.id' in query
+    assert 'subscriptions.user_id' in query
+
+
+@pytest.mark.parametrize(
+    ('route_name', 'kwargs', 'foreign_marker'),
+    [
+        ('get_user_panel_info', {}, 'owned-secret'),
+        ('get_user_devices', {}, 'owned-hwid'),
+        ('get_subscription_request_history', {}, '192.0.2.1'),
+        ('delete_user_device', {'hwid': 'owned-hwid'}, 'Device deleted'),
+    ],
+    ids=['panel-info', 'devices', 'request-history', 'delete-device'],
+)
+async def test_subscription_reads_and_device_delete_are_ownership_isolated(
+    ownership_boundary, panel_service, route_name, kwargs, foreign_marker
+):
+    """A foreign id must not disclose panel data or invoke the device mutation."""
+    route = getattr(admin_users, route_name)
+    db = AsyncMock()
+    admin = SimpleNamespace(id=1)
+
+    owned_result = await route(OWNER_ID, admin=admin, db=db, subscription_id=OWNED_ID, **kwargs)
+    assert foreign_marker in str(owned_result)
+
+    with pytest.raises(HTTPException) as foreign:
+        await route(OWNER_ID, admin=admin, db=db, subscription_id=FOREIGN_ID, **kwargs)
+    assert foreign.value.status_code == 404
+
+    with pytest.raises(HTTPException) as missing:
+        await route(OWNER_ID, admin=admin, db=db, subscription_id=MISSING_ID, **kwargs)
+    assert missing.value.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ('action', 'request_kwargs', 'state_field'),
+    [
+        ('set_end_date', {'end_date': datetime.now(UTC) + timedelta(days=30)}, 'end_date'),
+        ('set_traffic', {'traffic_limit_gb': 999}, 'traffic_limit_gb'),
+        ('set_device_limit', {'device_limit': 99}, 'device_limit'),
+        ('reset', {}, 'status'),
+    ],
+    ids=['set-expiry', 'set-traffic', 'set-device-limit', 'reset-one-subscription'],
+)
+async def test_subscription_actions_accept_an_owned_subscription(
+    monkeypatch, ownership_boundary, owned_subscription, action, request_kwargs, state_field
+):
+    """An ownership guard must not reject the requested user's own subscription."""
+    sync = AsyncMock()
+    reset = AsyncMock(return_value={'panel_disabled': True})
+    monkeypatch.setattr(admin_users, '_sync_subscription_to_panel', sync)
+    monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
+    monkeypatch.setattr('app.services.subscription_service.reset_subscription_with_panel', reset)
+    db = AsyncMock()
+    request = UpdateSubscriptionRequest(action=action, subscription_id=OWNED_ID, **request_kwargs)
+
+    result = await admin_users.update_user_subscription(OWNER_ID, request, admin=SimpleNamespace(id=1), db=db)
+
+    assert result.success is True
+    if action == 'reset':
+        reset.assert_awaited_once_with(db, ownership_boundary, owned_subscription)
+    else:
+        sync.assert_awaited_once_with(db, ownership_boundary, owned_subscription)
+        assert db.commit.await_count == 1
+
+
+@pytest.mark.parametrize(
+    ('action', 'request_kwargs', 'state_field'),
+    [
+        ('set_end_date', {'end_date': datetime.now(UTC) + timedelta(days=30)}, 'end_date'),
+        ('set_traffic', {'traffic_limit_gb': 999}, 'traffic_limit_gb'),
+        ('set_device_limit', {'device_limit': 99}, 'device_limit'),
+        ('reset', {}, 'status'),
+    ],
+    ids=['set-expiry', 'set-traffic', 'set-device-limit', 'reset-one-subscription'],
+)
+async def test_subscription_actions_reject_foreign_or_absent_ids_before_mutation(
+    monkeypatch, ownership_boundary, foreign_subscription, action, request_kwargs, state_field
+):
+    """Would fail if action selection trusted an eagerly loaded subscription list."""
+    sync = AsyncMock()
+    reset = AsyncMock(return_value={'panel_disabled': True})
+    monkeypatch.setattr(admin_users, '_sync_subscription_to_panel', sync)
+    monkeypatch.setattr(admin_users, '_build_subscription_info_async', AsyncMock(return_value=None))
+    monkeypatch.setattr('app.services.subscription_service.reset_subscription_with_panel', reset)
+    db = AsyncMock()
+    before = getattr(foreign_subscription, state_field)
+    request = UpdateSubscriptionRequest(action=action, subscription_id=FOREIGN_ID, **request_kwargs)
+
+    with pytest.raises(HTTPException) as foreign:
+        await admin_users.update_user_subscription(OWNER_ID, request, admin=SimpleNamespace(id=1), db=db)
+    assert foreign.value.status_code == 404
+    assert getattr(foreign_subscription, state_field) == before
+    sync.assert_not_awaited()
+    reset.assert_not_awaited()
+    db.commit.assert_not_awaited()
+
+    missing_request = UpdateSubscriptionRequest(action=action, subscription_id=MISSING_ID, **request_kwargs)
+    with pytest.raises(HTTPException) as missing:
+        await admin_users.update_user_subscription(OWNER_ID, missing_request, admin=SimpleNamespace(id=1), db=db)
+    assert missing.value.status_code == 404
+    assert getattr(foreign_subscription, state_field) == before

--- a/tests/cabinet/test_admin_user_remnawave_resolver.py
+++ b/tests/cabinet/test_admin_user_remnawave_resolver.py
@@ -1,0 +1,118 @@
+"""Contract tests for exact subscription-level Remnawave resolution."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_users
+
+
+UUID = '11111111-1111-4111-8111-111111111111'
+
+
+def _resolver():
+    resolver = getattr(admin_users, 'get_user_by_remnawave_uuid', None)
+    assert resolver is not None, 'The exact subscription resolver route must exist'
+    return resolver
+
+
+def _db_with_matches(*matches):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = list(matches)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _subscription(*, subscription_id: int, user_id: int, remnawave_uuid: str | None = UUID):
+    return SimpleNamespace(id=subscription_id, user_id=user_id, remnawave_uuid=remnawave_uuid)
+
+
+def test_resolver_route_is_registered_before_user_id_route(registered_paths) -> None:
+    assert 'GET' in registered_paths.get('/cabinet/admin/users/by-remnawave/{remnawave_uuid}', set())
+
+
+def test_resolver_requires_users_read_permission() -> None:
+    resolver = _resolver()
+    route = next(route for route in admin_users.router.routes if route.endpoint is resolver)
+    permission_dependency = route.dependant.dependencies[0].call
+    closure_values = [cell.cell_contents for cell in permission_dependency.__closure__ or ()]
+    assert ('users:read',) in closure_values
+
+
+@pytest.mark.parametrize(
+    ('subscription_id', 'user_id'),
+    [(101, 7), (202, 7)],
+    ids=['primary-subscription', 'non-primary-subscription'],
+)
+async def test_resolver_returns_the_exact_matching_subscription(subscription_id: int, user_id: int) -> None:
+    """Would fail if the resolver returned a user-level or primary subscription ID."""
+    subscription = _subscription(subscription_id=subscription_id, user_id=user_id)
+    db = _db_with_matches(subscription)
+
+    response = await _resolver()(UUID, admin=SimpleNamespace(id=1), db=db)
+
+    assert response.model_dump() == {
+        'user_id': user_id,
+        'subscription_id': subscription_id,
+        'matched_remnawave_uuid': UUID,
+    }
+
+
+@pytest.mark.parametrize(
+    'path_value',
+    [
+        '22222222-2222-4222-8222-222222222222',
+        None,
+        'not-a-uuid',
+    ],
+    ids=['unknown-uuid', 'null-uuid', 'malformed-uuid'],
+)
+async def test_resolver_rejects_unlinked_or_invalid_uuid_without_a_heuristic_lookup(path_value) -> None:
+    """Would fail if unknown, null, or malformed input were guessed from user data."""
+    db = _db_with_matches()
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolver()(path_value, admin=SimpleNamespace(id=1), db=db)
+
+    assert exc.value.status_code in {400, 404}
+    if path_value in (None, 'not-a-uuid'):
+        db.execute.assert_not_awaited()
+
+
+async def test_resolver_rejects_a_uuid_present_only_on_the_legacy_user_field() -> None:
+    """Would fail if the route reused legacy get_user_by_remnawave_uuid behavior."""
+    db = _db_with_matches()
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolver()(UUID, admin=SimpleNamespace(id=1), db=db)
+
+    assert exc.value.status_code == 404
+    query = str(db.execute.await_args.args[0])
+    assert 'subscriptions.remnawave_uuid' in query
+    assert 'users.remnawave_uuid' not in query
+
+
+async def test_resolver_treats_a_physically_absent_deleted_subscription_as_not_found() -> None:
+    """Would fail if absent/deleted records were accidentally resolved."""
+    db = _db_with_matches()
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolver()(UUID, admin=SimpleNamespace(id=1), db=db)
+
+    assert exc.value.status_code == 404
+
+
+async def test_resolver_rejects_duplicate_subscription_mappings_as_a_conflict() -> None:
+    """Would fail if corrupted mappings silently selected one subscription."""
+    db = _db_with_matches(
+        _subscription(subscription_id=101, user_id=7),
+        _subscription(subscription_id=202, user_id=8),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolver()(UUID, admin=SimpleNamespace(id=1), db=db)
+
+    assert exc.value.status_code == 409

--- a/tests/services/test_reset_subscription.py
+++ b/tests/services/test_reset_subscription.py
@@ -9,6 +9,8 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 import app.services.subscription_service as ss
 from app.cabinet.routes import admin_users
 from app.cabinet.schemas.users import ResetSubscriptionRequest
@@ -244,3 +246,54 @@ async def test_user_level_reset_deletes_all_three_current_subscriptions(monkeypa
     assert 'subscriptions.user_id' in str(delete_statement)
     assert 1 in compiled_delete.params.values()
     assert db.commit.await_count == 1
+
+
+@pytest.mark.parametrize(
+    'outcomes',
+    [(True, False), (RuntimeError('panel down'),)],
+    ids=['mixed-false-result', 'exception'],
+)
+async def test_user_level_reset_panel_failure_preserves_all_subscription_retry_identities(monkeypatch, outcomes):
+    subscriptions = [_sub(id=sub_id, remnawave_uuid=f'SUB-{sub_id}') for sub_id in (7, 8)]
+    user = SimpleNamespace(id=1, subscriptions=subscriptions, updated_at=None, remnawave_uuid='LEGACY_UUID')
+    db = AsyncMock()
+    panel_calls: list[str] = []
+    configured_outcomes = iter(outcomes)
+
+    monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
+    _set_multi_tariff(monkeypatch, True)
+
+    async def ensure_no_open_grace(_db, _subscription_ids):
+        return None
+
+    async def cancel_recurrent(_db, _subscription_id):
+        return None
+
+    class PanelService:
+        async def disable_remnawave_user(self, panel_uuid, *, db):
+            panel_calls.append(panel_uuid)
+            outcome = next(configured_outcomes)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    monkeypatch.setattr(
+        'app.services.grace_access_runtime.ensure_no_open_grace_for_subscriptions', ensure_no_open_grace
+    )
+    monkeypatch.setattr('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', cancel_recurrent)
+    monkeypatch.setattr('app.services.subscription_service.SubscriptionService', PanelService)
+
+    result = await admin_users.reset_user_subscription(
+        1,
+        ResetSubscriptionRequest(deactivate_in_panel=True),
+        admin=SimpleNamespace(id=99),
+        db=db,
+    )
+
+    assert result.success is False
+    assert result.subscription_deleted is False
+    assert result.panel_deactivated is False
+    assert panel_calls == (['SUB-7', 'SUB-8'] if len(outcomes) == 2 else ['SUB-7'])
+    assert [sub.remnawave_uuid for sub in subscriptions] == ['SUB-7', 'SUB-8']
+    db.execute.assert_not_awaited()
+    db.commit.assert_not_awaited()

--- a/tests/services/test_reset_subscription.py
+++ b/tests/services/test_reset_subscription.py
@@ -10,6 +10,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import app.services.subscription_service as ss
+from app.cabinet.routes import admin_users
+from app.cabinet.schemas.users import ResetSubscriptionRequest
 from app.config import Settings
 from app.database.crud.subscription import reset_subscription
 from app.database.models import SubscriptionStatus
@@ -202,3 +204,38 @@ async def test_user_modified_still_syncs_end_date_for_active():
     await svc._handle_user_modified(AsyncMock(), user, sub, data)
 
     assert abs((sub.end_date - new_expiry).total_seconds()) < 2  # synced from panel
+
+
+async def test_user_level_reset_deletes_all_three_current_subscriptions(monkeypatch):
+    """The user reset remains one user-scoped operation, not a selected-sub reset."""
+    subscriptions = [_sub(id=sub_id, remnawave_uuid=f'SUB-{sub_id}') for sub_id in (7, 8, 9)]
+    user = SimpleNamespace(id=1, subscriptions=subscriptions, updated_at=None, remnawave_uuid=None)
+    db = AsyncMock()
+    grace_checks: list[tuple[int, ...]] = []
+    cancelled: list[int] = []
+
+    monkeypatch.setattr(admin_users, 'get_user_by_id', AsyncMock(return_value=user))
+
+    async def ensure_no_open_grace(_db, subscription_ids):
+        grace_checks.append(subscription_ids)
+
+    async def cancel_recurrent(_db, subscription_id):
+        cancelled.append(subscription_id)
+
+    monkeypatch.setattr(
+        'app.services.grace_access_runtime.ensure_no_open_grace_for_subscriptions', ensure_no_open_grace
+    )
+    monkeypatch.setattr('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', cancel_recurrent)
+
+    result = await admin_users.reset_user_subscription(
+        1,
+        ResetSubscriptionRequest(deactivate_in_panel=False),
+        admin=SimpleNamespace(id=99),
+        db=db,
+    )
+
+    assert result.subscription_deleted is True
+    assert grace_checks == [(7, 8, 9), (7, 8, 9)]
+    assert cancelled == [7, 8, 9]
+    assert db.execute.await_count == 4  # three server cleanups plus one user-scoped subscription deletion
+    assert db.commit.await_count == 1

--- a/tests/services/test_reset_subscription.py
+++ b/tests/services/test_reset_subscription.py
@@ -238,4 +238,9 @@ async def test_user_level_reset_deletes_all_three_current_subscriptions(monkeypa
     assert grace_checks == [(7, 8, 9), (7, 8, 9)]
     assert cancelled == [7, 8, 9]
     assert db.execute.await_count == 4  # three server cleanups plus one user-scoped subscription deletion
+    delete_statement = db.execute.await_args_list[-1].args[0]
+    compiled_delete = delete_statement.compile()
+    assert 'DELETE FROM subscriptions' in str(delete_statement)
+    assert 'subscriptions.user_id' in str(delete_statement)
+    assert 1 in compiled_delete.params.values()
     assert db.commit.await_count == 1


### PR DESCRIPTION
## Summary

- add exact admin resolver from `Subscription.remnawave_uuid` to Bedolaga user/subscription IDs
- reject legacy user-level UUID lookup and duplicate mappings
- enforce subscription ownership across User Detail BP-S reads and mutations
- fail closed when selected subscriptions lack their own panel identity
- preserve reset identity when panel deactivation fails

## Scope

Backend prerequisite for the approved Bedolaga-first mobile User Detail R5.
User View/list, synchronization, mobile code, deployment, and release are out
of scope.

## Verification

- full test suite: 2377 passed
- focused resolver/ownership/reset suite: 60 passed
- Ruff lint: passed
- Ruff formatting check: passed
- `git diff --check`: passed
- detect-secrets 1.5.0: zero findings in the five changed files
- fresh task-level whole-branch review: approved, zero findings

## Tracking

- Plane: WAVEMACHIN-78
- Specification: `bf5361da34adc5af595dc38dd80c7af1940fdcda`
- Plan: `6bef0006833cbbe5b04d2a3bc1560794787edbfd`
- Reviewed head: `88572caf9b2f1c2a9f95343923277f1bb190b531`
