### PR TITLE
fix(notifications): Исправление кликабельности @username в Rich-сообщениях

### DIFF
--- a/app/services/admin_notification_service.py
+++ b/app/services/admin_notification_service.py
@@ -33,6 +33,7 @@ from app.database.models import (
     Transaction,
     User,
 )
+from app.utils.formatters import format_username_link
 from app.utils.message_patch import caption_exceeds_telegram_limit
 from app.utils.rich_admin import classic_admin_html_to_rich, try_send_rich_admin_message
 from app.utils.timezone import format_local_datetime
@@ -138,7 +139,7 @@ class AdminNotificationService:
                 return f'ID {referred_by_id} (не найден)'
 
             if referrer.username:
-                return f'@{html.escape(referrer.username)} (ID: {referred_by_id})'
+                return f'{format_username_link(referrer.username)} (ID: {referred_by_id})'
             if referrer.telegram_id:
                 return f'ID {referrer.telegram_id}'
             if referrer.email:
@@ -437,7 +438,7 @@ class AdminNotificationService:
                 '',
                 f'👤 <b>Пользователь:</b> {user_display}',
                 f'🆔 <b>{user_id_label}:</b> {user_id_display}',
-                f'📱 <b>Username:</b> @{html.escape(getattr(user, "username", None) or "отсутствует")}',
+                f'📱 <b>Username:</b> {format_username_link(getattr(user, "username", None), "отсутствует")}',
                 f'👥 <b>Статус:</b> {user_status}',
                 '',
             ]
@@ -586,7 +587,7 @@ class AdminNotificationService:
             # Добавляем username только если есть
             username = getattr(user, 'username', None)
             if username:
-                message_lines.append(f'📱 @{html.escape(username)}')
+                message_lines.append(f'📱 {format_username_link(username)}')
 
             message_lines.append(f'📋 {user_status}')
 
@@ -749,7 +750,7 @@ class AdminNotificationService:
 
         username = getattr(user, 'username', None)
         if username:
-            message_lines.append(f'📱 @{html.escape(username)}')
+            message_lines.append(f'📱 {format_username_link(username)}')
 
         message_lines.append(f'💳 {topup_status}')
 
@@ -1008,7 +1009,7 @@ class AdminNotificationService:
 
 👤 <b>Пользователь:</b> {user_display}
 🆔 <b>{user_id_label}:</b> {user_id_display}
-📱 <b>Username:</b> @{html.escape(getattr(user, 'username', None) or 'отсутствует')}
+📱 <b>Username:</b> {format_username_link(getattr(user, 'username', None), 'отсутствует')}
 
 {promo_block}
 
@@ -1095,7 +1096,7 @@ class AdminNotificationService:
                 '',
                 f'👤 <b>Пользователь:</b> {user_display}',
                 f'🆔 <b>{user_id_label}:</b> {user_id_display}',
-                f'📱 <b>Username:</b> @{html.escape(getattr(user, "username", None) or "отсутствует")}',
+                f'📱 <b>Username:</b> {format_username_link(getattr(user, "username", None), "отсутствует")}',
                 '',
                 promo_block,
                 '',
@@ -1220,7 +1221,7 @@ class AdminNotificationService:
             ]
 
             if telegram_user.username:
-                message_lines.append(f'📱 @{html.escape(telegram_user.username)}')
+                message_lines.append(f'📱 {format_username_link(telegram_user.username)}')
 
             message_lines.append(f'📋 {user_status}')
 
@@ -1320,7 +1321,7 @@ class AdminNotificationService:
                 f'👤 {html.escape(telegram_user_name)} (<code>{telegram_user_id}</code>)',
             ]
             if telegram_username:
-                message_lines.append(f'📱 @{html.escape(telegram_username)}')
+                message_lines.append(f'📱 {format_username_link(telegram_username)}')
 
             promo_group = await self._get_user_promo_group(db, user)
             if promo_group:
@@ -1409,7 +1410,7 @@ class AdminNotificationService:
                 '',
                 f'👤 <b>Пользователь:</b> {user_display}',
                 f'🆔 <b>{user_id_label}:</b> {user_id_display}',
-                f'📱 <b>Username:</b> @{html.escape(getattr(user, "username", None) or "отсутствует")}',
+                f'📱 <b>Username:</b> {format_username_link(getattr(user, "username", None), "отсутствует")}',
                 '',
                 self._format_promo_group_block(new_group, title='Новая промогруппа', icon='🏆'),
             ]
@@ -1658,8 +1659,12 @@ class AdminNotificationService:
                 # Cabinet gift: show buyer with link to user profile
                 buyer = getattr(purchase, 'buyer', None)
                 if buyer:
