### PR TITLE
feat: skip tariff selection screen when only one tariff is available

### DIFF
--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -755,6 +755,11 @@ async def show_tariffs_list(
         await callback.answer()
         return
 
+    # Один доступный тариф — сразу к периоду/подтверждению, без экрана «выбора из одной кнопки»
+    if len(tariffs) == 1:
+        await _proceed_with_selected_tariff(callback, db_user, db, state, tariffs[0].id)
+        return
+
     # В мульти-тарифе определяем какие тарифы уже куплены
     purchased_tariff_ids: set[int] = set()
     if settings.is_multi_tariff_enabled():
@@ -784,16 +789,19 @@ async def show_tariffs_list(
     await callback.answer()
 
 
-@error_handler
-async def select_tariff(
+async def _proceed_with_selected_tariff(
     callback: types.CallbackQuery,
     db_user: User,
     db: AsyncSession,
     state: FSMContext,
-):
-    """Обрабатывает выбор тарифа."""
+    tariff_id: int,
+) -> None:
+    """Переход к периоду/подтверждению выбранного тарифа (первая покупка).
+
+    Вызывается и из ``select_tariff`` (кнопка в списке), и из ``show_tariffs_list``
+    при единственном доступном тарифе — без дублирования логики.
+    """
     texts = get_texts(db_user.language)
-    tariff_id = int(callback.data.split(':')[1])
     tariff = await get_tariff_by_id(db, tariff_id)
 
     if not tariff or not tariff.is_active:
@@ -983,6 +991,18 @@ async def select_tariff(
 
     await state.update_data(selected_tariff_id=tariff_id)
     await callback.answer()
+
+
+@error_handler
+async def select_tariff(
+    callback: types.CallbackQuery,
+    db_user: User,
+    db: AsyncSession,
+    state: FSMContext,
+):
+    """Обрабатывает выбор тарифа."""
+    tariff_id = int(callback.data.split(':')[1])
+    await _proceed_with_selected_tariff(callback, db_user, db, state, tariff_id)
 
 
 @error_handler

--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -250,6 +250,7 @@ def get_tariff_periods_keyboard(
     tariff: Tariff,
     language: str,
     db_user: User | None = None,
+    back_callback: str = 'menu_buy',
 ) -> InlineKeyboardMarkup:
     """Создает клавиатуру выбора периода для тарифа с учетом скидок по периодам."""
     texts = get_texts(language)
@@ -274,7 +275,7 @@ def get_tariff_periods_keyboard(
         button_text = f'{format_period(period)} — {price_text}'
         buttons.append([InlineKeyboardButton(text=button_text, callback_data=f'tariff_period:{tariff.id}:{period}')])
 
-    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data='tariff_list')])
+    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data=back_callback)])
 
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
@@ -283,6 +284,7 @@ def get_tariff_periods_keyboard_with_traffic(
     tariff: Tariff,
     language: str,
     db_user: User | None = None,
+    back_callback: str = 'menu_buy',
 ) -> InlineKeyboardMarkup:
     """Клавиатура выбора периода для тарифа с кастомным трафиком (переход к настройке трафика)."""
     texts = get_texts(language)
@@ -310,7 +312,7 @@ def get_tariff_periods_keyboard_with_traffic(
             [InlineKeyboardButton(text=button_text, callback_data=f'tariff_period_traffic:{tariff.id}:{period}')]
         )
 
-    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data='tariff_list')])
+    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data=back_callback)])
 
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
@@ -456,6 +458,7 @@ def format_tariff_info_for_user(
 def get_daily_tariff_confirm_keyboard(
     tariff_id: int,
     language: str,
+    back_callback: str = 'menu_buy',
 ) -> InlineKeyboardMarkup:
     """Создает клавиатуру подтверждения покупки суточного тарифа."""
     texts = get_texts(language)
@@ -485,13 +488,14 @@ def get_daily_tariff_confirm_keyboard(
                 )
             ]
         )
