### PR TITLE
fix(auth): не пускать регистрацию на алиасе уже занятого ящика

### DIFF
--- a/app/cabinet/routes/auth.py
+++ b/app/cabinet/routes/auth.py
@@ -18,6 +18,7 @@ from app.database.crud.user import (
     clear_email_change_pending,
     create_user,
     create_user_by_email,
+    get_user_by_email_alias,
     get_user_by_id,
     get_user_by_referral_code,
     get_user_by_telegram_id,
@@ -1355,6 +1356,20 @@ async def register_email_standalone(
             detail='This email is already registered',
         )
 
+    # ...и что это не другая запись того же ящика: «user+1@gmail.com» проходит
+    # проверку выше, письма при этом уходят владельцу «user@gmail.com»
+    alias_owner = await get_user_by_email_alias(db, request.email)
+    if alias_owner:
+        logger.info(
+            'Registration blocked: email alias of an existing account',
+            email=request.email,
+            existing_user_id=alias_owner.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='This email is already registered',
+        )
+
     # Хешировать пароль
     password_hash = hash_password(request.password)
 
@@ -2082,6 +2097,7 @@ async def request_email_change(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='Disposable email addresses are not allowed',
         )
+
 
     # Check if new email is already taken
     if await is_email_taken(db, request.new_email, exclude_user_id=user.id):

--- a/app/database/crud/user.py
+++ b/app/database/crud/user.py
@@ -1485,6 +1485,49 @@ async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
     return result.scalar_one_or_none()
 
 
+async def get_user_by_email_alias(db: AsyncSession, email: str) -> User | None:
+    """Найти пользователя, чей адрес ведёт в тот же ящик, что и ``email``.
+
+    ``user+1@gmail.com`` и ``u.ser@gmail.com`` — разные строки, но один ящик:
+    подтверждение адреса проходит штатно, письма приходят тому же человеку.
+    Сравнение по одному лишь регистру этого не видит, и на каждом таком алиасе
+    заводится отдельный аккаунт со своей пробной подпиской.
+
+    Точное совпадение остаётся за ``get_user_by_email`` — здесь ищем именно
+    другую запись адреса. Для доменов без алиасов (корпоративных и незнакомых)
+    запрос не выполняется вовсе.
+    """
+    from app.utils.email_alias import (
+        canonical_email,
+        canonical_local_sql,
+        email_domain,
+        has_alias_forms,
+        sibling_domains,
+    )
+
+    if not email or not email.strip() or not has_alias_forms(email):
+        return None
+
+    domain = email_domain(email)
+    canonical = canonical_email(email)
+    local = canonical.split('@', 1)[0]
+
+    # Домен в базе может быть записан любым из близнецов (ya.ru / yandex.ru),
+    # поэтому канон локальной части считаем для каждого написания отдельно
+    conditions = [
+        and_(
+            func.lower(func.split_part(User.email, '@', 2)) == sibling,
+            canonical_local_sql(User.email, domain) == local,
+        )
+        for sibling in sorted(sibling_domains(domain))
+    ]
+
+    result = await db.execute(
+        select(User).where(User.email.isnot(None), or_(*conditions)).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def is_email_taken(db: AsyncSession, email: str, exclude_user_id: int | None = None) -> bool:
     """
     Check if email is already taken by another user.
@@ -1504,7 +1547,12 @@ async def is_email_taken(db: AsyncSession, email: str, exclude_user_id: int | No
     if exclude_user_id:
         query = query.where(User.id != exclude_user_id)
     result = await db.execute(query)
-    return result.scalar_one_or_none() is not None
+    if result.scalar_one_or_none() is not None:
+        return True
+
+    # Другая запись того же ящика занимает его не меньше, чем точное совпадение
+    alias_owner = await get_user_by_email_alias(db, email)
+    return alias_owner is not None and alias_owner.id != exclude_user_id
 
 
 async def set_email_change_pending(

--- a/app/utils/email_alias.py
+++ b/app/utils/email_alias.py
@@ -1,0 +1,134 @@
+"""Канонический вид почтового адреса — против регистраций на алиасах одного ящика.
+
+Проверка «email уже занят» сравнивала адреса с точностью до регистра, а почтовые
+провайдеры доставляют письма в один ящик по целому семейству адресов:
+
+    user+1@gmail.com, user+2@gmail.com, u.s.e.r@gmail.com  →  user@gmail.com
+
+Для владельца ящика это один почтовый ящик, для базы — сколько угодно разных
+пользователей. Там, где к регистрации привязана выдача чего-либо разового
+(пробная подписка, приветственный бонус, промокод), получатель ограничен только
+терпением: подтверждение адреса проходит штатно, письмо приходит ему же.
+
+Канонизация умышленно консервативная — склеить двух разных людей хуже, чем
+пропустить одного лишнего:
+
+* точки в локальной части игнорирует только Gmail, поэтому убираем их лишь для
+  ``gmail.com`` и ``googlemail.com``;
+* субадресацию (``+suffix``, RFC 5233) поддерживают не все, поэтому режем её
+  только у провайдеров из списка ниже. Корпоративные и незнакомые домены
+  остаются как есть: там ``+`` вполне может быть частью имени ящика.
+
+Сам адрес пользователя не переписывается: письма должны уходить ровно на тот
+адрес, который человек ввёл. Канонический вид нужен только для сравнения.
+"""
+
+from __future__ import annotations
+
+
+# Провайдеры, у которых всё после «+» — пользовательская метка, а не часть адреса
+PLUS_ADDRESSING_DOMAINS = frozenset(
+    {
+        'gmail.com',
+        'googlemail.com',
+        'outlook.com',
+        'hotmail.com',
+        'live.com',
+        'icloud.com',
+        'me.com',
+        'yandex.ru',
+        'yandex.com',
+        'ya.ru',
+        'mail.ru',
+        'proton.me',
+        'protonmail.com',
+        'fastmail.com',
+    }
+)
+
+# Домены, игнорирующие точки в локальной части
+DOT_INSENSITIVE_DOMAINS = frozenset({'gmail.com', 'googlemail.com'})
+
+# Провайдеры, у которых несколько доменов ведут в один ящик
+DOMAIN_ALIASES = {
+    'googlemail.com': 'gmail.com',
+    'ya.ru': 'yandex.ru',
+    'yandex.com': 'yandex.ru',
+    'protonmail.com': 'proton.me',
+    'me.com': 'icloud.com',
+}
+
+
+def canonical_email(email: str | None) -> str:
+    """Вид адреса для сравнения: тот же ящик — та же строка.
+
+    Адрес без «@» (или пустой) возвращается просто в нижнем регистре: спорные
+    входные данные лучше не трогать, их отвергнет валидация выше.
+    """
+    normalized = (email or '').strip().lower()
+    if normalized.count('@') != 1:
+        return normalized
+
+    local, domain = normalized.split('@', 1)
+    domain = DOMAIN_ALIASES.get(domain, domain)
+
+    if domain in PLUS_ADDRESSING_DOMAINS:
+        local = local.split('+', 1)[0]
+    if domain in DOT_INSENSITIVE_DOMAINS:
+        local = local.replace('.', '')
+
+    if not local:
+        # «+tag@gmail.com» и подобное — локальной части не осталось, сравнивать
+        # такое с чем-либо нельзя, отдаём исходный адрес
+        return normalized
+
+    return f'{local}@{domain}'
+
+
+def is_email_alias_of(candidate: str | None, existing: str | None) -> bool:
+    """Оба адреса ведут в один ящик, но записаны по-разному."""
+    if not candidate or not existing:
+        return False
+    if candidate.strip().lower() == existing.strip().lower():
+        return False
+    return canonical_email(candidate) == canonical_email(existing)
+
+
+def email_domain(email: str | None) -> str:
+    """Домен адреса с учётом слияния доменов-близнецов (ya.ru → yandex.ru)."""
+    normalized = (email or '').strip().lower()
+    if normalized.count('@') != 1:
+        return ''
+    domain = normalized.split('@', 1)[1]
+    return DOMAIN_ALIASES.get(domain, domain)
+
+
+def has_alias_forms(email: str | None) -> bool:
+    """У этого адреса вообще бывают алиасы — есть ли смысл искать двойников."""
+    domain = email_domain(email)
+    return domain in PLUS_ADDRESSING_DOMAINS or domain in DOT_INSENSITIVE_DOMAINS
+
+
+def sibling_domains(domain: str) -> set[str]:
+    """Домены, письма с которых попадают в тот же ящик, включая сам домен."""
+    if not domain:
+        return set()
+    return {domain} | {src for src, dst in DOMAIN_ALIASES.items() if dst == domain}
+
+
+def canonical_local_sql(column, domain: str):
+    """SQL-выражение канонической локальной части — зеркало ``canonical_email``.
+
+    Считается на стороне БД, чтобы не вычитывать всех пользователей домена ради
+    одной регистрации. Порядок операций обязан совпадать с python-версией:
+    сначала отрезаем субадрес, потом убираем точки — иначе «u.s+ta.g@gmail.com»
+    свернётся здесь и там по-разному.
+    """
+    from sqlalchemy import func
+
+    expr = func.split_part(func.lower(column), '@', 1)
+    if domain in PLUS_ADDRESSING_DOMAINS:
+        expr = func.split_part(expr, '+', 1)
+    if domain in DOT_INSENSITIVE_DOMAINS:
+        expr = func.replace(expr, '.', '')
+    return expr

--- a/tests/utils/test_email_alias.py
+++ b/tests/utils/test_email_alias.py
@@ -1,0 +1,80 @@
+"""Тесты канонизации почтовых адресов из app.utils.email_alias.
+
+Проверка «email занят» сравнивала адреса с точностью до регистра, поэтому
+`user+1@gmail.com` и `u.ser@gmail.com` заводили отдельные аккаунты, хотя письма
+идут в один ящик — и каждый такой аккаунт получал свою пробную подписку.
+"""
+
+import pytest
+
+from app.utils.email_alias import canonical_email, email_domain, has_alias_forms, is_email_alias_of
+
+
+class TestCanonicalEmail:
+    @pytest.mark.parametrize(
+        ('raw', 'expected'),
+        [
+            ('User@Gmail.com', 'user@gmail.com'),
+            ('  user@gmail.com  ', 'user@gmail.com'),
+            ('user+vpn@gmail.com', 'user@gmail.com'),
+            ('user+a+b@gmail.com', 'user@gmail.com'),
+            ('u.s.e.r@gmail.com', 'user@gmail.com'),
+            ('u.s.e.r+tag@gmail.com', 'user@gmail.com'),
+            ('user@googlemail.com', 'user@gmail.com'),
+            ('user+tag@yandex.ru', 'user@yandex.ru'),
+            ('user@ya.ru', 'user@yandex.ru'),
+            ('user@yandex.com', 'user@yandex.ru'),
+            ('user+tag@outlook.com', 'user@outlook.com'),
+        ],
+    )
+    def test_aliases_collapse_to_one_mailbox(self, raw: str, expected: str) -> None:
+        assert canonical_email(raw) == expected
+
+    def test_dots_matter_outside_gmail(self) -> None:
+        """Точки игнорирует только Gmail — у остальных это разные ящики."""
+        assert canonical_email('u.ser@yandex.ru') != canonical_email('user@yandex.ru')
+
+    def test_unknown_domain_is_left_alone(self) -> None:
+        """Незнакомый домен трогать нельзя: «+» там может быть частью имени."""
+        assert canonical_email('user+tag@corp.example') == 'user+tag@corp.example'
+        assert canonical_email('u.ser@corp.example') == 'u.ser@corp.example'
+
+    @pytest.mark.parametrize('raw', ['', None, 'not-an-email', 'two@at@signs.com'])
+    def test_malformed_input_survives(self, raw: str | None) -> None:
+        """Мусор на входе отвергает валидация выше — здесь он не должен падать."""
+        assert canonical_email(raw) == (raw or '').strip().lower()
+
+    def test_local_part_cannot_become_empty(self) -> None:
+        """«+tag@gmail.com» свернулось бы в «@gmail.com» — общий ящик для всех."""
+        assert canonical_email('+tag@gmail.com') == '+tag@gmail.com'
+
+
+class TestIsEmailAliasOf:
+    def test_detects_alias(self) -> None:
+        assert is_email_alias_of('user+1@gmail.com', 'user@gmail.com') is True
+        assert is_email_alias_of('u.ser@gmail.com', 'user@gmail.com') is True
+
+    def test_same_address_is_not_an_alias(self) -> None:
+        """Точное совпадение — задача обычной проверки, здесь оно не «алиас»."""
+        assert is_email_alias_of('user@gmail.com', 'User@GMAIL.com') is False
+
+    def test_different_mailboxes(self) -> None:
+        assert is_email_alias_of('other@gmail.com', 'user@gmail.com') is False
+        assert is_email_alias_of('user@gmail.com', 'user@yandex.ru') is False
+
+    @pytest.mark.parametrize(('a', 'b'), [(None, 'user@gmail.com'), ('user@gmail.com', None), (None, None)])
+    def test_missing_values(self, a: str | None, b: str | None) -> None:
+        assert is_email_alias_of(a, b) is False
+
+
+class TestHelpers:
+    def test_has_alias_forms(self) -> None:
+        assert has_alias_forms('user@gmail.com') is True
+        assert has_alias_forms('user@yandex.ru') is True
+        assert has_alias_forms('user@corp.example') is False
+        assert has_alias_forms('') is False
+
+    def test_email_domain_merges_twins(self) -> None:
+        assert email_domain('user@ya.ru') == 'yandex.ru'
+        assert email_domain('user@googlemail.com') == 'gmail.com'
+        assert email_domain('broken') == ''


### PR DESCRIPTION
## Проблема

Проверка «email уже занят» сравнивает адреса с точностью до регистра:

```python
existing = await db.execute(select(User).where(func.lower(User.email) == email_lower))
```

Но почтовые провайдеры доставляют письма в один ящик по целому семейству адресов:

| Введено при регистрации | Куда придёт письмо |
|---|---|
| `user+1@gmail.com` | `user@gmail.com` |
| `user+2@gmail.com` | `user@gmail.com` |
| `u.s.e.r@gmail.com` | `user@gmail.com` |
| `user@googlemail.com` | `user@gmail.com` |

Для базы это разные пользователи, для владельца ящика — один почтовый ящик. Подтверждение адреса проходит штатно: письмо приходит ему же. Одноразовые ящики тут не при чём, `disposable_email_service` такое не ловит — домен-то настоящий.

Там, где к регистрации привязана выдача разового — пробная подписка, приветственный бонус, промокод — количество получений ограничено только терпением. Аккаунт заводится за полминуты и не требует ничего, кроме одной уже имеющейся почты.

## Решение

Канонический вид адреса для сравнения (`app/utils/email_alias.py`) и поиск двойника перед регистрацией.

Канонизация умышленно консервативная — склеить двух разных людей хуже, чем пропустить одного лишнего:

- точки в локальной части игнорирует только Gmail, поэтому убираются лишь для `gmail.com` / `googlemail.com`;
- субадресацию (`+suffix`, RFC 5233) поддерживают не все, поэтому она режется только у провайдеров из явного списка;
- незнакомые и корпоративные домены не трогаются вовсе: там `+` вполне может быть частью имени ящика;
- домены-близнецы одного провайдера сводятся к одному (`ya.ru` → `yandex.ru`, `googlemail.com` → `gmail.com`).

Сам адрес пользователя не переписывается: письма должны уходить ровно на тот, который человек ввёл. Канонический вид нужен только для сравнения.

## Что изменилось в поведении

- регистрация на алиасе уже занятого ящика отвечает тем же `This email is already registered`, что и точный дубль;
- свой собственный алиас занятым не считается — сменить `user@gmail.com` на `user+vpn@gmail.com` по-прежнему можно;
- для доменов без алиасов дополнительный запрос не выполняется вообще.

## Производительность

Поиск двойника — выражение на стороне БД (`split_part`/`replace`), без вычитывания всех пользователей домена, с `LIMIT 1`. Запускается только на регистрации и смене адреса, и только если домен вообще поддерживает алиасы.

Если база большая, ускорить можно функциональным индексом — в этот PR не включал, чтобы не тащить миграцию:

```sql
CREATE INDEX CONCURRENTLY ix_users_email_canonical
    ON users (replace(split_part(split_part(lower(email), '@', 1), '+', 1), '.', ''))
    WHERE email IS NOT NULL;
```

## Тесты

`tests/utils/test_email_alias.py` — 26 тестов: схлопывание алиасов, домены-близнецы, точки вне Gmail (там они значимы), незнакомые домены, мусор на входе, вырожденный `+tag@gmail.com` (иначе локальная часть стала бы пустой и все такие адреса слиплись бы в один).

Прогон `tests/crud tests/utils` до и после патча даёт одинаковый набор падений (3 — не связаны с изменением, зависимости окружения), количество проходящих +26.
