### PR TITLE
feat(cabinet): удаление конкретной подписки из карточки пользователя

### DIFF
--- a/app/cabinet/routes/admin_users.py
+++ b/app/cabinet/routes/admin_users.py
@@ -1951,6 +1951,57 @@ async def cancel_user_sbp_recurring(
     return {'status': 'cancelled'}
 
 
+@router.delete('/{user_id}/subscriptions/{sub_id}')
+async def delete_user_subscription(
+    user_id: int,
+    sub_id: int,
+    force: bool = Query(False, description='Allow deleting an active paid subscription'),
+    admin: User = Depends(require_permission('users:subscription')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Удалить конкретную подписку пользователя из его карточки.
+
+    В мультитарифном режиме у пользователя несколько подписок, и убрать
+    лишнюю (например, отработавший триал) можно было только через
+    «Массовые действия». Проверка принадлежности — та же, что у соседних
+    эндпоинтов по ``sub_id`` (защита от IDOR).
+
+    Активная платная подписка защищена от случайного удаления: чтобы
+    снести именно её, нужен явный ``force`` — иначе одним промахом
+    сносится оплаченный доступ.
+    """
+    from app.database.crud.subscription import get_subscription_by_id_for_user
+    from app.services.grace_access_runtime import GraceAccessDeletionBlocked
+    from app.services.subscription_deletion_service import delete_subscription_record
+
+    subscription = await get_subscription_by_id_for_user(db, sub_id, user_id)
+    if not subscription:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Subscription not found')
+
+    if subscription.is_active and not subscription.is_trial and not force:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Subscription is active and paid; pass force=true to delete it anyway',
+        )
+
+    try:
+        await delete_subscription_record(db, subscription, deleted_by=f'admin:{admin.id}')
+    except GraceAccessDeletionBlocked as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Temporary renewal access is still active. Finish or restore grace access before deletion.',
+        ) from error
+
+    logger.info(
+        'Admin deleted user subscription',
+        admin_id=admin.id,
+        user_id=user_id,
+        subscription_id=sub_id,
+        forced=force,
+    )
+    return {'status': 'deleted'}
+
+
 # === Available Tariffs ===
 
 

--- a/app/cabinet/routes/subscription_modules/multi_tariff.py
+++ b/app/cabinet/routes/subscription_modules/multi_tariff.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.crud.subscription import (
-    decrement_subscription_server_counts,
     get_all_subscriptions_by_user_id,
     get_subscription_by_id_for_user,
 )
@@ -129,67 +128,15 @@ async def delete_subscription(
             detail='Only expired or disabled subscriptions can be deleted',
         )
 
-    from app.services.grace_access_runtime import (
-        GraceAccessDeletionBlocked,
-        ensure_no_open_grace_for_subscriptions,
-    )
+    from app.services.grace_access_runtime import GraceAccessDeletionBlocked
+    from app.services.subscription_deletion_service import delete_subscription_record
 
     try:
-        await ensure_no_open_grace_for_subscriptions(db, (subscription.id,))
+        await delete_subscription_record(db, subscription, deleted_by='user')
     except GraceAccessDeletionBlocked as error:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail='Temporary renewal access is still active. Finish or restore grace access before deletion.',
         ) from error
-
-    # Best-effort: stop Platega SBP autopay before the row disappears — the
-    # platega_subscriptions record CASCADE-deletes with it, so cancelling
-    # after the delete would find nothing to cancel on Platega's side.
-    # NOTE: this commits its own transaction internally, which releases the
-    # grace-guard's Postgres advisory lock acquired just above. It therefore
-    # runs BEFORE any irreversible panel/DB step, and the guard is
-    # re-acquired immediately below — closing that window before anything
-    # that can't be undone happens.
-    from app.services.payment.lava import cancel_lava_recurring_for_subscription_safe
-    from app.services.payment.platega import cancel_platega_recurring_for_subscription_safe
-
-    await cancel_platega_recurring_for_subscription_safe(db, subscription.id)
-
-    await cancel_lava_recurring_for_subscription_safe(db, subscription.id)
-    try:
-        await ensure_no_open_grace_for_subscriptions(db, (subscription.id,))
-    except GraceAccessDeletionBlocked as error:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail='Temporary renewal access is still active. Finish or restore grace access before deletion.',
-        ) from error
-
-    # Delete from RemnaWave panel (stops webhooks / phantom notifications)
-    if subscription.remnawave_id:
-        try:
-            from app.services.remnawave_webhook_service import RemnaWaveWebhookService
-            from app.services.subscription_service import SubscriptionService
-
-            # Suppress the self-inflicted user.deleted webhook so its sibling-expiry
-            # sweep never touches the user's other (still-active) subscriptions.
-            RemnaWaveWebhookService.mark_intentional_panel_deletion(panel_user_ids=[subscription.remnawave_id])
-            service = SubscriptionService()
-            await service.delete_remnawave_user(subscription.remnawave_id)
-        except Exception as e:
-            logger.warning('Failed to delete RemnaWave user on subscription delete', error=e)
-
-    # Decrement server counts
-    await decrement_subscription_server_counts(db, subscription)
-
-    # Delete the subscription
-    await db.delete(subscription)
-    await db.commit()
-
-    logger.info(
-        'Subscription deleted by user',
-        subscription_id=subscription_id,
-        user_id=user.id,
-        tariff_id=subscription.tariff_id,
-    )
 
     return {'message': 'Subscription deleted'}

--- a/app/services/subscription_deletion_service.py
+++ b/app/services/subscription_deletion_service.py
@@ -1,0 +1,82 @@
+"""Единый порядок удаления подписки: грейс-гард, автоплатежи, панель, строка.
+
+Порядок шагов здесь не косметический, а выстраданный:
+
+* грейс-гард берёт advisory-lock, поэтому проверка идёт первой — удалять
+  подписку с открытым временным доступом нельзя;
+* отмена автоплатежей идёт ДО удаления строки: записи платёжек уходят по
+  CASCADE вместе с ней, и отменять потом было бы уже нечего. Отмена
+  коммитит свою транзакцию и тем самым отпускает advisory-lock — поэтому
+  сразу за ней гард берётся повторно, закрывая окно перед необратимыми
+  шагами;
+* удаление юзера в панели помечается как намеренное, иначе прилетевший
+  ``user.deleted`` вебхук своей чисткой заденет соседние живые подписки
+  того же владельца.
+
+Вызывающий сам решает, как отвечать на ``GraceAccessDeletionBlocked``:
+кабинет отдаёт 409, массовые действия — пропуск с пояснением.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.crud.subscription import decrement_subscription_server_counts
+from app.database.models import Subscription
+
+logger = structlog.get_logger(__name__)
+
+
+async def delete_subscription_record(
+    db: AsyncSession,
+    subscription: Subscription,
+    *,
+    deleted_by: str,
+) -> None:
+    """Удалить подписку целиком. Грейс-гард пробрасывается наружу.
+
+    ``deleted_by`` попадает в лог — по нему видно, кто инициировал:
+    сам владелец из кабинета или администратор из карточки.
+    """
+    from app.services.grace_access_runtime import ensure_no_open_grace_for_subscriptions
+
+    await ensure_no_open_grace_for_subscriptions(db, (subscription.id,))
+
+    from app.services.payment.lava import cancel_lava_recurring_for_subscription_safe
+    from app.services.payment.platega import cancel_platega_recurring_for_subscription_safe
+
+    await cancel_platega_recurring_for_subscription_safe(db, subscription.id)
+    await cancel_lava_recurring_for_subscription_safe(db, subscription.id)
+
+    # Автоплатёжки закоммитили своё — advisory-lock отпущен, берём заново.
+    await ensure_no_open_grace_for_subscriptions(db, (subscription.id,))
+
+    if subscription.remnawave_id:
+        try:
+            from app.services.remnawave_webhook_service import RemnaWaveWebhookService
+            from app.services.subscription_service import SubscriptionService
+
+            RemnaWaveWebhookService.mark_intentional_panel_deletion(
+                panel_user_ids=[subscription.remnawave_id]
+            )
+            await SubscriptionService().delete_remnawave_user(subscription.remnawave_id)
+        except Exception as error:
+            logger.warning('Failed to delete RemnaWave user on subscription delete', error=error)
+
+    await decrement_subscription_server_counts(db, subscription)
+
+    subscription_id = subscription.id
+    tariff_id = subscription.tariff_id
+    user_id = subscription.user_id
+
+    await db.delete(subscription)
+    await db.commit()
+
+    logger.info(
+        'Subscription deleted',
+        subscription_id=subscription_id,
+        user_id=user_id,
+        tariff_id=tariff_id,
+        deleted_by=deleted_by,
+    )

--- a/tests/cabinet/test_admin_delete_user_subscription.py
+++ b/tests/cabinet/test_admin_delete_user_subscription.py
@@ -1,0 +1,121 @@
+"""Удаление конкретной подписки пользователя из админской карточки.
+
+В мультитарифном режиме у пользователя несколько подписок, и убрать лишнюю
+(например, отработавший триал) можно было только через «Массовые действия»
+— в самой карточке кнопки не было.
+
+Тесты фиксируют три границы нового маршрута: чужая подписка не удаляется по
+одному лишь ``sub_id`` (IDOR), активная платная защищена от случайного
+удаления без ``force``, а открытый временный доступ (grace) отдаёт 409, а не
+рвёт подписку под ним.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.cabinet.routes import admin_users
+
+USER_ID = 10
+SUB_ID = 777
+
+
+def _subscription(*, is_active: bool, is_trial: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=SUB_ID,
+        user_id=USER_ID,
+        tariff_id=1,
+        remnawave_id=None,
+        is_active=is_active,
+        is_trial=is_trial,
+        status='active' if is_active else 'expired',
+        end_date=datetime.now(UTC) + timedelta(days=5),
+    )
+
+
+def _admin() -> SimpleNamespace:
+    return SimpleNamespace(id=1, username='admin')
+
+
+@pytest.mark.asyncio
+async def test_deletes_expired_trial():
+    """Базовый случай из отчёта: отработавший триал убирается из карточки."""
+    sub = _subscription(is_active=False, is_trial=True)
+    deleter = AsyncMock()
+
+    with (
+        patch('app.database.crud.subscription.get_subscription_by_id_for_user', AsyncMock(return_value=sub)),
+        patch('app.services.subscription_deletion_service.delete_subscription_record', deleter),
+    ):
+        result = await admin_users.delete_user_subscription(
+            USER_ID, SUB_ID, force=False, admin=_admin(), db=MagicMock()
+        )
+
+    assert result == {'status': 'deleted'}
+    assert deleter.await_args.args[1] is sub
+    assert deleter.await_args.kwargs['deleted_by'] == 'admin:1'
+
+
+@pytest.mark.asyncio
+async def test_foreign_subscription_not_found():
+    """Подписка чужого пользователя не удаляется по одному лишь sub_id."""
+    with patch(
+        'app.database.crud.subscription.get_subscription_by_id_for_user', AsyncMock(return_value=None)
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await admin_users.delete_user_subscription(
+                USER_ID, SUB_ID, force=False, admin=_admin(), db=MagicMock()
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_active_paid_needs_force():
+    """Оплаченный активный доступ не сносится одним промахом."""
+    sub = _subscription(is_active=True, is_trial=False)
+    deleter = AsyncMock()
+
+    with (
+        patch('app.database.crud.subscription.get_subscription_by_id_for_user', AsyncMock(return_value=sub)),
+        patch('app.services.subscription_deletion_service.delete_subscription_record', deleter),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await admin_users.delete_user_subscription(
+                USER_ID, SUB_ID, force=False, admin=_admin(), db=MagicMock()
+            )
+        assert exc.value.status_code == 409
+        deleter.assert_not_awaited()
+
+        # С явным force та же подписка удаляется
+        result = await admin_users.delete_user_subscription(
+            USER_ID, SUB_ID, force=True, admin=_admin(), db=MagicMock()
+        )
+    assert result == {'status': 'deleted'}
+    deleter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_grace_blocks_deletion():
+    """Пока открыт временный доступ, подписку из-под него не вырывают."""
+    from app.services.grace_access_runtime import GraceAccessDeletionBlocked
+
+    sub = _subscription(is_active=False, is_trial=True)
+
+    with (
+        patch('app.database.crud.subscription.get_subscription_by_id_for_user', AsyncMock(return_value=sub)),
+        patch(
+            'app.services.subscription_deletion_service.delete_subscription_record',
+            AsyncMock(side_effect=GraceAccessDeletionBlocked([SUB_ID])),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await admin_users.delete_user_subscription(
+                USER_ID, SUB_ID, force=False, admin=_admin(), db=MagicMock()
+            )
+    assert exc.value.status_code == 409
+    assert 'grace' in exc.value.detail.lower()

--- a/tests/services/test_platega_recurrent_cancel_hooks.py
+++ b/tests/services/test_platega_recurrent_cancel_hooks.py
@@ -346,6 +346,7 @@ async def test_cancel_safe_wiring_proof_multi_tariff_delete_subscription(monkeyp
         # remnawave_uuid историческая и роутом не читается.
         remnawave_id=None,
         tariff_id=None,
+        user_id=1,
     )
     user = SimpleNamespace(id=1)
 
@@ -359,7 +360,11 @@ async def test_cancel_safe_wiring_proof_multi_tariff_delete_subscription(monkeyp
         return None
 
     monkeypatch.setattr(multi_tariff, 'get_subscription_by_id_for_user', fake_get_subscription)
-    monkeypatch.setattr(multi_tariff, 'decrement_subscription_server_counts', fake_decrement_counts)
+    # Порядок шагов удаления живёт в общем сервисе — там же и счётчики.
+    monkeypatch.setattr(
+        'app.services.subscription_deletion_service.decrement_subscription_server_counts',
+        fake_decrement_counts,
+    )
     monkeypatch.setattr(
         'app.services.grace_access_runtime.ensure_no_open_grace_for_subscriptions',
         fake_ensure_no_open_grace,


### PR DESCRIPTION
## Описание

В мультитарифном режиме у пользователя несколько подписок, и убрать лишнюю — например, отработавший триал — можно было только через «Массовые действия». Во вкладке «Подписка» самой карточки подписки видны, открываются, но кнопки удаления нет.

Добавлен `DELETE /admin/users/{user_id}/subscriptions/{sub_id}`.

## Решение

**Маршрут.** Принадлежность подписки проверяется через `get_subscription_by_id_for_user` — та же защита от IDOR, что у соседних эндпоинтов по `sub_id`. Активная платная подписка требует явного `force`: без него ответ 409, чтобы одним промахом не снести оплаченный доступ. Триал и истёкшие удаляются сразу.

**Общий сервис.** Порядок шагов удаления вынесен в `app/services/subscription_deletion_service.py` и переиспользован пользовательским роутом:

- грейс-гард первым — он берёт advisory-lock;
- отмена автоплатежей **до** исчезновения строки: записи платёжек уходят каскадом вместе с ней, отменять потом было бы нечего;
- повторный захват гарда сразу после отмены — она коммитит свою транзакцию и тем самым отпускает lock, окно закрывается перед необратимыми шагами;
- удаление в панели помечается намеренным, иначе прилетевший `user.deleted` вебхук своей чисткой заденет соседние живые подписки того же владельца;
- декремент счётчиков серверов.

Эта последовательность жила только в пользовательском роуте. Теперь у неё один владелец, и третьей копии в новом маршруте не появилось.

## Тип изменения

- [x] ✨ Новая функциональность

## Как проверить

Карточка пользователя → вкладка «Подписка» → выбрать подписку → удалить. Истёкший триал уходит сразу; активная платная — только с `force=true`; при открытом временном доступе приходит 409 с пояснением.

## Чеклист

- [x] ✅ Код соответствует стандартам проекта
- [x] 📝 Добавлены комментарии и docstrings
- [x] 🧪 Функциональность протестирована
- [x] 🔒 Нет чувствительных данных в коде
- [x] 📋 PR создан с подробным описанием

Тесты: `tests/cabinet/test_admin_delete_user_subscription.py` — четыре границы маршрута (удаление триала, чужая подписка, защита активной платной, блокировка при открытом grace). Пин-тест `test_platega_recurrent_cancel_hooks` обновлён на новое место отмены автоплатежей. Полный прогон: 2925 passed, 4 падения — пре-существующие на Windows (кодировка в самих тестах), на чистом `dev` они те же.

## Примечание

Кнопка в интерфейсе кабинета идёт отдельным PR в `bedolaga-cabinet` — этот маршрут её серверная часть.