-    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data='tariff_list')])
+    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data=back_callback)])
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
 def get_daily_tariff_insufficient_balance_keyboard(
     tariff_id: int,
     language: str,
+    back_callback: str = 'menu_buy',
 ) -> InlineKeyboardMarkup:
     """Создает клавиатуру при недостаточном балансе для суточного тарифа."""
     texts = get_texts(language)
@@ -499,7 +503,7 @@ def get_daily_tariff_insufficient_balance_keyboard(
         inline_keyboard=[
             [InlineKeyboardButton(text=texts.t('BALANCE_TOPUP', '💳 Пополнить баланс'), callback_data='balance_topup')],
             *_sbp_purchase_rows(tariff_id, texts),
-            [InlineKeyboardButton(text=texts.BACK, callback_data='tariff_list')],
+            [InlineKeyboardButton(text=texts.BACK, callback_data=back_callback)],
         ]
     )
 
@@ -518,6 +522,7 @@ def get_custom_tariff_keyboard(
     max_days: int = 365,
     min_traffic: int = 1,
     max_traffic: int = 1000,
+    back_callback: str = 'menu_buy',
 ) -> InlineKeyboardMarkup:
     """Создает клавиатуру для настройки кастомных дней и трафика."""
     texts = get_texts(language)
@@ -593,7 +598,7 @@ def get_custom_tariff_keyboard(
     )
 
     # Кнопка назад
-    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data='tariff_list')])
+    buttons.append([InlineKeyboardButton(text=texts.BACK, callback_data=back_callback)])
 
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
@@ -757,7 +762,7 @@ async def show_tariffs_list(
 
     # Один доступный тариф — сразу к периоду/подтверждению, без экрана «выбора из одной кнопки»
     if len(tariffs) == 1:
-        await _proceed_with_selected_tariff(callback, db_user, db, state, tariffs[0].id)
+        await _proceed_with_selected_tariff(callback, db_user, db, state, tariffs[0].id, skip_selection=True)
         return
 
     # В мульти-тарифе определяем какие тарифы уже куплены
@@ -795,13 +800,19 @@ async def _proceed_with_selected_tariff(
     db: AsyncSession,
     state: FSMContext,
     tariff_id: int,
+    *,
+    skip_selection: bool = False,
 ) -> None:
     """Переход к периоду/подтверждению выбранного тарифа (первая покупка).
 
     Вызывается и из ``select_tariff`` (кнопка в списке), и из ``show_tariffs_list``
     при единственном доступном тарифе — без дублирования логики.
+
+    ``skip_selection=True``: экран списка тарифов был пропущен, поэтому «Назад»
+    ведёт в главное меню (``back_to_menu``), а не в ``menu_buy`` / список.
     """
     texts = get_texts(db_user.language)
+    back_callback = 'back_to_menu' if skip_selection else 'menu_buy'
     tariff = await get_tariff_by_id(db, tariff_id)
 
     if not tariff or not tariff.is_active:
@@ -864,7 +875,9 @@ async def _proceed_with_selected_tariff(
                     discount=discount_text,
                     balance=format_price_kopeks(user_balance),
                 ),
-                reply_markup=get_daily_tariff_confirm_keyboard(tariff_id, db_user.language),
+                reply_markup=get_daily_tariff_confirm_keyboard(
+                    tariff_id, db_user.language, back_callback=back_callback
+                ),
                 parse_mode='HTML',
             )
         else:
@@ -917,7 +930,9 @@ async def _proceed_with_selected_tariff(
                     'TARIFF_PURCHASE_CART_SAVED_HINT',
                     '\n\n🛒 <i>Корзина сохранена! После пополнения баланса подписка будет оформлена автоматически.</i>',
                 ),
-                reply_markup=get_daily_tariff_insufficient_balance_keyboard(tariff_id, db_user.language),
+                reply_markup=get_daily_tariff_insufficient_balance_keyboard(
+                    tariff_id, db_user.language, back_callback=back_callback
+                ),
                 parse_mode='HTML',
             )
     else:
