### PR TITLE
perf(etoplatezhi): мгновенный ACK вебхука + фоновая обработка (фикс ретраев по таймауту)

### DIFF
--- a/app/webserver/payments.py
+++ b/app/webserver/payments.py
@@ -25,6 +25,16 @@ from app.services.tribute_service import TributeService
 
 logger = structlog.get_logger(__name__)
 
+# Strong refs to fire-and-forget webhook background tasks so they are not
+# garbage-collected mid-execution (per asyncio.create_task docs).
+_webhook_bg_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_webhook_bg(coro) -> None:
+    task = asyncio.create_task(coro)
+    _webhook_bg_tasks.add(task)
+    task.add_done_callback(_webhook_bg_tasks.discard)
+
 
 def _create_cors_response() -> Response:
     return Response(
@@ -1534,19 +1544,27 @@ def create_payment_router(bot: Bot, payment_service: PaymentService) -> APIRoute
                 logger.warning('Etoplatezhi webhook: invalid signature')
                 return JSONResponse({'status': False}, status_code=status.HTTP_400_BAD_REQUEST)
 
-            try:
-                success = await _process_payment_service_callback(
-                    payment_service,
-                    payload,
-                    'process_etoplatezhi_callback',
-                )
-                if not success:
-                    logger.error(
-                        'Etoplatezhi webhook processing failed',
-                        data=payload.get('payment', {}).get('id'),
+            # ACK instantly, process in background. Under callback bursts the
+            # synchronous processing made EtoPlatezhi's client time out
+            # (499/408) before we responded, triggering retries. The processor
+            # opens its own DB session and row-locks per payment, so concurrent
+            # callbacks stay safe. EtoPlatezhi still retries on non-200/timeout.
+            async def _process_etoplatezhi_bg() -> None:
+                try:
+                    success = await _process_payment_service_callback(
+                        payment_service,
+                        payload,
+                        'process_etoplatezhi_callback',
                     )
-            except Exception as e:
-                logger.exception('Etoplatezhi webhook processing error', error=e)
+                    if not success:
+                        logger.error(
+                            'Etoplatezhi webhook processing failed',
+                            data=payload.get('payment', {}).get('id'),
+                        )
+                except Exception as e:
+                    logger.exception('Etoplatezhi webhook processing error', error=e)
+
+            _spawn_webhook_bg(_process_etoplatezhi_bg())
             # Always return 200 — Etoplatezhi expects 200 for valid signature
             return JSONResponse({'status': True}, status_code=status.HTTP_200_OK)
 


### PR DESCRIPTION
Под бёрстами коллбеков синхронная обработка заставляла клиент EtoPlatezhi таймаутить (499/408) до нашего ответа — платформа ретраила доставку, умножая нагрузку.

Фикс: вебхук отвечает 200 сразу после проверки подписи, обработка уходит в background-task (strong refs от GC per asyncio docs). Обработчик открывает собственную DB-сессию и row-lock'ает платёж — конкурентные коллбеки безопасны; при падении обработки EtoPlatezhi всё равно ретраит по своему расписанию, семантика не хуже прежней.

В проде с июня.