### PR TITLE
feat(email): отписка от маркетинговых писем (one-click, RFC 8058)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,17 @@ SMTP_USE_TLS=true
 # Для портов 25/587 оставить false.
 SMTP_USE_SSL=false
 
+# Отписка от маркетинговых писем (winback, промопредложения, email-рассылки).
+# Gmail/Yahoo для массовых отправителей требуют one-click unsubscribe (RFC 8058);
+# без него люди жмут «Спам», и репутация домена падает. Транзакционных писем
+# (код входа, чек, окончание подписки) отписка не касается.
+EMAIL_UNSUBSCRIBE_ENABLED=true
+# Публичный URL эндпоинта отписки. Пусто → CABINET_URL + /api/cabinet/public/unsubscribe.
+# Указывать явно, если API кабинета проксируется не через /api.
+# EMAIL_UNSUBSCRIBE_BASE_URL=https://cab.example.com/api/cabinet/public/unsubscribe
+# Необязательный mailto-вариант в заголовке List-Unsubscribe.
+# EMAIL_UNSUBSCRIBE_MAILTO=unsubscribe@example.com
+
 # Уведомления администраторов
 ADMIN_NOTIFICATIONS_ENABLED=true
 # Rich-вид сообщений админ-чата (Bot API 10.1): заголовки, таблицы,

--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -72,6 +72,7 @@ from .ticket_notifications import (
     router as ticket_notifications_router,
 )
 from .tickets import router as tickets_router
+from .unsubscribe import router as unsubscribe_router
 from .websocket import router as websocket_router
 from .wheel import router as wheel_router
 from .withdrawal import router as withdrawal_router
@@ -84,6 +85,8 @@ router = APIRouter(prefix='/cabinet', tags=['Cabinet'], redirect_slashes=False)
 # Final path becomes `/cabinet/public/site-verification`. Has its own
 # `/public` prefix so it's clearly separated from authenticated routes.
 router.include_router(site_verification_router)
+# Отписка от рассылок — тоже без авторизации: по ссылке ходят почтовые клиенты.
+router.include_router(unsubscribe_router)
 
 # Include all sub-routers
 router.include_router(auth_router)

--- a/app/cabinet/routes/admin_broadcasts.py
+++ b/app/cabinet/routes/admin_broadcasts.py
@@ -673,6 +673,7 @@ async def create_combined_broadcast(
             email_subject=request.email_subject.strip(),
             email_html_content=request.email_html_content.strip(),
             initiator_name=admin_name,
+            category=request.category,
         )
 
         await email_broadcast_service.start_broadcast(broadcast.id, email_config)

