### PR TITLE
feat(grace): allow configuring external squad via GRACE_ACCESS_EXTERNAL_SQUAD_UUID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,6 +257,8 @@ GRACE_ACCESS_DURATION_HOURS=72
 GRACE_ACCESS_TRAFFIC_GB=1
 GRACE_ACCESS_EXPIRED_SQUAD_UUID=
 GRACE_ACCESS_LIMITED_SQUAD_UUID=
+# Внешний сквад (External Squad) для grace-доступа: пусто = сброс в None, keep = сохранять текущий внешний сквад, либо UUID аварийного внешнего сквада
+GRACE_ACCESS_EXTERNAL_SQUAD_UUID=
 # Дополнительные виды подписок; обычные платные несуточные разрешены при MODE=true
 GRACE_ACCESS_TRIAL_ENABLED=false
 GRACE_ACCESS_DAILY_ENABLED=false

--- a/app/config.py
+++ b/app/config.py
@@ -243,6 +243,8 @@ class Settings(BaseSettings):
     GRACE_ACCESS_DURATION_HOURS: int = 72
     GRACE_ACCESS_EXPIRED_SQUAD_UUID: str = ''
     GRACE_ACCESS_LIMITED_SQUAD_UUID: str = ''
+    # Внешний сквад для grace-доступа: пусто = сброс в None, 'keep' = сохранять текущий, либо UUID аварийного внешнего сквада
+    GRACE_ACCESS_EXTERNAL_SQUAD_UUID: str = ''
     GRACE_ACCESS_TRAFFIC_GB: int = 1
     GRACE_ACCESS_TRIAL_ENABLED: bool = False
     GRACE_ACCESS_DAILY_ENABLED: bool = False

--- a/app/services/grace_access_runtime.py
+++ b/app/services/grace_access_runtime.py
@@ -1512,6 +1512,7 @@ def _build_policy() -> GraceAccessPolicy:
         daily_enabled=settings.GRACE_ACCESS_DAILY_ENABLED,
         free_enabled=settings.GRACE_ACCESS_FREE_ENABLED,
         reconcile_batch_size=settings.GRACE_ACCESS_RECONCILE_BATCH_SIZE,
+        external_squad_uuid=settings.GRACE_ACCESS_EXTERNAL_SQUAD_UUID.strip() or None,
     )
 
 

--- a/app/services/grace_access_service.py
+++ b/app/services/grace_access_service.py
@@ -938,6 +938,27 @@ def panel_status_matches_reason(status: str, reason: GraceReason) -> bool:
     return normalized == 'limited'
 
 
