### PR TITLE
feat(email): заголовок Reply-To (SMTP_REPLY_TO)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,11 @@ SMTP_USE_TLS=true
 # Для портов 25/587 оставить false.
 SMTP_USE_SSL=false
 
+# Куда падают ответы клиентов на письма. Нужен, когда SMTP_FROM_EMAIL живёт на
+# поддомене без MX (типично для Resend/SES: noreply@mail.example.com) — ответ на
+# такое письмо просто отбивается. Пусто — заголовок Reply-To не ставится.
+# SMTP_REPLY_TO=support@example.com
+
 # Уведомления администраторов
 ADMIN_NOTIFICATIONS_ENABLED=true
 # Rich-вид сообщений админ-чата (Bot API 10.1): заголовки, таблицы,

--- a/app/cabinet/services/email_service.py
+++ b/app/cabinet/services/email_service.py
@@ -45,6 +45,10 @@ class EmailService:
         return settings.SMTP_FROM_NAME
 
     @property
+    def reply_to(self) -> str:
+        return (settings.SMTP_REPLY_TO or '').strip()
+
+    @property
     def use_tls(self) -> bool:
         return settings.SMTP_USE_TLS
 
@@ -148,6 +152,15 @@ class EmailService:
             safe_from_email = sender_email.replace('\n', '').replace('\r', '')
             msg['From'] = formataddr((safe_from_name, safe_from_email))
             msg['To'] = to_email
+            # Адрес из .env: перенос строки в нём дописал бы произвольный
+            # заголовок в письмо, поэтому кривое значение не чиним, а
+            # выбрасываем — письмо важнее обратного канала.
+            if reply_to := self.reply_to:
+                if any(ch in reply_to for ch in '\r\n') or '@' not in reply_to:
+                    logger.warning('Некорректный SMTP_REPLY_TO — заголовок Reply-To пропущен')
+                else:
+                    msg['Reply-To'] = formataddr((safe_from_name, reply_to))
+
             msg['Date'] = formatdate(localtime=False)
             msg['Message-ID'] = make_msgid(domain=safe_from_email.split('@')[-1])
 

--- a/app/config.py
+++ b/app/config.py
@@ -1327,6 +1327,10 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str | None = None
     SMTP_FROM_EMAIL: str | None = None
     SMTP_FROM_NAME: str = 'VPN Service'
+    # Куда должны падать ответы клиентов. Отправитель часто живёт на поддомене
+    # без MX (noreply@mail.example.com у Resend/SES) — ответ на такое письмо
+    # отбивается, и человек, нажавший «Ответить», уходит в никуда.
+    SMTP_REPLY_TO: str = ''
     SMTP_USE_TLS: bool = True
     # Implicit TLS (SMTPS) — required for port 465. Auto-enabled when SMTP_PORT == 465.
     SMTP_USE_SSL: bool = False

--- a/tests/cabinet/test_email_reply_to.py
+++ b/tests/cabinet/test_email_reply_to.py
@@ -1,0 +1,77 @@
+"""Заголовок ``Reply-To`` в исходящих письмах.
+
+Адрес отправителя часто живёт на поддомене без MX (`noreply@mail.example.com`
+у Resend/SES/Postmark): ответ клиента на такое письмо просто отбивается. Без
+``Reply-To`` человек, нажавший «Ответить», уходит в никуда, а провайдеры
+считают отсутствие обратного канала признаком массовой рассылки.
+"""
+
+from __future__ import annotations
+
+import email as email_mod
+from email.utils import parseaddr
+from typing import Self
+
+import pytest
+
+from app.cabinet.services.email_service import email_service
+
+
+class _FakeSMTP:
+    """Ловит сырое письмо, отданное в ``sendmail``, и работает как CM."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+    def sendmail(self, _from_addr: str, _to_addr: str, msg: str) -> None:
+        self.messages.append(msg)
+
+
+@pytest.fixture
+def smtp_ready(monkeypatch):
+    from app.config import settings
+
+    fake = _FakeSMTP()
+    monkeypatch.setattr(type(settings), 'is_smtp_configured', lambda self: True)
+    monkeypatch.setattr(settings, 'SMTP_FROM_EMAIL', 'noreply@mail.example.com')
+    monkeypatch.setattr(settings, 'SMTP_FROM_NAME', 'Example VPN')
+    monkeypatch.setattr(email_service, '_get_smtp_connection', lambda: fake)
+    return fake
+
+
+def _send(monkeypatch, smtp, reply_to: str) -> email_mod.message.Message:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'SMTP_REPLY_TO', reply_to)
+    assert email_service.send_email(to_email='user@example.com', subject='Тема', body_html='<p>hi</p>') is True
+    return email_mod.message_from_string(smtp.messages[0])
+
+
+def test_reply_to_is_set_when_configured(monkeypatch, smtp_ready):
+    """Настроенный адрес попадает в Reply-To, From остаётся прежним."""
+    msg = _send(monkeypatch, smtp_ready, 'support@example.com')
+
+    assert parseaddr(msg['Reply-To'])[1] == 'support@example.com'
+    assert parseaddr(msg['From'])[1] == 'noreply@mail.example.com'
+
+
+def test_no_reply_to_header_by_default(monkeypatch, smtp_ready):
+    """Пустая настройка — поведение как раньше, лишнего заголовка нет."""
+    msg = _send(monkeypatch, smtp_ready, '')
+
+    assert msg['Reply-To'] is None
+
+
+@pytest.mark.parametrize('bad', ['not-an-email', 'support@example.com\r\nBcc: victim@example.com', '   '])
+def test_broken_reply_to_is_dropped(monkeypatch, smtp_ready, bad):
+    """Мусор из .env не должен ни ломать письмо, ни дописывать чужой заголовок."""
+    msg = _send(monkeypatch, smtp_ready, bad)
+
+    assert msg['Reply-To'] is None
+    assert msg['Bcc'] is None


### PR DESCRIPTION
## Зачем

При отправке через Resend/SES/Postmark `SMTP_FROM_EMAIL` обычно живёт на поддомене без MX — например `noreply@mail.example.com`. Ответ клиента на такое письмо отбивается: человек нажал «Ответить», написал в поддержку и не получил ничего. Плюс отсутствие обратного канала само по себе учитывается фильтрами как признак массовой рассылки.

Сейчас `Reply-To` не выставляется нигде.

## Что внутри

- `SMTP_REPLY_TO` — новая настройка, **по умолчанию пустая**: без неё поведение ровно прежнее, заголовок не добавляется.
- Заголовок собирается через `formataddr` с тем же display name, что и `From`, поэтому не-ASCII имя сервиса кодируется корректно (та же причина, что в #3005).
- Значение с `\r`/`\n` или без `@` отбрасывается вместе с заголовком и логируется: строка из `.env` иначе дописала бы в письмо произвольный заголовок.

## Тесты

`tests/cabinet/test_email_reply_to.py` — заголовок появляется при настройке и не появляется без неё, `From` не подменяется, мусор (не-адрес, CRLF-инъекция, пробелы) отбрасывается.

Полный прогон без новых падений относительно базы.