### PR TITLE
feat(landing): засчитывать гостевые покупки в рекламные кампании

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -12,10 +12,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.database.crud.campaign import (
-    get_campaign_by_start_parameter,
-    get_campaign_registration_by_user,
-)
 from app.database.crud.rbac import UserRoleCRUD
 from app.database.crud.system_setting import get_setting_value
 from app.database.crud.user import (
@@ -269,70 +265,20 @@ async def _process_campaign_bonus(
     if not campaign_slug:
         return None
     try:
-        try:
-            campaign = await get_campaign_by_start_parameter(db, campaign_slug, only_active=True)
-            if not campaign:
-                return None
-
-            # Skip if user IS the campaign partner — prevent self-referral
-            if campaign.partner_user_id and campaign.partner_user_id == user.id:
-                logger.debug(
-                    'Skipping campaign attribution: user is the campaign partner',
-                    user_id=user.id,
-                    campaign_id=campaign.id,
-                )
-                return None
-
-            # Lock user row to prevent concurrent bonus application (race condition)
-            await db.execute(select(User).where(User.id == user.id).with_for_update())
-
-            existing = await get_campaign_registration_by_user(db, user.id)
-            if existing:
-                logger.debug('User already has campaign registration', user_id=user.id)
-                return None
-
-            # Привязать реферала к партнёру кампании (если партнёр назначен и юзер ещё не привязан)
-            if campaign.partner_user_id and not user.referred_by_id:
-                user.referred_by_id = campaign.partner_user_id
-                await db.flush()
-                try:
-                    from app.bot_factory import create_bot
-
-                    async with create_bot() as bot:
-                        await process_referral_registration(db, user.id, campaign.partner_user_id, bot=bot)
-                    logger.info(
-                        'Referral set from campaign partner',
-                        user_id=user.id,
-                        partner_user_id=campaign.partner_user_id,
-                        campaign_id=campaign.id,
-                    )
-                except Exception as e:
-                    logger.error('Failed to process referral from campaign partner', error=e)
-
-            service = AdvertisingCampaignService()
-            result = await service.apply_campaign_bonus(db, user, campaign)
-            if not result.success:
-                return None
-
-            # Refresh user to get updated balance after bonus
-            await db.refresh(user)
-
-            return CampaignBonusInfo(
-                campaign_name=campaign.name,
-                bonus_type=result.bonus_type or campaign.bonus_type,
-                balance_kopeks=result.balance_kopeks,
-                subscription_days=result.subscription_days,
-                tariff_name=result.tariff_name,
-            )
-        except Exception:
-            logger.exception('Failed to process campaign bonus', user_id=user.id, campaign_slug=campaign_slug)
-            try:
-                await db.rollback()
-                # Re-fetch user so session stays usable for the caller
-                await db.refresh(user)
-            except Exception:
-                logger.exception('Failed to rollback after campaign bonus error', user_id=user.id)
+        # Вся логика привязки живёт в сервисе — она общая с ботовым /start и
+        # с гостевой покупкой на лендинге. Сервис не бросает исключений.
+        service = AdvertisingCampaignService()
+        result = await service.attribute_campaign(db, user, campaign_slug)
+        if result is None:
             return None
+
+        return CampaignBonusInfo(
+            campaign_name=result.campaign_name or campaign_slug,
+            bonus_type=result.bonus_type or 'none',
+            balance_kopeks=result.balance_kopeks,
+            subscription_days=result.subscription_days,
+            tariff_name=result.tariff_name,
+        )
     finally:
         # Clear Redis pending_campaign whenever we consumed it. Done regardless
         # of success — if processing failed (already applied, race, exception),

--- a/app/cabinet/routes/landing.py
+++ b/app/cabinet/routes/landing.py
@@ -113,6 +113,9 @@ class LandingConfigResponse(BaseModel):
 
 _EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
 _TELEGRAM_RE = re.compile(r'^@?[a-zA-Z][a-zA-Z0-9_]{4,31}$')
+# Тот же набор символов, что валидирует кабинет в schemas/auth.py и утилита
+# captureCampaignFromUrl() во фронтенде — слаг ходит между ними без переводов.
+_CAMPAIGN_SLUG_RE = re.compile(r'^[a-zA-Z0-9_-]{1,64}$')
 
 
 def _validate_contact(contact_type: str, contact_value: str) -> None:
@@ -121,6 +124,24 @@ def _validate_contact(contact_type: str, contact_value: str) -> None:
         raise ValueError('Invalid email format')
     if contact_type == 'telegram' and not _TELEGRAM_RE.match(contact_value):
         raise ValueError('Invalid Telegram username format')
+
+
+def _extract_campaign_slug(body_slug: str | None, request: Request) -> str | None:
+    """Resolve the advertising campaign slug for a guest purchase.
+
+    Body wins over cookie: the body works for a landing on any domain, while
+    the cookie only survives when the landing sits on a sibling subdomain of
+    the cabinet. A malformed value is dropped instead of silently falling back
+    to the other source — attributing a purchase to the wrong campaign is worse
+    than not attributing it at all.
+    """
+    if body_slug is not None:
+        return body_slug if _CAMPAIGN_SLUG_RE.match(body_slug) else None
+
+    cookie_slug = request.cookies.get('campaign')
+    if cookie_slug and _CAMPAIGN_SLUG_RE.match(cookie_slug):
+        return cookie_slug
+    return None
 
 
 class PurchaseRequest(BaseModel):
@@ -137,6 +158,7 @@ class PurchaseRequest(BaseModel):
     referrer: str | None = Field(default=None, max_length=500)
     subid: str | None = Field(default=None, max_length=255)
     yclid: str | None = Field(default=None, max_length=64, pattern=r'^[0-9]{1,64}$')
+    campaign_slug: str | None = Field(default=None, max_length=64)
 
     @model_validator(mode='after')
     def validate_contacts(self) -> 'PurchaseRequest':
@@ -819,6 +841,7 @@ async def create_landing_purchase(
         gift_message=body.gift_message,
         subid=body.subid,
         referrer=body.referrer,
+        campaign_slug=_extract_campaign_slug(body.campaign_slug, raw_request),
         commit=False,
     )
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4529,6 +4529,10 @@ class GuestPurchase(Base):
     yandex_cid = Column(String(128), nullable=True)
     subid = Column(String(255), nullable=True)
     referrer = Column(String(500), nullable=True)
+    # Слаг рекламной кампании (``advertising_campaigns.start_parameter``).
+    # Оплату подтверждает вебхук платёжки, где куки и сессии покупателя уже
+    # нет, поэтому источник атрибуции хранится в самой покупке.
+    campaign_slug = Column(String(64), nullable=True)
 
     landing = relationship('LandingPage', back_populates='guest_purchases', lazy='selectin')
     tariff = relationship('Tariff', lazy='selectin')

--- a/app/services/campaign_service.py
+++ b/app/services/campaign_service.py
@@ -1,10 +1,15 @@
 from dataclasses import dataclass
 
 import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.database.crud.campaign import record_campaign_registration
+from app.database.crud.campaign import (
+    get_campaign_by_start_parameter,
+    get_campaign_registration_by_user,
+    record_campaign_registration,
+)
 from app.database.crud.subscription import (
     create_paid_subscription,
     get_subscription_by_user_id,
@@ -40,6 +45,9 @@ class CampaignBonusResult:
     tariff_id: int | None = None
     tariff_name: str | None = None
     tariff_duration_days: int | None = None
+    # Имя кампании, к которой привязали юзера. Заполняется attribute_campaign,
+    # чтобы caller не ходил за кампанией второй раз ради текста уведомления.
+    campaign_name: str | None = None
     # True если запись в advertising_campaign_registrations была создана этим вызовом
     # (а не вернулась как existing). Используется caller'ом, чтобы понять, нужно ли
     # слать админу уведомление о регистрации (один раз на первую успешную).
@@ -49,6 +57,102 @@ class CampaignBonusResult:
 class AdvertisingCampaignService:
     def __init__(self) -> None:
         self.subscription_service = SubscriptionService()
+
+    async def attribute_campaign(
+        self,
+        db: AsyncSession,
+        user: User,
+        campaign_slug: str | None,
+    ) -> CampaignBonusResult | None:
+        """Bind a user to an advertising campaign and grant its bonus.
+
+        Shared by every entry point that can produce a campaign-attributed
+        user: cabinet auth, the bot's /start handler and guest purchases made
+        on a landing page. Returns ``None`` when there is nothing to attribute
+        — unknown or inactive campaign, the user is the campaign's own partner,
+        the user already belongs to some campaign, or the bonus did not apply.
+
+        Never raises: attribution is a side effect and must not take down the
+        flow that called it.
+        """
+        if not campaign_slug:
+            return None
+
+        try:
+            campaign = await get_campaign_by_start_parameter(db, campaign_slug, only_active=True)
+            if not campaign:
+                return None
+
+            # Партнёр не может привести сам себя по собственной ссылке.
+            if campaign.partner_user_id and campaign.partner_user_id == user.id:
+                logger.debug(
+                    'Skipping campaign attribution: user is the campaign partner',
+                    user_id=user.id,
+                    campaign_id=campaign.id,
+                )
+                return None
+
+            # Блокируем строку юзера: два параллельных входа иначе успеют
+            # выдать бонус дважды до того, как сработает UNIQUE в регистрации.
+            await db.execute(select(User).where(User.id == user.id).with_for_update())
+
+            existing = await get_campaign_registration_by_user(db, user.id)
+            if existing:
+                logger.debug('User already has campaign registration', user_id=user.id)
+                return None
+
+            await self._link_partner_referral(db, user, campaign)
+
+            result = await self.apply_campaign_bonus(db, user, campaign)
+            if not result.success:
+                return None
+
+            result.campaign_name = campaign.name
+            result.bonus_type = result.bonus_type or campaign.bonus_type
+
+            # Обновляем юзера, чтобы вызывающий увидел начисленный баланс.
+            await db.refresh(user)
+            return result
+        except Exception:
+            logger.exception(
+                'Failed to attribute campaign',
+                user_id=getattr(user, 'id', None),
+                campaign_slug=campaign_slug,
+            )
+            try:
+                await db.rollback()
+                # Перечитываем юзера, чтобы сессия осталась пригодной для caller'а.
+                await db.refresh(user)
+            except Exception:
+                logger.exception('Failed to rollback after campaign attribution error')
+            return None
+
+    async def _link_partner_referral(
+        self,
+        db: AsyncSession,
+        user: User,
+        campaign: AdvertisingCampaign,
+    ) -> None:
+        """Attach the campaign's partner as the user's referrer, if unset."""
+        if not campaign.partner_user_id or user.referred_by_id:
+            return
+
+        user.referred_by_id = campaign.partner_user_id
+        await db.flush()
+        try:
+            from app.bot_factory import create_bot
+            from app.services.referral_service import process_referral_registration
+
+            async with create_bot() as bot:
+                await process_referral_registration(db, user.id, campaign.partner_user_id, bot=bot)
+            logger.info(
+                'Referral set from campaign partner',
+                user_id=user.id,
+                partner_user_id=campaign.partner_user_id,
+                campaign_id=campaign.id,
+            )
+        except Exception as e:
+            logger.error('Failed to process referral from campaign partner', error=e)
 
     async def apply_campaign_bonus(
         self,

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -156,6 +156,7 @@ async def create_purchase(
     source: str = 'landing',
     subid: str | None = None,
     referrer: str | None = None,
+    campaign_slug: str | None = None,
     buyer_user_id: int | None = None,
     commit: bool = True,
 ) -> GuestPurchase:
@@ -165,6 +166,7 @@ async def create_purchase(
         commit=commit,
         subid=subid,
         referrer=referrer,
+        campaign_slug=campaign_slug,
         landing_id=landing.id if landing else None,
         tariff_id=tariff.id,
         period_days=period_days,

--- a/app/services/guest_purchase_service.py
+++ b/app/services/guest_purchase_service.py
@@ -52,6 +52,47 @@ GIFT_TOKEN_MIN_PREFIX_LENGTH = 48
 _TELEGRAM_USERNAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]{4,31}$')
 
 
+async def _attribute_purchase_campaign(
+    db: AsyncSession,
+    purchase: GuestPurchase,
+    user: User,
+) -> None:
+    """Attribute a delivered guest purchase to its advertising campaign.
+
+    MUST be called only after the caller's final ``commit()``. The balance
+    bonus commits on its own (``add_user_balance``), which would otherwise
+    release the ``FOR UPDATE`` lock ``fulfill_purchase`` holds on the purchase
+    row halfway through delivery.
+
+    Gifts are deliberately skipped: the user created on this path is the
+    recipient, while the campaign brought in the buyer. A guest buyer has no
+    account at all, so there is nobody to attribute — the slug still stays on
+    the purchase row for reporting.
+    """
+    if not purchase.campaign_slug or purchase.is_gift:
+        return
+
+    try:
+        from app.services.campaign_service import AdvertisingCampaignService
+
+        service = AdvertisingCampaignService()
+        result = await service.attribute_campaign(db, user, purchase.campaign_slug)
+        if result and result.success:
+            logger.info(
+                'Guest purchase attributed to campaign',
+                purchase_id=purchase.id,
+                user_id=user.id,
+                campaign_slug=purchase.campaign_slug,
+                bonus_type=result.bonus_type,
+            )
+    except Exception:
+        logger.exception(
+            'Failed to attribute guest purchase to campaign',
+            purchase_id=purchase.id,
+            campaign_slug=purchase.campaign_slug,
+        )
+
+
 async def _send_admin_notification(
     purchase: GuestPurchase,
     tariff_name: str,
@@ -428,6 +469,8 @@ async def fulfill_purchase(
                 purchase.cabinet_password = None
                 await db.commit()
 
+            await _attribute_purchase_campaign(db, purchase, user)
+
             logger.info(
                 'Guest purchase held for activation (existing subscription)',
                 purchase_id=purchase.id,
@@ -598,6 +641,8 @@ async def fulfill_purchase(
         if purchase.cabinet_password:
             purchase.cabinet_password = None
             await db.commit()
+
+        await _attribute_purchase_campaign(db, purchase, user)
 
         logger.info(
             'Guest purchase fulfilled',

--- a/migrations/alembic/versions/0099_guest_purchase_campaign.py
+++ b/migrations/alembic/versions/0099_guest_purchase_campaign.py
@@ -1,0 +1,44 @@
+"""guest_purchases: слаг рекламной кампании
+
+Revision ID: 0099
+Revises: 0098
+Create Date: 2026-08-12
+
+Добавляет ``campaign_slug`` в ``guest_purchases``. Покупатель приходит с
+рекламного лендинга, а оплату подтверждает вебхук платёжки — в этот момент ни
+куки, ни сессии покупателя уже нет. Поэтому слаг кампании хранится в самой
+покупке: только так её можно привязать к кампании после оплаты.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0099'
+down_revision: Union[str, None] = '0098'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'guest_purchases' not in inspector.get_table_names():
+        return
+    existing = {col['name'] for col in inspector.get_columns('guest_purchases')}
+    if 'campaign_slug' not in existing:
+        op.add_column(
+            'guest_purchases',
+            sa.Column('campaign_slug', sa.String(length=64), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'guest_purchases' not in inspector.get_table_names():
+        return
+    existing = {col['name'] for col in inspector.get_columns('guest_purchases')}
+    if 'campaign_slug' in existing:
+        op.drop_column('guest_purchases', 'campaign_slug')

--- a/migrations/alembic/versions/0105_guest_purchase_campaign.py
+++ b/migrations/alembic/versions/0105_guest_purchase_campaign.py
@@ -1,7 +1,7 @@
 """guest_purchases: слаг рекламной кампании
 
-Revision ID: 0099
-Revises: 0098
+Revision ID: 0105
+Revises: 0104
 Create Date: 2026-08-12
 
 Добавляет ``campaign_slug`` в ``guest_purchases``. Покупатель приходит с
@@ -15,8 +15,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = '0099'
-down_revision: Union[str, None] = '0098'
+revision: str = '0105'
+down_revision: Union[str, None] = '0104'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/tests/cabinet/test_landing_purchase_campaign.py
+++ b/tests/cabinet/test_landing_purchase_campaign.py
@@ -1,0 +1,53 @@
+"""Захват слага рекламной кампании при создании гостевой покупки.
+
+Реклама ведёт на лендинг, а покупка оформляется гостем — без auth-флоу,
+в котором кампания привязывается обычно. Слаг приезжает либо в теле запроса
+(лендинг на любом домене), либо в куке ``campaign``, если лендинг стоит на
+соседнем поддомене. Оплату подтверждает вебхук платёжки, где куки уже нет,
+поэтому слаг обязан осесть в самой покупке.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.cabinet.routes.landing import _extract_campaign_slug
+
+
+def _request(cookies: dict[str, str] | None = None) -> SimpleNamespace:
+    """Минимальный дубль starlette Request — нужен только ``.cookies``."""
+    return SimpleNamespace(cookies=cookies or {})
+
+
+def test_body_slug_wins_over_cookie() -> None:
+    assert _extract_campaign_slug('from_body', _request({'campaign': 'from_cookie'})) == 'from_body'
+
+
+def test_cookie_is_used_when_body_has_no_slug() -> None:
+    assert _extract_campaign_slug(None, _request({'campaign': 'from_cookie'})) == 'from_cookie'
+
+
+def test_returns_none_without_any_source() -> None:
+    assert _extract_campaign_slug(None, _request()) is None
+
+
+@pytest.mark.parametrize(
+    'bad',
+    [
+        '',
+        'has space',
+        'semi;colon',
+        'слаг',
+        'a' * 65,
+    ],
+)
+def test_invalid_cookie_is_ignored(bad: str) -> None:
+    assert _extract_campaign_slug(None, _request({'campaign': bad})) is None
+
+
+def test_invalid_body_slug_does_not_fall_back_to_cookie() -> None:
+    """Мусор в теле — ошибка вызывающей стороны, а не повод молча подставить
+    другой источник и записать покупку не на ту кампанию."""
+    assert _extract_campaign_slug('bad slug', _request({'campaign': 'good_one'})) is None

--- a/tests/services/test_campaign_attribution.py
+++ b/tests/services/test_campaign_attribution.py
@@ -1,0 +1,162 @@
+"""Единая точка привязки пользователя к рекламной кампании.
+
+Логика раньше жила только в кабинетном auth-флоу; гостевой покупке с лендинга
+нужна ровно она же, поэтому она вынесена в сервис. Тесты пиннят правила,
+которые нельзя потерять при переносе.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.campaign_service import AdvertisingCampaignService
+
+
+def _db() -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _campaign(**kw: object) -> SimpleNamespace:
+    base: dict[str, object] = {'id': 7, 'name': 'main', 'partner_user_id': None, 'bonus_type': 'balance'}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _user(user_id: int = 42, referred_by_id: int | None = None) -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, referred_by_id=referred_by_id)
+
+
+@pytest.mark.asyncio
+async def test_returns_none_for_empty_slug() -> None:
+    service = AdvertisingCampaignService()
+    assert await service.attribute_campaign(_db(), _user(), None) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_campaign_not_found() -> None:
+    service = AdvertisingCampaignService()
+    with patch(
+        'app.services.campaign_service.get_campaign_by_start_parameter',
+        AsyncMock(return_value=None),
+    ):
+        assert await service.attribute_campaign(_db(), _user(), 'ghost') is None
+
+
+@pytest.mark.asyncio
+async def test_partner_cannot_be_attributed_to_own_campaign() -> None:
+    """Иначе партнёр накрутит себе регистрацию по собственной ссылке."""
+    service = AdvertisingCampaignService()
+    with patch(
+        'app.services.campaign_service.get_campaign_by_start_parameter',
+        AsyncMock(return_value=_campaign(partner_user_id=42)),
+    ):
+        assert await service.attribute_campaign(_db(), _user(user_id=42), 'main') is None
+
+
+@pytest.mark.asyncio
+async def test_existing_registration_blocks_second_bonus() -> None:
+    service = AdvertisingCampaignService()
+    with (
+        patch(
+            'app.services.campaign_service.get_campaign_by_start_parameter',
+            AsyncMock(return_value=_campaign()),
+        ),
+        patch(
+            'app.services.campaign_service.get_campaign_registration_by_user',
+            AsyncMock(return_value=SimpleNamespace(id=1)),
+        ),
+        patch.object(AdvertisingCampaignService, 'apply_campaign_bonus', AsyncMock()) as apply_mock,
+    ):
+        assert await service.attribute_campaign(_db(), _user(), 'main') is None
+        apply_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_successful_attribution_applies_bonus() -> None:
+    service = AdvertisingCampaignService()
+    expected = SimpleNamespace(success=True, bonus_type='balance', is_new_registration=True)
+    with (
+        patch(
+            'app.services.campaign_service.get_campaign_by_start_parameter',
+            AsyncMock(return_value=_campaign()),
+        ),
+        patch(
+            'app.services.campaign_service.get_campaign_registration_by_user',
+            AsyncMock(return_value=None),
+        ),
+        patch.object(AdvertisingCampaignService, 'apply_campaign_bonus', AsyncMock(return_value=expected)),
+    ):
+        result = await service.attribute_campaign(_db(), _user(), 'main')
+
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_unsuccessful_bonus_returns_none() -> None:
+    service = AdvertisingCampaignService()
+    with (
+        patch(
+            'app.services.campaign_service.get_campaign_by_start_parameter',
+            AsyncMock(return_value=_campaign()),
+        ),
+        patch(
+            'app.services.campaign_service.get_campaign_registration_by_user',
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            AdvertisingCampaignService,
+            'apply_campaign_bonus',
+            AsyncMock(return_value=SimpleNamespace(success=False)),
+        ),
+    ):
+        assert await service.attribute_campaign(_db(), _user(), 'main') is None
+
+
+@pytest.mark.asyncio
+async def test_partner_is_attached_as_referrer() -> None:
+    """Кампания партнёра должна проставить его реферером — иначе он не
+    получит комиссию за приведённого клиента."""
+    service = AdvertisingCampaignService()
+    user = _user(user_id=42, referred_by_id=None)
+    with (
+        patch(
+            'app.services.campaign_service.get_campaign_by_start_parameter',
+            AsyncMock(return_value=_campaign(partner_user_id=99)),
+        ),
+        patch(
+            'app.services.campaign_service.get_campaign_registration_by_user',
+            AsyncMock(return_value=None),
+        ),
+        patch.object(AdvertisingCampaignService, '_link_partner_referral', AsyncMock()) as link_mock,
+        patch.object(
+            AdvertisingCampaignService,
+            'apply_campaign_bonus',
+            AsyncMock(return_value=SimpleNamespace(success=True, bonus_type='balance')),
+        ),
+    ):
+        await service.attribute_campaign(_db(), user, 'main')
+
+    link_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_errors_are_swallowed_and_rolled_back() -> None:
+    """Привязка кампании — побочный эффект: она не имеет права уронить
+    вызывающий флоу (регистрацию в кабинете или доставку подписки)."""
+    service = AdvertisingCampaignService()
+    db = _db()
+    with patch(
+        'app.services.campaign_service.get_campaign_by_start_parameter',
+        AsyncMock(side_effect=RuntimeError('boom')),
+    ):
+        assert await service.attribute_campaign(db, _user(), 'main') is None
+
+    db.rollback.assert_awaited()

--- a/tests/services/test_guest_purchase_campaign.py
+++ b/tests/services/test_guest_purchase_campaign.py
@@ -1,0 +1,75 @@
+"""Привязка гостевой покупки к рекламной кампании.
+
+Покупатель приходит с рекламного лендинга и оформляет подписку гостем —
+auth-флоу, в котором кампания привязывается обычно, здесь не срабатывает.
+Слаг лежит в самой покупке (миграция 0099), а привязка выполняется после
+доставки подписки.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.guest_purchase_service import _attribute_purchase_campaign
+
+
+def _purchase(campaign_slug: str | None = 'main', is_gift: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(id=1, token='tok12345', campaign_slug=campaign_slug, is_gift=is_gift)
+
+
+def _user() -> SimpleNamespace:
+    return SimpleNamespace(id=42)
+
+
+@pytest.mark.asyncio
+async def test_campaign_is_attributed_after_delivery() -> None:
+    db = AsyncMock()
+    with patch(
+        'app.services.campaign_service.AdvertisingCampaignService.attribute_campaign',
+        AsyncMock(return_value=SimpleNamespace(success=True, bonus_type='balance')),
+    ) as attribute_mock:
+        await _attribute_purchase_campaign(db, _purchase(), _user())
+
+    attribute_mock.assert_awaited_once()
+    assert attribute_mock.await_args.args[2] == 'main'
+
+
+@pytest.mark.asyncio
+async def test_purchase_without_slug_is_skipped() -> None:
+    db = AsyncMock()
+    with patch(
+        'app.services.campaign_service.AdvertisingCampaignService.attribute_campaign',
+        AsyncMock(),
+    ) as attribute_mock:
+        await _attribute_purchase_campaign(db, _purchase(campaign_slug=None), _user())
+
+    attribute_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gift_is_not_attributed_to_recipient() -> None:
+    """Гифт активирует получатель, а по рекламе приходил покупатель — записать
+    кампанию на получателя означало бы приписать ей чужого клиента."""
+    db = AsyncMock()
+    with patch(
+        'app.services.campaign_service.AdvertisingCampaignService.attribute_campaign',
+        AsyncMock(),
+    ) as attribute_mock:
+        await _attribute_purchase_campaign(db, _purchase(is_gift=True), _user())
+
+    attribute_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attribution_failure_does_not_propagate() -> None:
+    """Подписка уже доставлена и оплачена — упасть здесь значит уронить
+    успешный платёж из-за побочного эффекта."""
+    db = AsyncMock()
+    with patch(
+        'app.services.campaign_service.AdvertisingCampaignService.attribute_campaign',
+        AsyncMock(side_effect=RuntimeError('boom')),
+    ):
+        await _attribute_purchase_campaign(db, _purchase(), _user())


### PR DESCRIPTION
## Проблема

Клиент, пришедший по ссылке рекламной кампании и купивший подписку **гостем на лендинге**, не попадает в статистику этой кампании и не получает её бонус. В карточке кампании такие продажи показываются нулём, а обещанный в креативе бонус (например, на баланс) молча не начисляется.

Регистрация через кабинет или через `/start` в боте при этом атрибутируется нормально — расходятся именно лендинговые продажи.

## Почему так

Кампания применяется ровно в двух местах: `_process_campaign_bonus()` в `app/cabinet/routes/auth.py` и `/start` в `app/handlers/start.py`. В гостевой покупке пользователь создаётся в `_find_or_create_user()` внутри `fulfill_purchase()` — и вызова `apply_campaign_bonus()` там нет вообще.

Просто «дотянуть» слаг до этого места нельзя: `fulfill_purchase()` вызывается **из вебхука платёжки**, где ни куки, ни сессии покупателя уже не существует.

## Решение

Слаг перехватывается в момент создания покупки, когда браузер покупателя ещё на связи, и хранится в самой покупке — так он переживает вебхук, отложенную оплату и ретраи.

```
POST /landing/{slug}/purchase   ← слаг из тела запроса или из куки
    └─ guest_purchases.campaign_slug
оплата → вебхук платёжки
    └─ fulfill_purchase() → _find_or_create_user() → user
        └─ attribute_campaign(user, slug)   ← после финального commit
```

**Три коммита:**

1. **Колонка + захват слага.** `guest_purchases.campaign_slug` (миграция `0105`), поле `campaign_slug` в `PurchaseRequest`, хелпер `_extract_campaign_slug()`.

   Источника два: тело запроса и кука `campaign`. Тело работает для лендинга на любом домене; кука — когда лендинг стоит на соседнем поддомене кабинета и её выставляет edge. Тело имеет приоритет, а невалидный слаг **отбрасывается без фолбэка на второй источник**: приписать покупку чужой кампании хуже, чем не приписать никакой. Регэксп `^[a-zA-Z0-9_-]{1,64}$` — тот же, что уже валидирует `schemas/auth.py` и `captureCampaignFromUrl()` во фронтенде.

2. **Рефакторинг: привязка переехала в сервис.** Логика привязки — self-referral партнёра, блокировка строки юзера, проверка существующей регистрации, реферал от партнёра, выдача бонуса — жила целиком внутри кабинетного auth-роута. Гостевой покупке нужна ровно она же, копировать 60 строк не хотелось.

   Теперь это `AdvertisingCampaignService.attribute_campaign()`, а `_process_campaign_bonus()` — тонкая обёртка: Redis-фолбэк `pending_campaign` и сборка `CampaignBonusInfo`. Имя кампании приезжает в `CampaignBonusResult`, чтобы обёртке не ходить за кампанией второй раз. **Внешнее поведение кабинетного флоу не меняется.**

3. **Применение после доставки.** Вызов стоит строго **после финального `commit()`** обеих веток `fulfill_purchase` (DELIVERED и PENDING_ACTIVATION). Это не стилистика: балансный бонус коммитит сам (`add_user_balance`), а `fulfill_purchase` держит `SELECT … FOR UPDATE` на строке покупки — врезка в середину отпустила бы блокировку на полпути к доставке. Ошибки привязки логируются и проглатываются: подписка к этому моменту уже оплачена и доставлена, ронять её из-за побочного эффекта нельзя.

Двойного начисления нет: `attribute_campaign` проверяет `get_campaign_registration_by_user()` под блокировкой строки, а `record_campaign_registration()` дополнительно защищён UNIQUE `(campaign_id, user_id)` в savepoint. Если клиент купил гостем, а потом вошёл в кабинет — засчитается один раз.

## Сознательные ограничения

- **Гифты не атрибутируются.** Гифт остаётся в `PAID` до клейма, и создаваемый на этом пути пользователь — получатель, тогда как по рекламе приходил покупатель. У гостевого покупателя аккаунта нет вовсе (`buyer_user_id` заполняется только для залогиненных), так что привязывать некого. Слаг при этом сохраняется на записи покупки — данные для отчёта не теряются.
- **Уведомление админу на этом пути не шлётся.** `send_campaign_registration_notification()` требует `telegram_id`, которого у email-покупателя нет. Расширение сигнатуры сервиса — отдельная задача.

## Проверка

- Новые тесты: `tests/cabinet/test_landing_purchase_campaign.py` (9), `tests/services/test_campaign_attribution.py` (8), `tests/services/test_guest_purchase_campaign.py` (4).
- Полный прогон: `2901 passed`, регрессий нет.
- `ruff format --check` и `ruff check` — чисто.
- Миграция `0105` прогнана на PostgreSQL 16 циклом upgrade → downgrade → upgrade, плюс проверена идемпотентность в обе стороны (повторный upgrade при уже существующей колонке и повторный downgrade при отсутствующей).

Фронтенд, отправляющий `campaign_slug` из localStorage: BEDOLAGA-DEV/bedolaga-cabinet — ветка `feat/campaign-slug-on-guest-purchase`. Бэкенд самодостаточен и без него: куку читает сам.