+# Просьба «оставить как есть»: без неё настройка знала бы только «отцепить» и
+# «подставить конкретный», а сохранить уже назначенный сквад было бы нельзя.
+GRACE_EXTERNAL_SQUAD_KEEP = 'keep'
+
+
+def _resolve_grace_external_squad(configured: str | None, snapshot: GracePanelSnapshot) -> str | None:
+    """Какой внешний сквад назначить на время grace.
+
+    Пусто — отцепить, как было всегда. ``keep`` — оставить текущий из снимка.
+    Иначе — назначить указанный. Без разбора ``keep`` эта строка уходила бы в
+    панель как UUID, то есть настройка, описанная в .env.example, назначала бы
+    несуществующий сквад.
+    """
+    value = (configured or '').strip()
+    if not value:
+        return None
+    if value.lower() == GRACE_EXTERNAL_SQUAD_KEEP:
+        return snapshot.external_squad_uuid or None
+    return value
+
+
 def build_panel_overlay(
     snapshot: GracePanelSnapshot,
     reason: GraceReason,
@@ -955,7 +976,11 @@ def build_panel_overlay(
     # old remaining limit or an old unlimited (zero) limit.
     temporary_limit = snapshot.used_traffic_bytes + policy.traffic_bytes
 
-    external_squad_uuid = policy.external_squad_uuid.strip() if policy.external_squad_uuid else None
+    # Внешний сквад даёт доступ независимо от внутреннего telegram-only сквада,
+    # поэтому grace по умолчанию его отцепляет: иначе ограничение обходится мимо
+    # всей схемы. Значение задаётся админом осознанно — 'keep' сохраняет текущий
+    # (например, со шаблонами под блокировки), UUID подставляет аварийный.
+    external_squad_uuid = _resolve_grace_external_squad(policy.external_squad_uuid, snapshot)
 
     return GracePanelOverlay(
         status='ACTIVE',

--- a/app/services/grace_access_service.py
+++ b/app/services/grace_access_service.py
@@ -112,6 +112,7 @@ class GraceAccessPolicy:
     daily_enabled: bool = False
     free_enabled: bool = False
     reconcile_batch_size: int = 200
+    external_squad_uuid: str | None = None
 
     def __post_init__(self) -> None:
         if self.duration <= timedelta(0):
@@ -954,14 +955,14 @@ def build_panel_overlay(
     # old remaining limit or an old unlimited (zero) limit.
     temporary_limit = snapshot.used_traffic_bytes + policy.traffic_bytes
 
+    external_squad_uuid = policy.external_squad_uuid.strip() if policy.external_squad_uuid else None
+
     return GracePanelOverlay(
         status='ACTIVE',
         expire_at=_as_utc(now) + policy.duration,
         traffic_limit_bytes=temporary_limit,
         squad_uuids=(policy.squad_for(reason),),
-        # External squads can provide unrestricted access independently of the
-        # internal Telegram-only squad, so grace must temporarily detach them.
-        external_squad_uuid=None,
+        external_squad_uuid=external_squad_uuid,
     )
 
 

--- a/tests/services/test_grace_access_service.py
+++ b/tests/services/test_grace_access_service.py
@@ -1120,7 +1120,8 @@ async def test_grace_external_squad_policy_options() -> None:
     )
     result_default = await service_default.start_if_eligible(billing, GraceReason.EXPIRED)
     assert result_default.decision is GraceStartDecision.STARTED
-    assert panel_default.applied_overlays[0].external_squad_uuid is None
+    # applied_overlays хранит пары (remnawave_id, overlay) — сам overlay второй.
+    assert panel_default.applied_overlays[0][1].external_squad_uuid is None
 
     # 2. Custom external squad: overlay receives configured external_squad_uuid
     service_custom, _, panel_custom, _ = make_service(
@@ -1131,5 +1132,30 @@ async def test_grace_external_squad_policy_options() -> None:
     )
     result_custom = await service_custom.start_if_eligible(billing, GraceReason.EXPIRED)
     assert result_custom.decision is GraceStartDecision.STARTED
-    assert panel_custom.applied_overlays[0].external_squad_uuid == 'emergency-ext-squad-uuid'
+    assert panel_custom.applied_overlays[0][1].external_squad_uuid == 'emergency-ext-squad-uuid'
 
+    # 3. 'keep': сохраняется внешний сквад, уже назначенный пользователю.
+    #
+    # Значение описано в .env.example и в комментарии к настройке, но кода под
+    # него не было: строка 'keep' уходила бы в панель как UUID, то есть настройка
+    # назначала бы несуществующий сквад.
+    service_keep, _, panel_keep, _ = make_service(
+        billing=billing,
+        snapshot=snapshot,
+        clock=clock,
+        policy=make_policy(external_squad_uuid='keep'),
+    )
+    result_keep = await service_keep.start_if_eligible(billing, GraceReason.EXPIRED)
+    assert result_keep.decision is GraceStartDecision.STARTED
+    assert panel_keep.applied_overlays[0][1].external_squad_uuid == 'original-ext-squad-uuid'
+
+    # 4. 'keep' при отсутствующем внешнем скваде: сохранять нечего.
+    service_keep_empty, _, panel_keep_empty, _ = make_service(
+        billing=billing,
+        snapshot=replace(make_snapshot(expire_at=now), external_squad_uuid=None),
+        clock=clock,
+        policy=make_policy(external_squad_uuid='keep'),
+    )
+    result_keep_empty = await service_keep_empty.start_if_eligible(billing, GraceReason.EXPIRED)
+    assert result_keep_empty.decision is GraceStartDecision.STARTED
+    assert panel_keep_empty.applied_overlays[0][1].external_squad_uuid is None

--- a/tests/services/test_grace_access_service.py
+++ b/tests/services/test_grace_access_service.py
@@ -1099,3 +1099,37 @@ async def test_intentional_admin_expiry_is_suppressed_for_current_incident() -> 
     assert result.decision is GraceStartDecision.NOT_ELIGIBLE
     assert store.sessions == {}
     assert panel.applied_overlays == []
+
+
+@pytest.mark.asyncio
+async def test_grace_external_squad_policy_options() -> None:
+    now = datetime(2026, 7, 15, 12, tzinfo=UTC)
+    clock = MutableClock(now)
+    billing = make_billing(status='expired', end_at=now)
+    snapshot = replace(
+        make_snapshot(expire_at=now),
+        external_squad_uuid='original-ext-squad-uuid',
+    )
+
+    # 1. Default policy (external_squad_uuid=None): overlay has external_squad_uuid=None
+    service_default, _, panel_default, _ = make_service(
+        billing=billing,
+        snapshot=snapshot,
+        clock=clock,
+        policy=make_policy(external_squad_uuid=None),
+    )
+    result_default = await service_default.start_if_eligible(billing, GraceReason.EXPIRED)
+    assert result_default.decision is GraceStartDecision.STARTED
+    assert panel_default.applied_overlays[0].external_squad_uuid is None
+
+    # 2. Custom external squad: overlay receives configured external_squad_uuid
+    service_custom, _, panel_custom, _ = make_service(
+        billing=billing,
+        snapshot=snapshot,
+        clock=clock,
+        policy=make_policy(external_squad_uuid='emergency-ext-squad-uuid'),
+    )
+    result_custom = await service_custom.start_if_eligible(billing, GraceReason.EXPIRED)
+    assert result_custom.decision is GraceStartDecision.STARTED
+    assert panel_custom.applied_overlays[0].external_squad_uuid == 'emergency-ext-squad-uuid'
+


### PR DESCRIPTION
### 📝 Описание изменений (Description)

Добавлена возможность опционально настраивать кастомный **External Squad (Внешний сквад)** при переходе пользователя в аварийный Grace-доступ (`GRACE_ACCESS_MODE=true`).

#### 🎯 Мотивация (Motivation)
Ранее в `build_panel_overlay()` поле `external_squad_uuid` принудительно сбрасывалось (`external_squad_uuid=None`).
Если администратор использует специальный External Squad с адаптированными шаблонами подписок (Sing-box, Clash/Mihomo, V2Ray) для работы в условиях блокировок, требовалась возможность указать этот аварийный внешний сквад в конфигурации бота.

#### 🛠️ Что сделано (Changes)
1. В `Settings` (`app/config.py`) добавлена переменная:
   - `GRACE_ACCESS_EXTERNAL_SQUAD_UUID: str = ''`
     - Пустая строка (по умолчанию) — сброс `external_squad_uuid` в `None` (100% обратная совместимость).
     - `<UUID>` — назначение указанного аварийного внешнего сквада.
2. В `GraceAccessPolicy` (`app/services/grace_access_service.py`) добавлено поле `external_squad_uuid: str | None = None`.
3. В `build_panel_overlay()` подставляется `policy.external_squad_uuid` (или `None`, если не задан).
4. В `_build_policy()` (`app/services/grace_access_runtime.py`) передается значение из `settings.GRACE_ACCESS_EXTERNAL_SQUAD_UUID`.
5. Обновлен `.env.example`.
6. Добавлены unit-тесты в `tests/services/test_grace_access_service.py` на поведение по умолчанию (`None`) и кастомный UUID.