### PR TITLE
feat(mulenpay): передавать контакт клиента в поле client

### DIFF
--- a/app/services/mulenpay_service.py
+++ b/app/services/mulenpay_service.py
@@ -162,6 +162,7 @@ class MulenPayService:
         subscribe: str | None = None,
         hold_time: int | None = None,
         website_url: str | None = None,
+        client: str | None = None,
     ) -> dict[str, Any] | None:
         if not self.is_configured:
             logger.error('MulenPay service is not configured')
@@ -186,6 +187,10 @@ class MulenPayService:
             payload['holdTime'] = hold_time
         if website_url:
             payload['website_url'] = website_url
+        if client:
+            # MulenPay ожидает единый идентификатор клиента (email, телефон или Telegram ID),
+            # чтобы иметь возможность связаться с плательщиком по вопросам платежа.
+            payload['client'] = client[:255]
 
         response = await self._request('POST', '/v2/payments', json_data=payload)
         if not response or not response.get('success'):

--- a/app/services/payment/mulenpay.py
+++ b/app/services/payment/mulenpay.py
@@ -18,6 +18,32 @@ from app.utils.user_utils import format_referrer_info
 class MulenPayPaymentMixin:
     """Mixin с созданием платежей, обработкой callback и проверкой статусов MulenPay."""
 
+    @staticmethod
+    def _build_mulenpay_client(user: Any) -> str | None:
+        """Собирает значение поля ``client`` для MulenPay.
+
+        MulenPay просит передавать контакт плательщика (email, телефон или
+        Telegram ID), чтобы иметь возможность связаться с ним по вопросам
+        платежа. Отдаём то, что реально известно о пользователе, по приоритету
+        email -> телефон -> Telegram ID.
+        """
+        if user is None:
+            return None
+
+        email = getattr(user, 'email', None)
+        if email:
+            return str(email)
+
+        phone = getattr(user, 'phone', None)
+        if phone:
+            return str(phone)
+
+        telegram_id = getattr(user, 'telegram_id', None)
+        if telegram_id:
+            return str(telegram_id)
+
+        return None
+
     async def create_mulenpay_payment(
         self,
         db: AsyncSession,
@@ -56,6 +82,11 @@ class MulenPayPaymentMixin:
             payment_uuid = f'mulen_{user_id or "guest"}_{uuid.uuid4().hex}'
             amount_rubles = amount_kopeks / 100
 
+            client = None
+            if user_id is not None:
+                user = await payment_module.get_user_by_id(db, user_id)
+                client = self._build_mulenpay_client(user)
+
             items = [
                 {
                     'description': description[:128],
@@ -74,6 +105,7 @@ class MulenPayPaymentMixin:
                 items=items,
                 language=language or settings.MULENPAY_LANGUAGE,
                 website_url=settings.MULENPAY_WEBSITE_URL or settings.WEBHOOK_URL,
+                client=client,
             )
 
             if not response:

--- a/tests/services/test_mulenpay_service_adapter.py
+++ b/tests/services/test_mulenpay_service_adapter.py
@@ -128,6 +128,31 @@ async def test_create_payment_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured_payload['method'] == 'POST'
     assert captured_payload['endpoint'] == '/v2/payments'
     assert captured_payload['json_data']['language'] == 'ru'
+    assert 'client' not in captured_payload['json_data']
+
+
+@pytest.mark.anyio('asyncio')
+async def test_create_payment_includes_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_service(monkeypatch)
+
+    captured_payload: dict[str, Any] = {}
+
+    async def fake_request(method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        captured_payload.update({'method': method, 'endpoint': endpoint, **kwargs})
+        return {'success': True, 'id': 101, 'paymentUrl': 'https://mulenpay/pay'}
+
+    service = MulenPayService()
+    monkeypatch.setattr(service, '_request', fake_request, raising=False)
+
+    await service.create_payment(
+        amount_kopeks=25000,
+        description='Пополнение',
+        uuid='uuid-1',
+        items=[{'description': 'item', 'quantity': 1, 'price': 250.0}],
+        client='user@example.com',
+    )
+
+    assert captured_payload['json_data']['client'] == 'user@example.com'
 
 
 @pytest.mark.anyio('asyncio')

--- a/tests/services/test_payment_service_mulenpay.py
+++ b/tests/services/test_payment_service_mulenpay.py
@@ -75,10 +75,22 @@ async def test_create_mulenpay_payment_success(monkeypatch: pytest.MonkeyPatch) 
         captured_args.update(kwargs)
         return DummyLocalPayment(payment_id=999)
 
+    dummy_user = SimpleNamespace(email='user@example.com', telegram_id=555)
+
+    async def fake_get_user_by_id(_db: DummySession, user_id: int) -> SimpleNamespace:
+        assert user_id == 77
+        return dummy_user
+
     monkeypatch.setattr(
         payment_service_module,
         'create_mulenpay_payment',
         fake_create_mulenpay_payment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        payment_service_module,
+        'get_user_by_id',
+        fake_get_user_by_id,
         raising=False,
     )
     monkeypatch.setattr(settings, 'MULENPAY_MIN_AMOUNT_KOPEKS', 1000, raising=False)
@@ -103,9 +115,25 @@ async def test_create_mulenpay_payment_success(monkeypatch: pytest.MonkeyPatch) 
     assert result['payment_url'] == 'https://mulenpay/pay'
     assert result['status'] == 'created'
     assert stub.calls and stub.calls[0]['language'] == 'en'
+    assert stub.calls[0]['client'] == 'user@example.com'
     assert captured_args['user_id'] == 77
     assert captured_args['amount_kopeks'] == 25000
     assert captured_args['uuid'].startswith('mulen_77_')
+
+
+@pytest.mark.parametrize(
+    ('user', 'expected'),
+    [
+        (SimpleNamespace(email='user@example.com', phone='+70000000000', telegram_id=555), 'user@example.com'),
+        (SimpleNamespace(email=None, phone='+70000000000', telegram_id=555), '+70000000000'),
+        (SimpleNamespace(email=None, phone=None, telegram_id=555), '555'),
+        (SimpleNamespace(email=None, phone=None, telegram_id=None), None),
+        (None, None),
+    ],
+)
+def test_build_mulenpay_client_priority(user: Any, expected: str | None) -> None:
+    service = _make_service(None)
+    assert service._build_mulenpay_client(user) == expected
 
 
 @pytest.mark.anyio('asyncio')


### PR DESCRIPTION
MulenPay просит указывать в payments.client email, телефон или Telegram ID плательщика для связи по вопросам платежа. Теперь бот сам подставляет это значение по приоритету email -> phone -> telegram_id, без новых настроек.