@@ -966,6 +981,7 @@ async def _proceed_with_selected_tariff(
                     max_days=tariff.max_days,
                     min_traffic=tariff.min_traffic_gb,
                     max_traffic=tariff.max_traffic_gb,
+                    back_callback=back_callback,
                 ),
                 parse_mode='HTML',
             )
@@ -978,14 +994,18 @@ async def _proceed_with_selected_tariff(
                     'TARIFF_PURCHASE_TRAFFIC_SETUP_HINT',
                     '\n\n📊 <i>После выбора периода вы сможете настроить трафик</i>',
                 ),
-                reply_markup=get_tariff_periods_keyboard_with_traffic(tariff, db_user.language, db_user=db_user),
+                reply_markup=get_tariff_periods_keyboard_with_traffic(
+                    tariff, db_user.language, db_user=db_user, back_callback=back_callback
+                ),
                 parse_mode='HTML',
             )
         else:
             # Для обычного тарифа показываем выбор периода
             await callback.message.edit_text(
                 format_tariff_info_for_user(tariff, db_user.language),
-                reply_markup=get_tariff_periods_keyboard(tariff, db_user.language, db_user=db_user),
+                reply_markup=get_tariff_periods_keyboard(
+                    tariff, db_user.language, db_user=db_user, back_callback=back_callback
+                ),
                 parse_mode='HTML',
             )
 

