### PR TITLE
fix(cabinet): отдавать в /info/service реальные настройки

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ BOT_TOKEN=
 ADMIN_IDS=
 # Ссылка на поддержку: Telegram username (например, @support) или полный URL
 SUPPORT_USERNAME=@support
+# Публичные контакты сервиса — отдаются кабинетом в GET /info/service
+# SUPPORT_EMAIL=support@example.com
+# SERVICE_WEBSITE_URL=https://example.com
 # Имя пользователя бота (опционально, автоопределяется)
 # BOT_USERNAME=
 

--- a/app/cabinet/routes/info.py
+++ b/app/cabinet/routes/info.py
@@ -298,14 +298,28 @@ async def get_recurrent_payments(
 
 
 @router.get('/service', response_model=ServiceInfoResponse)
-async def get_service_info():
-    """Get general service information."""
+async def get_service_info(
+    language: str = Query('ru', min_length=2, max_length=10),
+):
+    """Get general service information.
+
+    Название и описание берём из брендинга (MINIAPP_SERVICE_NAME_*/
+    MINIAPP_SERVICE_DESCRIPTION_*) — того же источника, что и мини-апп, чтобы
+    сервис не назывался в двух местах по-разному. Раньше здесь читались
+    SERVICE_NAME / SERVICE_DESCRIPTION / WEBSITE_URL, которых в Settings нет,
+    поэтому любой инстанс отдавал «VPN Service» с пустыми контактами.
+    """
+    requested_lang = language.split('-', maxsplit=1)[0].lower()
+    branding = settings.get_miniapp_branding()
+    name = branding['service_name'].get(requested_lang) or branding['service_name']['default']
+    description = branding['service_description'].get(requested_lang) or branding['service_description']['default']
+
     return ServiceInfoResponse(
-        name=getattr(settings, 'SERVICE_NAME', None) or getattr(settings, 'BOT_NAME', 'VPN Service'),
-        description=getattr(settings, 'SERVICE_DESCRIPTION', None),
-        support_email=getattr(settings, 'SUPPORT_EMAIL', None),
-        support_telegram=getattr(settings, 'SUPPORT_USERNAME', None) or getattr(settings, 'SUPPORT_TELEGRAM', None),
-        website=getattr(settings, 'WEBSITE_URL', None),
+        name=name,
+        description=description,
+        support_email=settings.SUPPORT_EMAIL,
+        support_telegram=settings.SUPPORT_USERNAME,
+        website=settings.SERVICE_WEBSITE_URL,
     )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -92,6 +92,11 @@ class Settings(BaseSettings):
     TEST_EMAIL_PASSWORD: str = ''  # Password for test account
 
     SUPPORT_USERNAME: str = '@support'
+    # Публичные контакты сервиса, которые кабинет отдаёт в GET /info/service.
+    # До этого хендлер читал SUPPORT_EMAIL и WEBSITE_URL через getattr, но таких
+    # полей в Settings никогда не было — эндпоинт всегда возвращал None.
+    SUPPORT_EMAIL: str | None = None
+    SERVICE_WEBSITE_URL: str | None = None
     SUPPORT_MENU_ENABLED: bool = True
     SUPPORT_SYSTEM_MODE: str = 'both'  # one of: tickets, contact, both
     # SLA for support tickets. Дефолты совпадают с .env.example: без него бот


### PR DESCRIPTION
## Проблема

`GET /cabinet/info/service` собирает ответ из `SERVICE_NAME`, `SERVICE_DESCRIPTION`, `BOT_NAME` и `WEBSITE_URL`, читая их через `getattr(settings, ..., None)`. Ни одного из этих полей в `Settings` нет, а `model_config` стоит `extra: 'ignore'` — задать их через `.env` тоже нельзя. В итоге эндпоинт на любом инстансе отвечает одинаково:

```json
{"name":"VPN Service","description":null,"support_email":null,"support_telegram":"@support","website":null}
```

Работает только `support_telegram` — единственное поле, которое действительно существует.

## Что меняется

- Название и описание берутся из `get_miniapp_branding()` — того же источника, что и мини-апп, чтобы сервис не назывался в двух местах по-разному. Добавлен параметр `language`, как у соседних ручек `/info/*`.
- Для контактов заведены настоящие настройки `SUPPORT_EMAIL` и `SERVICE_WEBSITE_URL` (обе опциональные, дефолт `None`), они же добавлены в `.env.example`.
- `support_telegram` читается напрямую из `SUPPORT_USERNAME` без `getattr`-фолбэка на несуществующий `SUPPORT_TELEGRAM`.

Обратная совместимость: форма ответа не меняется. Инстансы без новых переменных получают `null` в тех же полях, что и раньше, но имя и описание перестают быть заглушкой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ww7sT8754ZmCxRqgx9bcA