### PR TITLE
feat(start): предлагать подключение, когда подписку уже выдала кампания

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -2283,13 +2283,21 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
     offer_text = await get_welcome_text_for_user(db, callback.from_user)
     pinned_message = await get_active_pinned_message(db)
 
+    # Подписку мог выдать бонус рекламной кампании — она создаётся сама,
+    # без шага «активировать пробную». Тогда на приветственном экране
+    # предлагаем подключиться, а не активировать несуществующий триал.
+    _post_reg_subs = getattr(user, 'subscriptions', None) or []
+    has_subscription_after_registration = any(s.is_active for s in _post_reg_subs)
+
     if offer_text:
         try:
             if pinned_message and pinned_message.send_before_menu:
                 await _send_pinned_message(callback.bot, db, user, pinned_message)
             await callback.message.answer(
                 offer_text,
-                reply_markup=get_post_registration_keyboard(user.language),
+                reply_markup=get_post_registration_keyboard(
+                    user.language, has_active_subscription=has_subscription_after_registration
+                ),
                 parse_mode='HTML',
             )
             logger.info('✅ Приветственное сообщение отправлено пользователю', telegram_id=user.telegram_id)
@@ -2301,7 +2309,9 @@ async def complete_registration_from_callback(callback: types.CallbackQuery, sta
                 try:
                     await callback.message.answer(
                         offer_text,
-                        reply_markup=get_post_registration_keyboard(user.language),
+                        reply_markup=get_post_registration_keyboard(
+                    user.language, has_active_subscription=has_subscription_after_registration
+                ),
                         parse_mode=None,
                     )
                     if pinned_message and not pinned_message.send_before_menu:
@@ -2644,13 +2654,15 @@ async def complete_registration(message: types.Message, state: FSMContext, db: A
 
     if offer_text:
         try:
-            # Если у пользователя уже есть подписка (например, от промокода), не предлагаем триал
+            # Подписка уже есть (промокод, бонус рекламной кампании) — вместо
+            # активации триала предлагаем подключить устройство: раньше здесь
+            # оставалась только кнопка «Назад», и человек уходил с экрана,
+            # так и не узнав, как подключиться.
             _subs = getattr(user, 'subscriptions', None) or []
             user_has_subscription = any(s.is_active for s in _subs)
-            if user_has_subscription:
-                keyboard = get_back_keyboard(user.language, callback_data='back_to_menu')
-            else:
-                keyboard = get_post_registration_keyboard(user.language)
+            keyboard = get_post_registration_keyboard(
+                user.language, has_active_subscription=user_has_subscription
+            )
 
             if pinned_message and pinned_message.send_before_menu:
                 await _send_pinned_message(message.bot, db, user, pinned_message)

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -275,16 +275,31 @@ def get_channel_sub_keyboard(
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
-def get_post_registration_keyboard(language: str = DEFAULT_LANGUAGE) -> InlineKeyboardMarkup:
+def get_post_registration_keyboard(
+    language: str = DEFAULT_LANGUAGE,
+    *,
+    has_active_subscription: bool = False,
+) -> InlineKeyboardMarkup:
     texts = get_texts(language)
+
+    # Подписку могла выдать рекламная кампания — она создаётся сама, без
+    # шага «активировать пробную». Предлагать активацию поверх уже выданной
+    # подписки бессмысленно: кнопка ведёт в триал, которого у человека
+    # больше нет, а подключиться ему при этом не предлагают вовсе.
+    if has_active_subscription:
+        first_button = InlineKeyboardButton(
+            text=texts.t('CONNECT_BUTTON', '🔗 Подключиться'),
+            callback_data='subscription_connect',
+        )
+    else:
+        first_button = InlineKeyboardButton(
+            text=texts.t('POST_REGISTRATION_TRIAL_BUTTON', '🚀 Подключиться бесплатно 🚀'),
+            callback_data='trial_activate',
+        )
+
     return InlineKeyboardMarkup(
         inline_keyboard=[
-            [
-                InlineKeyboardButton(
-                    text=texts.t('POST_REGISTRATION_TRIAL_BUTTON', '🚀 Подключиться бесплатно 🚀'),
-                    callback_data='trial_activate',
-                )
-            ],
+            [first_button],
             [InlineKeyboardButton(text=texts.t('SKIP_BUTTON', 'Пропустить ➡️'), callback_data='back_to_menu')],
         ]
     )

--- a/tests/handlers/test_post_registration_keyboard.py
+++ b/tests/handlers/test_post_registration_keyboard.py
@@ -1,0 +1,39 @@
+"""Приветственный экран после регистрации: что предлагать, если подписка уже есть.
+
+Бонус рекламной кампании создаёт подписку САМ, без шага «активировать
+пробную». Экран при этом продолжал предлагать «🚀 Подключиться бесплатно»
+(callback ``trial_activate``) — активацию триала, которого у человека уже
+нет. Во второй ветке было не лучше: при существующей подписке кнопку
+триала убирали, но взамен оставляли только «Назад», и пользователь уходил,
+так и не узнав, как подключить устройство.
+"""
+
+from __future__ import annotations
+
+from app.keyboards.inline import get_post_registration_keyboard
+
+
+def _callbacks(markup) -> list[str]:
+    return [button.callback_data for row in markup.inline_keyboard for button in row]
+
+
+def test_offers_trial_activation_when_no_subscription():
+    """Обычная регистрация: подписки нет — предлагаем активировать пробную."""
+    markup = get_post_registration_keyboard('ru')
+    assert _callbacks(markup) == ['trial_activate', 'back_to_menu']
+
+
+def test_offers_connect_when_subscription_already_granted():
+    """Подписку выдала кампания — ведём подключать устройство, а не в триал."""
+    markup = get_post_registration_keyboard('ru', has_active_subscription=True)
+    callbacks = _callbacks(markup)
+
+    assert callbacks == ['subscription_connect', 'back_to_menu']
+    assert 'trial_activate' not in callbacks
+
+
+def test_skip_button_survives_in_both_modes():
+    """Уйти с экрана можно в любом случае — «Пропустить» на месте."""
+    for granted in (False, True):
+        markup = get_post_registration_keyboard('ru', has_active_subscription=granted)
+        assert 'back_to_menu' in _callbacks(markup)


### PR DESCRIPTION
## Описание

Если в рекламной кампании бонусом выбрана подписка, она создаётся **автоматически** — без шага «активировать пробную», который проходит обычный пользователь при регистрации.

Приветственный экран об этом не знал и всё равно показывал «🚀 Подключиться бесплатно» (callback `trial_activate`) — предложение активировать триал, которого у человека уже нет. Нажатие вело в тупик, а как подключить устройство, экран не подсказывал.

Во второй ветке того же экрана было не лучше: при существующей подписке кнопку триала убирали, но взамен оставалась только «Назад» — пользователь уходил, так и не увидев, куда идти дальше.

## Решение

`get_post_registration_keyboard` принимает `has_active_subscription`. Если подписка уже есть, первая кнопка ведёт на подключение (`subscription_connect`), если нет — прежнее предложение активировать пробную. Обе ветки экрана сведены к одному поведению; кнопка «Пропустить» остаётся в любом случае.

Заодно это закрывает тот же случай для подписки, выданной промокодом, — там раньше и была та самая одинокая «Назад».

## Тип изменения

- [x] ✨ Новая функциональность

## Как проверить

Кампания с бонусом-подпиской → перейти по её ссылке и зарегистрироваться. На приветственном экране первая кнопка — «Подключиться». Обычная регистрация без кампании по-прежнему предлагает активировать пробную подписку.

## Чеклист

- [x] ✅ Код соответствует стандартам проекта
- [x] 📝 Добавлены комментарии и docstrings
- [x] 🧪 Функциональность протестирована
- [x] 🔒 Нет чувствительных данных в коде
- [x] 📋 PR создан с подробным описанием

Тесты: `tests/handlers/test_post_registration_keyboard.py` — обе ветки экрана и сохранение кнопки «Пропустить». Полный прогон: 2921 passed, 4 падения — пре-существующие на Windows (кодировка в самих тестах), на чистом `dev` они те же.