--- a/app/cabinet/routes/admin_promo_offers.py
+++ b/app/cabinet/routes/admin_promo_offers.py
@@ -36,6 +36,7 @@ from app.database.models import (
 from app.handlers.admin.messages import get_custom_users, get_target_users, get_target_users_count
 from app.services.broadcast_service import BroadcastConfig, broadcast_service
 from app.utils.miniapp_buttons import build_miniapp_or_callback_button
+from app.utils.notification_prefs import is_promo_offers_enabled
 
 from ..dependencies import get_cabinet_db, require_permission
 
@@ -551,7 +552,7 @@ def _build_default_promo_message(
 
 
 async def _send_promo_email_notifications(
-    targets: list[tuple[str, str, str]],
+    targets: list[tuple[str, str, str, int]],
     *,
     message_text: str | None,
     discount_percent: int,
@@ -561,7 +562,7 @@ async def _send_promo_email_notifications(
     """Send promo offer notifications to email-only users.
 
     Args:
-        targets: list of (email, language, username). Скалярные значения (не
+        targets: list of (email, language, username, user_id). Скалярные значения (не
             ORM) — как и Telegram-фан-аут, может бежать detached после
             закрытия сессии запроса.
 
@@ -576,13 +577,14 @@ async def _send_promo_email_notifications(
     # SMTP медленнее и капризнее Telegram — небольшой параллелизм
     semaphore = asyncio.Semaphore(4)
 
-    async def send_single(email: str, language: str, username: str) -> bool:
+    async def send_single(email: str, language: str, username: str, user_id: int) -> bool:
         async with semaphore:
             try:
                 return await send_promo_offer_email(
                     email=email,
                     language=language,
                     username=username,
+                    user_id=user_id,
                     message_text=message_text,
                     valid_hours=valid_hours,
                     discount_percent=discount_percent,
@@ -682,9 +684,14 @@ async def broadcast_offer(
     # на подтверждённую почту тот же текст (скалярные поля — фан-аут может
     # бежать detached после закрытия сессии запроса).
     email_targets = [
-        (recipient.email, recipient.language or 'ru', recipient.first_name or recipient.username or '')
+        (recipient.email, recipient.language or 'ru', recipient.first_name or recipient.username or '', recipient.id)
         for recipient, _offer in offers_to_notify
-        if not recipient.telegram_id and recipient.email and recipient.email_verified
+        # Отписавшихся от промо пропускаем: тумблер кабинета обязан работать и
+        # для почты, иначе отписка ничего не меняет и превращается в жалобу.
+        if not recipient.telegram_id
+        and recipient.email
+        and recipient.email_verified
+        and is_promo_offers_enabled(recipient)
     ]
 
     # Send Telegram/email notifications if requested

--- a/app/cabinet/routes/unsubscribe.py
+++ b/app/cabinet/routes/unsubscribe.py
@@ -1,0 +1,93 @@
+"""Публичный эндпоинт отписки от маркетинговых писем.
+
+Намеренно БЕЗ авторизации: по ссылке из письма ходят и почтовые клиенты
+(Gmail дёргает POST сам, по RFC 8058), и пользователи, которые давно вышли из
+кабинета. Требовать вход — значит гарантированно получить жалобу «Спам»
+вместо отписки.
+
+``GET`` отписывает сразу и показывает страницу-подтверждение: почтовые клиенты
+всё равно открывают ссылку в браузере, а лишний экран «нажмите, чтобы
+подтвердить» роняет конверсию отписки и провоцирует жалобу. ``POST`` — тот же
+эффект для one-click.
+"""
+
+from __future__ import annotations
+
+import html
+
+from fastapi import APIRouter, Depends, Response
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cabinet.dependencies import get_cabinet_db
+from app.cabinet.services.email_unsubscribe import apply_unsubscribe
+from app.config import settings
+
+
+router = APIRouter(prefix='/public', tags=['Cabinet:Public'])
+
+
+def _page(title: str, message: str, *, ok: bool) -> HTMLResponse:
+    """Самодостаточная страница: письма читают где угодно, внешние ресурсы не тянем."""
+    service_name = html.escape(settings.SMTP_FROM_NAME or 'VPN')
+    cabinet_url = (getattr(settings, 'CABINET_URL', '') or '').strip()
+    accent = '#16a34a' if ok else '#dc2626'
+    link = (
+        f'<p style="margin:22px 0 0"><a href="{html.escape(cabinet_url, quote=True)}" '
+        f'style="color:{accent}">Настройки уведомлений в личном кабинете</a></p>'
+        if cabinet_url
+        else ''
+    )
+    body = f"""<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{html.escape(title)}</title>
+</head>
+<body style="margin:0;background:#eef0f3;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f2933">
+  <div style="max-width:520px;margin:12vh auto;padding:34px 30px;background:#fff;border:1px solid #e6e8ec;border-top:3px solid {accent};border-radius:16px">
+    <h1 style="margin:0 0 12px;font-size:21px;color:#0a0f1a">{html.escape(title)}</h1>
+    <p style="margin:0;font-size:15px;line-height:1.6">{html.escape(message)}</p>
+    {link}
+    <p style="margin:26px 0 0;font-size:12px;color:#98a2b3">&copy; {service_name}</p>
+  </div>
+</body>
+</html>"""
+    return HTMLResponse(body, status_code=200 if ok else 400)
+
+
+async def _unsubscribe(token: str, db: AsyncSession) -> bool:
+    if not getattr(settings, 'EMAIL_UNSUBSCRIBE_ENABLED', True):
+        return False
+    return await apply_unsubscribe(db, token)
+
+
+@router.get('/unsubscribe', summary='Отписка от маркетинговых писем (ссылка из письма)')
+async def unsubscribe_page(token: str = '', db: AsyncSession = Depends(get_cabinet_db)) -> HTMLResponse:
+    """Отписывает по токену и показывает результат человеку."""
+    if await _unsubscribe(token, db):
+        return _page(
+            'Вы отписались',
+            'Больше не будем присылать новости и промо-предложения на этот адрес. '
+            'Письма по вашей подписке — оплата, продление, доступ — продолжат приходить.',
+            ok=True,
+        )
+    return _page(
+        'Ссылка не сработала',
+        'Ссылка устарела или адрес почты изменился. Отключить рассылки можно в '
+        'настройках уведомлений личного кабинета.',
+        ok=False,
+    )
+
+
+@router.post('/unsubscribe', summary='One-click отписка (RFC 8058)')
+async def unsubscribe_one_click(token: str = '', db: AsyncSession = Depends(get_cabinet_db)) -> Response:
+    """Обработчик кнопки «Отписаться» в Gmail/Yahoo.
+
+    Тело запроса (``List-Unsubscribe=One-Click``) не читаем — токен уже в
+    query-строке. Отвечаем 200 даже на протухший токен: почтовый клиент
+    покажет пользователю ошибку, хотя делать ему с ней нечего.
+    """
+    await _unsubscribe(token, db)
+    return Response(status_code=200)

--- a/app/cabinet/services/email_service.py
+++ b/app/cabinet/services/email_service.py
@@ -111,6 +111,7 @@ class EmailService:
         body_html: str,
         body_text: str | None = None,
         attachments: list[tuple[str, bytes, str]] | None = None,
+        unsubscribe_url: str | None = None,
     ) -> bool:
         """
         Send an email.
@@ -121,6 +122,9 @@ class EmailService:
             body_html: HTML body content
             body_text: Plain text body (optional, generated from HTML if not provided)
             attachments: Optional list of (filename, content, mimetype) tuples
+            unsubscribe_url: One-click unsubscribe URL. Задаётся ТОЛЬКО для
+                маркетинговых писем — на транзакционных (код входа, чек об
+                оплате) List-Unsubscribe не ставят.
 
         Returns:
             True if email was sent successfully, False otherwise
@@ -150,6 +154,28 @@ class EmailService:
             msg['To'] = to_email
             msg['Date'] = formatdate(localtime=False)
             msg['Message-ID'] = make_msgid(domain=safe_from_email.split('@')[-1])
+
+            # RFC 8058: пара List-Unsubscribe + List-Unsubscribe-Post — это то, из
+            # чего Gmail/Yahoo рисуют свою кнопку «Отписаться» рядом с адресом
+            # отправителя. Без -Post заголовок считается «старым» и кнопку дают
+            # не всегда.
+            if unsubscribe_url:
+                safe_unsubscribe = unsubscribe_url.strip()
+                # URL приходит из настроек/БД: перенос строки в нём дописал бы
+                # произвольный заголовок в письмо, поэтому такой URL не чиним, а
+                # выбрасываем целиком вместе с заголовками.
+                if any(ch in safe_unsubscribe for ch in '\r\n<>') or not safe_unsubscribe.startswith(
+                    ('http://', 'https://')
+                ):
+                    logger.warning('Некорректный unsubscribe_url — заголовки отписки пропущены')
+                else:
+                    from .email_unsubscribe import build_unsubscribe_mailto
+
+                    targets = [f'<{safe_unsubscribe}>']
+                    if mailto := build_unsubscribe_mailto():
+                        targets.append(f'<{mailto}>')
+                    msg['List-Unsubscribe'] = ', '.join(targets)
+                    msg['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click'
 
             # Plain text version
             if body_text is None:

--- a/app/cabinet/services/email_template_overrides.py
+++ b/app/cabinet/services/email_template_overrides.py
@@ -20,7 +20,15 @@ logger = structlog.get_logger(__name__)
 # Placeholders available in EVERY template regardless of notification type.
 # Injected at the single render chokepoint (get_rendered_override), so an
 # admin can use them in any subject/body; per-type context wins on conflict.
-COMMON_CONTEXT_VARS = ['service_name', 'cabinet_url', 'support_username', 'username', 'email', 'date']
+COMMON_CONTEXT_VARS = [
+    'service_name',
+    'cabinet_url',
+    'support_username',
+    'username',
+    'email',
+    'date',
+    'unsubscribe_url',
+]
 
 
 def build_common_context() -> dict[str, Any]:
@@ -41,6 +49,10 @@ def build_common_context() -> dict[str, Any]:
         'username': '',
         'email': '',
         'date': format_email_datetime(datetime.now(UTC), fmt='%d.%m.%Y'),
+        # Пустая строка по умолчанию: у транзакционных писем отписки нет, но
+        # плейсхолдер обязан резолвиться — иначе админский шаблон с
+        # {unsubscribe_url} доставил бы его литералом.
+        'unsubscribe_url': '',
     }
 
 

--- a/app/cabinet/services/email_templates.py
+++ b/app/cabinet/services/email_templates.py
@@ -133,8 +133,20 @@ class EmailNotificationTemplates:
         # Tier 3: Simple HTML fragment — use base template for structure
         return self._get_base_template(content, language)
 
-    def _get_base_template(self, content: str, language: str = 'ru') -> str:
-        """Wrap content in base HTML template."""
+    _UNSUBSCRIBE_TEXTS = {
+        'ru': 'Отписаться от рассылок',
+        'en': 'Unsubscribe from marketing emails',
+        'zh': '退订营销邮件',
+        'ua': 'Відписатися від розсилок',
+        'fa': 'لغو اشتراک ایمیل‌های تبلیغاتی',
+    }
+
+    def _get_base_template(self, content: str, language: str = 'ru', unsubscribe_url: str = '') -> str:
+        """Wrap content in base HTML template.
+
+        ``unsubscribe_url`` непустой только у маркетинговых писем — у писем со
+        сбросом пароля или чеком отписке взяться неоткуда.
+        """
         footer_texts = {
             'ru': 'Это автоматическое сообщение. Пожалуйста, не отвечайте на это письмо.',
             'en': 'This is an automated message. Please do not reply to this email.',
@@ -143,6 +155,14 @@ class EmailNotificationTemplates:
             'fa': 'این یک پیام خودکار است. لطفاً به این ایمیل پاسخ ندهید.',
         }
         footer_text = footer_texts.get(language, footer_texts['ru'])
+
+        unsubscribe_block = ''
+        if unsubscribe_url:
+            unsubscribe_label = self._UNSUBSCRIBE_TEXTS.get(language, self._UNSUBSCRIBE_TEXTS['ru'])
+            unsubscribe_block = (
+                f'<p><a href="{html.escape(unsubscribe_url, quote=True)}" '
+                f'style="color: #666;">{unsubscribe_label}</a></p>'
+            )
 
         return f"""
 <!DOCTYPE html>
@@ -235,6 +255,7 @@ class EmailNotificationTemplates:
         <div class="footer">
             <p>&copy; {self.service_name}</p>
             <p>{footer_text}</p>
+            {unsubscribe_block}
         </div>
     </div>
 </body>
@@ -814,7 +835,9 @@ class EmailNotificationTemplates:
         }
         return {
             'subject': subjects.get(language, subjects['ru']),
-            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+            'body_html': self._get_base_template(
+                bodies.get(language, bodies['ru']), language, context.get('unsubscribe_url', '')
+            ),
         }
 
     def _winback_discount_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
@@ -835,7 +858,9 @@ class EmailNotificationTemplates:
         }
         return {
             'subject': subjects.get(language, subjects['ru']),
-            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+            'body_html': self._get_base_template(
+                bodies.get(language, bodies['ru']), language, context.get('unsubscribe_url', '')
+            ),
         }
 
     def _winback_trial_ending_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
@@ -854,7 +879,9 @@ class EmailNotificationTemplates:
         }
         return {
             'subject': subjects.get(language, subjects['ru']),
-            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+            'body_html': self._get_base_template(
+                bodies.get(language, bodies['ru']), language, context.get('unsubscribe_url', '')
+            ),
         }
 
     def _subscription_activated_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
@@ -1346,7 +1373,9 @@ class EmailNotificationTemplates:
 
         return {
             'subject': subjects.get(language, subjects['ru']),
-            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+            'body_html': self._get_base_template(
+                bodies.get(language, bodies['ru']), language, context.get('unsubscribe_url', '')
+            ),
         }
 
     def _referral_registered_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:

--- a/app/cabinet/services/email_unsubscribe.py
+++ b/app/cabinet/services/email_unsubscribe.py
@@ -1,0 +1,135 @@
+"""Отписка от маркетинговых писем (ссылка в футере + one-click по RFC 8058).
+
+Отдельной таблицы нет: отписка выставляет те же флаги ``news_enabled`` /
+``promo_offers_enabled`` в ``User.notification_settings``, которыми управляет
+кабинет — иначе у пользователя было бы два несогласованных переключателя.
+
+Токен — ``<user_id>.<category>.<hmac>``, где HMAC-SHA256 берётся от
+``user_id:category:email`` на секрете кабинета. Адрес входит в подпись, но НЕ
+в ссылку: он не утекает в логи прокси и в Referer, а смена почты автоматически
+обесценивает старые ссылки. Срока жизни у токена нет — письмо могут открыть
+через год, и отписка обязана сработать.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+
+
+logger = structlog.get_logger(__name__)
+
+# Путь публичного эндпоинта внутри API кабинета (см. app/cabinet/routes/unsubscribe.py).
+DEFAULT_UNSUBSCRIBE_PATH = '/api/cabinet/public/unsubscribe'
+
+# Категория рассылки → флаги в User.notification_settings.
+# 'all' — то, что ставится в письмах: нажавший «отписаться» ждёт тишины, а не
+# переключения одного из двух потоков.
+CATEGORY_PREF_KEYS: dict[str, tuple[str, ...]] = {
+    'news': ('news_enabled',),
+    'promo': ('promo_offers_enabled',),
+    'all': ('news_enabled', 'promo_offers_enabled'),
+}
+
+
+def _secret() -> str:
+    """Секрет для подписи. Тот же, что у сессий кабинета."""
+    return settings.get_cabinet_jwt_secret()
+
+
+def _sign(user_id: int, category: str, email: str) -> str:
+    payload = f'{user_id}:{category}:{email.strip().lower()}'.encode()
+    digest = hmac.new(_secret().encode(), payload, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip('=')
+
+
+def build_token(user_id: int, email: str, category: str = 'all') -> str:
+    """Собирает токен отписки для конкретного адреса."""
+    if category not in CATEGORY_PREF_KEYS:
+        category = 'all'
+    return f'{user_id}.{category}.{_sign(user_id, category, email)}'
+
+
+def parse_token(token: str) -> tuple[int, str] | None:
+    """Достаёт (user_id, category) БЕЗ проверки подписи.
+
+    Подпись проверить нечем, пока не известен текущий email пользователя, —
+    поэтому разбор и проверка разделены. Мусор отдаёт None, а не исключение:
+    эндпоинт публичный, туда прилетает что угодно.
+    """
+    parts = (token or '').split('.')
+    if len(parts) != 3:
+        return None
+    raw_id, category, signature = parts
+    if not raw_id.isdigit() or not signature or category not in CATEGORY_PREF_KEYS:
+        return None
+    return int(raw_id), category
+
+
+def verify_token(token: str, email: str) -> bool:
+    """Проверяет подпись токена против текущего адреса пользователя."""
+    parsed = parse_token(token)
+    if not parsed or not email:
+        return False
+    user_id, category = parsed
+    expected = _sign(user_id, category, email)
+    return hmac.compare_digest(token.split('.')[2], expected)
+
+
+def build_unsubscribe_url(user_id: int, email: str, category: str = 'all') -> str:
+    """Публичная ссылка отписки. Пустая строка = отписки в этом письме не будет."""
+    if not getattr(settings, 'EMAIL_UNSUBSCRIBE_ENABLED', True):
+        return ''
+    if not user_id or not email:
+        return ''
+
+    base = (getattr(settings, 'EMAIL_UNSUBSCRIBE_BASE_URL', '') or '').strip()
+    if not base:
+        cabinet_url = (getattr(settings, 'CABINET_URL', '') or '').strip()
+        if not cabinet_url:
+            return ''
+        base = f'{cabinet_url.rstrip("/")}{DEFAULT_UNSUBSCRIBE_PATH}'
+
+    return f'{base.rstrip("/")}?token={build_token(user_id, email, category)}'
+
+
+def build_unsubscribe_mailto() -> str:
+    """mailto-вариант для клиентов без HTTP one-click. Пусто, если не настроен."""
+    address = (getattr(settings, 'EMAIL_UNSUBSCRIBE_MAILTO', '') or '').strip()
+    return f'mailto:{address}?subject=unsubscribe' if address else ''
+
+
+async def apply_unsubscribe(db: AsyncSession, token: str) -> bool:
+    """Выключает маркетинговые рассылки по токену.
+
+    Идемпотентна: повторный запрос по той же ссылке — снова True. Так и должно
+    быть, иначе антивирус-прескан почты, дёрнувший ссылку до пользователя,
+    показал бы ему ошибку.
+    """
+    from app.database.models import User
+
+    parsed = parse_token(token)
+    if not parsed:
+        return False
+    user_id, category = parsed
+
+    user = await db.get(User, user_id)
+    if not user or not user.email or not verify_token(token, user.email):
+        logger.warning('Отписка: токен не прошёл проверку', user_id=user_id)
+        return False
+
+    current = dict(getattr(user, 'notification_settings', None) or {})
+    for key in CATEGORY_PREF_KEYS[category]:
+        current[key] = False
+    # Присваиваем новый dict целиком: мутация на месте не помечает JSONB грязным.
+    user.notification_settings = current
+    await db.commit()
+
+    logger.info('Пользователь отписался от рассылок', user_id=user_id, category=category)
+    return True

--- a/app/config.py
+++ b/app/config.py
@@ -1331,6 +1331,16 @@ class Settings(BaseSettings):
     # Implicit TLS (SMTPS) — required for port 465. Auto-enabled when SMTP_PORT == 465.
     SMTP_USE_SSL: bool = False
 
+    # Отписка от маркетинговых писем (winback, промопредложения, email-рассылки).
+    # Gmail/Yahoo для bulk-отправителей требуют one-click unsubscribe (RFC 8058),
+    # а жалобы «Спам» вместо отписки бьют по репутации домена.
+    EMAIL_UNSUBSCRIBE_ENABLED: bool = True
+    # Публичный URL эндпоинта отписки. Пусто → CABINET_URL + /api/cabinet/public/unsubscribe.
+    # Задавать явно, если API кабинета проксируется не через /api.
+    EMAIL_UNSUBSCRIBE_BASE_URL: str = ''
+    # Необязательный mailto-вариант в List-Unsubscribe для клиентов без HTTP one-click.
+    EMAIL_UNSUBSCRIBE_MAILTO: str = ''
+
     # Ban System Integration (BedolagaBan monitoring)
     BAN_SYSTEM_ENABLED: bool = False
     BAN_SYSTEM_API_URL: str | None = None  # e.g., http://ban-server:8000

--- a/app/handlers/admin/promo_offers.py
+++ b/app/handlers/admin/promo_offers.py
@@ -2038,6 +2038,7 @@ async def _send_offer_to_users(
                             email=user.email,
                             language=user.language or db_user.language,
                             username=user.first_name or user.username or '',
+                            user_id=user.id,
                             message_text=message_text,
                             valid_hours=template.valid_hours,
                             discount_percent=template.discount_percent or 0,

--- a/app/services/broadcast_service.py
+++ b/app/services/broadcast_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -86,6 +87,7 @@ class EmailBroadcastConfig:
     email_subject: str
     email_html_content: str
     initiator_name: str | None = None
+    category: str = 'system'  # system|news|promo — как у Telegram-рассылки
 
 
 @dataclass(slots=True)
@@ -94,6 +96,7 @@ class _EmailRecipient:
 
     email: str
     user_name: str
+    user_id: int = 0
 
 
 @dataclass(slots=True)
@@ -262,15 +265,10 @@ class BroadcastService:
                 users_orm = await get_target_users(session, target)
 
             # Filter by user notification preferences based on broadcast category
-            if category == 'news':
-                from app.utils.notification_prefs import is_news_enabled
+            from app.utils.notification_prefs import filter_users_by_broadcast_category
 
-                users_orm = [u for u in users_orm if is_news_enabled(u)]
-            elif category == 'promo':
-                from app.utils.notification_prefs import is_promo_offers_enabled
-
-                users_orm = [u for u in users_orm if is_promo_offers_enabled(u)]
             # category == 'system' → no filtering, sent to everyone
+            users_orm = filter_users_by_broadcast_category(users_orm, category)
 
             # Извлекаем telegram_id сразу, пока сессия жива.
             # После выхода из блока ORM-объекты станут detached.
@@ -739,7 +737,7 @@ class EmailBroadcastService:
                 await session.commit()
 
             # Fetch email recipients
-            recipients = await self._fetch_email_recipients(config.target)
+            recipients = await self._fetch_email_recipients(config.target, config.category)
 
             # Update total count
             async with AsyncSessionLocal() as session:
@@ -781,16 +779,21 @@ class EmailBroadcastService:
             logger.exception('Critical error in email broadcast', broadcast_id=broadcast_id, exc=exc)
             await self._mark_failed(broadcast_id, sent_count, failed_count)
 
-    async def _fetch_email_recipients(self, target: str) -> list[_EmailRecipient]:
+    async def _fetch_email_recipients(self, target: str, category: str = 'system') -> list[_EmailRecipient]:
         """
         Загружает получателей email-рассылки.
 
         Возвращает список _EmailRecipient (скалярные данные), а не ORM-объектов,
         чтобы избежать detached state при долгих рассылках.
+
+        Фильтрует по тем же тумблерам кабинета, что и Telegram-путь: до этого
+        выключенные новости резали только Telegram, а на почту всё равно
+        приходили.
         """
         from sqlalchemy import select
 
         from app.database.models import Subscription, SubscriptionStatus, User
+        from app.utils.notification_prefs import filter_users_by_broadcast_category
 
         async with AsyncSessionLocal() as session:
             # Base query: verified email users with active status
@@ -857,7 +860,7 @@ class EmailBroadcastService:
                 if not batch:
                     break
 
-                for user in batch:
+                for user in filter_users_by_broadcast_category(list(batch), category):
                     email = user.email
                     if not email:
                         continue
@@ -871,7 +874,7 @@ class EmailBroadcastService:
                     if not user_name:
                         user_name = email.split('@')[0]
 
-                    recipients.append(_EmailRecipient(email=email, user_name=user_name))
+                    recipients.append(_EmailRecipient(email=email, user_name=user_name, user_id=user.id))
 
                 offset += batch_size
 
@@ -895,6 +898,8 @@ class EmailBroadcastService:
         last_progress_count = 0
         last_progress_time: float = 0.0
 
+        from app.cabinet.services.email_unsubscribe import build_unsubscribe_url
+
         semaphore = asyncio.Semaphore(EMAIL_RATE_LIMIT)
 
         async def send_single_email(recipient: _EmailRecipient) -> bool | None:
@@ -906,14 +911,24 @@ class EmailBroadcastService:
                 html_content = self._render_template(config.email_html_content, recipient)
                 subject = self._render_template(config.email_subject, recipient)
 
+                # Системные рассылки отписке не подлежат — заголовок им не ставим.
+                unsubscribe_url = (
+                    build_unsubscribe_url(recipient.user_id, recipient.email)
+                    if config.category in ('news', 'promo')
+                    else ''
+                )
+
                 try:
                     loop = asyncio.get_event_loop()
                     success = await loop.run_in_executor(
                         None,
-                        self._email_service.send_email,
-                        recipient.email,
-                        subject,
-                        html_content,
+                        functools.partial(
+                            self._email_service.send_email,
+                            to_email=recipient.email,
+                            subject=subject,
+                            body_html=html_content,
+                            unsubscribe_url=unsubscribe_url or None,
+                        ),
                     )
                     return success
                 except Exception as exc:

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -98,6 +98,20 @@ class NotificationType(Enum):
     GUEST_CABINET_CREDENTIALS = 'guest_cabinet_credentials'
 
 
+# Письма, которые почтовые провайдеры считают массовой рассылкой: только они
+# получают List-Unsubscribe и уважают отписку. Уведомления по действующей
+# подписке (оплата, истечение, блокировка) сюда не входят — это транзакционная
+# переписка, отписывать от неё нельзя.
+MARKETING_NOTIFICATION_TYPES = frozenset(
+    {
+        NotificationType.PROMO_OFFER,
+        NotificationType.WINBACK_EXPIRED_1D,
+        NotificationType.WINBACK_DISCOUNT,
+        NotificationType.WINBACK_TRIAL_ENDING,
+    }
+)
+
+
 class NotificationDeliveryService:
     """
     Service for delivering notifications to users through appropriate channels.
@@ -343,6 +357,20 @@ class NotificationDeliveryService:
             logger.debug('У пользователя нет подтверждённого email', user_id=user.id)
             return False
 
+        # Маркетинг уважает отписку; транзакционные письма — нет (иначе человек
+        # перестал бы узнавать об оплате и окончании собственной подписки).
+        unsubscribe_url = ''
+        if notification_type in MARKETING_NOTIFICATION_TYPES:
+            from app.utils.notification_prefs import is_promo_offers_enabled
+
+            if not is_promo_offers_enabled(user):
+                logger.debug('Пользователь отписан от промо-писем', user_id=user.id)
+                return False
+
+            from app.cabinet.services.email_unsubscribe import build_unsubscribe_url
+
+            unsubscribe_url = build_unsubscribe_url(user.id, user.email)
+
         try:
             # Get email template (check DB override first, then fall back to hardcoded)
             language = user.language or 'ru'
@@ -352,6 +380,7 @@ class NotificationDeliveryService:
                 'cabinet_url': getattr(settings, 'CABINET_URL', '') or '',
                 'username': user.first_name or user.username or '',
                 'email': user.email or '',
+                'unsubscribe_url': unsubscribe_url,
                 **context,
             }
 
@@ -404,6 +433,7 @@ class NotificationDeliveryService:
                 subject=template['subject'],
                 body_html=template['body_html'],
                 body_text=template.get('body_text'),
+                unsubscribe_url=unsubscribe_url or None,
             )
 
             if success:

--- a/app/services/promo_offer_email.py
+++ b/app/services/promo_offer_email.py
@@ -29,6 +29,7 @@ async def send_promo_offer_email(
     email: str,
     language: str | None,
     username: str = '',
+    user_id: int | None = None,
     message_text: str | None,
     valid_hours: int,
     discount_percent: int = 0,
@@ -41,6 +42,7 @@ async def send_promo_offer_email(
     """
     from app.cabinet.services.email_service import email_service
     from app.cabinet.services.email_templates import EmailNotificationTemplates
+    from app.cabinet.services.email_unsubscribe import build_unsubscribe_url
     from app.config import settings
     from app.services.notification_delivery_service import NotificationType
 
@@ -59,6 +61,9 @@ async def send_promo_offer_email(
         'valid_hours': valid_hours,
         'discount_percent': discount_percent,
         'bonus_amount_kopeks': bonus_amount_kopeks,
+        # Промо — массовая рассылка: без ссылки отписки жалобы «Спам» идут в
+        # репутацию домена. user_id обязателен, токен подписывается по нему.
+        'unsubscribe_url': build_unsubscribe_url(user_id, email) if user_id else '',
     }
     if bonus_amount_kopeks:
         context['amount'] = settings.format_price(bonus_amount_kopeks)
@@ -88,6 +93,7 @@ async def send_promo_offer_email(
             subject=template['subject'],
             body_html=template['body_html'],
             body_text=template.get('body_text'),
+            unsubscribe_url=context['unsubscribe_url'] or None,
         )
     except Exception as e:
         logger.error('Ошибка отправки промо-письма', email=email, e=e)

--- a/app/utils/notification_prefs.py
+++ b/app/utils/notification_prefs.py
@@ -83,3 +83,18 @@ def is_news_enabled(user: User) -> bool:
 def is_promo_offers_enabled(user: User) -> bool:
     """Check if promo offer notifications are enabled for user."""
     return bool(get_user_notification_pref(user, 'promo_offers_enabled'))
+
+
+def filter_users_by_broadcast_category(users: list[User], category: str) -> list[User]:
+    """Отсеивает отписавшихся от рассылки этой категории.
+
+    Общая точка для Telegram- и email-путей рассылки: раньше фильтр жил только
+    в Telegram-ветке, и выключенные в кабинете новости всё равно приходили на
+    почту. Категория ``system`` не фильтруется никогда — иначе отписка от
+    новостей отключила бы письмо об истечении подписки.
+    """
+    if category == 'news':
+        return [u for u in users if is_news_enabled(u)]
+    if category == 'promo':
+        return [u for u in users if is_promo_offers_enabled(u)]
+    return list(users)

--- a/tests/cabinet/test_email_template_editor.py
+++ b/tests/cabinet/test_email_template_editor.py
@@ -240,7 +240,15 @@ async def test_override_render_injects_common_vars(monkeypatch):
 
 def test_common_vars_exposed_to_editor():
     """Редактор получает список общих переменных для всех типов."""
-    assert COMMON_CONTEXT_VARS == ['service_name', 'cabinet_url', 'support_username', 'username', 'email', 'date']
+    assert COMMON_CONTEXT_VARS == [
+        'service_name',
+        'cabinet_url',
+        'support_username',
+        'username',
+        'email',
+        'date',
+        'unsubscribe_url',
+    ]
     common = build_common_context()
     assert set(common) == set(COMMON_CONTEXT_VARS)
     # Инстанс-уровень заполнен сразу; получательские — пустые дефолты,
@@ -249,6 +257,8 @@ def test_common_vars_exposed_to_editor():
     assert common['date']
     assert common['username'] == ''
     assert common['email'] == ''
+    # Ссылку отписки подставляет отправляющий код и только маркетинговым письмам.
+    assert common['unsubscribe_url'] == ''
 
 
 @pytest.mark.asyncio

--- a/tests/cabinet/test_email_unsubscribe.py
+++ b/tests/cabinet/test_email_unsubscribe.py
@@ -1,0 +1,211 @@
+"""Отписка от маркетинговых писем: подпись токена, заголовки RFC 8058,
+ссылка в футере и фильтрация получателей email-рассылки по настройкам.
+
+Без отписки Gmail/Yahoo штрафуют отправителя за жалобы «Спам» вместо клика по
+ссылке, а bulk-политики этих провайдеров прямо требуют one-click unsubscribe.
+До этих тестов email-путь рассылки ещё и игнорировал тумблеры
+``news_enabled`` / ``promo_offers_enabled``, которые Telegram-путь уважает:
+пользователь выключал новости в кабинете и всё равно получал их на почту.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+import pytest
+
+from app.cabinet.services import email_unsubscribe as unsub
+from app.cabinet.services.email_service import email_service
+from app.cabinet.services.email_templates import EmailNotificationTemplates
+
+
+class _FakeSMTP:
+    """Ловит сырое письмо, отданное в ``sendmail``, и работает как CM."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+    def sendmail(self, _from_addr: str, _to_addr: str, msg: str) -> None:
+        self.messages.append(msg)
+
+
+@pytest.fixture
+def smtp_ready(monkeypatch):
+    """Делает email_service «настроенным» и подменяет SMTP-соединение."""
+    from app.config import settings
+
+    fake = _FakeSMTP()
+    monkeypatch.setattr(type(settings), 'is_smtp_configured', lambda self: True)
+    monkeypatch.setattr(settings, 'SMTP_FROM_EMAIL', 'noreply@example.com')
+    monkeypatch.setattr(settings, 'SMTP_FROM_NAME', 'Example VPN')
+    monkeypatch.setattr(email_service, '_get_smtp_connection', lambda: fake)
+    return fake
+
+
+# --------------------------------------------------------------------------
+# Токен
+# --------------------------------------------------------------------------
+
+
+def test_token_roundtrip(monkeypatch):
+    """Свежий токен опознаётся: отдаёт user_id и категорию."""
+    monkeypatch.setattr(unsub, '_secret', lambda: 'unit-test-secret')
+
+    token = unsub.build_token(42, 'User@Example.com', 'all')
+    assert unsub.parse_token(token) == (42, 'all')
+    assert unsub.verify_token(token, 'user@example.com') is True
+
+
+def test_token_email_is_case_insensitive(monkeypatch):
+    """Регистр адреса не должен ломать ссылку из письма."""
+    monkeypatch.setattr(unsub, '_secret', lambda: 'unit-test-secret')
+
+    token = unsub.build_token(42, 'user@example.com', 'all')
+    assert unsub.verify_token(token, 'USER@EXAMPLE.COM') is True
+
+
+def test_token_rejects_tampering(monkeypatch):
+    """Подменённый user_id не проходит проверку подписи."""
+    monkeypatch.setattr(unsub, '_secret', lambda: 'unit-test-secret')
+
+    token = unsub.build_token(42, 'user@example.com', 'all')
+    forged = token.replace('42.', '43.', 1)
+
+    assert unsub.parse_token(forged) == (43, 'all')
+    assert unsub.verify_token(forged, 'user@example.com') is False
+
+
+def test_token_dies_with_old_email(monkeypatch):
+    """Смена адреса обесценивает старые ссылки — токен привязан к email."""
+    monkeypatch.setattr(unsub, '_secret', lambda: 'unit-test-secret')
+
+    token = unsub.build_token(42, 'old@example.com', 'all')
+    assert unsub.verify_token(token, 'new@example.com') is False
+
+
+@pytest.mark.parametrize('garbage', ['', 'nonsense', 'a.b.c', '42.all', '42.all.', 'x.all.sig'])
+def test_parse_token_survives_garbage(garbage):
+    """Мусор в query-параметре не должен ронять публичный эндпоинт."""
+    assert unsub.parse_token(garbage) is None
+
+
+def test_build_url_empty_when_disabled(monkeypatch):
+    """Выключенная отписка не должна протаскивать битую ссылку в письмо."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'EMAIL_UNSUBSCRIBE_ENABLED', False)
+    assert unsub.build_unsubscribe_url(1, 'user@example.com') == ''
+
+
+def test_build_url_uses_cabinet_url_by_default(monkeypatch):
+    """Без явного EMAIL_UNSUBSCRIBE_BASE_URL берём публичный путь кабинета."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'EMAIL_UNSUBSCRIBE_ENABLED', True)
+    monkeypatch.setattr(settings, 'EMAIL_UNSUBSCRIBE_BASE_URL', '')
+    monkeypatch.setattr(settings, 'CABINET_URL', 'https://cab.example.com/')
+    monkeypatch.setattr(unsub, '_secret', lambda: 'unit-test-secret')
+
+    url = unsub.build_unsubscribe_url(7, 'user@example.com')
+    assert url.startswith('https://cab.example.com/api/cabinet/public/unsubscribe?token=7.all.')
+
+
+# --------------------------------------------------------------------------
+# Заголовки письма (RFC 8058)
+# --------------------------------------------------------------------------
+
+
+def test_send_email_adds_one_click_headers(smtp_ready):
+    """List-Unsubscribe + One-Click — то, из чего Gmail рисует свою кнопку."""
+    ok = email_service.send_email(
+        to_email='user@example.com',
+        subject='Скидка',
+        body_html='<p>hi</p>',
+        unsubscribe_url='https://cab.example.com/api/cabinet/public/unsubscribe?token=7.all.sig',
+    )
+
+    assert ok is True
+    raw = smtp_ready.messages[0]
+    assert 'List-Unsubscribe: <https://cab.example.com/api/cabinet/public/unsubscribe?token=7.all.sig>' in raw
+    assert 'List-Unsubscribe-Post: List-Unsubscribe=One-Click' in raw
+
+
+def test_transactional_email_has_no_unsubscribe_headers(smtp_ready):
+    """Письмо со сбросом пароля не должно предлагать отписку."""
+    email_service.send_email(to_email='user@example.com', subject='Код', body_html='<p>1234</p>')
+
+    raw = smtp_ready.messages[0]
+    assert 'List-Unsubscribe' not in raw
+
+
+def test_unsubscribe_url_is_header_injection_safe(smtp_ready):
+    """Перенос строки в URL не должен дописать чужой заголовок."""
+    email_service.send_email(
+        to_email='user@example.com',
+        subject='Скидка',
+        body_html='<p>hi</p>',
+        unsubscribe_url='https://x.example.com/u\r\nBcc: victim@example.com',
+    )
+
+    raw = smtp_ready.messages[0]
+    assert 'Bcc: victim@example.com' not in raw
+
+
+# --------------------------------------------------------------------------
+# Шаблоны
+# --------------------------------------------------------------------------
+
+
+def test_base_template_renders_footer_link():
+    """Ссылка в футере — для клиентов, которые не рисуют кнопку из заголовка."""
+    html = EmailNotificationTemplates()._get_base_template(
+        '<p>text</p>', 'ru', unsubscribe_url='https://cab.example.com/u?token=t'
+    )
+    assert 'https://cab.example.com/u?token=t' in html
+    assert 'Отписаться' in html
+
+
+def test_base_template_without_url_has_no_dangling_footer():
+    """У транзакционных писем футер остаётся прежним."""
+    html = EmailNotificationTemplates()._get_base_template('<p>text</p>', 'ru')
+    assert 'Отписаться' not in html
+
+
+def test_common_context_exposes_unsubscribe_placeholder():
+    """{unsubscribe_url} обязан резолвиться, иначе он утечёт в письмо литералом."""
+    from app.cabinet.services.email_template_overrides import COMMON_CONTEXT_VARS, build_common_context
+
+    assert 'unsubscribe_url' in COMMON_CONTEXT_VARS
+    assert 'unsubscribe_url' in build_common_context()
+
+
+# --------------------------------------------------------------------------
+# Фильтрация получателей рассылки
+# --------------------------------------------------------------------------
+
+
+class _StubUser:
+    def __init__(self, notification_settings: dict | None) -> None:
+        self.notification_settings = notification_settings
+
+
+def test_email_broadcast_filters_by_category():
+    """Тумблеры кабинета обязаны резать email-рассылку так же, как Telegram."""
+    from app.utils.notification_prefs import filter_users_by_broadcast_category
+
+    opted_out_news = _StubUser({'news_enabled': False})
+    opted_out_promo = _StubUser({'promo_offers_enabled': False})
+    default_user = _StubUser(None)
+
+    users = [opted_out_news, opted_out_promo, default_user]
+
+    assert filter_users_by_broadcast_category(users, 'news') == [opted_out_promo, default_user]
+    assert filter_users_by_broadcast_category(users, 'promo') == [opted_out_news, default_user]
+    # Системные письма (истечение подписки, оплата) отписке не подлежат.
+    assert filter_users_by_broadcast_category(users, 'system') == users

--- a/tests/cabinet/test_promo_offer_email_notify.py
+++ b/tests/cabinet/test_promo_offer_email_notify.py
@@ -117,9 +117,9 @@ async def test_email_fanout_counts_sent_and_failed(monkeypatch):
 
     sent, failed = await route_module._send_promo_email_notifications(
         [
-            ('a@example.com', 'ru', 'A'),
-            ('bad@example.com', 'en', 'B'),
-            ('c@example.com', 'ru', 'C'),
+            ('a@example.com', 'ru', 'A', 1),
+            ('bad@example.com', 'en', 'B', 2),
+            ('c@example.com', 'ru', 'C', 3),
         ],
         message_text='hi',
         discount_percent=10,


### PR DESCRIPTION
## Зачем

Маркетинговые письма (промопредложения, winback, email-рассылки из админки) уходили без `List-Unsubscribe` и без ссылки отписки в футере. Единственный способ их прекратить — кнопка «Спам», а она бьёт по репутации домена отправителя. Для Gmail/Yahoo one-click unsubscribe у массовых отправителей обязателен.

Заодно чинится расхождение каналов: тумблеры `news_enabled` / `promo_offers_enabled` из кабинета фильтровали только Telegram-рассылку — email-путь (`_fetch_email_recipients`) их игнорировал, и выключенные новости всё равно приходили на почту.

## Что внутри

- **`app/cabinet/services/email_unsubscribe.py`** — токен `<user_id>.<category>.<hmac>` на секрете кабинета. Адрес входит в подпись, но не в ссылку: не утекает в `Referer` и логи прокси, а смена почты автоматически обесценивает старые ссылки. Срока жизни нет — письмо могут открыть через год, отписка обязана сработать.
- **`app/cabinet/routes/unsubscribe.py`** — публичный `GET`/`POST /cabinet/public/unsubscribe` рядом с существующим `site_verification`. Без авторизации: по ссылке ходят и почтовые клиенты (Gmail дёргает POST сам), и давно разлогиненные пользователи. Идемпотентен, чтобы антиспам-прескан почты не показал человеку ошибку.
- Отписка выставляет те же флаги в `User.notification_settings`, которыми управляет кабинет — **миграция не нужна**, и у пользователя не появляется второй несогласованный переключатель.
- `List-Unsubscribe` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click` ставятся **только маркетинговым** письмам (`MARKETING_NOTIFICATION_TYPES` + рассылки категорий `news`/`promo`). Транзакционные — код входа, чек, окончание подписки — не трогаем. URL с CR/LF или не-http отбрасывается вместе с заголовками (header injection).
- `filter_users_by_broadcast_category` — общая точка фильтрации для Telegram и email; `EmailBroadcastConfig` получил `category`.
- `{unsubscribe_url}` добавлен в `COMMON_CONTEXT_VARS`, чтобы кастомный шаблон из админки мог поставить ссылку — и чтобы плейсхолдер не доставился литералом.

## Конфиг

Всё по умолчанию включено и работает без правки `.env`: ссылка собирается как `CABINET_URL` + `/api/cabinet/public/unsubscribe`.

| Переменная | По умолчанию | Зачем |
|---|---|---|
| `EMAIL_UNSUBSCRIBE_ENABLED` | `true` | Выключатель |
| `EMAIL_UNSUBSCRIBE_BASE_URL` | пусто | Если API кабинета проксируется не через `/api` |
| `EMAIL_UNSUBSCRIBE_MAILTO` | пусто | mailto-вариант в `List-Unsubscribe` |

## Тесты

`tests/cabinet/test_email_unsubscribe.py` — 19 тестов: подпись/подделка/смена адреса/мусор в токене, наличие и отсутствие заголовков, header injection, футер шаблона, фильтрация по категориям.

Полный прогон: `2734 passed` против `2715 passed` на базе — новых падений нет (165 падений в обоих прогонах предсуществующие, к этому PR отношения не имеют).