### PR TITLE
fix: make BroadcastResponse.message_text Optional[str]

### DIFF
--- a/app/webapi/schemas/broadcasts.py
+++ b/app/webapi/schemas/broadcasts.py
@@ -85,7 +85,7 @@ class BroadcastCreateRequest(BaseModel):
 class BroadcastResponse(BaseModel):
     id: int
     target_type: str
-    message_text: str
+    message_text: str | None = None
     has_media: bool
     media_type: str | None = None
     media_file_id: str | None = None


### PR DESCRIPTION
## Summary
- `broadcast_history.message_text` is a nullable DB column, but `BroadcastResponse.message_text` was declared as a required `str`.
- A row with `message_text IS NULL` (we hit this on an email-channel broadcast) makes `GET /broadcasts` throw a pydantic `ValidationError` and 500 for the **entire list**, not just that row.
- Minimal one-line fix: `message_text: str | None = None`, matching how the sibling nullable field `media_caption` is already typed two lines below.

Fixes #3151

## Test plan
- [x] `python -m py_compile app/webapi/schemas/broadcasts.py`
- [x] Deployed the same fix locally, rebuilt the bot image, confirmed `GET /broadcasts` returns 200 with a row that previously had `message_text IS NULL`