### PR TITLE
fix: корректно переносить classic-подписки на тарифы с сохранением устройств

### DIFF
--- a/app/cabinet/routes/subscription_modules/lava_recurrent.py
+++ b/app/cabinet/routes/subscription_modules/lava_recurrent.py
@@ -88,6 +88,7 @@ async def enable_lava_recurrent(
 @router.post('/lava-recurrent/purchase')
 async def purchase_with_lava_recurrent(
     tariff_id: int = Query(..., description='Tariff to subscribe to'),
+    subscription_id: int | None = Query(None, description='Legacy subscription to convert'),
     user: User = Depends(get_current_cabinet_user),
     db: AsyncSession = Depends(get_cabinet_db),
 ):
@@ -108,10 +109,24 @@ async def purchase_with_lava_recurrent(
     if not tariff or not getattr(tariff, 'is_active', False):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Tariff not found')
 
+    target_subscription = None
+    if isinstance(subscription_id, int):
+        target_subscription = await resolve_subscription(db, user, subscription_id)
+        if not target_subscription:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='No subscription found')
+
     from app.services.payment.lava import purchase_tariff_with_lava_recurring
 
     try:
-        result = await purchase_tariff_with_lava_recurring(db, user=user, tariff=tariff)
+        if target_subscription is None:
+            result = await purchase_tariff_with_lava_recurring(db, user=user, tariff=tariff)
+        else:
+            result = await purchase_tariff_with_lava_recurring(
+                db,
+                user=user,
+                tariff=tariff,
+                subscription=target_subscription,
+            )
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
     except Exception as error:

--- a/app/cabinet/routes/subscription_modules/platega_recurrent.py
+++ b/app/cabinet/routes/subscription_modules/platega_recurrent.py
@@ -93,6 +93,7 @@ async def enable_platega_recurrent(
 @router.post('/platega-recurrent/purchase')
 async def purchase_with_platega_recurrent(
     tariff_id: int = Query(..., description='Tariff to subscribe to'),
+    subscription_id: int | None = Query(None, description='Legacy subscription to convert'),
     user: User = Depends(get_current_cabinet_user),
     db: AsyncSession = Depends(get_cabinet_db),
 ):
@@ -113,10 +114,24 @@ async def purchase_with_platega_recurrent(
     if not tariff or not getattr(tariff, 'is_active', False):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Tariff not found')
 
+    target_subscription = None
+    if isinstance(subscription_id, int):
+        target_subscription = await resolve_subscription(db, user, subscription_id)
+        if not target_subscription:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='No subscription found')
+
     from app.services.payment.platega import purchase_tariff_with_sbp_recurring
 
     try:
-        result = await purchase_tariff_with_sbp_recurring(db, user=user, tariff=tariff)
+        if target_subscription is None:
+            result = await purchase_tariff_with_sbp_recurring(db, user=user, tariff=tariff)
+        else:
+            result = await purchase_tariff_with_sbp_recurring(
+                db,
+                user=user,
+                tariff=tariff,
+                subscription=target_subscription,
+            )
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
     except RuntimeError as error:

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -255,13 +255,26 @@ async def _build_tariff_response(
             price_per_day = pricing_engine.apply_discount(price_per_day, custom_days_discount_percent)
 
     # Apply discount to device price if applicable
-    device_price = tariff.device_price_kopeks if tariff.device_price_kopeks is not None else 0
+    device_price = tariff.device_price_kopeks if tariff.device_price_kopeks is not None else settings.PRICE_PER_DEVICE
     original_device_price = device_price
     device_discount_percent = 0
     if promo_group and device_price > 0:
         device_discount_percent = promo_group.get_discount_percent('devices', 30)
         if device_discount_percent > 0:
             device_price = pricing_engine.apply_discount(device_price, device_discount_percent)
+
+    # Daily cards have no period object from which the cabinet could read the
+    # add-on breakdown. Return the exact one-day charge, including preserved
+    # legacy devices and all discounts, in the existing daily-price fields.
+    if getattr(tariff, 'is_daily', False) and daily_price > 0:
+        daily_result = await pricing_engine.calculate_tariff_purchase_price(
+            tariff,
+            1,
+            device_limit=actual_device_limit,
+            user=user,
+        )
+        daily_price = daily_result.final_total
+        original_daily_price = daily_result.original_total
 
     response: dict[str, Any] = {
         'id': tariff.id,

--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -28,6 +28,7 @@ from app.database.crud.subscription import (
     extend_subscription,
     get_subscription_by_id_for_user,
     get_subscription_by_user_id,
+    resolve_tariff_purchase_device_limit,
     should_carry_trial_remaining_days,
 )
 from app.database.crud.tariff import get_tariff_by_id, get_tariffs_for_user
@@ -145,10 +146,11 @@ async def _build_tariff_response(
     promo_group_name = promo_group.name if promo_group else None
 
     # Вычисляем доп. устройства для текущего тарифа (при продлении)
+    actual_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
     extra_devices_count = 0
     extra_device_price_per_month = 0
-    if subscription and subscription.tariff_id == tariff.id:
-        extra_devices_count = max(0, (subscription.device_limit or 0) - (tariff.device_limit or 0))
+    if subscription and subscription.tariff_id in (None, tariff.id):
+        extra_devices_count = max(0, actual_device_limit - (tariff.device_limit or 0))
         if extra_devices_count > 0:
             extra_device_price_per_month = (
                 tariff.device_price_kopeks if tariff.device_price_kopeks is not None else settings.PRICE_PER_DEVICE
@@ -260,11 +262,6 @@ async def _build_tariff_response(
         device_discount_percent = promo_group.get_discount_percent('devices', 30)
         if device_discount_percent > 0:
             device_price = pricing_engine.apply_discount(device_price, device_discount_percent)
-
-    # Показываем реальное количество устройств (с докупленными) для текущего тарифа
-    actual_device_limit = tariff.device_limit
-    if subscription and subscription.tariff_id == tariff.id:
-        actual_device_limit = max(tariff.device_limit or 0, subscription.device_limit or 0)
 
     response: dict[str, Any] = {
         'id': tariff.id,
@@ -777,18 +774,13 @@ async def purchase_tariff(
                 )
         else:
             existing_subscription = await get_subscription_by_user_id(db, user.id)
-        device_limit = None
-        effective_device_limit = tariff.device_limit
-        if existing_subscription and existing_subscription.tariff_id == tariff.id:
-            device_limit = existing_subscription.device_limit
-            if (existing_subscription.device_limit or 0) > (tariff.device_limit or 0):
-                effective_device_limit = existing_subscription.device_limit
+        effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
 
         # Calculate price via PricingEngine (single source of truth)
         result = await pricing_engine.calculate_tariff_purchase_price(
             tariff,
             period_days,
-            device_limit=device_limit,
+            device_limit=effective_device_limit,
             custom_traffic_gb=custom_traffic_gb,
             user=user,
         )

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -105,6 +105,41 @@ def calc_device_limit_on_tariff_switch(
     return new_base
 
 
+def resolve_tariff_purchase_device_limit(
+    subscription: Subscription | None,
+    tariff: Tariff,
+) -> int:
+    """Resolve the device limit that must be priced and applied on purchase.
+
+    Renewals of the same tariff already preserve purchased devices.  A legacy
+    classic subscription has no ``tariff_id``, but its ``device_limit`` also
+    contains devices previously purchased by the user.  Treat that first
+    classic -> tariff purchase like a renewal and carry the limit over, while
+    keeping the existing reset-to-base behaviour for real tariff switches.
+
+    Legacy limits are capped by the target tariff's maximum (or by the global
+    maximum when the tariff has no explicit cap), so migration cannot create a
+    subscription that the selected tariff would not normally allow.
+    """
+    tariff_base = max(1, tariff.device_limit or 1)
+    if subscription is None:
+        return tariff_base
+
+    is_legacy_migration = subscription.tariff_id is None
+    is_same_tariff_renewal = subscription.tariff_id == tariff.id
+    if not (is_legacy_migration or is_same_tariff_renewal):
+        return tariff_base
+
+    resolved_limit = max(tariff_base, subscription.device_limit or tariff_base)
+    if not is_legacy_migration:
+        return resolved_limit
+
+    effective_max = tariff.max_device_limit or (settings.MAX_DEVICES_LIMIT if settings.MAX_DEVICES_LIMIT > 0 else None)
+    if effective_max:
+        resolved_limit = min(resolved_limit, effective_max)
+    return resolved_limit
+
+
 def is_active_paid_subscription(subscription: Subscription | None) -> bool:
     """Return True if subscription is active, paid (non-trial), and not expired."""
     if not subscription:

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -140,6 +140,31 @@ def resolve_tariff_purchase_device_limit(
     return resolved_limit
 
 
+async def apply_recurrent_tariff_charge(
+    db: AsyncSession,
+    subscription: Subscription,
+    tariff: Tariff,
+    days: int,
+) -> Subscription:
+    """Extend a recurrent subscription and convert a legacy classic row atomically."""
+    if subscription.tariff_id is not None:
+        subscription.extend_subscription(days)
+        return subscription
+
+    device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
+    connected_squads = list(tariff.allowed_squads or subscription.connected_squads or [])
+    return await extend_subscription(
+        db,
+        subscription,
+        days,
+        tariff_id=tariff.id,
+        traffic_limit_gb=tariff.traffic_limit_gb,
+        device_limit=device_limit,
+        connected_squads=connected_squads,
+        commit=False,
+    )
+
+
 def is_active_paid_subscription(subscription: Subscription | None) -> bool:
     """Return True if subscription is active, paid (non-trial), and not expired."""
     if not subscription:

--- a/app/handlers/subscription/tariff_purchase.py
+++ b/app/handlers/subscription/tariff_purchase.py
@@ -17,6 +17,7 @@ from app.database.crud.subscription import (
     get_active_subscriptions_by_user_id,
     get_subscription_by_id_for_user,
     get_subscription_by_user_id,
+    resolve_tariff_purchase_device_limit,
 )
 from app.database.crud.tariff import get_tariff_by_id, get_tariffs_for_user
 from app.database.crud.transaction import create_transaction
@@ -122,6 +123,15 @@ async def _resolve_switch_subscription(callback, db_user, db, state=None):
         get_texts(db_user.language).t('TARIFF_PURCHASE_SELECT_SUBSCRIPTION', 'Выберите подписку'), show_alert=True
     )
     return None, None
+
+
+async def _resolve_existing_purchase_subscription(db: AsyncSession, user_id: int, tariff_id: int):
+    """Resolve the row whose limits must be carried into a tariff purchase."""
+    if settings.is_multi_tariff_enabled():
+        from app.database.crud.subscription import get_subscription_by_user_and_tariff
+
+        return await get_subscription_by_user_and_tariff(db, user_id, tariff_id)
+    return await get_subscription_by_user_id(db, user_id)
 
 
 def _apply_promo_discount(price: int, group_pct: int, offer_pct: int = 0) -> int:
@@ -641,6 +651,7 @@ async def format_custom_tariff_preview(
     discount_percent: int = 0,
     group_pct: int = 0,
     offer_pct: int = 0,
+    device_limit: int | None = None,
 ) -> str:
     """Форматирует предпросмотр покупки с кастомными параметрами.
 
@@ -654,7 +665,7 @@ async def format_custom_tariff_preview(
         result = await pricing_engine.calculate_tariff_purchase_price(
             tariff,
             days,
-            device_limit=tariff.device_limit,
+            device_limit=device_limit,
             custom_traffic_gb=traffic_gb if tariff.can_purchase_custom_traffic() else None,
             user=db_user,
         )
@@ -701,7 +712,7 @@ async def format_custom_tariff_preview(
         text += texts.t('TARIFF_PURCHASE_TRAFFIC_LINE', '📊 Трафик: {traffic}\n').format(traffic=traffic_display)
 
     text += texts.t('TARIFF_PURCHASE_DEVICES_LINE', '📱 Устройств: {devices}\n').format(
-        devices=Texts.format_device_limit(tariff.device_limit)
+        devices=Texts.format_device_limit(device_limit if device_limit is not None else tariff.device_limit)
     )
 
     if has_discount:
@@ -800,6 +811,10 @@ async def select_tariff(
         await callback.answer(texts.t('TARIFF_PURCHASE_UNAVAILABLE', 'Тариф недоступен'), show_alert=True)
         return
 
+    existing_purchase_subscription = await _resolve_existing_purchase_subscription(db, db_user.id, tariff.id)
+    purchase_device_limit = resolve_tariff_purchase_device_limit(existing_purchase_subscription, tariff)
+    await state.update_data(purchase_device_limit=purchase_device_limit)
+
     # В мульти-тарифе проверяем не куплен ли уже этот тариф
     if settings.is_multi_tariff_enabled():
         from app.database.crud.subscription import get_active_subscriptions_by_user_id
@@ -822,10 +837,17 @@ async def select_tariff(
 
     if is_daily:
         # Для суточного тарифа показываем подтверждение без выбора периода
-        raw_daily_price = getattr(tariff, 'daily_price_kopeks', 0)
-        group_pct, offer_pct, daily_discount = _get_user_period_discount(db_user, 1)
-        daily_price = (
-            _apply_promo_discount(raw_daily_price, group_pct, offer_pct) if daily_discount > 0 else raw_daily_price
+        from app.services.pricing_engine import pricing_engine
+
+        daily_result = await pricing_engine.calculate_tariff_purchase_price(
+            tariff,
+            period_days=1,
+            device_limit=purchase_device_limit,
+            user=db_user,
+        )
+        daily_price = daily_result.final_total
+        daily_discount = (
+            round((1 - daily_price / daily_result.original_total) * 100) if daily_result.original_total > 0 else 0
         )
         discount_text = (
             texts.t('TARIFF_PURCHASE_DAILY_DISCOUNT_LINE', '\n💎 Скидка: {percent}%').format(percent=daily_discount)
@@ -851,7 +873,7 @@ async def select_tariff(
                 ).format(
                     name=html.escape(tariff.name),
                     traffic=traffic,
-                    devices=tariff.device_limit,
+                    devices=purchase_device_limit,
                     price=format_price_kopeks(daily_price),
                     discount=discount_text,
                     balance=format_price_kopeks(user_balance),
@@ -883,7 +905,7 @@ async def select_tariff(
                 'return_to_cart': True,
                 'description': f'Покупка суточного тарифа {tariff.name}',
                 'traffic_limit_gb': tariff.traffic_limit_gb,
-                'device_limit': tariff.device_limit,
+                'device_limit': purchase_device_limit,
                 'allowed_squads': tariff.allowed_squads or [],
                 'subscription_id': _daily_existing_sub.id if _daily_existing_sub else None,
             }
@@ -943,6 +965,7 @@ async def select_tariff(
                 user_balance=user_balance,
                 db_user=db_user,
                 discount_percent=discount_percent,
+                device_limit=purchase_device_limit,
             )
 
             await callback.message.edit_text(
@@ -1030,6 +1053,7 @@ async def handle_custom_days_change(
         user_balance=user_balance,
         db_user=db_user,
         discount_percent=discount_percent,
+        device_limit=state_data.get('purchase_device_limit'),
     )
 
     await callback.message.edit_text(
@@ -1089,6 +1113,7 @@ async def handle_custom_traffic_change(
         user_balance=user_balance,
         db_user=db_user,
         discount_percent=discount_percent,
+        device_limit=state_data.get('purchase_device_limit'),
     )
 
     await callback.message.edit_text(
@@ -1134,6 +1159,8 @@ async def handle_custom_confirm(
     state_data = await state.get_data()
     custom_days = state_data.get('custom_days', tariff.min_days)
     custom_traffic = state_data.get('custom_traffic_gb', tariff.min_traffic_gb)
+    existing_subscription = await _resolve_existing_purchase_subscription(db, db_user.id, tariff.id)
+    effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
 
     # Calculate price via PricingEngine (single source of truth for all discounts)
     from app.services.pricing_engine import pricing_engine
@@ -1141,7 +1168,7 @@ async def handle_custom_confirm(
     result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
         custom_days,
-        device_limit=tariff.device_limit,
+        device_limit=effective_device_limit,
         custom_traffic_gb=custom_traffic if tariff.can_purchase_custom_traffic() else None,
         user=db_user,
     )
@@ -1213,21 +1240,9 @@ async def handle_custom_confirm(
     # Определяем трафик
     traffic_limit = custom_traffic if tariff.can_purchase_custom_traffic() else tariff.traffic_limit_gb
 
-    # Проверяем есть ли уже подписка
-    if settings.is_multi_tariff_enabled():
-        active_subs = await get_active_subscriptions_by_user_id(db, db_user.id)
-        existing_subscription = next((s for s in active_subs if s.tariff_id == tariff.id), None)
-    else:
-        existing_subscription = await get_subscription_by_user_id(db, db_user.id)
-
     try:
         if existing_subscription:
             # Продлеваем существующую подписку и обновляем параметры тарифа
-            # Сохраняем докупленные устройства при продлении того же тарифа
-            if existing_subscription.tariff_id == tariff.id:
-                effective_device_limit = max(tariff.device_limit or 0, existing_subscription.device_limit or 0)
-            else:
-                effective_device_limit = tariff.device_limit
             subscription = await extend_subscription(
                 db,
                 existing_subscription,
@@ -1380,7 +1395,7 @@ async def handle_custom_confirm(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic_display,
-                devices=tariff.device_limit,
+                devices=effective_device_limit,
                 period=format_period(custom_days),
                 price=format_price_kopeks(total_price),
             ),
@@ -1457,6 +1472,7 @@ async def select_tariff_period_with_traffic(
         user_balance=user_balance,
         db_user=db_user,
         discount_percent=discount_percent,
+        device_limit=(await state.get_data()).get('purchase_device_limit'),
     )
 
     await callback.message.edit_text(
@@ -1505,9 +1521,7 @@ async def select_tariff_period(
     else:
         _existing_sub = await get_subscription_by_user_id(db, db_user.id)
 
-    device_limit = None
-    if _existing_sub and _existing_sub.tariff_id == tariff.id:
-        device_limit = _existing_sub.device_limit
+    device_limit = resolve_tariff_purchase_device_limit(_existing_sub, tariff)
 
     # Цена — тем же PricingEngine, что и confirm_tariff_purchase: ручной расчёт от
     # period_prices не видел доплату за устройства сверх включённых в тариф, превью
@@ -1527,7 +1541,7 @@ async def select_tariff_period(
     discount_percent = (
         round((1 - final_price / original_price) * 100) if original_price > 0 and total_discount > 0 else 0
     )
-    shown_device_limit = device_limit if device_limit is not None else tariff.device_limit
+    shown_device_limit = device_limit
 
     # Проверяем баланс
     user_balance = db_user.balance_kopeks or 0
@@ -1707,9 +1721,7 @@ async def confirm_tariff_purchase(
     else:
         existing_sub = await get_subscription_by_user_id(db, db_user.id)
 
-    device_limit = None
-    if existing_sub and existing_sub.tariff_id == tariff.id:
-        device_limit = existing_sub.device_limit
+    device_limit = resolve_tariff_purchase_device_limit(existing_sub, tariff)
 
     result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
@@ -1846,10 +1858,7 @@ async def confirm_tariff_purchase(
         elif existing_subscription:
             # Legacy single-subscription: extend or switch
             # Сохраняем докупленные устройства при продлении того же тарифа
-            if existing_subscription.tariff_id == tariff.id:
-                effective_device_limit = max(tariff.device_limit or 0, existing_subscription.device_limit or 0)
-            else:
-                effective_device_limit = tariff.device_limit
+            effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
             subscription = await extend_subscription(
                 db,
                 existing_subscription,
@@ -2118,6 +2127,8 @@ async def confirm_daily_tariff_purchase(
     from app.database.crud.user import lock_user_for_pricing
 
     db_user = await lock_user_for_pricing(db, db_user.id)
+    existing_subscription = await _resolve_existing_purchase_subscription(db, db_user.id, tariff.id)
+    effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
 
     # Apply group + promo-offer discounts via PricingEngine (single source of truth)
     from app.services.pricing_engine import pricing_engine
@@ -2125,7 +2136,7 @@ async def confirm_daily_tariff_purchase(
     pricing_result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
         period_days=1,
-        device_limit=tariff.device_limit,
+        device_limit=effective_device_limit,
         user=db_user,
     )
     final_daily_price = pricing_result.final_total
@@ -2180,30 +2191,12 @@ async def confirm_daily_tariff_purchase(
         all_servers, _ = await get_all_server_squads(db, available_only=True)
         squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
 
-    # Проверяем есть ли уже подписка
-    if settings.is_multi_tariff_enabled():
-        active_subs = await get_active_subscriptions_by_user_id(db, db_user.id)
-        existing_subscription = next((s for s in active_subs if s.tariff_id == tariff.id), None)
-    else:
-        existing_subscription = await get_subscription_by_user_id(db, db_user.id)
-
     try:
         if existing_subscription:
             # Обновляем существующую подписку на суточный тариф
-            # Сбрасываем лимит устройств на базу нового тарифа (докупленные не переносятся)
-            from app.database.crud.subscription import calc_device_limit_on_tariff_switch
-
-            old_tariff = (
-                await get_tariff_by_id(db, existing_subscription.tariff_id) if existing_subscription.tariff_id else None
-            )
             existing_subscription.tariff_id = tariff.id
             existing_subscription.traffic_limit_gb = tariff.traffic_limit_gb
-            existing_subscription.device_limit = calc_device_limit_on_tariff_switch(
-                current_device_limit=existing_subscription.device_limit,
-                old_tariff_device_limit=old_tariff.device_limit if old_tariff else None,
-                new_tariff_device_limit=tariff.device_limit,
-                max_device_limit=getattr(tariff, 'max_device_limit', None),
-            )
+            existing_subscription.device_limit = effective_device_limit
             existing_subscription.connected_squads = squads
             existing_subscription.status = 'active'
             existing_subscription.is_trial = False  # Сбрасываем триальный статус
@@ -3530,10 +3523,13 @@ async def select_tariff_switch_period(
     # Calculate price via PricingEngine (per-category discounts: period + devices for new tariff)
     from app.services.pricing_engine import pricing_engine
 
+    subscription, _sw_period_sub_id = await _resolve_switch_subscription(callback, db_user, db, state)
+    effective_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
+
     result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
         period,
-        device_limit=tariff.device_limit or 0,
+        device_limit=effective_device_limit,
         user=db_user,
     )
     final_price = result.final_total
@@ -3556,7 +3552,6 @@ async def select_tariff_switch_period(
             current_tariff_name = html.escape(current_tariff.name)
 
     # Получаем текущую подписку (switched FROM, not TO) для расчёта оставшегося времени
-    subscription, _sw_period_sub_id = await _resolve_switch_subscription(callback, db_user, db, state)
     if subscription and subscription.end_date:
         max(0, (subscription.end_date - datetime.now(UTC)).days)
 
@@ -3587,7 +3582,7 @@ async def select_tariff_switch_period(
                 current=current_tariff_name,
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=effective_device_limit,
                 time_info=time_info,
                 discount=discount_text,
                 total=format_price_kopeks(final_price),
@@ -3680,8 +3675,9 @@ async def confirm_tariff_switch(
     # Calculate price via PricingEngine (handles per-category discounts + extra devices)
     from app.services.pricing_engine import pricing_engine
 
-    # New tariff device_limit applies on switch (extra devices not transferred)
-    effective_device_limit = tariff.device_limit or 0
+    # Legacy classic subscriptions keep their already purchased devices. A real
+    # tariff-to-tariff switch still resets the limit to the new tariff base.
+    effective_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
     result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
         period,
@@ -3739,10 +3735,7 @@ async def confirm_tariff_switch(
 
         # Обновляем подписку с новыми параметрами тарифа
         # Сохраняем докупленные устройства при продлении того же тарифа
-        if subscription.tariff_id == tariff.id:
-            effective_device_limit = max(tariff.device_limit or 0, subscription.device_limit or 0)
-        else:
-            effective_device_limit = tariff.device_limit
+        effective_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
         subscription = await extend_subscription(
             db,
             subscription,
@@ -3870,7 +3863,7 @@ async def confirm_tariff_switch(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=effective_device_limit,
                 price=format_price_kopeks(final_price),
                 time_info=time_info,
             ),
@@ -3935,13 +3928,21 @@ async def confirm_daily_tariff_switch(
 
     db_user = await lock_user_for_pricing(db, db_user.id)
 
+    # Ищем подписку FROM до расчёта цены: legacy-лимит устройств должен
+    # участвовать и в списании за первый день суточного тарифа.
+    subscription, _sub_id = await _resolve_switch_subscription(callback, db_user, db, state)
+    if not subscription:
+        await callback.answer(texts.t('NO_SUBSCRIPTION_ERROR', '❌ У вас нет активной подписки'), show_alert=True)
+        return
+    effective_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
+
     # Apply group + promo-offer discounts via PricingEngine (single source of truth)
     from app.services.pricing_engine import pricing_engine
 
     pricing_result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
         period_days=1,
-        device_limit=tariff.device_limit,
+        device_limit=effective_device_limit,
         user=db_user,
     )
     final_daily_price = pricing_result.final_total
@@ -3953,12 +3954,6 @@ async def confirm_daily_tariff_switch(
         await callback.answer(
             texts.t('MINIAPP_PURCHASE_STATUS_INSUFFICIENT', 'Недостаточно средств на балансе'), show_alert=True
         )
-        return
-
-    # Проверяем наличие подписки — ищем подписку FROM (текущую), не TO (новый тариф)
-    subscription, _sub_id = await _resolve_switch_subscription(callback, db_user, db, state)
-    if not subscription:
-        await callback.answer(texts.t('NO_SUBSCRIPTION_ERROR', '❌ У вас нет активной подписки'), show_alert=True)
         return
 
     # Проверяем разрешение на смену в данном направлении
@@ -4012,19 +4007,11 @@ async def confirm_daily_tariff_switch(
             all_servers, _ = await get_all_server_squads(db, available_only=True)
             squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
 
-        # Обновляем подписку на суточный тариф
-        # Сбрасываем лимит устройств на базу нового тарифа (докупленные не переносятся)
-        from app.database.crud.subscription import calc_device_limit_on_tariff_switch
-
-        old_tariff = await get_tariff_by_id(db, subscription.tariff_id) if subscription.tariff_id else None
+        # Обновляем подписку на суточный тариф. Для legacy-подписки лимит
+        # сохранён и уже включён в рассчитанную выше стоимость.
         subscription.tariff_id = tariff.id
         subscription.traffic_limit_gb = tariff.traffic_limit_gb
-        subscription.device_limit = calc_device_limit_on_tariff_switch(
-            current_device_limit=subscription.device_limit,
-            old_tariff_device_limit=old_tariff.device_limit if old_tariff else None,
-            new_tariff_device_limit=tariff.device_limit,
-            max_device_limit=getattr(tariff, 'max_device_limit', None),
-        )
+        subscription.device_limit = effective_device_limit
         subscription.connected_squads = squads
         subscription.status = 'active'
         subscription.is_trial = False  # Сбрасываем триальный статус
@@ -4155,7 +4142,7 @@ async def confirm_daily_tariff_switch(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=effective_device_limit,
                 price=format_price_kopeks(final_daily_price),
             ),
             reply_markup=InlineKeyboardMarkup(
@@ -5328,7 +5315,7 @@ async def return_to_saved_tariff_cart(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=cart_data.get('device_limit', tariff.device_limit),
                 price=format_price_kopeks(daily_price),
                 balance=format_price_kopeks(user_balance),
                 after=format_price_kopeks(user_balance - daily_price),
@@ -5364,7 +5351,7 @@ async def return_to_saved_tariff_cart(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=cart_data.get('device_limit', tariff.device_limit),
                 period=format_period(period),
                 discount=discount_text,
                 total=format_price_kopeks(total_price),
@@ -5413,7 +5400,7 @@ async def return_to_saved_tariff_cart(
             ).format(
                 name=html.escape(tariff.name),
                 traffic=traffic,
-                devices=tariff.device_limit,
+                devices=cart_data.get('device_limit', tariff.device_limit),
                 period=format_period(period),
                 discount=discount_text,
                 total=format_price_kopeks(total_price),

--- a/app/services/payment/lava.py
+++ b/app/services/payment/lava.py
@@ -755,9 +755,21 @@ class LavaPaymentMixin:
         # подписки докуплены устройства/трафик), привязка недобирала бы разницу
         # при каждом списании — отказываем с конкретными числами, чтобы
         # оператор завёл продукт с нужной ценой.
-        from app.services.recurrent_amount import resolve_true_renewal_amount
+        if subscription.tariff_id is None:
+            from app.database.crud.subscription import resolve_tariff_purchase_device_limit
+            from app.services.pricing_engine import pricing_engine
 
-        true_amount = await resolve_true_renewal_amount(db, subscription, charge_days)
+            legacy_device_limit = resolve_tariff_purchase_device_limit(subscription, tariff)
+            target_pricing = await pricing_engine.calculate_tariff_purchase_price(
+                tariff,
+                charge_days,
+                device_limit=legacy_device_limit,
+            )
+            true_amount = int(target_pricing.final_total)
+        else:
+            from app.services.recurrent_amount import resolve_true_renewal_amount
+
+            true_amount = await resolve_true_renewal_amount(db, subscription, charge_days)
         if true_amount and true_amount - amount_kopeks > 1:
             raise ValueError(
                 f'Продукт Lava стоит {amount_kopeks / 100:.2f} ₽, а продление подписки — '
@@ -1062,7 +1074,21 @@ class LavaPaymentMixin:
 
             await _lock_subscription_row(db, subscription)
 
-            subscription.extend_subscription(record.charge_days)
+            if subscription.tariff_id is None and record.tariff_id is not None:
+                from app.database.crud.subscription import apply_recurrent_tariff_charge
+                from app.database.crud.tariff import get_tariff_by_id
+
+                tariff = await get_tariff_by_id(db, record.tariff_id)
+                if tariff is None:
+                    logger.error(
+                        'Lava subscription callback: тариф не найден для успешного списания',
+                        tariff_id=record.tariff_id,
+                        subscription_id=subscription.id,
+                    )
+                    return False
+                await apply_recurrent_tariff_charge(db, subscription, tariff, record.charge_days)
+            else:
+                subscription.extend_subscription(record.charge_days)
 
             # Списание по локально ОТМЕНЁННОЙ записи = удалённая отмена не
             # прошла. Деньги взяты — продлеваем честно, но запись НЕ воскрешаем
@@ -1201,6 +1227,7 @@ async def purchase_tariff_with_lava_recurring(
     *,
     user: Any,
     tariff: Any,
+    subscription: Any | None = None,
 ) -> dict[str, Any]:
     """Оформление подписки на тариф оплатой через автопродление Lava.
 
@@ -1227,11 +1254,16 @@ async def purchase_tariff_with_lava_recurring(
         get_subscription_by_user_id,
     )
 
-    if settings.is_multi_tariff_enabled():
+    if subscription is not None:
+        if subscription.user_id != user.id:
+            raise ValueError('Subscription does not belong to user')
+        if subscription.tariff_id not in (None, tariff.id):
+            raise ValueError('Оформление через Lava недоступно при подписке другого тарифа — оплатите с баланса')
+    elif settings.is_multi_tariff_enabled():
         subscription = await get_subscription_by_user_and_tariff(db, user.id, tariff.id, include_inactive=True)
     else:
         subscription = await get_subscription_by_user_id(db, user.id)
-        if subscription is not None and subscription.tariff_id != tariff.id:
+        if subscription is not None and subscription.tariff_id not in (None, tariff.id):
             raise ValueError('Оформление через Lava недоступно при подписке другого тарифа — оплатите с баланса')
 
     if subscription is not None:

--- a/app/services/payment/platega.py
+++ b/app/services/payment/platega.py
@@ -500,7 +500,21 @@ class PlategaPaymentMixin:
                 )
                 return
 
-            subscription.extend_subscription(record.charge_days)
+            if subscription.tariff_id is None and record.tariff_id is not None:
+                from app.database.crud.subscription import apply_recurrent_tariff_charge
+                from app.database.crud.tariff import get_tariff_by_id
+
+                tariff = await get_tariff_by_id(db, record.tariff_id)
+                if tariff is None:
+                    logger.error(
+                        'Platega subscription callback: тариф не найден для успешного списания',
+                        tariff_id=record.tariff_id,
+                        subscription_id=subscription.id,
+                    )
+                    return
+                await apply_recurrent_tariff_charge(db, subscription, tariff, record.charge_days)
+            else:
+                subscription.extend_subscription(record.charge_days)
 
             # Списание по локально ОТМЕНЁННОЙ записи = удалённая отмена не
             # прошла (сбой Platega в момент cancel). Деньги взяты — продлеваем
@@ -1115,6 +1129,7 @@ async def purchase_tariff_with_sbp_recurring(
     *,
     user: Any,
     tariff: Any,
+    subscription: Any | None = None,
 ) -> dict[str, Any]:
     """Оформление подписки на тариф с оплатой через СБП-автопродление Platega.
 
@@ -1148,11 +1163,16 @@ async def purchase_tariff_with_sbp_recurring(
         get_subscription_by_user_id,
     )
 
-    if settings.is_multi_tariff_enabled():
+    if subscription is not None:
+        if subscription.user_id != user.id:
+            raise ValueError('Subscription does not belong to user')
+        if subscription.tariff_id not in (None, tariff.id):
+            raise ValueError('СБП-оформление недоступно при подписке другого тарифа — оплатите с баланса')
+    elif settings.is_multi_tariff_enabled():
         subscription = await get_subscription_by_user_and_tariff(db, user.id, tariff.id, include_inactive=True)
     else:
         subscription = await get_subscription_by_user_id(db, user.id)
-        if subscription is not None and subscription.tariff_id != tariff.id:
+        if subscription is not None and subscription.tariff_id not in (None, tariff.id):
             raise ValueError('СБП-оформление недоступно при подписке другого тарифа — оплатите с баланса')
 
     if subscription is not None:

--- a/app/services/subscription_auto_purchase_service.py
+++ b/app/services/subscription_auto_purchase_service.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.database.crud.subscription import extend_subscription
+from app.database.crud.subscription import extend_subscription, resolve_tariff_purchase_device_limit
 from app.database.crud.transaction import create_transaction
 from app.database.crud.user import subtract_user_balance
 from app.database.models import Subscription, SubscriptionStatus, TransactionType, User
@@ -897,9 +897,7 @@ async def _auto_purchase_tariff(
     user = await lock_user_for_pricing(db, user.id)
 
     # Calculate price via PricingEngine (single source of truth)
-    device_limit = None
-    if existing_subscription and existing_subscription.tariff_id == tariff_id:
-        device_limit = existing_subscription.device_limit
+    device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
 
     result = await pricing_engine.calculate_tariff_purchase_price(
         tariff,
@@ -959,10 +957,7 @@ async def _auto_purchase_tariff(
         if existing_subscription:
             # Продлеваем существующую подписку
             # Сохраняем докупленные устройства при продлении того же тарифа
-            if existing_subscription.tariff_id == tariff.id:
-                effective_device_limit = max(tariff.device_limit or 0, existing_subscription.device_limit or 0)
-            else:
-                effective_device_limit = tariff.device_limit
+            effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
             subscription = await extend_subscription(
                 db,
                 existing_subscription,
@@ -1240,18 +1235,33 @@ async def _auto_purchase_daily_tariff(
         )
         return False
 
-    # Блокируем пользователя и применяем скидки (group + promo-offer)
+    # Блокируем пользователя и повторно разрешаем целевую подписку: корзина
+    # legacy-перехода должна сохранить оплаченные ранее устройства.
     from app.database.crud.user import lock_user_for_pricing
-    from app.utils.promo_offer import get_user_active_promo_discount_percent
 
     user = await lock_user_for_pricing(db, user.id)
 
-    promo_group = user.get_primary_promo_group()
-    group_pct = promo_group.get_discount_percent('period', 1) if promo_group else 0
-    offer_pct = get_user_active_promo_discount_percent(user)
+    if settings.is_multi_tariff_enabled():
+        from app.database.crud.subscription import get_active_subscriptions_by_user_id
 
-    final_price, _, _ = PricingEngine.apply_stacked_discounts(daily_price, group_pct, offer_pct)
-    consume_promo = offer_pct > 0
+        active_subs = await get_active_subscriptions_by_user_id(db, user.id)
+        _cart_sub_id = cart_data.get('subscription_id')
+        if _cart_sub_id:
+            existing_subscription = next((s for s in active_subs if s.id == int(_cart_sub_id)), None)
+        else:
+            existing_subscription = next((s for s in active_subs if s.tariff_id == tariff_id), None)
+    else:
+        existing_subscription = await get_subscription_by_user_id(db, user.id)
+
+    effective_device_limit = resolve_tariff_purchase_device_limit(existing_subscription, tariff)
+    pricing_result = await pricing_engine.calculate_tariff_purchase_price(
+        tariff,
+        period_days=1,
+        device_limit=effective_device_limit,
+        user=user,
+    )
+    final_price = pricing_result.final_total
+    consume_promo = pricing_result.promo_offer_discount > 0
 
     if final_price > 0 and user.balance_kopeks < final_price:
         logger.info(
@@ -1294,44 +1304,14 @@ async def _auto_purchase_daily_tariff(
         all_servers, _ = await get_all_server_squads(db, available_only=True)
         squads = [s.squad_uuid for s in all_servers if s.squad_uuid]
 
-    # Проверяем есть ли уже подписка
-    if settings.is_multi_tariff_enabled():
-        from app.database.crud.subscription import get_active_subscriptions_by_user_id
-
-        active_subs = await get_active_subscriptions_by_user_id(db, user.id)
-        _cart_sub_id = cart_data.get('subscription_id')
-        if _cart_sub_id:
-            existing_subscription = next(
-                (s for s in active_subs if s.id == int(_cart_sub_id)),
-                None,
-            )
-        else:
-            existing_subscription = next(
-                (s for s in active_subs if s.tariff_id == tariff_id),
-                None,
-            )
-    else:
-        existing_subscription = await get_subscription_by_user_id(db, user.id)
-
     try:
         if existing_subscription:
             # Обновляем существующую подписку на суточный тариф
             # Суточность определяется через tariff.is_daily, поэтому достаточно установить tariff_id
             was_trial_conversion = existing_subscription.is_trial  # Сохраняем до изменения
-            from app.database.crud.subscription import calc_device_limit_on_tariff_switch
-            from app.database.crud.tariff import get_tariff_by_id as _get_old_tariff
-
-            old_tariff = (
-                await _get_old_tariff(db, existing_subscription.tariff_id) if existing_subscription.tariff_id else None
-            )
             existing_subscription.tariff_id = tariff.id
             existing_subscription.traffic_limit_gb = tariff.traffic_limit_gb
-            existing_subscription.device_limit = calc_device_limit_on_tariff_switch(
-                current_device_limit=existing_subscription.device_limit,
-                old_tariff_device_limit=old_tariff.device_limit if old_tariff else None,
-                new_tariff_device_limit=tariff.device_limit,
-                max_device_limit=getattr(tariff, 'max_device_limit', None),
-            )
+            existing_subscription.device_limit = effective_device_limit
             existing_subscription.connected_squads = squads
             existing_subscription.status = 'active'
             existing_subscription.is_trial = False

--- a/tests/cabinet/test_platega_recurrent_routes.py
+++ b/tests/cabinet/test_platega_recurrent_routes.py
@@ -467,6 +467,29 @@ async def test_purchase_happy_path_returns_redirect_and_subscription_id(monkeypa
     mock_purchase.assert_awaited_once_with(db, user=user, tariff=tariff)
 
 
+async def test_purchase_forwards_legacy_subscription_to_recurring_service(monkeypatch, user):
+    _configure_gate(monkeypatch, enabled=True)
+    tariff = SimpleNamespace(id=5, is_active=True)
+    legacy_subscription = SimpleNamespace(id=77, user_id=user.id, tariff_id=None)
+    db = AsyncMock()
+    mock_purchase = AsyncMock(
+        return_value={'status': 'PENDING', 'redirect_url': 'https://pay/x', 'subscription_id': 77}
+    )
+
+    monkeypatch.setattr('app.database.crud.tariff.get_tariff_by_id', AsyncMock(return_value=tariff))
+    monkeypatch.setattr(route, 'resolve_subscription', AsyncMock(return_value=legacy_subscription))
+    monkeypatch.setattr('app.services.payment.platega.purchase_tariff_with_sbp_recurring', mock_purchase)
+
+    await route.purchase_with_platega_recurrent(tariff_id=5, subscription_id=77, user=user, db=db)
+
+    mock_purchase.assert_awaited_once_with(
+        db,
+        user=user,
+        tariff=tariff,
+        subscription=legacy_subscription,
+    )
+
+
 async def test_purchase_value_error_maps_to_400(monkeypatch, user):
     """Отказ сервиса (триал/чужой тариф/disabled) -> 400 с текстом причины."""
     _configure_gate(monkeypatch, enabled=True)

--- a/tests/handlers/test_legacy_tariff_device_migration.py
+++ b/tests/handlers/test_legacy_tariff_device_migration.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from app.config import settings
-from app.database.crud.subscription import resolve_tariff_purchase_device_limit
+from app.database.crud.subscription import apply_recurrent_tariff_charge, resolve_tariff_purchase_device_limit
 from app.database.models import (
     PromoGroup,
     Subscription,
@@ -51,6 +51,36 @@ def test_real_tariff_switch_still_resets_devices_to_new_base(monkeypatch) -> Non
     another_tariff_subscription = SimpleNamespace(tariff_id=6, device_limit=3)
 
     assert resolve_tariff_purchase_device_limit(another_tariff_subscription, tariff) == 1
+
+
+async def test_recurrent_charge_converts_legacy_subscription_with_preserved_devices(monkeypatch) -> None:
+    from app.database.crud import subscription as subscription_crud
+
+    legacy_subscription = SimpleNamespace(
+        tariff_id=None,
+        device_limit=3,
+        connected_squads=['legacy-squad'],
+    )
+    tariff = SimpleNamespace(
+        id=7,
+        device_limit=1,
+        max_device_limit=5,
+        traffic_limit_gb=100,
+        allowed_squads=['tariff-squad'],
+    )
+    extend = AsyncMock(return_value=legacy_subscription)
+    monkeypatch.setattr(subscription_crud, 'extend_subscription', extend)
+
+    result = await apply_recurrent_tariff_charge(AsyncMock(), legacy_subscription, tariff, 30)
+
+    assert result is legacy_subscription
+    assert extend.await_args.kwargs == {
+        'tariff_id': 7,
+        'traffic_limit_gb': 100,
+        'device_limit': 3,
+        'connected_squads': ['tariff-squad'],
+        'commit': False,
+    }
 
 
 async def test_legacy_preview_prices_and_saves_preserved_devices(monkeypatch) -> None:

--- a/tests/handlers/test_legacy_tariff_device_migration.py
+++ b/tests/handlers/test_legacy_tariff_device_migration.py
@@ -1,0 +1,121 @@
+"""Regression tests for preserving devices on classic -> tariff migration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.config import settings
+from app.database.crud.subscription import resolve_tariff_purchase_device_limit
+from app.database.models import (
+    PromoGroup,
+    Subscription,
+    SubscriptionStatus,
+    Tariff,
+    User,
+    UserStatus,
+    tariff_promo_groups,
+)
+from tests.fixtures.sqlite_memory import memory_session
+
+
+TABLES = (
+    User.__table__,
+    Subscription.__table__,
+    Tariff.__table__,
+    PromoGroup.__table__,
+    tariff_promo_groups,
+)
+
+
+def test_legacy_device_limit_is_preserved_within_tariff_maximum(monkeypatch) -> None:
+    monkeypatch.setattr(settings, 'MAX_DEVICES_LIMIT', 10)
+    tariff = SimpleNamespace(id=7, device_limit=1, max_device_limit=5)
+    legacy_subscription = SimpleNamespace(tariff_id=None, device_limit=3)
+
+    assert resolve_tariff_purchase_device_limit(legacy_subscription, tariff) == 3
+
+
+def test_legacy_device_limit_is_capped_by_tariff_maximum(monkeypatch) -> None:
+    monkeypatch.setattr(settings, 'MAX_DEVICES_LIMIT', 10)
+    tariff = SimpleNamespace(id=7, device_limit=1, max_device_limit=2)
+    legacy_subscription = SimpleNamespace(tariff_id=None, device_limit=3)
+
+    assert resolve_tariff_purchase_device_limit(legacy_subscription, tariff) == 2
+
+
+def test_real_tariff_switch_still_resets_devices_to_new_base(monkeypatch) -> None:
+    monkeypatch.setattr(settings, 'MAX_DEVICES_LIMIT', 10)
+    tariff = SimpleNamespace(id=7, device_limit=1, max_device_limit=5)
+    another_tariff_subscription = SimpleNamespace(tariff_id=6, device_limit=3)
+
+    assert resolve_tariff_purchase_device_limit(another_tariff_subscription, tariff) == 1
+
+
+async def test_legacy_preview_prices_and_saves_preserved_devices(monkeypatch) -> None:
+    from app.handlers.subscription import tariff_purchase as handler
+
+    async with memory_session(monkeypatch, TABLES) as db:
+        monkeypatch.setattr(settings, 'MULTI_TARIFF_ENABLED', False)
+        monkeypatch.setattr(settings, 'SALES_MODE', 'tariffs')
+        monkeypatch.setattr(settings, 'MAX_DEVICES_LIMIT', 10)
+        monkeypatch.setattr(settings, 'PRICE_PER_DEVICE', 5000)
+
+        user = User(
+            telegram_id=501,
+            username='legacy501',
+            first_name='Legacy',
+            status=UserStatus.ACTIVE.value,
+            language='ru',
+            balance_kopeks=10000,
+        )
+        db.add(user)
+        await db.commit()
+
+        tariff = Tariff(
+            name='Новый тариф',
+            is_active=True,
+            device_limit=1,
+            max_device_limit=5,
+            traffic_limit_gb=100,
+            period_prices={'30': 10000},
+        )
+        db.add(tariff)
+        await db.commit()
+
+        now = datetime.now(UTC)
+        db.add(
+            Subscription(
+                user_id=user.id,
+                tariff_id=None,
+                status=SubscriptionStatus.ACTIVE.value,
+                is_trial=False,
+                start_date=now - timedelta(days=20),
+                end_date=now + timedelta(days=10),
+                device_limit=3,
+                remnawave_short_id='legacy-devices',
+            )
+        )
+        await db.commit()
+
+        save_cart = AsyncMock()
+        monkeypatch.setattr(handler.user_cart_service, 'save_user_cart', save_cart)
+
+        callback = SimpleNamespace(
+            data=f'tariff_period:{tariff.id}:30',
+            message=SimpleNamespace(edit_text=AsyncMock()),
+            answer=AsyncMock(),
+        )
+        state = MagicMock()
+        state.update_data = AsyncMock()
+
+        await handler.select_tariff_period.__wrapped__(callback, user, db, state)
+
+        rendered = callback.message.edit_text.await_args.args[0]
+        assert 'Недостаточно средств' in rendered
+        assert '200' in rendered  # 100 ₽ tariff + 2 × 50 ₽ extra devices
+
+        saved_cart = save_cart.await_args.args[1]
+        assert saved_cart['device_limit'] == 3
+        assert saved_cart['total_price'] == 20000


### PR DESCRIPTION
## Что исправлено

Исправлен переход пользователей со старых classic-подписок на новую тарифную систему.

Ранее у classic-подписки поле `tariff_id` оставалось пустым. Из-за этого первая покупка тарифа воспринималась как обычная смена тарифного плана, и лимит устройств сбрасывался до базового значения выбранного тарифа.

Например, если у пользователя была classic-подписка с одним базовым и двумя ранее докупленными устройствами, после перехода на тариф он мог получить только базовое количество устройств нового тарифа. Дополнительные устройства не попадали в предварительный расчёт стоимости и не переносились в итоговую подписку.

## Новое поведение

При первой покупке тарифа пользователем с classic-подпиской:

- определяется существующая legacy-подписка с `tariff_id = NULL`;
- сохраняется её текущий `device_limit`, включая ранее докупленные устройства;
- итоговый лимит не может быть ниже базового лимита нового тарифа;
- лимит ограничивается `max_device_limit` выбранного тарифа;
- если у тарифа отсутствует индивидуальное ограничение, используется глобальный `MAX_DEVICES_LIMIT`;
- дополнительные устройства включаются в расчёт полной стоимости;
- рассчитанный лимит записывается в подписку;
- итоговые параметры синхронизируются с Remnawave.

Например, если classic-подписка имела лимит три устройства, а новый тариф включает одно устройство, первая покупка тарифа будет рассчитана как:

- базовая стоимость тарифа;
- стоимость двух дополнительных устройств;
- применимые скидки и промокоды.

После оплаты пользователь получит выбранный тариф с лимитом три устройства.

Если базовый лимит нового тарифа больше старого лимита пользователя, будет применён базовый лимит нового тарифа.

## Какие сценарии покрыты

Единая логика переноса устройств применяется для:

- обычной покупки тарифа через Telegram-бота;
- покупки тарифа через кабинет;
- тарифа с фиксированным периодом;
- тарифа с произвольным количеством дней;
- посуточного тарифа;
- покупки с баланса;
- покупки после пополнения баланса;
- автоматической покупки из сохранённой корзины;
- возврата пользователя к сохранённой корзине;
- покупки через СБП/Platega;
- покупки через Lava;
- обычного и мультитарифного режима.

Все стандартные платёжные провайдеры продолжают работать через существующую общую схему:

1. Бот сохраняет выбранный тариф и его параметры в корзине.
2. Платёжный провайдер пополняет баланс пользователя.
3. После успешного webhook запускается общая автопокупка.
4. Автопокупка повторно рассчитывает стоимость с сохранённым количеством устройств.
5. Выбранный тариф применяется к существующей classic-подписке.

Поэтому отдельная реализация миграции для каждого платёжного провайдера не требуется.

## Обычная смена тарифов

Поведение существующих тарифных подписок не изменено.

- При продлении того же тарифа докупленные устройства сохраняются.
- При переходе с classic-подписки на первый тариф устройства переносятся.
- При обычной смене одного тарифного плана на другой лимит устройств, как и раньше, сбрасывается до базового значения нового тарифа.

Таким образом, перенос применяется только к legacy-миграции и не изменяет правила обычного переключения тарифов.

## Сохранённая корзина и автопокупка

В сохранённую корзину теперь записывается перенесённый лимит устройств.

Это обеспечивает одинаковый результат на всех этапах:

- в предварительном расчёте;
- на экране подтверждения;
- после возврата с пополнения баланса;
- при автоматической покупке;
- при фактическом списании;
- после применения параметров к подписке в Remnawave.

Автопокупка повторно рассчитывает стоимость на backend и не доверяет только сохранённой клиентской сумме. Это исключает расхождение между показанной ценой, списанной суммой и фактическим количеством устройств.

## СБП/Platega и Lava

Эндпоинты рекуррентной покупки через Platega и Lava теперь принимают `subscription_id`.

Backend:

- проверяет принадлежность подписки пользователю;
- использует именно выбранную classic-подписку;
- не создаёт параллельную подписку;
- разрешает переход с `tariff_id = NULL`;
- после подтверждённого платежа назначает выбранный тариф;
- переносит устройства, трафик и список серверов;
- сохраняет изменения атомарно.

Для Lava стоимость первой покупки рассчитывается по выбранному тарифу с учётом перенесённых дополнительных устройств, а не по старой classic-конфигурации.

Защита от недосписания сохранена: стоимость продукта Lava должна соответствовать полной сумме тарифа с дополнительными устройствами. Это ограничение относится только к рекуррентным продуктам Lava и не затрагивает обычное пополнение баланса через Lava.

## Расчёт стоимости посуточных тарифов

Ответ `purchase-options` для посуточных тарифов теперь содержит полную стоимость одного списания с учётом:

- дополнительных устройств;
- тарифной стоимости устройства;
- глобального `PRICE_PER_DEVICE`, если у тарифа не задана отдельная цена;
- скидок;
- пользовательской промоскидки.

Это позволяет кабинету показывать ту же сумму, которая будет фактически списана backend.

## Совместимость

Изменений структуры базы данных нет.

Новые Alembic-миграции не требуются.

Существующие данные пользователей изменяются только в момент подтверждённой покупки нового тарифа. Classic-подписка преобразуется в тарифную в рамках обычной транзакции покупки.

Обычные пополнения баланса, существующие тарифные подписки и стандартные продления продолжают работать без изменений.

## Проверки

Добавлены регрессионные тесты для следующих случаев:

- перенос лимита устройств из classic-подписки;
- использование базового лимита нового тарифа;
- ограничение максимальным количеством устройств тарифа;
- использование глобального ограничения устройств;
- сохранение прежнего поведения при обычной смене тарифов;
- включение дополнительных устройств в полную стоимость;
- сохранение лимита в корзине;
- автоматическая покупка после пополнения;
- передача `subscription_id` в рекуррентные методы;
- проверка принадлежности подписки;
- конвертация существующей classic-подписки;
- обработка callback Platega и Lava;
- идемпотентность повторных callback;
- расчёт стоимости посуточного тарифа.

Пройдены 108 связанных backend-тестов. Проверки Ruff и форматирования проходят успешно.