### PR TITLE
fix(etoplatezhi): уникальный customer_id для guest-платежей

### DIFF
--- a/app/services/payment/etoplatezhi.py
+++ b/app/services/payment/etoplatezhi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+import hashlib
 from datetime import UTC, datetime, timedelta
 from importlib import import_module
 from typing import Any
@@ -80,8 +81,18 @@ class EtoplatezhiPaymentMixin:
         # customer_id="None" и отклонение анти-фрод-системой EtoPlatezhi).
         if user_id is not None:
             tg_id = user_id
+            customer_id_value = str(user_id)
         else:
             tg_id = 'guest'
+            # Уникальный, но стабильный per-customer id. Раньше слали константу
+            # 'guest' на всех guest-платежах → ЭП схлопывал их в одного клиента
+            # и антифрод резал трафик. Хешируем email (стабилен для повторных).
+            if email:
+                customer_id_value = 'g' + hashlib.sha1(
+                    email.strip().lower().encode()
+                ).hexdigest()[:15]
+            else:
+                customer_id_value = f'guest-{uuid.uuid4().hex[:12]}'
 
         # Генерируем уникальный order_id с user_id для удобного поиска
         order_id = f'etp{tg_id}_{uuid.uuid4().hex[:6]}'
@@ -118,7 +129,7 @@ class EtoplatezhiPaymentMixin:
                 payment_id=order_id,
                 payment_amount=amount_kopeks,
                 payment_currency=currency,
-                customer_id=str(tg_id),
+                customer_id=customer_id_value,
                 description=description,
                 callback_url=webhook_url,
                 success_url=return_url or settings.ETOPLATEZHI_RETURN_URL,


### PR DESCRIPTION
Проблема: при guest-оплате с лендинга (user_id=None) в ЭтоПлатежи уходил customer_id="guest" — константа для всех гостевых платежей. Платёжка схлопывает их в одного клиента, и её антифрод-система начинает отклонять трафик (у нас success rate guest-платежей просел ~58% -> ~43%).

Фикс: для guest формируем стабильно-уникальный customer_id:
- если есть email — sha1(email)[:15] с префиксом g (стабилен для повторных покупок того же клиента, уникален между клиентами);
- иначе — guest-{uuid}.

Путь с user_id не меняется (как и раньше str(user_id)). Затрагивает только гостевую ветку create_etoplatezhi_payment.