--- a/tests/handlers/test_show_tariffs_list_single_skip.py
+++ b/tests/handlers/test_show_tariffs_list_single_skip.py
@@ -1,0 +1,92 @@
+"""Первая покупка: один доступный тариф — сразу к периоду, без экрана списка."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.handlers.subscription import tariff_purchase as m
+
+
+def _callback(data: str = 'menu_buy'):
+    return SimpleNamespace(
+        data=data,
+        message=SimpleNamespace(edit_text=AsyncMock()),
+        answer=AsyncMock(),
+    )
+
+
+def _state():
+    state = MagicMock()
+    state.clear = AsyncMock()
+    state.update_data = AsyncMock()
+    state.get_data = AsyncMock(return_value={})
+    return state
+
+
+def _user():
+    user = MagicMock()
+    user.language = 'ru'
+    user.promo_group_id = None
+    user.balance_kopeks = 100_000
+    user.get_primary_promo_group = MagicMock(return_value=None)
+    return user
+
+
+async def test_show_tariffs_list_single_tariff_skips_list_and_proceeds(monkeypatch):
+    """Один тариф из get_tariffs_for_user → не рисуем список, сразу _proceed_with_selected_tariff."""
+    tariff = SimpleNamespace(id=42, name='Единственный')
+    proceed = AsyncMock()
+
+    monkeypatch.setattr(m, 'get_tariffs_for_user', AsyncMock(return_value=[tariff]))
+    monkeypatch.setattr(m, '_proceed_with_selected_tariff', proceed)
+    monkeypatch.setattr(m, 'format_tariffs_list_text', MagicMock(return_value='LIST'))
+    monkeypatch.setattr(m, 'get_tariffs_keyboard', MagicMock(return_value='KB'))
+
+    callback = _callback()
+    await m.show_tariffs_list.__wrapped__(callback, _user(), AsyncMock(), _state())
+
+    proceed.assert_awaited_once()
+    assert proceed.await_args.args[4] == 42
+    callback.message.edit_text.assert_not_awaited()
+
+
+async def test_show_tariffs_list_multiple_tariffs_shows_list(monkeypatch):
+    """Два и больше тарифов → список как раньше, без авто-перехода."""
+    from app.config import Settings
+
+    tariffs = [
+        SimpleNamespace(id=1, name='A'),
+        SimpleNamespace(id=2, name='B'),
+    ]
+    proceed = AsyncMock()
+
+    monkeypatch.setattr(m, 'get_tariffs_for_user', AsyncMock(return_value=tariffs))
+    monkeypatch.setattr(m, '_proceed_with_selected_tariff', proceed)
+    monkeypatch.setattr(m, 'format_tariffs_list_text', MagicMock(return_value='LIST TEXT'))
+    monkeypatch.setattr(m, 'get_tariffs_keyboard', MagicMock(return_value='LIST KB'))
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+
+    callback = _callback()
+    await m.show_tariffs_list.__wrapped__(callback, _user(), AsyncMock(), _state())
+
+    proceed.assert_not_awaited()
+    callback.message.edit_text.assert_awaited_once()
+    assert callback.message.edit_text.await_args.args[0] == 'LIST TEXT'
+    assert callback.message.edit_text.await_args.kwargs['reply_markup'] == 'LIST KB'
+    callback.answer.assert_awaited_once()
+
+
+async def test_select_tariff_wrapper_parses_id_and_delegates(monkeypatch):
+    """select_tariff остаётся тонкой обёрткой: парсит id и зовёт _proceed_with_selected_tariff."""
+    proceed = AsyncMock()
+    monkeypatch.setattr(m, '_proceed_with_selected_tariff', proceed)
+
+    callback = _callback('tariff_select:77')
+    db_user = _user()
+    db = AsyncMock()
+    state = _state()
+
+    await m.select_tariff.__wrapped__(callback, db_user, db, state)
+
+    proceed.assert_awaited_once_with(callback, db_user, db, state, 77)

--- a/tests/handlers/test_show_tariffs_list_single_skip.py
+++ b/tests/handlers/test_show_tariffs_list_single_skip.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from app.config import Settings
 from app.handlers.subscription import tariff_purchase as m
 
 
@@ -33,8 +34,22 @@ def _user():
     return user
 
 
+def _period_tariff(tariff_id: int = 42):
+    tariff = MagicMock()
+    tariff.id = tariff_id
+    tariff.name = 'Единственный'
+    tariff.is_active = True
+    tariff.is_daily = False
+    tariff.can_purchase_custom_days = MagicMock(return_value=False)
+    tariff.can_purchase_custom_traffic = MagicMock(return_value=False)
+    tariff.period_prices = {'30': 10000}
+    tariff.device_limit = 1
+    tariff.traffic_limit_gb = 0
+    return tariff
+
+
 async def test_show_tariffs_list_single_tariff_skips_list_and_proceeds(monkeypatch):
-    """Один тариф из get_tariffs_for_user → не рисуем список, сразу _proceed_with_selected_tariff."""
+    """Один тариф из get_tariffs_for_user → не рисуем список, сразу _proceed с skip_selection."""
     tariff = SimpleNamespace(id=42, name='Единственный')
     proceed = AsyncMock()
 
@@ -48,13 +63,12 @@ async def test_show_tariffs_list_single_tariff_skips_list_and_proceeds(monkeypat
 
     proceed.assert_awaited_once()
     assert proceed.await_args.args[4] == 42
+    assert proceed.await_args.kwargs.get('skip_selection') is True
     callback.message.edit_text.assert_not_awaited()
 
 
 async def test_show_tariffs_list_multiple_tariffs_shows_list(monkeypatch):
     """Два и больше тарифов → список как раньше, без авто-перехода."""
-    from app.config import Settings
-
     tariffs = [
         SimpleNamespace(id=1, name='A'),
         SimpleNamespace(id=2, name='B'),
@@ -78,7 +92,7 @@ async def test_show_tariffs_list_multiple_tariffs_shows_list(monkeypatch):
 
 
 async def test_select_tariff_wrapper_parses_id_and_delegates(monkeypatch):
-    """select_tariff остаётся тонкой обёрткой: парсит id и зовёт _proceed_with_selected_tariff."""
+    """select_tariff остаётся тонкой обёрткой: парсит id и зовёт _proceed без skip_selection."""
     proceed = AsyncMock()
     monkeypatch.setattr(m, '_proceed_with_selected_tariff', proceed)
 
@@ -90,3 +104,40 @@ async def test_select_tariff_wrapper_parses_id_and_delegates(monkeypatch):
     await m.select_tariff.__wrapped__(callback, db_user, db, state)
 
     proceed.assert_awaited_once_with(callback, db_user, db, state, 77)
+
+
+async def test_proceed_skip_selection_uses_back_to_menu(monkeypatch):
+    """Схлопнутый выбор: клавиатура периодов с back_callback=back_to_menu."""
+    tariff = _period_tariff(42)
+    periods_kb = MagicMock(name='periods_kb')
+
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    monkeypatch.setattr(m, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(m, 'format_tariff_info_for_user', MagicMock(return_value='INFO'))
+    monkeypatch.setattr(m, 'get_tariff_periods_keyboard', MagicMock(return_value=periods_kb))
+
+    callback = _callback()
+    db_user = _user()
+    await m._proceed_with_selected_tariff(callback, db_user, AsyncMock(), _state(), 42, skip_selection=True)
+
+    m.get_tariff_periods_keyboard.assert_called_once()
+    assert m.get_tariff_periods_keyboard.call_args.kwargs['back_callback'] == 'back_to_menu'
+    assert callback.message.edit_text.await_args.kwargs['reply_markup'] is periods_kb
+
+
+async def test_proceed_normal_selection_uses_menu_buy_back(monkeypatch):
+    """Обычный выбор из списка: клавиатура периодов с back_callback=menu_buy."""
+    tariff = _period_tariff(77)
+    periods_kb = MagicMock(name='periods_kb')
+
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: False)
+    monkeypatch.setattr(m, 'get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(m, 'format_tariff_info_for_user', MagicMock(return_value='INFO'))
+    monkeypatch.setattr(m, 'get_tariff_periods_keyboard', MagicMock(return_value=periods_kb))
+
+    callback = _callback('tariff_select:77')
+    db_user = _user()
+    await m._proceed_with_selected_tariff(callback, db_user, AsyncMock(), _state(), 77)
+
+    m.get_tariff_periods_keyboard.assert_called_once()
+    assert m.get_tariff_periods_keyboard.call_args.kwargs['back_callback'] == 'menu_buy'


### PR DESCRIPTION
## Описание
Когда пользователю для покупки доступен ровно один тариф, экран выбора тарифа из единственной кнопки пропускается — пользователь сразу попадает на выбор периода/подтверждение. Убирает лишнее нажатие в самом частом случае (одиночный тариф).

## Реализация
Тело `select_tariff` вынесено в `_proceed_with_selected_tariff(tariff_id, *, skip_selection=False)`, `select_tariff` стал тонкой обёрткой. `show_tariffs_list` при `len(tariffs) == 1` вызывает эту функцию напрямую с `skip_selection=True`. Вся логика (суточные тарифы, кастомные дни/трафик, проверки баланса и мультитарифа) переиспользована, не дублирована.

При схлопнутом выборе кнопка «Назад» на экране периодов ведёт в главное меню (`back_to_menu`) вместо списка тарифов (`menu_buy`) — иначе возникала петля: «Назад» → `show_tariffs_list` → снова пропуск на периоды. Это же восстанавливает перерисовку rich-шапки. `back_callback` проброшен во все клавиатуры периодов (обычные, с трафиком, суточные, кастомные).

## Объём
Затрагивает только первую покупку (`show_tariffs_list`). Ветки смены тарифа (`tariff_switch` / `instant_switch`) не тронуты — там выбор осмыслен и при одном тарифе, а при единственном доступном тарифе ветка смены корректно показывает сообщение «нет тарифов для переключения». Условие схлопывания — по `get_tariffs_for_user`, то есть по тарифам, доступным конкретному пользователю с учётом промогруппы.

## Тип изменений
- [x] New feature

## Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены тесты (пропуск при одном тарифе, показ списка при нескольких, делегирование обёртки, оба back-callback'а)
- [x] Совместимость с существующим API (вход `select_tariff` не изменился)
- [x] Проверено на проде