### PR TITLE
fix(notifications): не отправлять отключённые уведомления пользователям

### DIFF
--- a/app/cabinet/routes/admin_promo_offers.py
+++ b/app/cabinet/routes/admin_promo_offers.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, validator
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database.crud.discount_offer import (
     count_discount_offers,
     list_discount_offers,
@@ -36,6 +37,7 @@ from app.database.models import (
 from app.handlers.admin.messages import get_custom_users, get_target_users, get_target_users_count
 from app.services.broadcast_service import BroadcastConfig, broadcast_service
 from app.utils.miniapp_buttons import build_miniapp_or_callback_button
+from app.utils.notification_prefs import is_promo_offers_enabled
 
 from ..dependencies import get_cabinet_db, require_permission
 
@@ -673,8 +675,11 @@ async def broadcast_offer(
 
     # Reduce to plain (telegram_id, offer_id) so the fan-out can run detached: the
     # request's DB session closes on return, and ORM objects would then fail to lazy-load.
+    notifications_enabled = settings.is_notifications_enabled()
     notify_targets = [
-        (recipient.telegram_id, offer.id) for recipient, offer in offers_to_notify if recipient.telegram_id
+        (recipient.telegram_id, offer.id)
+        for recipient, offer in offers_to_notify
+        if notifications_enabled and recipient.telegram_id and is_promo_offers_enabled(recipient)
     ]
 
     # Email-only юзеры (без telegram_id): оффер у них уже создан выше, но о нём
@@ -684,7 +689,11 @@ async def broadcast_offer(
     email_targets = [
         (recipient.email, recipient.language or 'ru', recipient.first_name or recipient.username or '')
         for recipient, _offer in offers_to_notify
-        if not recipient.telegram_id and recipient.email and recipient.email_verified
+        if notifications_enabled
+        and not recipient.telegram_id
+        and recipient.email
+        and recipient.email_verified
+        and is_promo_offers_enabled(recipient)
     ]
 
     # Send Telegram/email notifications if requested

--- a/app/handlers/admin/promo_offers.py
+++ b/app/handlers/admin/promo_offers.py
@@ -1979,6 +1979,11 @@ async def _send_offer_to_users(
 
     async def send_single_offer(user):
         """Отправляет одно предложение с семафором ограничения"""
+        from app.utils.notification_prefs import is_promo_offers_enabled
+
+        if not settings.is_notifications_enabled() or not is_promo_offers_enabled(user):
+            return False
+
         # Email-only юзеры (без telegram_id) раньше пропускались целиком —
         # ни оффера, ни уведомления. Теперь оффер создаётся, а уведомление
         # уходит на подтверждённую почту (активация — в кабинете).

--- a/app/handlers/admin/subscriptions.py
+++ b/app/handlers/admin/subscriptions.py
@@ -382,6 +382,11 @@ async def send_expiry_reminders(callback: types.CallbackQuery, db_user: User, db
                     logger.debug('Пропуск email-пользователя при отправке напоминания', user_id=user.id)
                     continue
 
+                from app.utils.notification_prefs import is_subscription_expiry_enabled
+
+                if not settings.is_notifications_enabled() or not is_subscription_expiry_enabled(user):
+                    continue
+
                 days_left = max(1, subscription.days_left)
 
                 tariff_label = ''

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -5257,7 +5257,7 @@ async def admin_buy_subscription_execute(callback: types.CallbackQuery, db_user:
         )
 
         try:
-            if callback.bot and target_user.telegram_id:
+            if callback.bot and target_user.telegram_id and settings.is_notifications_enabled():
                 tariff_line = ''
                 if settings.is_multi_tariff_enabled() and getattr(subscription, 'tariff', None):
                     tariff_line = f'\n📦 Тариф: «{subscription.tariff.name}»'
@@ -5663,7 +5663,7 @@ async def admin_buy_tariff_execute(callback: types.CallbackQuery, db_user: User,
 
         # Уведомляем пользователя
         try:
-            if callback.bot and target_user.telegram_id:
+            if callback.bot and target_user.telegram_id and settings.is_notifications_enabled():
                 await callback.bot.send_message(
                     chat_id=target_user.telegram_id,
                     text=f'💳 <b>Администратор оформил вам тариф</b>\n\n'

--- a/app/handlers/channel_member.py
+++ b/app/handlers/channel_member.py
@@ -108,6 +108,9 @@ async def on_user_joined_channel(event: ChatMemberUpdated, bot: Bot) -> None:
 
             # Notify the user
             try:
+                if not settings.is_notifications_enabled():
+                    await db.commit()
+                    return
                 texts = get_texts(db_user.language or DEFAULT_LANGUAGE)
                 notification_text = texts.t(
                     'SUBSCRIPTION_REACTIVATED_CHANNEL_SUBSCRIBE',
@@ -192,6 +195,9 @@ async def on_user_left_channel(event: ChatMemberUpdated, bot: Bot) -> None:
 
             # Notify the user with channel subscription keyboard
             try:
+                if not settings.is_notifications_enabled():
+                    await db.commit()
+                    return
                 texts = get_texts(db_user.language or DEFAULT_LANGUAGE)
                 unsub_channels = await channel_subscription_service.get_channels_with_status(user.id)
                 notification_text = texts.t(

--- a/app/handlers/referral.py
+++ b/app/handlers/referral.py
@@ -860,7 +860,12 @@ async def confirm_withdrawal_request(callback: types.CallbackQuery, db_user: Use
 
     # Уведомление в топик, если настроено
     topic_id = settings.REFERRAL_WITHDRAWAL_NOTIFICATIONS_TOPIC_ID
-    if topic_id and settings.ADMIN_NOTIFICATIONS_CHAT_ID:
+    if (
+        topic_id
+        and settings.ADMIN_NOTIFICATIONS_CHAT_ID
+        and settings.ADMIN_NOTIFICATIONS_ENABLED
+        and settings.ADMIN_NOTIFICATIONS_PARTNERS_ENABLED
+    ):
         try:
             await callback.bot.send_message(
                 chat_id=settings.ADMIN_NOTIFICATIONS_CHAT_ID,

--- a/app/middlewares/channel_checker.py
+++ b/app/middlewares/channel_checker.py
@@ -505,7 +505,7 @@ class ChannelCheckerMiddleware(BaseMiddleware):
                             )
 
                 # Notify user about deactivation
-                if deactivated_subs:
+                if deactivated_subs and settings.is_notifications_enabled():
                     try:
                         normalized = _normalize_channels(channels)
                         texts = get_texts(user.language or DEFAULT_LANGUAGE)
@@ -594,6 +594,9 @@ class ChannelCheckerMiddleware(BaseMiddleware):
 
                 # Notify user about reactivation
                 try:
+                    if not settings.is_notifications_enabled():
+                        await db.commit()
+                        return
                     texts = get_texts(user.language or DEFAULT_LANGUAGE)
                     if settings.is_multi_tariff_enabled() and len(disabled_subs) > 1:
                         notification_text = texts.t(

--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -1496,8 +1496,7 @@ class AdminNotificationService:
         *,
         category: NotificationCategory | None = None,
     ) -> bool:
-        if not self.chat_id:
-            logger.warning('ADMIN_NOTIFICATIONS_CHAT_ID не настроен')
+        if not self._is_enabled():
             return False
 
         # Per-category suppression
@@ -2358,8 +2357,7 @@ class AdminNotificationService:
             bot: экземпляр бота для отправки сообщения
             topic_id: ID топика для отправки уведомления (если не указан, использует стандартный)
         """
-        if not self.chat_id:
-            logger.warning('ADMIN_NOTIFICATIONS_CHAT_ID не настроен')
+        if not self._is_enabled() or not self.category_enabled.get(NotificationCategory.INFRASTRUCTURE, True):
             return False
 
         # Используем специальный топик для подозрительной активности, если он задан

--- a/app/services/ban_notification_service.py
+++ b/app/services/ban_notification_service.py
@@ -96,6 +96,8 @@ class BanNotificationService:
         """
         if not self._bot:
             return False, 'Бот не инициализирован', None
+        if not settings.is_notifications_enabled():
+            return False, 'Уведомления пользователям отключены', None
 
         # Находим пользователя
         user = await self._find_user_by_identifier(db, user_identifier)
@@ -164,6 +166,8 @@ class BanNotificationService:
         """
         if not self._bot:
             return False, 'Бот не инициализирован', None
+        if not settings.is_notifications_enabled():
+            return False, 'Уведомления пользователям отключены', None
 
         # Находим пользователя
         user = await self._find_user_by_identifier(db, user_identifier)
@@ -214,6 +218,8 @@ class BanNotificationService:
         """
         if not self._bot:
             return False, 'Бот не инициализирован', None
+        if not settings.is_notifications_enabled():
+            return False, 'Уведомления пользователям отключены', None
 
         # Находим пользователя
         user = await self._find_user_by_identifier(db, user_identifier)
@@ -275,6 +281,8 @@ class BanNotificationService:
         """
         if not self._bot:
             return False, 'Бот не инициализирован', None
+        if not settings.is_notifications_enabled():
+            return False, 'Уведомления пользователям отключены', None
 
         # Находим пользователя
         user = await self._find_user_by_identifier(db, user_identifier)
@@ -353,6 +361,8 @@ class BanNotificationService:
         """
         if not self._bot:
             return False, 'Бот не инициализирован', None
+        if not settings.is_notifications_enabled():
+            return False, 'Уведомления пользователям отключены', None
 
         # Находим пользователя
         user = await self._find_user_by_identifier(db, user_identifier)

--- a/app/services/bulk_ban_service.py
+++ b/app/services/bulk_ban_service.py
@@ -6,6 +6,7 @@ import structlog
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database.crud.user import get_user_by_telegram_id
 from app.database.models import UserStatus
 from app.services.admin_notification_service import AdminNotificationService
@@ -75,7 +76,7 @@ class BulkBanService:
                     logger.info('Пользователь успешно заблокирован', telegram_id=telegram_id)
 
                     # Отправляем уведомление пользователю, если возможно
-                    if bot:
+                    if bot and settings.is_notifications_enabled():
                         try:
                             await bot.send_message(
                                 chat_id=telegram_id,

--- a/app/services/contest_rotation_service.py
+++ b/app/services/contest_rotation_service.py
@@ -332,7 +332,7 @@ class ContestRotationService:
 
     async def _broadcast_to_users(self, text: str) -> None:
         """Отправляет анонс всем пользователям с активной/триальной подпиской."""
-        if not self.bot:
+        if not self.bot or not settings.is_notifications_enabled():
             return
 
         try:
@@ -358,6 +358,10 @@ class ContestRotationService:
                     nonlocal sent, failed
                     # Skip email-only users (no telegram_id)
                     if not u.telegram_id:
+                        return
+                    from app.utils.notification_prefs import is_promo_offers_enabled
+
+                    if not is_promo_offers_enabled(u):
                         return
                     async with semaphore:
                         try:

--- a/app/services/manual_topup_service.py
+++ b/app/services/manual_topup_service.py
@@ -306,6 +306,9 @@ async def _notify_user(
     *,
     bot: Bot | None,
 ) -> None:
+    if not settings.is_notifications_enabled():
+        return
+
     if bot is not None and user.telegram_id:
         keyboard = None
         try:

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -495,6 +495,9 @@ class MonitoringService:
 
         `cause` ('charge_error' | 'insufficient_balance') selects the email/non-Telegram
         reason wording so a non-balance charge failure isn't mislabelled as low balance."""
+        if not NotificationSettingsService.are_notifications_globally_enabled():
+            return
+
         cycle_token = int(subscription.end_date.timestamp())
         now_ts = current_time.timestamp()
         hours_left = (subscription.end_date - current_time).total_seconds() / 3600.0
@@ -551,8 +554,13 @@ class MonitoringService:
 
                 user = await get_user_by_id(db, subscription.user_id)
                 if user and self.bot:
+                    from app.utils.notification_prefs import is_subscription_expiry_enabled
+
                     # Skip notification if user has another ACTIVE subscription (multi-tariff)
-                    skip_notify = False
+                    skip_notify = (
+                        not NotificationSettingsService.are_notifications_globally_enabled()
+                        or not is_subscription_expiry_enabled(user)
+                    )
                     if settings.is_multi_tariff_enabled():
                         other_active = await db.execute(
                             select(Subscription.id)
@@ -564,7 +572,7 @@ class MonitoringService:
                             )
                             .limit(1)
                         )
-                        skip_notify = other_active.scalar_one_or_none() is not None
+                        skip_notify = skip_notify or other_active.scalar_one_or_none() is not None
                     if not skip_notify:
                         await self._send_subscription_expired_notification(user, subscription, tariff_name=_tariff_name)
 
@@ -707,6 +715,9 @@ class MonitoringService:
             return None
 
     async def _check_expiring_subscriptions(self, db: AsyncSession):
+        if not NotificationSettingsService.are_notifications_globally_enabled():
+            return
+
         try:
             warning_days = settings.get_autopay_warning_days()
             all_processed_users = set()
@@ -825,6 +836,9 @@ class MonitoringService:
             logger.error('Ошибка проверки истекающих подписок', error=e)
 
     async def _check_trial_expiring_soon(self, db: AsyncSession):
+        if not NotificationSettingsService.are_notifications_globally_enabled():
+            return
+
         try:
             threshold_time = datetime.now(UTC) + timedelta(hours=2)
 
@@ -853,6 +867,11 @@ class MonitoringService:
             for subscription in trial_expiring:
                 user = subscription.user
                 if not user:
+                    continue
+
+                from app.utils.notification_prefs import is_subscription_expiry_enabled
+
+                if not is_subscription_expiry_enabled(user):
                     continue
 
                 if await notification_sent(db, user.id, subscription.id, 'trial_2h'):
@@ -1221,6 +1240,11 @@ class MonitoringService:
                 if not user:
                     continue
 
+                from app.utils.notification_prefs import is_subscription_expiry_enabled
+
+                if not is_subscription_expiry_enabled(user):
+                    continue
+
                 if subscription.end_date is None:
                     continue
 
@@ -1422,7 +1446,12 @@ class MonitoringService:
                     try:
                         if not await cache.exists(autopay_legacy_key):
                             user = sub.user
-                            if user and user.telegram_id and self.bot:
+                            if (
+                                user
+                                and user.telegram_id
+                                and self.bot
+                                and NotificationSettingsService.are_notifications_globally_enabled()
+                            ):
                                 await self.bot.send_message(
                                     chat_id=user.telegram_id,
                                     text=(
@@ -1681,7 +1710,11 @@ class MonitoringService:
                                 )
 
                             # Send notification via appropriate channel
-                            if user.telegram_id and self.bot:
+                            if (
+                                user.telegram_id
+                                and self.bot
+                                and NotificationSettingsService.are_notifications_globally_enabled()
+                            ):
                                 await self._send_autopay_success_notification(
                                     user, charge_amount, autopay_period, subscription=subscription
                                 )
@@ -2397,7 +2430,7 @@ class MonitoringService:
 
     async def _check_traffic_warnings(self, db: AsyncSession):
         """Check subscriptions approaching traffic limit and notify users."""
-        if not self.bot:
+        if not self.bot or not NotificationSettingsService.are_notifications_globally_enabled():
             return
 
         try:
@@ -2495,7 +2528,7 @@ class MonitoringService:
         - Quiet hours: skips sending between 22:00 and 09:00 server time
         - Rate-limited: max 1 alert per 24 hours per user
         """
-        if not self.bot:
+        if not self.bot or not NotificationSettingsService.are_notifications_globally_enabled():
             return
 
         try:

--- a/app/services/nalogo_queue_service.py
+++ b/app/services/nalogo_queue_service.py
@@ -93,6 +93,9 @@ class NalogoQueueService:
         if not self._bot:
             return
 
+        if not settings.ADMIN_NOTIFICATIONS_ENABLED or not settings.ADMIN_NOTIFICATIONS_INFRASTRUCTURE_ENABLED:
+            return
+
         chat_id = settings.get_admin_notifications_chat_id()
         if not chat_id:
             return

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -111,6 +111,68 @@ class NotificationDeliveryService:
         self._email_templates = None
         self._ws_manager = None
 
+    @staticmethod
+    def _is_allowed_by_preferences(user: User, notification_type: NotificationType) -> bool:
+        """Apply global, category and per-user notification switches centrally."""
+        global_switch_exempt_types = {
+            NotificationType.EMAIL_VERIFICATION,
+            NotificationType.PASSWORD_RESET,
+            NotificationType.EMAIL_CHANGE_CODE,
+            NotificationType.GUEST_SUBSCRIPTION_DELIVERED,
+            NotificationType.GUEST_ACTIVATION_REQUIRED,
+            NotificationType.GUEST_GIFT_RECEIVED,
+            NotificationType.GUEST_CABINET_CREDENTIALS,
+        }
+        if notification_type not in global_switch_exempt_types and not settings.is_notifications_enabled():
+            logger.debug(
+                'Уведомление отключено глобальным переключателем',
+                user_id=user.id,
+                notification_type_value=notification_type.value,
+            )
+            return False
+
+        referral_types = {
+            NotificationType.REFERRAL_BONUS,
+            NotificationType.REFERRAL_REGISTERED,
+        }
+        if notification_type in referral_types and not settings.is_referral_notifications_enabled():
+            logger.debug(
+                'Реферальное уведомление отключено',
+                user_id=user.id,
+                notification_type_value=notification_type.value,
+            )
+            return False
+
+        from app.utils.notification_prefs import (
+            is_balance_low_enabled,
+            is_promo_offers_enabled,
+            is_subscription_expiry_enabled,
+            is_traffic_warning_enabled,
+        )
+
+        expiry_types = {
+            NotificationType.SUBSCRIPTION_EXPIRING,
+            NotificationType.SUBSCRIPTION_EXPIRED,
+            NotificationType.WINBACK_EXPIRED_1D,
+            NotificationType.WINBACK_DISCOUNT,
+            NotificationType.WINBACK_TRIAL_ENDING,
+            NotificationType.WEBHOOK_SUB_EXPIRING,
+            NotificationType.WEBHOOK_SUB_EXPIRED,
+        }
+        if notification_type in expiry_types and not is_subscription_expiry_enabled(user):
+            return False
+        if notification_type is NotificationType.BALANCE_LOW and not is_balance_low_enabled(user):
+            return False
+        if (
+            notification_type is NotificationType.WEBHOOK_SUB_BANDWIDTH_THRESHOLD
+            and not is_traffic_warning_enabled(user)
+        ):
+            return False
+        if notification_type is NotificationType.PROMO_OFFER and not is_promo_offers_enabled(user):
+            return False
+
+        return True
+
     @property
     def email_service(self):
         """Lazy load email service."""
@@ -161,8 +223,20 @@ class NotificationDeliveryService:
         Returns:
             True if notification was sent successfully through at least one channel
         """
-        if user.status in (UserStatus.BLOCKED.value, UserStatus.DELETED.value):
+        is_deleted = user.status == UserStatus.DELETED.value
+        is_blocked_without_ban_notice = (
+            user.status == UserStatus.BLOCKED.value and notification_type is not NotificationType.BAN_NOTIFICATION
+        )
+        if is_deleted or is_blocked_without_ban_notice:
             logger.debug('Пропускаем уведомление для неактивного пользователя', user_id=user.id, status=user.status)
+            return False
+
+        if not self._is_allowed_by_preferences(user, notification_type):
+            logger.debug(
+                'Уведомление отключено настройками пользователя',
+                user_id=user.id,
+                notification_type_value=notification_type.value,
+            )
             return False
 
         if user.telegram_id:

--- a/app/services/payment/antilopay.py
+++ b/app/services/payment/antilopay.py
@@ -469,7 +469,7 @@ class AntilopayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Antilopay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/aurapay.py
+++ b/app/services/payment/aurapay.py
@@ -471,7 +471,7 @@ class AuraPayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления AuraPay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/cispay.py
+++ b/app/services/payment/cispay.py
@@ -454,7 +454,7 @@ class CisPayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления cisPay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/cloudpayments.py
+++ b/app/services/payment/cloudpayments.py
@@ -461,6 +461,8 @@ class CloudPaymentsPaymentMixin:
         transaction: Any,
     ) -> None:
         """Send success notification to user via Telegram."""
+        if not settings.is_notifications_enabled():
+            return
 
         from app.bot_factory import create_bot
         from app.localization.texts import get_texts
@@ -512,6 +514,8 @@ class CloudPaymentsPaymentMixin:
         message: str,
     ) -> None:
         """Send failure notification to user via Telegram."""
+        if not settings.is_notifications_enabled():
+            return
 
         from app.bot_factory import create_bot
 

--- a/app/services/payment/common.py
+++ b/app/services/payment/common.py
@@ -161,6 +161,9 @@ class PaymentCommonMixin:
         payment_method_title: str | None = None,
     ) -> None:
         """Отправляет пользователю уведомление об успешном платеже."""
+        if not settings.is_notifications_enabled():
+            return
+
         # Lazy import to avoid circular dependency
         from app.cabinet.routes.websocket import notify_user_balance_topup
 

--- a/app/services/payment/cryptobot.py
+++ b/app/services/payment/cryptobot.py
@@ -371,14 +371,15 @@ class CryptoBotPaymentMixin:
                             f'🆔 Транзакция: {invoice_id[:8]}...\n\n'
                             'Баланс пополнен автоматически!'
                         )
-                        user_notification = _UserNotificationPayload(
-                            telegram_id=user.telegram_id,
-                            text=message_text,
-                            parse_mode='HTML',
-                            reply_markup=keyboard,
-                            amount_rubles=amount_rubles_rounded,
-                            asset=updated_payment.asset,
-                        )
+                        if settings.is_notifications_enabled():
+                            user_notification = _UserNotificationPayload(
+                                telegram_id=user.telegram_id,
+                                text=message_text,
+                                parse_mode='HTML',
+                                reply_markup=keyboard,
+                                amount_rubles=amount_rubles_rounded,
+                                asset=updated_payment.asset,
+                            )
                     except Exception as error:
                         logger.error('Ошибка подготовки уведомления о пополнении CryptoBot', error=error)
 
@@ -636,6 +637,9 @@ class CryptoBotPaymentMixin:
                 logger.error('Ошибка отправки админ-уведомления о пополнении CryptoBot', error=error, exc_info=True)
 
     async def _deliver_user_topup_notification(self, payload: _UserNotificationPayload) -> None:
+        if not settings.is_notifications_enabled():
+            return
+
         bot_instance = getattr(self, 'bot', None)
         if not bot_instance:
             return

--- a/app/services/payment/donut.py
+++ b/app/services/payment/donut.py
@@ -439,7 +439,7 @@ class DonutPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Donut', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/etoplatezhi.py
+++ b/app/services/payment/etoplatezhi.py
@@ -468,7 +468,7 @@ class EtoplatezhiPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Etoplatezhi', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/freekassa.py
+++ b/app/services/payment/freekassa.py
@@ -374,7 +374,7 @@ class FreekassaPaymentMixin:
                 logger.error('Ошибка отправки админ уведомления Freekassa', error=error)
 
         # Отправка уведомления пользователю
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
 

--- a/app/services/payment/heleket.py
+++ b/app/services/payment/heleket.py
@@ -425,7 +425,7 @@ class HeleketPaymentMixin:
                 logger.error('Ошибка отправки админ-уведомления Heleket', error=error)
 
             # Отправляем уведомление только Telegram-пользователям
-            if user.telegram_id:
+            if user.telegram_id and settings.is_notifications_enabled():
                 try:
                     keyboard = await self.build_topup_success_keyboard(user)
 

--- a/app/services/payment/jupiter.py
+++ b/app/services/payment/jupiter.py
@@ -433,7 +433,7 @@ class JupiterPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Jupiter', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/kassa_ai.py
+++ b/app/services/payment/kassa_ai.py
@@ -379,7 +379,7 @@ class KassaAiPaymentMixin:
                 logger.error('Ошибка отправки админ уведомления KassaAI', error=error)
 
         # Отправка уведомления пользователю (только Telegram-пользователям)
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 display_name = settings.get_kassa_ai_display_name()
 

--- a/app/services/payment/lava.py
+++ b/app/services/payment/lava.py
@@ -536,7 +536,7 @@ class LavaPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Lava', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(
@@ -651,6 +651,9 @@ class LavaPaymentMixin:
         Никогда не бросает наружу — вебхук обязан завершиться 200 независимо
         от доставки сообщения (зеркало ``_notify_sbp_recurring`` у Platega).
         """
+        if not settings.is_notifications_enabled():
+            return
+
         try:
             from app.cabinet.routes.websocket import cabinet_ws_manager
 

--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -363,7 +363,7 @@ class MulenPayPaymentMixin:
                     except Exception as error:
                         logger.error('Ошибка отправки уведомления о пополнении', display_name=display_name, error=error)
 
-                if getattr(self, 'bot', None) and user.telegram_id:
+                if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
                     try:
                         keyboard = await self.build_topup_success_keyboard(user)
                         await self.bot.send_message(

--- a/app/services/payment/overpay.py
+++ b/app/services/payment/overpay.py
@@ -524,7 +524,7 @@ class OverpayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Overpay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/pal24.py
+++ b/app/services/payment/pal24.py
@@ -484,7 +484,7 @@ class Pal24PaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления Pal24', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/paypear.py
+++ b/app/services/payment/paypear.py
@@ -477,7 +477,7 @@ class PayPearPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления PayPear', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -637,6 +637,9 @@ class PlategaPaymentMixin:
         завершиться 200 OK независимо от того, доставилось ли сообщение в
         Telegram.
         """
+        if not settings.is_notifications_enabled():
+            return
+
         try:
             from app.cabinet.routes.websocket import cabinet_ws_manager
 
@@ -1027,7 +1030,7 @@ class PlategaPaymentMixin:
 
         method_title = settings.get_platega_method_display_title(payment.payment_method_code)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/riopay.py
+++ b/app/services/payment/riopay.py
@@ -412,7 +412,7 @@ class RioPayPaymentMixin:
                 logger.error('Ошибка отправки админ уведомления RioPay', error=error)
 
         # Отправка уведомления пользователю (только Telegram-пользователям)
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 display_name = settings.get_riopay_display_name()
 

--- a/app/services/payment/rollypay.py
+++ b/app/services/payment/rollypay.py
@@ -466,7 +466,7 @@ class RollyPayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления RollyPay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/severpay.py
+++ b/app/services/payment/severpay.py
@@ -462,7 +462,7 @@ class SeverPayPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления SeverPay', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/stars.py
+++ b/app/services/payment/stars.py
@@ -446,7 +446,7 @@ class TelegramStarsMixin:
             period_display = settings.SIMPLE_SUBSCRIPTION_PERIOD_DAYS
 
         # Отправляем уведомление только Telegram-пользователям (Stars требует Telegram)
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 from aiogram import types
 

--- a/app/services/payment/wata.py
+++ b/app/services/payment/wata.py
@@ -574,7 +574,7 @@ class WataPaymentMixin:
             except Exception as error:
                 logger.error('Ошибка отправки админ уведомления WATA', error=error)
 
-        if getattr(self, 'bot', None) and user.telegram_id:
+        if getattr(self, 'bot', None) and user.telegram_id and settings.is_notifications_enabled():
             try:
                 keyboard = await self.build_topup_success_keyboard(user)
                 await self.bot.send_message(

--- a/app/services/payment/yookassa.py
+++ b/app/services/payment/yookassa.py
@@ -703,7 +703,11 @@ class YooKassaPaymentMixin:
                                         logger.warning('Ошибка уведомления админов о триале', admin_error=admin_error)
 
                                 # Уведомление пользователю (только для Telegram-пользователей)
-                                if getattr(self, 'bot', None) and user.telegram_id:
+                                if (
+                                    getattr(self, 'bot', None)
+                                    and user.telegram_id
+                                    and settings.is_notifications_enabled()
+                                ):
                                     try:
                                         await self.bot.send_message(
                                             chat_id=user.telegram_id,
@@ -913,7 +917,11 @@ class YooKassaPaymentMixin:
                     # Для рекуррентных автоплатежей уведомления отправляет recurrent_payment_service
                     if not is_recurrent_topup:
                         # Отправляем уведомление пользователю (только Telegram-пользователям)
-                        if getattr(self, 'bot', None) and user.telegram_id:
+                        if (
+                            getattr(self, 'bot', None)
+                            and user.telegram_id
+                            and settings.is_notifications_enabled()
+                        ):
                             try:
                                 # Передаем только простые данные, чтобы избежать проблем с ленивой загрузкой
                                 await self._send_payment_success_notification(
@@ -1008,7 +1016,11 @@ class YooKassaPaymentMixin:
                                 )
 
                             # Отправляем уведомление пользователю об активации подписки (только Telegram)
-                            if getattr(self, 'bot', None) and user.telegram_id:
+                            if (
+                                getattr(self, 'bot', None)
+                                and user.telegram_id
+                                and settings.is_notifications_enabled()
+                            ):
                                 from aiogram import types
 
                                 tariff_line = ''

--- a/app/services/poll_service.py
+++ b/app/services/poll_service.py
@@ -72,6 +72,10 @@ async def send_poll_to_users(
 ) -> dict:
     from app.database.database import AsyncSessionLocal
 
+    if not settings.is_notifications_enabled():
+        skipped = len(list(users))
+        return {'sent': 0, 'failed': 0, 'skipped': skipped, 'total': skipped}
+
     sent = 0
     failed = 0
     skipped = 0

--- a/app/services/promo_offer_email.py
+++ b/app/services/promo_offer_email.py
@@ -44,7 +44,7 @@ async def send_promo_offer_email(
     from app.config import settings
     from app.services.notification_delivery_service import NotificationType
 
-    if not email:
+    if not email or not settings.is_notifications_enabled():
         return False
     if not email_service.is_configured():
         logger.debug('SMTP не настроен — промо-письмо пропущено', email=email)

--- a/app/services/recurrent_payment_service.py
+++ b/app/services/recurrent_payment_service.py
@@ -381,7 +381,7 @@ async def _process_single_subscription(
             logger.warning('Ошибка создания локальной записи рекуррентного платежа', error=e)
 
         # Уведомляем пользователя
-        if bot and user.telegram_id:
+        if bot and user.telegram_id and settings.is_notifications_enabled():
             try:
                 from app.localization.texts import get_texts
 
@@ -436,7 +436,7 @@ async def _process_single_subscription(
         return 'created'
 
     # Все карты не сработали — уведомляем пользователя
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             from app.localization.texts import get_texts
 

--- a/app/services/referral_contest_service.py
+++ b/app/services/referral_contest_service.py
@@ -219,6 +219,9 @@ class ReferralContestService:
         day_end_utc: datetime,
         is_final: bool,
     ) -> None:
+        if not settings.is_notifications_enabled() or not settings.is_referral_notifications_enabled():
+            return
+
         if not self.bot:
             return
 
@@ -302,7 +305,9 @@ class ReferralContestService:
             lines.append(f'Приз: {html.escape(contest.prize_text)}')
 
         # Respect per-category enable/disable
-        if not getattr(settings, 'ADMIN_NOTIFICATIONS_PROMO_ENABLED', True):
+        if not getattr(settings, 'ADMIN_NOTIFICATIONS_ENABLED', False) or not getattr(
+            settings, 'ADMIN_NOTIFICATIONS_PROMO_ENABLED', True
+        ):
             return
 
         try:

--- a/app/services/referral_service.py
+++ b/app/services/referral_service.py
@@ -518,6 +518,22 @@ async def send_referral_notification(
         bonus_kopeks: Сумма бонуса в копейках
         referral_name: Имя реферала
     """
+    if not settings.is_notifications_enabled():
+        logger.debug(
+            'Реферальное уведомление подавлено: уведомления пользователям отключены',
+            telegram_id=telegram_id,
+            user_id=getattr(user, 'id', None),
+        )
+        return
+
+    if not settings.is_referral_notifications_enabled():
+        logger.debug(
+            'Реферальное уведомление подавлено: реферальные уведомления отключены',
+            telegram_id=telegram_id,
+            user_id=getattr(user, 'id', None),
+        )
+        return
+
     # Handle email-only users via notification delivery service
     if telegram_id is None:
         if user is not None:

--- a/app/services/remnawave_webhook_service.py
+++ b/app/services/remnawave_webhook_service.py
@@ -953,6 +953,22 @@ class RemnaWaveWebhookService:
             logger.debug('Webhook notification disabled via', text_key=text_key, setting_key=setting_key)
             return
 
+        expiry_days_by_text_key = {
+            'WEBHOOK_SUB_EXPIRES_72H': 3,
+            'WEBHOOK_SUB_EXPIRES_48H': 2,
+            'WEBHOOK_SUB_EXPIRES_24H': 1,
+        }
+        if text_key in expiry_days_by_text_key:
+            from app.utils.notification_prefs import get_subscription_expiry_days
+
+            if expiry_days_by_text_key[text_key] > get_subscription_expiry_days(user):
+                logger.debug(
+                    'Webhook expiry notification is earlier than user preference',
+                    user_id=user.id,
+                    text_key=text_key,
+                )
+                return
+
         texts = get_texts(user.language)
         message = texts.get(text_key)
         if not message:

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -724,7 +724,7 @@ async def _auto_extend_subscription(
         )
 
     # Send user notification only for Telegram users
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             auto_message = texts.t(
                 'AUTO_PURCHASE_SUBSCRIPTION_EXTENDED',
@@ -1098,7 +1098,7 @@ async def _auto_purchase_tariff(
         )
 
     # Send user notification only for Telegram users
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             texts = get_texts(getattr(user, 'language', 'ru'))
             period_label = format_period_description(period_days, getattr(user, 'language', 'ru'))
@@ -1461,7 +1461,7 @@ async def _auto_purchase_daily_tariff(
         )
 
     # Send user notification only for Telegram users
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             texts = get_texts(getattr(user, 'language', 'ru'))
 
@@ -1804,7 +1804,7 @@ async def _auto_add_devices(
         logger.warning('⚠️ Автопокупка устройств: не удалось отправить WebSocket уведомление', ws_error=ws_error)
 
     # Уведомление пользователю
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         texts = get_texts(getattr(user, 'language', 'ru'))
         try:
             message = texts.t(
@@ -2160,7 +2160,7 @@ async def _auto_add_traffic(
         logger.warning('⚠️ Автопокупка трафика: не удалось отправить WebSocket уведомление', ws_error=ws_error)
 
     # User notification
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         texts = get_texts(getattr(user, 'language', 'ru'))
         try:
             message = texts.t(
@@ -2546,7 +2546,7 @@ async def try_auto_extend_expired_after_topup(
         )
 
     # Send user notification (only for Telegram users)
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             auto_message = texts.t(
                 'AUTO_PURCHASE_SUBSCRIPTION_EXTENDED',
@@ -2931,7 +2931,7 @@ async def try_resume_disabled_daily_after_topup(
         )
 
     # User notification
-    if bot and user.telegram_id:
+    if bot and user.telegram_id and settings.is_notifications_enabled():
         try:
             texts = get_texts(getattr(user, 'language', 'ru'))
 
@@ -3350,7 +3350,7 @@ async def _process_legacy_generic_cart(
             )
 
         # Send user notification only for Telegram users
-        if user.telegram_id:
+        if user.telegram_id and settings.is_notifications_enabled():
             try:
                 period_label = format_period_description(
                     selection.period.days,

--- a/app/services/tribute_service.py
+++ b/app/services/tribute_service.py
@@ -298,6 +298,9 @@ class TributeService:
             logger.error('Ошибка обработки возврата Tribute', error=e)
 
     async def _send_success_notification(self, user_id: int, amount_kopeks: int):
+        if not settings.is_notifications_enabled():
+            return
+
         # Skip if no telegram_id (email-only user)
         if not user_id:
             logger.debug('Пропуск уведомления Tribute для пользователя без telegram_id')
@@ -336,6 +339,9 @@ class TributeService:
             logger.error('Ошибка отправки уведомления об успешном платеже', error=e)
 
     async def _send_failure_notification(self, user_id: int):
+        if not settings.is_notifications_enabled():
+            return
+
         # Skip if no telegram_id (email-only user)
         if not user_id:
             logger.debug('Пропуск уведомления об ошибке Tribute для пользователя без telegram_id')
@@ -365,6 +371,9 @@ class TributeService:
             logger.error('Ошибка отправки уведомления о неудачном платеже', error=e)
 
     async def _send_refund_notification(self, user_id: int, amount_kopeks: int):
+        if not settings.is_notifications_enabled():
+            return
+
         # Skip if no telegram_id (email-only user)
         if not user_id:
             logger.debug('Пропуск уведомления о возврате Tribute для пользователя без telegram_id')

--- a/tests/cabinet/test_promo_offer_broadcast_notify.py
+++ b/tests/cabinet/test_promo_offer_broadcast_notify.py
@@ -58,7 +58,13 @@ def _payload(**kwargs) -> PromoOfferBroadcastRequest:
     return PromoOfferBroadcastRequest(**defaults)
 
 
-async def _seed_subscriber(db, *, telegram_id: int | None, email: str | None = None) -> User:
+async def _seed_subscriber(
+    db,
+    *,
+    telegram_id: int | None,
+    email: str | None = None,
+    notification_settings: dict | None = None,
+) -> User:
     now = datetime.now(UTC)
     user = User(
         telegram_id=telegram_id,
@@ -69,6 +75,7 @@ async def _seed_subscriber(db, *, telegram_id: int | None, email: str | None = N
         status=UserStatus.ACTIVE.value,
         balance_kopeks=0,
         last_activity=now,
+        notification_settings=notification_settings,
     )
     db.add(user)
     await db.commit()
@@ -135,3 +142,43 @@ async def test_nothing_queued_without_telegram_recipients(monkeypatch):
         assert response.created_offers == 1
         assert response.telegram_recipients == 0
         assert response.broadcast_id is None
+
+
+async def test_promo_preferences_filter_telegram_and_email_notifications(monkeypatch):
+    started: list[object] = []
+
+    async def fail_send_emails(*args, **kwargs):
+        raise AssertionError('email notification must be filtered')
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.admin_promo_offers._send_promo_email_notifications',
+        fail_send_emails,
+    )
+
+    async def fake_start_broadcast(broadcast_id, config):
+        started.append(config)
+
+    monkeypatch.setattr(
+        'app.cabinet.routes.admin_promo_offers.broadcast_service.start_broadcast',
+        fake_start_broadcast,
+    )
+
+    async with memory_session(monkeypatch, NOTIFY_TABLES) as db:
+        await _seed_subscriber(
+            db,
+            telegram_id=111,
+            notification_settings={'promo_offers_enabled': False},
+        )
+        await _seed_subscriber(
+            db,
+            telegram_id=None,
+            email='disabled@example.com',
+            notification_settings={'promo_offers_enabled': False},
+        )
+
+        response = await broadcast_offer(_payload(), admin=_admin(), db=db)
+
+        assert response.created_offers == 2
+        assert response.telegram_recipients == 0
+        assert response.broadcast_id is None
+        assert started == []

--- a/tests/services/test_admin_notification_hardening.py
+++ b/tests/services/test_admin_notification_hardening.py
@@ -104,6 +104,17 @@ async def test_send_message_retries_on_flood_control(
 
 
 @pytest.mark.asyncio
+async def test_send_message_respects_global_admin_switch(admin_service: AdminNotificationService) -> None:
+    admin_service.enabled = False
+    admin_service.bot.send_message = AsyncMock()
+
+    result = await admin_service._send_message('hello', category=NotificationCategory.INFRASTRUCTURE)
+
+    assert result is False
+    admin_service.bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_message_gives_up_after_three_flood_errors(
     admin_service: AdminNotificationService, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/services/test_monitoring_notification_switches.py
+++ b/tests/services/test_monitoring_notification_switches.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from app.services import monitoring_service
+from app.services.monitoring_service import MonitoringService
+from app.services.notification_settings_service import NotificationSettingsService
+
+
+def _service():
+    service = MonitoringService.__new__(MonitoringService)
+    service.bot = SimpleNamespace(send_message=AsyncMock())
+    return service
+
+
+async def test_global_switch_stops_monitoring_notification_queries(monkeypatch):
+    monkeypatch.setattr(
+        NotificationSettingsService,
+        'are_notifications_globally_enabled',
+        classmethod(lambda cls: False),
+    )
+    service = _service()
+    db = SimpleNamespace(execute=AsyncMock())
+
+    await service._check_expiring_subscriptions(db)
+    await service._check_trial_expiring_soon(db)
+    await service._check_traffic_warnings(db)
+    await service._check_low_balance_alerts(db)
+
+    db.execute.assert_not_awaited()
+    service.bot.send_message.assert_not_awaited()
+
+
+async def test_expiration_state_updates_even_when_notifications_are_disabled(monkeypatch):
+    monkeypatch.setattr(
+        NotificationSettingsService,
+        'are_notifications_globally_enabled',
+        classmethod(lambda cls: False),
+    )
+    subscription = SimpleNamespace(id=7, user_id=42, tariff=None)
+    user = SimpleNamespace(id=42, notification_settings={})
+    expire_subscription = AsyncMock()
+
+    monkeypatch.setattr(monitoring_service, 'get_expired_subscriptions', AsyncMock(return_value=[subscription]))
+    monkeypatch.setattr(monitoring_service, 'get_user_by_id', AsyncMock(return_value=user))
+    monkeypatch.setattr(
+        'app.database.crud.subscription.is_recently_updated_by_webhook',
+        lambda subscription: False,
+    )
+    monkeypatch.setattr('app.database.crud.subscription.expire_subscription', expire_subscription)
+
+    service = _service()
+    service._send_subscription_expired_notification = AsyncMock()
+    service._log_monitoring_event = AsyncMock()
+    db = SimpleNamespace(execute=AsyncMock())
+
+    await service._check_expired_subscriptions(db)
+
+    expire_subscription.assert_awaited_once_with(db, subscription)
+    service._send_subscription_expired_notification.assert_not_awaited()

--- a/tests/services/test_notification_delivery_preferences.py
+++ b/tests/services/test_notification_delivery_preferences.py
@@ -1,0 +1,120 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.config import settings
+from app.database.models import UserStatus
+from app.services.notification_delivery_service import NotificationDeliveryService, NotificationType
+
+
+def _user(**notification_settings):
+    return SimpleNamespace(
+        id=42,
+        status=UserStatus.ACTIVE.value,
+        telegram_id=4242,
+        email=None,
+        email_verified=False,
+        notification_settings=notification_settings,
+    )
+
+
+async def _send(service, user, notification_type):
+    return await service.send_notification(
+        user=user,
+        notification_type=notification_type,
+        context={},
+        bot=SimpleNamespace(),
+        telegram_message='test',
+    )
+
+
+async def test_global_switch_blocks_regular_notifications(monkeypatch):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', False)
+
+    result = await _send(service, _user(), NotificationType.BALANCE_TOPUP)
+
+    assert result is False
+    service._send_telegram_notification.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    'notification_type',
+    [
+        NotificationType.EMAIL_VERIFICATION,
+        NotificationType.PASSWORD_RESET,
+        NotificationType.GUEST_SUBSCRIPTION_DELIVERED,
+    ],
+)
+async def test_transactional_messages_bypass_global_switch(monkeypatch, notification_type):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', False)
+
+    result = await _send(service, _user(), notification_type)
+
+    assert result is True
+    service._send_telegram_notification.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ('notification_type', 'preference'),
+    [
+        (NotificationType.SUBSCRIPTION_EXPIRING, 'subscription_expiry_enabled'),
+        (NotificationType.SUBSCRIPTION_EXPIRED, 'subscription_expiry_enabled'),
+        (NotificationType.WEBHOOK_SUB_EXPIRING, 'subscription_expiry_enabled'),
+        (NotificationType.WINBACK_DISCOUNT, 'subscription_expiry_enabled'),
+        (NotificationType.BALANCE_LOW, 'balance_low_enabled'),
+        (NotificationType.WEBHOOK_SUB_BANDWIDTH_THRESHOLD, 'traffic_warning_enabled'),
+        (NotificationType.PROMO_OFFER, 'promo_offers_enabled'),
+    ],
+)
+async def test_per_user_preferences_block_matching_notifications(monkeypatch, notification_type, preference):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', True)
+
+    result = await _send(service, _user(**{preference: False}), notification_type)
+
+    assert result is False
+    service._send_telegram_notification.assert_not_awaited()
+
+
+async def test_referral_switch_is_enforced_by_unified_delivery(monkeypatch):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', True)
+    monkeypatch.setattr(settings, 'REFERRAL_NOTIFICATIONS_ENABLED', False)
+
+    result = await _send(service, _user(), NotificationType.REFERRAL_BONUS)
+
+    assert result is False
+    service._send_telegram_notification.assert_not_awaited()
+
+
+async def test_blocked_user_can_receive_the_ban_notification(monkeypatch):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', True)
+    user = _user()
+    user.status = UserStatus.BLOCKED.value
+
+    result = await _send(service, user, NotificationType.BAN_NOTIFICATION)
+
+    assert result is True
+    service._send_telegram_notification.assert_awaited_once()
+
+
+async def test_blocked_user_does_not_receive_unrelated_notifications(monkeypatch):
+    service = NotificationDeliveryService()
+    service._send_telegram_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', True)
+    user = _user()
+    user.status = UserStatus.BLOCKED.value
+
+    result = await _send(service, user, NotificationType.BALANCE_TOPUP)
+
+    assert result is False
+    service._send_telegram_notification.assert_not_awaited()

--- a/tests/services/test_referral_service.py
+++ b/tests/services/test_referral_service.py
@@ -13,6 +13,76 @@ if str(ROOT_DIR) not in sys.path:
 from app.services import referral_service
 
 
+@pytest.mark.parametrize(
+    ('notifications_enabled', 'referral_notifications_enabled'),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_referral_notification_respects_notification_switches(
+    monkeypatch,
+    notifications_enabled,
+    referral_notifications_enabled,
+):
+    bot = SimpleNamespace(send_message=AsyncMock())
+    user = SimpleNamespace(id=2)
+
+    monkeypatch.setattr(referral_service.settings, 'ENABLE_NOTIFICATIONS', notifications_enabled)
+    monkeypatch.setattr(
+        referral_service.settings,
+        'REFERRAL_NOTIFICATIONS_ENABLED',
+        referral_notifications_enabled,
+    )
+
+    await referral_service.send_referral_notification(
+        bot,
+        telegram_id=202,
+        message='Реферал пополнил баланс',
+        user=user,
+    )
+
+    bot.send_message.assert_not_awaited()
+
+
+async def test_referral_notification_enabled_sends_telegram_message(monkeypatch):
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    monkeypatch.setattr(referral_service.settings, 'ENABLE_NOTIFICATIONS', True)
+    monkeypatch.setattr(referral_service.settings, 'REFERRAL_NOTIFICATIONS_ENABLED', True)
+
+    await referral_service.send_referral_notification(
+        bot,
+        telegram_id=202,
+        message='Реферал пополнил баланс',
+    )
+
+    bot.send_message.assert_awaited_once_with(202, 'Реферал пополнил баланс', parse_mode='HTML')
+
+
+async def test_disabled_referral_notifications_skip_email_delivery(monkeypatch):
+    user = SimpleNamespace(id=2)
+    notify_referral_bonus = AsyncMock()
+
+    monkeypatch.setattr(referral_service.settings, 'ENABLE_NOTIFICATIONS', True)
+    monkeypatch.setattr(referral_service.settings, 'REFERRAL_NOTIFICATIONS_ENABLED', False)
+    monkeypatch.setattr(
+        referral_service.notification_delivery_service,
+        'notify_referral_bonus',
+        notify_referral_bonus,
+    )
+
+    await referral_service.send_referral_notification(
+        SimpleNamespace(send_message=AsyncMock()),
+        telegram_id=None,
+        message='Начислен реферальный бонус',
+        user=user,
+        bonus_kopeks=1000,
+    )
+
+    notify_referral_bonus.assert_not_awaited()
+
+
 async def test_commission_accrues_before_minimum_first_topup(monkeypatch):
     user = SimpleNamespace(
         id=1,

--- a/tests/services/test_remnawave_expiration_webhook.py
+++ b/tests/services/test_remnawave_expiration_webhook.py
@@ -6,8 +6,11 @@ while still accepting the old events from 2.7.x panels.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from app.config import settings
+from app.services import remnawave_webhook_service
 from app.services.remnawave_webhook_service import RemnaWaveWebhookService
 
 
@@ -114,6 +117,29 @@ async def test_no_subscription_sends_nothing():
     svc = _service()
     await svc._handle_user_expiration(None, _user(), None, _receiver_data(-24))
     svc._notify_user.assert_not_awaited()
+
+
+async def test_webhook_expiry_respects_user_days_threshold(monkeypatch):
+    svc = RemnaWaveWebhookService(MagicMock())
+    send_notification = AsyncMock(return_value=True)
+    monkeypatch.setattr(remnawave_webhook_service.notification_delivery_service, 'send_notification', send_notification)
+    monkeypatch.setattr(settings, 'WEBHOOK_NOTIFY_USER_ENABLED', True)
+    monkeypatch.setattr(settings, 'WEBHOOK_NOTIFY_SUB_EXPIRING', True)
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', True)
+    user = SimpleNamespace(
+        id=1,
+        language='ru',
+        notification_settings={
+            'subscription_expiry_enabled': True,
+            'subscription_expiry_days': 1,
+        },
+    )
+
+    await svc._notify_user(user, 'WEBHOOK_SUB_EXPIRES_72H')
+    send_notification.assert_not_awaited()
+
+    await svc._notify_user(user, 'WEBHOOK_SUB_EXPIRES_24H')
+    send_notification.assert_awaited_once()
 
 
 async def test_new_2_8_0_api_token_admin_events_registered():


### PR DESCRIPTION
## 📝 Описание

Переключатели уведомлений применялись не во всех точках доставки. В частности, реферальные сообщения о пополнениях могли приходить при выключенных реферальных уведомлениях, а часть платёжных и фоновых сообщений обходила общий переключатель клиентских уведомлений.

Поведение также различалось между Telegram, email и WebSocket: один канал мог учитывать настройку, а другой — продолжать отправку.

## 🐛 Причина

Единый сервис доставки не проверял глобальные и пользовательские настройки. Дополнительно часть обработчиков отправляла сообщения напрямую через Telegram-бота, минуя общий сервис.

## ✅ Что исправлено

- Общий переключатель клиентских уведомлений применяется к Telegram, email и WebSocket.
- Реферальный переключатель учитывается для регистраций, бонусов, комиссий и сообщений о пополнениях.
- Персональные настройки применяются к уведомлениям об окончании подписки, трафике, низком балансе и промопредложениях.
- Закрыты прямые обходы в платёжных обработчиках, автопродлении, мониторинге, webhook-событиях, конкурсах, опросах и уведомлениях о статусе подписки.
- Общий и категорийные переключатели админских уведомлений проверяются на уровне сервиса доставки.
- Уведомление о блокировке теперь может быть доставлено уже заблокированному пользователю.

## 🛡 Совместимость

Отключение уведомлений не отменяет бизнес-операции: начисления, пополнения, продления и смена статусов выполняются как раньше.

Обязательные сообщения не подавляются общим переключателем:

- коды входа, восстановления пароля и смены email;
- выдача оплаченного гостевого заказа;
- фискальные чеки.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## 🧪 Тестирование

- `pytest -q` — 2665 passed;
- `ruff check app tests` — All checks passed;
- `git diff --check` — passed.

Добавлены регрессионные тесты для глобального, реферального, категорийного и пользовательских переключателей, а также для одинакового поведения разных каналов доставки.