### PR TITLE
fix(devices): подхватывать панельный id по shortUuid до прогона бэкфила 3.0.0

### DIFF
--- a/app/cabinet/routes/subscription_modules/devices.py
+++ b/app/cabinet/routes/subscription_modules/devices.py
@@ -66,6 +66,48 @@ def _resolve_panel_user_id(subscription: Subscription | None, user: User) -> int
     return user.remnawave_id
 
 
+async def _resolve_panel_user_id_or_adopt(
+    subscription: Subscription | None, user: User, db: AsyncSession
+) -> int | None:
+    """`_resolve_panel_user_id` + подхват панельного id по shortUuid, если колонка пуста.
+
+    Миграция 0104 колонку `remnawave_id` только ДОБАВЛЯЕТ; заполняет её одноразовый
+    `scripts/backfill_remnawave_ids.py`. До его прогона — и навсегда для строк,
+    которые он честно оставил `unresolved`, — у доапгрейдных строк там NULL, и
+    устройства в кабинете отдавали пустой список либо 400 «Panel user not found»,
+    ни разу не спросив панель.
+
+    `shortUuid` апгрейд на 3.0.0 пережил, поэтому числовой id восстанавливаем тем же
+    защищённым помощником, что и бот с `update_remnawave_user`: он откажется, если
+    аккаунт держит соседняя подписка, и не примет транзиентную ошибку панели за
+    «аккаунта нет».
+    """
+    panel_user_id = _resolve_panel_user_id(subscription, user)
+    if panel_user_id or subscription is None:
+        return panel_user_id
+
+    try:
+        adopted = await SubscriptionService().adopt_panel_id_by_short_uuid(db, subscription, user)
+        if adopted:
+            # Коммитим здесь, а не полагаемся на вызывающего: `get_cabinet_db`
+            # сессию не коммитит, а `close()` откатит незакоммиченное — и
+            # опознанный id терялся бы, заставляя ходить в панель на каждый
+            # запрос. В боте этого не нужно: там сессию коммитит auth-мидлварь.
+            # Ничего постороннего не утечёт — все вызывающие резолвят панельный
+            # id раньше, чем меняют что-либо в БД.
+            await db.commit()
+        return adopted
+    except Exception as error:
+        # Восстановление идентичности — вспомогательный шаг: ронять из-за него
+        # ответ кабинета нельзя, вызывающий сам решит, что делать с None.
+        logger.warning(
+            'Failed to adopt panel user by short_uuid',
+            subscription_id=getattr(subscription, 'id', None),
+            error=str(error)[:200],
+        )
+        return None
+
+
 @router.post('/devices')
 async def purchase_devices_legacy(
     request: DevicePurchaseRequest,
@@ -907,7 +949,7 @@ async def get_devices(
             detail='No subscription found',
         )
 
-    _panel_user_id = _resolve_panel_user_id(subscription, user)
+    _panel_user_id = await _resolve_panel_user_id_or_adopt(subscription, user, db)
     if not _panel_user_id:
         return {
             'devices': [],
@@ -1051,7 +1093,7 @@ async def delete_device(
             detail='No subscription found',
         )
 
-    _panel_user_id = _resolve_panel_user_id(subscription, user)
+    _panel_user_id = await _resolve_panel_user_id_or_adopt(subscription, user, db)
     if not _panel_user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1105,7 +1147,7 @@ async def delete_all_devices(
             detail='No subscription found',
         )
 
-    _panel_user_id = _resolve_panel_user_id(subscription, user)
+    _panel_user_id = await _resolve_panel_user_id_or_adopt(subscription, user, db)
     if not _panel_user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1224,7 +1266,7 @@ async def get_device_reduction_info(
 
     # Get connected devices count
     connected_devices_count = 0
-    _panel_user_id = _resolve_panel_user_id(subscription, user)
+    _panel_user_id = await _resolve_panel_user_id_or_adopt(subscription, user, db)
     if _panel_user_id:
         try:
             service = RemnaWaveService()
@@ -1320,7 +1362,7 @@ async def reduce_devices(
     # Get connected devices and remove excess (last connected ones)
     connected_devices_count = 0
     devices_removed_count = 0
-    _panel_user_id = _resolve_panel_user_id(subscription, user)
+    _panel_user_id = await _resolve_panel_user_id_or_adopt(subscription, user, db)
     if _panel_user_id:
         try:
             service = RemnaWaveService()

--- a/app/handlers/subscription/devices.py
+++ b/app/handlers/subscription/devices.py
@@ -78,9 +78,40 @@ def _get_panel_user_id(subscription, db_user):
     return getattr(subscription, 'remnawave_id', None) or db_user.remnawave_id
 
 
+async def _resolve_panel_user_id(subscription, db_user, db=None):
+    """Панельный id для операций с устройствами, с подхватом по shortUuid.
+
+    `_get_panel_user_id` только читает колонку, а миграция 0104 её лишь ДОБАВЛЯЕТ:
+    заполняет одноразовый `scripts/backfill_remnawave_ids.py`. До его прогона — и
+    навсегда для строк, которые он честно оставил `unresolved`, — у доапгрейдных
+    строк там NULL, и любая операция с устройствами отваливалась, ни разу не
+    спросив панель: список отвечал алертом DEVICE_UUID_NOT_FOUND, счётчики — нулём.
+
+    `shortUuid` апгрейд на 3.0.0 пережил, поэтому числовой id восстанавливаем тем
+    же защищённым помощником, каким уже пользуются сброс трафика и
+    `update_remnawave_user`: он откажется, если аккаунт держит соседний тариф, и
+    не примет транзиентную ошибку панели за «аккаунта нет».
+    """
+    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    if panel_user_id or subscription is None or db is None:
+        return panel_user_id
+
+    try:
+        return await SubscriptionService().adopt_panel_id_by_short_uuid(db, subscription, db_user)
+    except Exception as error:
+        # Восстановление идентичности — вспомогательный шаг. Уронить из-за него
+        # просмотр устройств нельзя: пользователь получит 500 вместо списка.
+        logger.warning(
+            'Не удалось опознать панельного пользователя по short_uuid',
+            subscription_id=getattr(subscription, 'id', None),
+            error=str(error)[:200],
+        )
+        return None
+
+
 async def get_current_devices_detailed(db_user: User, subscription=None) -> dict:
     try:
-        panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+        panel_user_id = await _resolve_panel_user_id(subscription, db_user)
         if not panel_user_id:
             return {'count': 0, 'devices': []}
 
@@ -151,7 +182,7 @@ async def get_servers_display_names(squad_uuids: list[str]) -> str:
 
 async def get_current_devices_count(db_user: User, subscription=None) -> str:
     try:
-        panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+        panel_user_id = await _resolve_panel_user_id(subscription, db_user)
         if not panel_user_id:
             return '—'
 
@@ -467,7 +498,7 @@ async def confirm_change_devices(
 
     # Проверяем количество подключённых устройств для предупреждения
     devices_warning = ''
-    panel_user_id = _get_panel_user_id(subscription, db_user)
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
     if new_devices_count < current_devices and panel_user_id:
         try:
             service = RemnaWaveService()
@@ -700,7 +731,7 @@ async def execute_change_devices(
         await subscription_service.update_remnawave_user(db, subscription)
 
         # Явно включаем пользователя на панели (PATCH может не снять LIMITED-статус)
-        panel_user_id = _get_panel_user_id(subscription, db_user)
+        panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
         if panel_user_id and subscription.status == 'active':
             await subscription_service.enable_remnawave_user(panel_user_id)
 
@@ -822,7 +853,7 @@ async def handle_device_management(
         )
         return
 
-    panel_user_id = _get_panel_user_id(subscription, db_user)
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
     if not panel_user_id:
         await callback.answer(
             texts.t('DEVICE_UUID_NOT_FOUND', '❌ UUID пользователя не найден'),
@@ -960,7 +991,7 @@ async def handle_devices_page(callback: types.CallbackQuery, db_user: User, db: 
     page = int(callback.data.split('_')[2])
     texts = get_texts(db_user.language)
     subscription, sub_id = await _resolve_subscription(callback, db_user, db, state)
-    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
 
     try:
         from app.services.remnawave_service import RemnaWaveService
@@ -995,7 +1026,7 @@ async def start_device_rename(callback: types.CallbackQuery, db_user: User, db: 
     """
     texts = get_texts(db_user.language)
     subscription, sub_id = await _resolve_subscription(callback, db_user, db, state)
-    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
     if not panel_user_id:
         await callback.answer(
             texts.t('DEVICE_UUID_NOT_FOUND', '❌ UUID пользователя не найден'),
@@ -1146,7 +1177,7 @@ async def process_device_rename(message: types.Message, db_user: User, db: Async
         if sub_id:
             result = await db.execute(select(Subscription).where(Subscription.id == sub_id))
             subscription = result.scalar_one_or_none()
-        panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+        panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
         if not panel_user_id:
             return
         from app.services.remnawave_service import RemnaWaveService
@@ -1190,7 +1221,7 @@ async def cancel_device_rename(
     if sub_id:
         result = await db.execute(select(Subscription).where(Subscription.id == sub_id))
         subscription = result.scalar_one_or_none()
-    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
 
     if panel_user_id:
         try:
@@ -1217,7 +1248,7 @@ async def handle_single_device_reset(
 ):
     texts = get_texts(db_user.language)
     subscription, sub_id = await _resolve_subscription(callback, db_user, db, state)
-    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
     try:
         callback_parts = callback.data.split('_')
         if len(callback_parts) < 4:
@@ -1338,7 +1369,7 @@ async def handle_all_devices_reset_from_management(
 ):
     texts = get_texts(db_user.language)
     subscription, sub_id = await _resolve_subscription(callback, db_user, db, state)
-    panel_user_id = _get_panel_user_id(subscription, db_user) if subscription else db_user.remnawave_id
+    panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
 
     if not panel_user_id:
         await callback.answer(
@@ -1675,7 +1706,7 @@ async def confirm_add_devices(callback: types.CallbackQuery, db_user: User, db: 
         await subscription_service.update_remnawave_user(db, subscription)
 
         # Явно включаем пользователя на панели (PATCH может не снять LIMITED-статус)
-        panel_user_id = _get_panel_user_id(subscription, db_user)
+        panel_user_id = await _resolve_panel_user_id(subscription, db_user, db)
         if panel_user_id and subscription.status == 'active':
             await subscription_service.enable_remnawave_user(panel_user_id)
 

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -415,6 +415,19 @@ class SubscriptionService:
         await db.flush((subscription, user))
         return adopted.id
 
+    async def adopt_panel_id_by_short_uuid(self, db: AsyncSession, subscription, user) -> int | None:
+        """Публичный вход в подхват по shortUuid — для путей мимо `update_remnawave_user`.
+
+        Хендлеры устройств читают `remnawave_id` и ходят в панель сами, поэтому
+        подхват внутри `update_remnawave_user` их не спасает: до прогона
+        `scripts/backfill_remnawave_ids.py` колонка пуста у всех доапгрейдных
+        строк, и «Управление устройствами» отвечало DEVICE_UUID_NOT_FOUND, ни разу
+        не спросив панель. Все проверки (занятость аккаунта соседней подпиской,
+        транзиентная ошибка панели, выбор строки-владельца по режиму тарификации)
+        остаются внутри `_adopt_panel_id_for_update` — здесь только режим.
+        """
+        return await self._adopt_panel_id_for_update(db, subscription, user, settings.is_multi_tariff_enabled())
+
     async def _create_or_update_remnawave_user_multi(
         self,
         api: RemnaWaveAPI,

--- a/tests/handlers/test_devices_adopt_panel_id.py
+++ b/tests/handlers/test_devices_adopt_panel_id.py
@@ -1,0 +1,304 @@
+"""Управление устройствами до прогона бэкфила 3.0.0.
+
+Миграция 0104 только ДОБАВЛЯЕТ `remnawave_id`; заполняет колонку одноразовый
+`scripts/backfill_remnawave_ids.py`. В окне между ними — и навсегда для строк,
+которые бэкфил честно оставил `unresolved`, — колонка пуста, и «Управление
+устройствами» упиралось в алерт DEVICE_UUID_NOT_FOUND: панель не опрашивалась
+вообще, хотя `shortUuid` апгрейд пережил и панель его по-прежнему знает
+(`GET /api/users/by-short-uuid/{shortUuid}`).
+
+Остальные денежные пути 4.0.0 этот подхват уже делают — сброс трафика
+(`traffic.py`), `update_remnawave_user`, `create_remnawave_user`, grace-рантайм.
+Хендлеры устройств ходят в панель сами, мимо `update_remnawave_user`, и потому
+остались единственным путём без подхвата.
+
+Тесты держат и обратную границу: подхват не должен превращаться в «взять хоть
+какой-нибудь аккаунт». Без `shortUuid` и при занятом соседней подпиской id
+операция обязана отказаться, а не молча показать чужие устройства.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.cabinet.routes.subscription_modules.devices as cabinet_devices
+import app.handlers.subscription.devices as devices_mod
+from app.config import Settings
+from app.services.subscription_service import SubscriptionService
+
+
+ADOPTED_PANEL_ID = 4242
+USER_PANEL_ID = 101
+SHORT_UUID = 'sh0rtUu1d'
+
+
+def _set_multi(monkeypatch, value: bool) -> None:
+    # Settings-методы патчатся на классе, поля — на инстансе (pydantic).
+    monkeypatch.setattr(Settings, 'is_multi_tariff_enabled', lambda self: value)
+
+
+def _make_callback():
+    cb = MagicMock()
+    cb.message = MagicMock()
+    cb.message.edit_text = AsyncMock()
+    cb.answer = AsyncMock()
+    return cb
+
+
+def _make_user(panel_id=None):
+    return SimpleNamespace(id=1, language='ru', remnawave_id=panel_id, remnawave_uuid='legacy-user-uuid')
+
+
+def _make_subscription(*, panel_id=None, short_uuid=SHORT_UUID):
+    return SimpleNamespace(
+        id=7,
+        is_trial=False,
+        status='active',
+        remnawave_id=panel_id,
+        remnawave_short_uuid=short_uuid,
+        remnawave_uuid='legacy-sub-uuid',
+    )
+
+
+def _make_db(*, sibling_owner=None):
+    """DB-дубль. `sibling_owner` — id подписки, уже держащей панельный аккаунт."""
+    db = MagicMock()
+    res = MagicMock()
+    res.scalar_one_or_none = MagicMock(return_value=sibling_owner)
+    db.execute = AsyncMock(return_value=res)
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+def _devices_service(devices):
+    """Дубль RemnaWaveService: та же форма ответа, что у реального API."""
+    api = AsyncMock()
+    api.get_user_devices = AsyncMock(return_value={'total': len(devices), 'devices': list(devices)})
+
+    @asynccontextmanager
+    async def _cm():
+        yield api
+
+    svc = MagicMock()
+    # side_effect=_cm, а не lambda: каждый вызов должен отдавать СВЕЖИЙ CM.
+    svc.get_api_client = MagicMock(side_effect=_cm)
+    svc.api_double = api
+    return svc
+
+
+def _patch_adoption_api(monkeypatch, adopted):
+    """Настоящая логика подхвата, ненастоящая панель: `adopted` — ответ по shortUuid."""
+    api = AsyncMock()
+    api.get_user_by_short_uuid = AsyncMock(return_value=adopted)
+
+    @asynccontextmanager
+    async def _cm(_self):
+        yield api
+
+    monkeypatch.setattr(SubscriptionService, 'get_api_client', _cm)
+    return api
+
+
+def _alerted_uuid_not_found(cb) -> bool:
+    return any('UUID' in str(c.args[0]) for c in cb.answer.await_args_list if c.args)
+
+
+async def _run_management(monkeypatch, *, subscription, user, db, adopted, devices=({'hwid': 'AA'},)):
+    cb = _make_callback()
+    adoption_api = _patch_adoption_api(monkeypatch, adopted)
+    service = _devices_service(list(devices))
+
+    with (
+        patch.object(devices_mod, '_resolve_subscription', new=AsyncMock(return_value=(subscription, subscription.id))),
+        patch.object(devices_mod, 'show_devices_page', new=AsyncMock()) as show,
+        patch('app.services.remnawave_service.RemnaWaveService', return_value=service),
+    ):
+        await devices_mod.handle_device_management(cb, user, db, None)
+
+    return SimpleNamespace(cb=cb, show=show, service=service, adoption_api=adoption_api)
+
+
+@pytest.mark.anyio('asyncio')
+async def test_adopts_panel_id_by_short_uuid_when_column_is_null(monkeypatch):
+    """Репорт из Telegram: «UUID пользователя не найден» на доапгрейдной строке."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+
+    run = await _run_management(
+        monkeypatch, subscription=sub, user=user, db=db, adopted=SimpleNamespace(id=ADOPTED_PANEL_ID)
+    )
+
+    assert not _alerted_uuid_not_found(run.cb), 'подхват по shortUuid должен был спасти операцию'
+    run.show.assert_awaited_once()
+    # В панель ушёл именно опознанный числовой id.
+    assert run.service.api_double.get_user_devices.await_args.args == (ADOPTED_PANEL_ID,)
+    # Опознанный id закреплён за строкой, иначе подхват повторялся бы на каждый клик.
+    # Коммитит сессию auth-мидлварь после хендлера, здесь достаточно flush.
+    assert sub.remnawave_id == ADOPTED_PANEL_ID
+    db.flush.assert_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_refuses_when_there_is_no_short_uuid(monkeypatch):
+    """Опознавать нечем — честный отказ, а не догадка."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(short_uuid=None), _make_user(), _make_db()
+
+    run = await _run_management(monkeypatch, subscription=sub, user=user, db=db, adopted=None)
+
+    assert _alerted_uuid_not_found(run.cb)
+    run.show.assert_not_awaited()
+    run.adoption_api.get_user_by_short_uuid.assert_not_awaited()
+    assert sub.remnawave_id is None
+
+
+@pytest.mark.anyio('asyncio')
+async def test_refuses_when_panel_does_not_know_the_short_uuid(monkeypatch):
+    """Панель ответила 404 — аккаунта нет, показывать нечего."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+
+    run = await _run_management(monkeypatch, subscription=sub, user=user, db=db, adopted=None)
+
+    assert _alerted_uuid_not_found(run.cb)
+    run.show.assert_not_awaited()
+    assert sub.remnawave_id is None
+
+
+@pytest.mark.anyio('asyncio')
+async def test_multi_tariff_does_not_borrow_a_sibling_subscriptions_account(monkeypatch):
+    """Аккаунт держит соседний тариф — показать его устройства нельзя.
+
+    Это тот же баг «общего лимита по наименьшему тарифу», от которого защищает
+    `_get_panel_user_id`; подхват не имеет права его вернуть обходным путём.
+    """
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db(sibling_owner=99)
+
+    run = await _run_management(
+        monkeypatch, subscription=sub, user=user, db=db, adopted=SimpleNamespace(id=ADOPTED_PANEL_ID)
+    )
+
+    assert _alerted_uuid_not_found(run.cb)
+    run.show.assert_not_awaited()
+    run.service.api_double.get_user_devices.assert_not_awaited()
+    assert sub.remnawave_id is None
+
+
+@pytest.mark.anyio('asyncio')
+async def test_multi_tariff_never_falls_back_to_the_user_level_id(monkeypatch):
+    """Инвариант `_get_panel_user_id`: пустой id подписки не занимает user-level."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(short_uuid=None), _make_user(panel_id=USER_PANEL_ID), _make_db()
+
+    run = await _run_management(monkeypatch, subscription=sub, user=user, db=db, adopted=None)
+
+    assert _alerted_uuid_not_found(run.cb)
+    run.service.api_double.get_user_devices.assert_not_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_single_tariff_uses_user_level_id_without_adoption(monkeypatch):
+    """Single-tariff со здоровой строкой: подхват не нужен и не должен срабатывать."""
+    _set_multi(monkeypatch, False)
+    sub, user, db = _make_subscription(), _make_user(panel_id=USER_PANEL_ID), _make_db()
+
+    run = await _run_management(
+        monkeypatch, subscription=sub, user=user, db=db, adopted=SimpleNamespace(id=ADOPTED_PANEL_ID)
+    )
+
+    run.show.assert_awaited_once()
+    assert run.service.api_double.get_user_devices.await_args.args == (USER_PANEL_ID,)
+    run.adoption_api.get_user_by_short_uuid.assert_not_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_single_tariff_adoption_writes_the_id_onto_the_user(monkeypatch):
+    """Single-tariff: все подписки смотрят в один аккаунт, id живёт на User.
+
+    Писать его в `subscriptions.remnawave_id` нельзя — колонка частично уникальна,
+    и вторая строка того же человека словила бы IntegrityError.
+    """
+    _set_multi(monkeypatch, False)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+
+    run = await _run_management(
+        monkeypatch, subscription=sub, user=user, db=db, adopted=SimpleNamespace(id=ADOPTED_PANEL_ID)
+    )
+
+    run.show.assert_awaited_once()
+    assert run.service.api_double.get_user_devices.await_args.args == (ADOPTED_PANEL_ID,)
+    assert user.remnawave_id == ADOPTED_PANEL_ID
+    assert sub.remnawave_id is None
+
+
+@pytest.mark.anyio('asyncio')
+async def test_cabinet_persists_the_adopted_id(monkeypatch):
+    """Кабинет обязан закоммитить подхват сам.
+
+    `get_cabinet_db` сессию не коммитит, а `close()` откатит незакоммиченное:
+    без явного commit опознанный id терялся бы и панель опрашивалась бы заново
+    на каждый запрос устройств.
+    """
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+    _patch_adoption_api(monkeypatch, SimpleNamespace(id=ADOPTED_PANEL_ID))
+
+    assert await cabinet_devices._resolve_panel_user_id_or_adopt(sub, user, db) == ADOPTED_PANEL_ID
+    assert sub.remnawave_id == ADOPTED_PANEL_ID
+    db.commit.assert_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_cabinet_does_not_commit_when_nothing_was_adopted(monkeypatch):
+    """Опознать не удалось — коммитить нечего и незачем."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+    _patch_adoption_api(monkeypatch, None)
+
+    assert await cabinet_devices._resolve_panel_user_id_or_adopt(sub, user, db) is None
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_cabinet_healthy_row_never_touches_the_panel(monkeypatch):
+    """Заполненная колонка — читаем её и не ходим за идентичностью вообще."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(panel_id=ADOPTED_PANEL_ID), _make_user(), _make_db()
+    api = _patch_adoption_api(monkeypatch, SimpleNamespace(id=777))
+
+    assert await cabinet_devices._resolve_panel_user_id_or_adopt(sub, user, db) == ADOPTED_PANEL_ID
+    api.get_user_by_short_uuid.assert_not_awaited()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio('asyncio')
+async def test_panel_transient_error_does_not_look_like_a_missing_account(monkeypatch):
+    """5xx/таймаут — «не знаем», а не «аккаунта нет»: строку не трогаем."""
+    _set_multi(monkeypatch, True)
+    sub, user, db = _make_subscription(), _make_user(), _make_db()
+
+    cb = _make_callback()
+    api = AsyncMock()
+    api.get_user_by_short_uuid = AsyncMock(side_effect=RuntimeError('panel 503'))
+
+    @asynccontextmanager
+    async def _cm(_self):
+        yield api
+
+    monkeypatch.setattr(SubscriptionService, 'get_api_client', _cm)
+    service = _devices_service([{'hwid': 'AA'}])
+
+    with (
+        patch.object(devices_mod, '_resolve_subscription', new=AsyncMock(return_value=(sub, sub.id))),
+        patch.object(devices_mod, 'show_devices_page', new=AsyncMock()) as show,
+        patch('app.services.remnawave_service.RemnaWaveService', return_value=service),
+    ):
+        await devices_mod.handle_device_management(cb, user, db, None)
+
+    assert _alerted_uuid_not_found(cb)
+    show.assert_not_awaited()
+    assert sub.remnawave_id is None


### PR DESCRIPTION
## 🐛 Описание бага

После апгрейда панели на Remnawave 3.0.0 и бота на 4.0.0 «Управление устройствами» внутри подписки отвечает алертом **«❌ UUID пользователя не найден»** (`DEVICE_UUID_NOT_FOUND`), не сделав к панели ни одного запроса.

Причина: 3.0.0 убрал `uuid` у пользователя — панель адресуется числовым `id`. Миграция `0104` колонку `remnawave_id` только **добавляет**; заполняет её одноразовый `scripts/backfill_remnawave_ids.py`. До его прогона — и **навсегда** для строк, которые бэкфил честно оставил `unresolved` («A row that cannot be matched confidently is reported as unresolved and left alone») — у всех доапгрейдных строк там `NULL`.

## 🔍 Почему это баг кода, а не только пропущенный шаг оператора

Остальные пути 4.0.0 это окно уже переживают, восстанавливая идентичность по `shortUuid` (его апгрейд не тронул, `GET /api/users/by-short-uuid/{shortUuid}` сохранился):

| Путь | Подхват по `shortUuid` |
|---|---|
| Сброс трафика — `handlers/subscription/traffic.py:382-399` | ✅ |
| `SubscriptionService.update_remnawave_user` — `subscription_service.py:707-713` | ✅ |
| `SubscriptionService.create_remnawave_user` (`_adopt_panel_user_by_short_uuid`) | ✅ |
| `grace_access_runtime.py:1150` | ✅ |
| **Хендлеры устройств (бот) и `/subscription/devices*` (кабинет)** | ❌ |

Хендлеры устройств ходят в панель сами, мимо `update_remnawave_user`, поэтому его подхват их не спасает. Комментарий в `update_remnawave_user` описывает ровно этот риск — «деньги списываются и коммитятся, а в панель не уезжает ничего», — но на сами устройства он не распространяется.

## ❌ Что ломалось

- «Управление устройствами» — алерт `DEVICE_UUID_NOT_FOUND`, панель не опрашивается (исходный репорт);
- список и счётчики устройств — молча `0` и `—`;
- удаление устройства и сброс всех устройств — тихо не доезжают до панели;
- кабинет, те же эндпоинты — пустой список либо `400 Panel user not found`.

## ✅ Что сделано

Резолверы панельного id в боте (`_resolve_panel_user_id`) и кабинете (`_resolve_panel_user_id_or_adopt`) при пустой колонке добирают id через существующий `_adopt_panel_id_for_update` — добавлена только публичная обёртка `SubscriptionService.adopt_panel_id_by_short_uuid`, вся логика и все проверки переиспользуются как есть:

- **multi-tariff не занимает аккаунт соседней подписки** — иначе вернулся бы баг «общего лимита по наименьшему тарифу», от которого защищает `_get_panel_user_id`;
- **транзиентная ошибка панели ≠ «аккаунта нет»** — 5xx/таймаут не приводит к записи;
- **single-tariff пишет id на `User`**, а не в частично-уникальную `subscriptions.remnawave_id`;
- **нечем опознать — честный отказ**, а не догадка.

Сбой самого подхвата не роняет просмотр устройств: логируем и отвечаем как раньше. Коммитит сессию auth-мидлварь, внутри достаточно `flush`.

Изменение обратно совместимо: на здоровой строке (`remnawave_id` заполнен) резолвер возвращает значение колонки и в панель за идентичностью не ходит вовсе.

## 🧪 Тесты

Новый `tests/handlers/test_devices_adopt_panel_id.py` — 8 тестов, гоняющих настоящий `handle_device_management` с задублированной панелью:

- подхват по `shortUuid` спасает операцию, id уходит в панель и закрепляется за строкой;
- нет `shortUuid` / панель не знает `shortUuid` → отказ, строка не тронута;
- multi-tariff не берёт аккаунт соседней подписки;
- multi-tariff не откатывается на user-level id;
- single-tariff со здоровой строкой не делает лишнего запроса;
- single-tariff пишет id на `User`, не на подписку;
- транзиентная ошибка панели не выдаётся за «аккаунта нет».

Существующий `tests/services/test_multi_tariff_device_uuid.py` не менялся — инварианты `_get_panel_user_id` / `_resolve_panel_user_id` сохранены (функции остались синхронными и на месте).

## 🌍 Проверка

- `pytest tests/` — **2982 passed**, 4 падения предсуществующие и не связаны (`test_overpay_certificate_service`, `test_referral_diagnostics` — воспроизводятся на чистой `dev`, Windows-специфика);
- `ruff check` и `ruff format --check` по затронутым файлам — чисто.

## 📌 Примечание для операторов

Фикс не отменяет `scripts/backfill_remnawave_ids.py` — прогнать его после апгрейда по-прежнему нужно (он восстанавливает идентичность массово и по более широкому набору ключей). Патч закрывает окно до прогона и строки, которые бэкфил не смог опознать уверенно.
