### PR TITLE
feat: show payment methods directly on extend insufficient-balance screen

### DIFF
--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -398,6 +398,51 @@ def get_tariff_insufficient_balance_keyboard(
     )
 
 
+def get_tariff_extend_insufficient_balance_keyboard(
+    tariff_id: int,
+    subscription_id: int | None,
+    period: int,
+    language: str,
+    missing_kopeks: int = 0,
+) -> InlineKeyboardMarkup:
+    """Клавиатура «Недостаточно средств» при продлении тарифа.
+
+    Зеркало ``get_tariff_insufficient_balance_keyboard`` для buy-flow: при
+    ``AUTO_PURCHASE_AFTER_TOPUP_ENABLED`` встраивает кнопки прямой оплаты на
+    недостающую сумму (``topup_amount|метод|сумма``), иначе — классический
+    переход ``balance_topup``. «Назад» всегда ``subscription_extend`` (не
+    ``tariff_select``).
+
+    ``tariff_id`` / ``subscription_id`` / ``period`` — контекст вызывающего
+    (симметрия с insufficient-веткой); на состав кнопок сейчас влияют только
+    language, missing_kopeks и флаг автопокупки.
+
+    SBP/Lava-строки (``tariff_sbp`` / ``tariff_lava``) не добавляем: их
+    обработчики оформляют новую подписку с привязкой провайдера, а не продление
+    существующей — отдельных extend-callback'ов нет.
+    """
+    texts = get_texts(language)
+    back_button = InlineKeyboardButton(text=texts.BACK, callback_data='subscription_extend')
+
+    if settings.is_auto_purchase_after_topup_enabled() and missing_kopeks > 0:
+        from app.keyboards.inline import get_payment_methods_keyboard
+
+        payment_rows = [
+            row
+            for row in get_payment_methods_keyboard(missing_kopeks, language).inline_keyboard
+            if row and all((button.callback_data or '').startswith('topup_amount|') for button in row)
+        ]
+        if payment_rows:
+            return InlineKeyboardMarkup(inline_keyboard=[*payment_rows, [back_button]])
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text=texts.t('BALANCE_TOPUP', '💳 Пополнить баланс'), callback_data='balance_topup')],
+            [back_button],
+        ]
+    )
+
+
 def _sbp_purchase_rows(tariff_id: int, texts) -> list[list[InlineKeyboardButton]]:
     """Ряды оформления привязкой провайдера — те же, что на confirm-экранах."""
     rows: list[list[InlineKeyboardButton]] = []
@@ -2802,15 +2847,12 @@ async def select_tariff_extend_period(
                 'TARIFF_RENEW_CART_SAVED_HINT',
                 '\n\n🛒 <i>Корзина сохранена! После пополнения баланса подписка будет продлена автоматически.</i>',
             ),
-            reply_markup=InlineKeyboardMarkup(
-                inline_keyboard=[
-                    [
-                        InlineKeyboardButton(
-                            text=texts.t('BALANCE_TOPUP', '💳 Пополнить баланс'), callback_data='balance_topup'
-                        )
-                    ],
-                    [InlineKeyboardButton(text=texts.BACK, callback_data='subscription_extend')],
-                ]
+            reply_markup=get_tariff_extend_insufficient_balance_keyboard(
+                tariff_id,
+                subscription.id if subscription else None,
+                period,
+                db_user.language,
+                missing_kopeks=missing,
             ),
             parse_mode='HTML',
         )
@@ -5235,8 +5277,12 @@ async def return_to_saved_tariff_cart(
                     balance=format_price_kopeks(user_balance),
                     missing=format_price_kopeks(missing),
                 ),
-                reply_markup=get_tariff_insufficient_balance_keyboard(
-                    tariff_id, period, db_user.language, missing_kopeks=missing
+                reply_markup=get_tariff_extend_insufficient_balance_keyboard(
+                    tariff_id,
+                    cart_data.get('subscription_id'),
+                    period,
+                    db_user.language,
+                    missing_kopeks=missing,
                 ),
                 parse_mode='HTML',
             )

--- a/tests/test_tariff_insufficient_balance_keyboard.py
+++ b/tests/test_tariff_insufficient_balance_keyboard.py
@@ -1,5 +1,8 @@
 from app.config import settings