-                    buyer_name = f'@{buyer.username}' if buyer.username else buyer.email or f'id:{buyer.id}'
-                    message_lines.append(f'👤 Покупатель: <code>{html.escape(buyer_name)}</code>')
+                    if buyer.username:
+                        buyer_display = format_username_link(buyer.username)
+                    else:
+                        buyer_name = buyer.email or f'id:{buyer.id}'
+                        buyer_display = f'<code>{html.escape(buyer_name)}</code>'
+                    message_lines.append(f'👤 Покупатель: {buyer_display}')
                 else:
                     message_lines.append(f'{contact_icon} Покупатель: <code>{contact_display}</code>')
             else:
@@ -2035,7 +2040,7 @@ class AdminNotificationService:
             # Добавляем username только если есть
             username = getattr(user, 'username', None)
             if username:
-                message_lines.append(f'📱 @{html.escape(username)}')
+                message_lines.append(f'📱 {format_username_link(username)}')
 
             # Тариф (если есть)
             if tariff_name:
@@ -2141,7 +2146,7 @@ class AdminNotificationService:
 
             username = getattr(user, 'username', None)
             if username:
-                message_lines.append(f'📱 @{html.escape(username)}')
+                message_lines.append(f'📱 {format_username_link(username)}')
 
             message_lines.append('')
 
@@ -2196,7 +2201,7 @@ class AdminNotificationService:
 
             username = getattr(user, 'username', None)
             if username:
-                message_lines.append(f'📱 @{html.escape(username)}')
+                message_lines.append(f'📱 {format_username_link(username)}')
 
             message_lines.extend(
                 [

--- a/app/utils/formatters.py
+++ b/app/utils/formatters.py
@@ -1,3 +1,4 @@
+import html
 from datetime import UTC, datetime
 
 
@@ -172,6 +173,19 @@ def format_username(username: str | None, user_id: int, full_name: str | None = 
     if username:
         return f'@{username}'
     return f'ID{user_id}'
+
+
+def format_username_link(username: str | None, fallback: str = '') -> str:
+    """Format a Telegram username as an explicit HTML link for Rich messages."""
+    if not username:
+        return fallback
+
+    normalized_username = username.lstrip('@')
+    if not normalized_username:
+        return fallback
+
+    safe_username = html.escape(normalized_username, quote=True)
+    return f'<a href="https://t.me/{safe_username}">@{safe_username}</a>'
 
 
 def format_subscription_status(is_active: bool, is_trial: bool, end_date: datetime | str, language: str = 'ru') -> str:

--- a/app/utils/rich_menu.py
+++ b/app/utils/rich_menu.py
@@ -507,9 +507,7 @@ async def build_main_menu_rich_html(user: User, texts, db: AsyncSession) -> str:
 
     has_name = bool(getattr(user, 'first_name', None) or getattr(user, 'last_name', None))
     user_name = (
-        html.escape(user.full_name or '')
-        if has_name or not user.username
-        else format_username_link(user.username)
+        html.escape(user.full_name or '') if has_name or not user.username else format_username_link(user.username)
     )
     blocks.append(f'<h4>👤 {user_name}</h4>')
     blocks.append('<hr/>')

--- a/app/utils/rich_menu.py
+++ b/app/utils/rich_menu.py
@@ -46,6 +46,7 @@ from app.database.crud.tariff import get_tariff_by_id
 from app.database.crud.user_message import get_random_active_message
 from app.database.models import User
 from app.localization.texts import Texts
+from app.utils.formatters import format_username_link
 from app.utils.miniapp_buttons import build_miniapp_startapp_url
 from app.utils.promo_offer import build_promo_offer_hint, build_test_access_hint
 from app.utils.subscription_utils import get_happ_cryptolink_redirect_link
@@ -504,7 +505,12 @@ async def build_main_menu_rich_html(user: User, texts, db: AsyncSession) -> str:
     if logo_url:
         blocks.append(f'<img src="{html.escape(logo_url, quote=True)}"/>')
 
-    user_name = html.escape(user.full_name or '')
+    has_name = bool(getattr(user, 'first_name', None) or getattr(user, 'last_name', None))
+    user_name = (
+        html.escape(user.full_name or '')
+        if has_name or not user.username
+        else format_username_link(user.username)
+    )
     blocks.append(f'<h4>👤 {user_name}</h4>')
     blocks.append('<hr/>')
 


### PR DESCRIPTION
## Что изменено

- Добавлен общий форматтер для явных ссылок вида `<a href="https://t.me/username">@username</a>`.
- Юзернеймы в админ-уведомлениях сделаны кликабельными.
- Юзернейм в главном Rich-меню сделан кликабельным, когда он используется вместо имени.
- Флаг `skip_entity_detection=True` оставлен без изменений.
- Значение «отсутствует» отображается обычным текстом без ссылки.

## Проверка

Тесты не запускались.

https://github.com/BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot/issues/3106