### PR TITLE
fix(cabinet): удаление подписки в массовых действиях падало MissingGreenlet

### DIFF
--- a/app/cabinet/routes/admin_bulk_actions.py
+++ b/app/cabinet/routes/admin_bulk_actions.py
@@ -7,6 +7,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy import delete as sa_delete, select
+from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -103,6 +104,26 @@ def _require_device_limit(params: BulkActionParams) -> int:
 # ---------------------------------------------------------------------------
 # Subscription resolver
 # ---------------------------------------------------------------------------
+
+
+def _known_subscriptions(user: User, fallback: Subscription | None = None) -> list[Subscription]:
+    """Подписки пользователя, если они уже в сессии; иначе — только целевая.
+
+    В режиме «по подписке» пользователь приходит из ``sub.user``, а его
+    коллекция подписок в этот запрос не грузится. В async-сессии обращение
+    к незагруженной коллекции не подтягивает её лениво, а роняет
+    MissingGreenlet — на удалении подписки это падало прямо в ответ админу.
+    """
+    try:
+        subs = getattr(user, 'subscriptions', None)
+    except MissingGreenlet:
+        subs = None
+    if subs is None:
+        # Коллекция недоступна — отдаём хотя бы целевую подписку.
+        return [fallback] if fallback is not None else []
+    # Загруженный пустой список — это ответ «подписок нет», а не пробел
+    # в данных: подставлять сюда целевую было бы враньём.
+    return list(subs)
 
 
 def _resolve_subscription(user: User, override: Subscription | None = None) -> Subscription | None:
@@ -513,7 +534,7 @@ async def _do_delete_subscription(
             success=False,
             message=f'Skipped: {tariff_name} is active and paid (enable force_delete_active_paid to override)',
             username=user.username,
-            subscriptions=_build_subscription_info(getattr(user, 'subscriptions', None) or []),
+            subscriptions=_build_subscription_info(_known_subscriptions(user, sub)),
         )
 
     if dry_run:
@@ -531,7 +552,7 @@ async def _do_delete_subscription(
 
     blocked_user_id = user.id
     blocked_username = user.username
-    blocked_subscriptions = _build_subscription_info(getattr(user, 'subscriptions', None) or [])
+    blocked_subscriptions = _build_subscription_info(_known_subscriptions(user, sub))
     try:
         await ensure_no_open_grace_for_subscriptions(db, (sub.id,))
     except GraceAccessDeletionBlocked:
@@ -868,8 +889,7 @@ async def _execute_for_user(
 
         # Attach subscription info to result when not already set
         if result.subscriptions is None:
-            subs = getattr(user, 'subscriptions', None) or []
-            result.subscriptions = _build_subscription_info(subs)
+            result.subscriptions = _build_subscription_info(_known_subscriptions(user))
 
         return result
 

--- a/tests/cabinet/test_bulk_delete_subscription_lazy_user.py
+++ b/tests/cabinet/test_bulk_delete_subscription_lazy_user.py
@@ -1,0 +1,99 @@
+"""Regression: удаление подписки через «Массовые действия» роняло MissingGreenlet.
+
+Отчёт админа: в мультитарифном режиме при удалении истёкшей подписки
+«Пробный» из кабинета приходила ошибка вместо результата:
+
+    File "app/cabinet/routes/admin_bulk_actions.py", line 534, in _do_delete_subscription
+      blocked_subscriptions = _build_subscription_info(getattr(user, 'subscriptions', None) or [])
+    sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called
+
+Причина: в режиме «по подписке» пользователь приходит из ``sub.user``
+(`get_subscription_by_id` грузит только ``user`` и ``tariff``), поэтому его
+коллекция подписок не загружена. В async-сессии обращение к незагруженной
+коллекции не подтягивает её лениво, а бросает MissingGreenlet — и падало
+это ДО того, как подписка вообще удалялась.
+
+Здесь пользователь ведёт себя ровно так же: доступ к ``subscriptions``
+кидает MissingGreenlet. Окружение (панель, платёжки, БД) замокано —
+проверяем только то, что удаление доходит до конца.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import MissingGreenlet
+
+import app.cabinet.routes.admin_bulk_actions as bulk
+
+
+class _LazyUser:
+    """Пользователь с незагруженной коллекцией подписок — как из sub.user."""
+
+    def __init__(self, user_id: int = 42, username: str = 'NickBerg33') -> None:
+        self.id = user_id
+        self.username = username
+        self.remnawave_id = None
+
+    @property
+    def subscriptions(self):
+        raise MissingGreenlet('greenlet_spawn has not been called')
+
+
+def _expired_trial_sub(user) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=777,
+        user=user,
+        user_id=user.id,
+        tariff_id=1,
+        tariff=SimpleNamespace(id=1, name='Пробный'),
+        is_active=False,
+        is_trial=True,
+        remnawave_id=None,
+        status='expired',
+        end_date=datetime.now(UTC) - timedelta(days=1),
+        traffic_used_gb=0,
+        traffic_limit_gb=10,
+        device_limit=2,
+    )
+
+
+def test_known_subscriptions_falls_back_to_target():
+    """Коллекция недоступна → берём целевую подписку, а не падаем."""
+    user = _LazyUser()
+    sub = _expired_trial_sub(user)
+    assert bulk._known_subscriptions(user, sub) == [sub]
+    # Без запасной подписки отдаём пустой список, а не исключение
+    assert bulk._known_subscriptions(user) == []
+
+
+def test_known_subscriptions_uses_loaded_collection():
+    """Коллекция загружена → отдаём её целиком, запасная не нужна."""
+    loaded = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    user = SimpleNamespace(id=1, username='u', subscriptions=loaded)
+    assert bulk._known_subscriptions(user, SimpleNamespace(id=99)) == loaded
+
+
+@pytest.mark.asyncio
+async def test_delete_subscription_survives_unloaded_collection():
+    """Удаление истёкшего триала доходит до конца, а не падает на подписках."""
+    user = _LazyUser()
+    sub = _expired_trial_sub(user)
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    params = SimpleNamespace(force_delete_active_paid=False)
+
+    with (
+        patch('app.services.grace_access_runtime.ensure_no_open_grace_for_subscriptions', AsyncMock()),
+        patch('app.services.payment.platega.cancel_platega_recurring_for_subscription_safe', AsyncMock()),
+        patch('app.services.payment.lava.cancel_lava_recurring_for_subscription_safe', AsyncMock()),
+    ):
+        result = await bulk._do_delete_subscription(db, user, params, dry_run=False, sub_override=sub)
+
+    assert result.success is True
+    assert 'Пробный' in result.message
+    db.commit.assert_awaited()


### PR DESCRIPTION
## Описание

Удаление подписки через «Массовые действия» в кабинете завершалось ошибкой вместо результата:

```
File "app/cabinet/routes/admin_bulk_actions.py", line 534, in _do_delete_subscription
  blocked_subscriptions = _build_subscription_info(getattr(user, 'subscriptions', None) or [])
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called
```

Подписка при этом даже не начинала удаляться — падало на сборке ответа, до самого удаления.

## Причина

В режиме «по подписке» пользователь приходит из `sub.user`, а `get_subscription_by_id` грузит только `user` и `tariff` — коллекция `user.subscriptions` остаётся незагруженной. В async-сессии обращение к незагруженной коллекции не подтягивает её лениво, а бросает `MissingGreenlet`.

Ниже по коду (`_execute_for_subscription`) этот случай уже был обойдён комментарием «use the targeted sub directly to avoid MissingGreenlet», но внутри `_do_delete_subscription` два обращения к коллекции остались.

## Решение

Хелпер `_known_subscriptions(user, fallback)`: коллекция берётся, только если она уже в сессии, иначе в ответ идёт целевая подписка. Пустой загруженный список остаётся пустым — это ответ «подписок нет», а не пробел в данных, и подставлять туда целевую было бы враньём.

## Тип изменения

- [x] 🐛 Исправление ошибки

## Как проверить

В мультитарифном режиме открыть «Массовые действия» → выбрать конкретную подписку пользователя → удалить. До правки — ошибка в отчёте, после — подписка удаляется.

## Чеклист

- [x] ✅ Код соответствует стандартам проекта
- [x] 📝 Добавлены комментарии и docstrings
- [x] 🧪 Функциональность протестирована
- [x] 🔒 Нет чувствительных данных в коде
- [x] 📋 PR создан с подробным описанием

Тесты: `tests/cabinet/test_bulk_delete_subscription_lazy_user.py` — воспроизводит падение (пользователь, чья коллекция бросает `MissingGreenlet`) и фиксирует обе границы хелпера. Полный прогон: 2925 passed, 4 падения — пре-существующие на Windows (кодировка в самих тестах), на чистом `dev` они те же.