-from app.handlers.subscription.tariff_purchase import get_tariff_insufficient_balance_keyboard
+from app.handlers.subscription.tariff_purchase import (
+    get_tariff_extend_insufficient_balance_keyboard,
+    get_tariff_insufficient_balance_keyboard,
+)
 
 
 def _callbacks(keyboard):
@@ -93,3 +96,47 @@ def test_falls_back_to_topup_without_direct_payment_methods(monkeypatch):
     keyboard = get_tariff_insufficient_balance_keyboard(7, 30, 'ru', missing_kopeks=50000)
 
     assert 'balance_topup' in _callbacks(keyboard)
+
+
+def test_extend_inlines_prefilled_payment_when_autopurchase_enabled(monkeypatch):
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', True)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', True)
+
+    keyboard = get_tariff_extend_insufficient_balance_keyboard(7, 42, 30, 'ru', missing_kopeks=50000)
+    callbacks = _callbacks(keyboard)
+
+    assert 'topup_amount|stars|50000' in callbacks
+    assert 'balance_topup' not in callbacks
+    assert 'subscription_extend' in callbacks
+    assert not any((c or '').startswith('tariff_select:') for c in callbacks)
+    assert not any((c or '').startswith('tariff_sbp:') for c in callbacks)
+
+
+def test_extend_classic_topup_when_autopurchase_disabled(monkeypatch):
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', False)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', True)
+
+    keyboard = get_tariff_extend_insufficient_balance_keyboard(7, 42, 30, 'ru', missing_kopeks=50000)
+    callbacks = _callbacks(keyboard)
+
+    assert 'balance_topup' in callbacks
+    assert 'subscription_extend' in callbacks
+    assert not any((c or '').startswith('topup_amount|') for c in callbacks)
+
+
+def test_extend_prefilled_amount_is_missing_not_full_price(monkeypatch):
+    """Частичная нехватка: доплата = missing (260), не цена (630) и не баланс (370)."""
+    monkeypatch.setattr(settings, 'AUTO_PURCHASE_AFTER_TOPUP_ENABLED', True)
+    monkeypatch.setattr(settings, 'TELEGRAM_STARS_ENABLED', True)
+
+    price = 63000
+    balance = 37000
+    missing = price - balance  # 26000
+
+    keyboard = get_tariff_extend_insufficient_balance_keyboard(7, 42, 30, 'ru', missing_kopeks=missing)
+    callbacks = _callbacks(keyboard)
+
+    assert f'topup_amount|stars|{missing}' in callbacks
+    assert f'topup_amount|stars|{price}' not in callbacks
+    assert f'topup_amount|stars|{balance}' not in callbacks
+    assert 'subscription_extend' in callbacks


### PR DESCRIPTION
## Описание
Выравнивает продление тарифа с покупкой на экране «Недостаточно средств». При включённой `AUTO_PURCHASE_AFTER_TOPUP_ENABLED` покупка уже показывает способы оплаты прямо на этом экране (предзаполненные недостающей суммой, с автозавершением после оплаты), а продление — нет, оно вело через отдельный шаг «Пополнить баланс». Теперь продление ведёт себя так же, убирая лишний экран.

## Реализация
Новая `get_tariff_extend_insufficient_balance_keyboard` по образцу `get_tariff_insufficient_balance_keyboard`: при включённой автопокупке встраивает строки прямой оплаты (`topup_amount|`) из `get_payment_methods_keyboard(missing_kopeks, ...)`, иначе — классическую кнопку пополнения. «Назад» ведёт на `subscription_extend`. SBP/Lava-строки не добавлены намеренно: их callback'и оформляют новую подписку, а не продление. Автозавершение — тот же хук после пополнения, ветвящийся по `cart_mode='extend'` в `_auto_extend_subscription`. Попутно исправлен still-insufficient экран продления, который ошибочно вёл «Назад» в покупочную ветку.

## Тип изменений
- [x] New feature

## Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены тесты (автопокупка вкл/выкл, частичная нехватка с предзаполнением недостачи)
- [x] Совместимость с существующим API
- [x] Проверено на проде