### PR TITLE
feat: sort user list by soonest subscription expiry

### DIFF
--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -587,7 +587,7 @@ async def list_users(
     - **search**: Search by telegram_id, username, first_name, last_name
     - **email**: Search by email
     - **status**: Filter by user status (active, blocked, deleted)
-    - **sort_by**: Sort field (created_at, balance, traffic, last_activity, total_spent, purchase_count)
+    - **sort_by**: Sort field (created_at, balance, traffic, last_activity, total_spent, purchase_count, subscription_end_date)
     """
     # Convert status enum to model enum
     user_status = None
@@ -600,6 +600,7 @@ async def list_users(
     order_by_last_activity = sort_by == SortByEnum.LAST_ACTIVITY
     order_by_total_spent = sort_by == SortByEnum.TOTAL_SPENT
     order_by_purchase_count = sort_by == SortByEnum.PURCHASE_COUNT
+    order_by_subscription_end = sort_by == SortByEnum.SUBSCRIPTION_END_DATE
 
     # Parse comma-separated tariff_ids
     tariff_ids: list[int] | None = None
@@ -626,6 +627,7 @@ async def list_users(
         order_by_last_activity=order_by_last_activity,
         order_by_total_spent=order_by_total_spent,
         order_by_purchase_count=order_by_purchase_count,
+        order_by_subscription_end=order_by_subscription_end,
     )
 
     total = await get_users_count(

--- a/app/cabinet/schemas/users.py
+++ b/app/cabinet/schemas/users.py
@@ -35,6 +35,7 @@ class SortByEnum(StrEnum):
     LAST_ACTIVITY = 'last_activity'
     TOTAL_SPENT = 'total_spent'
     PURCHASE_COUNT = 'purchase_count'
+    SUBSCRIPTION_END_DATE = 'subscription_end_date'
 
 
 # === User Subscription Info ===

--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -944,6 +944,7 @@ async def get_users_list(
     order_by_last_activity: bool = False,
     order_by_total_spent: bool = False,
     order_by_purchase_count: bool = False,
+    order_by_subscription_end: bool = False,
 ) -> list[User]:
     query = select(User).options(
         selectinload(User.subscriptions).selectinload(Subscription.tariff),
@@ -1009,10 +1010,11 @@ async def get_users_list(
         order_by_last_activity,
         order_by_total_spent,
         order_by_purchase_count,
+        order_by_subscription_end,
     ]
     if sum(int(flag) for flag in sort_flags) > 1:
         logger.debug(
-            'Выбрано несколько сортировок пользователей — применяется приоритет: трафик > траты > покупки > баланс > активность'
+            'Выбрано несколько сортировок пользователей — применяется приоритет: трафик > траты > покупки > баланс > активность > окончание подписки'
         )
 
     transactions_stats = None
@@ -1041,6 +1043,18 @@ async def get_users_list(
         query = query.order_by(User.balance_kopeks.desc(), User.created_at.desc())
     elif order_by_last_activity:
         query = query.order_by(nullslast(User.last_activity.desc()), User.created_at.desc())
+    elif order_by_subscription_end:
+        # MIN(end_date) среди ACTIVE-подписок; без outerjoin — иначе дубли строк
+        # при нескольких подписках у одного пользователя.
+        soonest_end = (
+            select(func.min(Subscription.end_date))
+            .where(
+                Subscription.user_id == User.id,
+                Subscription.status == SubscriptionStatus.ACTIVE.value,
+            )
+            .scalar_subquery()
+        )
+        query = query.order_by(nullslast(soonest_end.asc()), User.created_at.desc())
     else:
         query = query.order_by(User.created_at.desc())
 

--- a/tests/crud/test_users_list_subscription_end_sort.py
+++ b/tests/crud/test_users_list_subscription_end_sort.py
@@ -1,0 +1,75 @@
+"""Сортировка get_users_list по ближайшему окончанию активной подписки."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.database.crud.user import get_users_list
+from app.database.models import PromoGroup, Subscription, SubscriptionStatus, Tariff, User, UserStatus
+from tests.fixtures.sqlite_memory import memory_session
+
+
+TABLES = (
+    User.__table__,
+    Subscription.__table__,
+    Tariff.__table__,
+    PromoGroup.__table__,
+)
+
+
+@pytest.mark.asyncio
+async def test_order_by_subscription_end_soonest_first_then_no_sub(monkeypatch):
+    async with memory_session(monkeypatch, TABLES) as db:
+        now = datetime.now(UTC)
+
+        soon = User(
+            telegram_id=101,
+            username='soon',
+            first_name='Soon',
+            status=UserStatus.ACTIVE.value,
+            language='ru',
+        )
+        later = User(
+            telegram_id=102,
+            username='later',
+            first_name='Later',
+            status=UserStatus.ACTIVE.value,
+            language='ru',
+        )
+        no_sub = User(
+            telegram_id=103,
+            username='nosub',
+            first_name='NoSub',
+            status=UserStatus.ACTIVE.value,
+            language='ru',
+        )
+        db.add_all([soon, later, no_sub])
+        await db.commit()
+
+        db.add_all(
+            [
+                Subscription(
+                    user_id=soon.id,
+                    status=SubscriptionStatus.ACTIVE.value,
+                    is_trial=False,
+                    start_date=now - timedelta(days=10),
+                    end_date=now + timedelta(days=2),
+                    remnawave_short_id='short-soon',
+                ),
+                Subscription(
+                    user_id=later.id,
+                    status=SubscriptionStatus.ACTIVE.value,
+                    is_trial=False,
+                    start_date=now - timedelta(days=10),
+                    end_date=now + timedelta(days=30),
+                    remnawave_short_id='short-later',
+                ),
+            ]
+        )
+        await db.commit()
+
+        users = await get_users_list(db, order_by_subscription_end=True, limit=50)
+
+        assert [u.username for u in users] == ['soon', 'later', 'nosub']


### PR DESCRIPTION
## Описание
Добавляет в список пользователей админ-кабинета сортировку по дате окончания подписки — админ видит, у кого подписка истекает раньше всего (истекающие сверху). Полезно для проактивного продления: сразу видно, с кем связаться в первую очередь.

## Реализация
Новый член `SortByEnum.SUBSCRIPTION_END_DATE` (`app/cabinet/schemas/users.py`), флаг `order_by_subscription_end` проброшен из эндпоинта списка пользователей в `get_users_list`.

Сортировка — по ближайшей дате окончания среди активных подписок пользователя, через скалярный коррелированный подзапрос `MIN(Subscription.end_date)` с фильтром `Subscription.status == 'active'`. Использован подзапрос, а не `outerjoin`, чтобы избежать дублирования строк при нескольких подписках у одного пользователя (мульти-тариф). Пользователи без активной подписки уходят в конец списка (`nullslast`), вторичная сортировка по `created_at` — как в остальных ветках.

Фильтрация по колонке `status`, а не по свойству `is_active` (оно Python-property и в SQL недоступно).

## Объём
Только backend бота. Фронтенд кабинета (пункт в дропдауне + локализация) — в парном PR: https://github.com/BEDOLAGA-DEV/bedolaga-cabinet/pull/534.

## Тип изменений
- [x] New feature

## Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены тесты (истекающая раньше → позже → без подписки)
- [x] Совместимость с существующим API (новый параметр опционален, дефолт False)